### PR TITLE
fix: keep custom naming format out of standard schema (contract-diff)

### DIFF
--- a/docs/specifications/api/admin_console_and_ui.json
+++ b/docs/specifications/api/admin_console_and_ui.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Admin Console And Ui",
     "description": "Dashboard customization through namespace-bounded asset libraries. Storage systems for branding resources, layout templates, and interactive widgets. Catalog organization with system object references tracking modification history and deployment status. Schema enforcement ensuring configuration validity across tenant hierarchies and environment boundaries.",
-    "version": "2.1.182",
+    "version": "2.1.181",
     "contact": {
       "name": "F5 Distributed Cloud",
       "url": "https://docs.cloud.f5.com"
@@ -635,7 +635,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:21.537190+00:00"
+                "validatedAt": "2026-07-20T14:41:27.528055+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -658,7 +658,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:21.537262+00:00"
+                "validatedAt": "2026-07-20T14:41:27.528076+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -669,7 +669,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.859402+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.515832+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -801,7 +801,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:21.537328+00:00"
+                "validatedAt": "2026-07-20T14:41:27.528093+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -881,7 +881,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:21.537383+00:00"
+                "validatedAt": "2026-07-20T14:41:27.528109+00:00"
               },
               "deterministic": true
             },
@@ -893,9 +893,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.859450+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.515860+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -1060,7 +1059,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:21.537520+00:00"
+                "validatedAt": "2026-07-20T14:41:27.528155+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -1075,7 +1074,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.859494+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.515887+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -1147,7 +1146,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:21.537563+00:00"
+                "validatedAt": "2026-07-20T14:41:27.528174+00:00"
               },
               "deterministic": true
             },
@@ -1159,9 +1158,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.859527+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.515909+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -1194,7 +1192,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:21.537591+00:00"
+                "validatedAt": "2026-07-20T14:41:27.528187+00:00"
               },
               "deterministic": true
             },
@@ -1206,9 +1204,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.859545+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.515921+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -1271,7 +1268,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:21.537622+00:00"
+                "validatedAt": "2026-07-20T14:41:27.528199+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -1283,7 +1280,7 @@
             "readOnly": true,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.859565+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.515934+00:00"
           },
           "name": {
             "type": "string",
@@ -1316,7 +1313,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:21.537649+00:00"
+                "validatedAt": "2026-07-20T14:41:27.528211+00:00"
               },
               "deterministic": true
             },
@@ -1328,9 +1325,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.859584+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.515946+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -1363,7 +1359,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:21.537689+00:00"
+                "validatedAt": "2026-07-20T14:41:27.528224+00:00"
               },
               "deterministic": true
             },
@@ -1375,9 +1371,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.859602+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.515958+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -1396,7 +1391,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:21.537722+00:00"
+                "validatedAt": "2026-07-20T14:41:27.528237+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -1409,7 +1404,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.859621+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.515970+00:00"
           },
           "uid": {
             "type": "string",
@@ -1428,7 +1423,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:21.537747+00:00"
+                "validatedAt": "2026-07-20T14:41:27.528247+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -1442,7 +1437,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.859641+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.515982+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -1521,7 +1516,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:21.537794+00:00"
+                "validatedAt": "2026-07-20T14:41:27.528265+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -1532,7 +1527,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.859676+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.515999+00:00"
           },
           "status": {
             "type": "string",
@@ -1550,7 +1545,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:21.537827+00:00"
+                "validatedAt": "2026-07-20T14:41:27.528278+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -1561,7 +1556,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.859695+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.516012+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -1621,7 +1616,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:21.537871+00:00"
+                "validatedAt": "2026-07-20T14:41:27.528295+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -1648,7 +1643,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:21.537911+00:00"
+                "validatedAt": "2026-07-20T14:41:27.528310+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -1675,7 +1670,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:21.537947+00:00"
+                "validatedAt": "2026-07-20T14:41:27.528324+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -1703,7 +1698,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:21.537990+00:00"
+                "validatedAt": "2026-07-20T14:41:27.528341+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -1779,7 +1774,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:21.538053+00:00"
+                "validatedAt": "2026-07-20T14:41:27.528364+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -1847,7 +1842,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:21.538103+00:00"
+                "validatedAt": "2026-07-20T14:41:27.528383+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -1859,7 +1854,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.859783+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.516064+00:00"
           },
           "uid": {
             "type": "string",
@@ -1878,7 +1873,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:21.538129+00:00"
+                "validatedAt": "2026-07-20T14:41:27.528394+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -1891,7 +1886,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.859803+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.516076+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -1959,7 +1954,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:21.538161+00:00"
+                "validatedAt": "2026-07-20T14:41:27.528405+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -1970,7 +1965,7 @@
             },
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.859823+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.516089+00:00"
           },
           "name": {
             "type": "string",
@@ -2003,7 +1998,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:21.538188+00:00"
+                "validatedAt": "2026-07-20T14:41:27.528418+00:00"
               },
               "deterministic": true
             },
@@ -2015,9 +2010,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.859842+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.516101+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -2050,7 +2044,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:21.538216+00:00"
+                "validatedAt": "2026-07-20T14:41:27.528430+00:00"
               },
               "deterministic": true
             },
@@ -2062,9 +2056,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.859860+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.516113+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "uid": {
             "type": "string",
@@ -2081,7 +2074,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:21.538240+00:00"
+                "validatedAt": "2026-07-20T14:41:27.528439+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2094,7 +2087,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.859879+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.516126+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -2292,7 +2285,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.859942+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.516164+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -2367,7 +2360,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:10:21.538346+00:00"
+                "validatedAt": "2026-07-20T14:41:27.528479+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2448,7 +2441,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:10:21.538397+00:00"
+                "validatedAt": "2026-07-20T14:41:27.528500+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2459,7 +2452,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.859988+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.516191+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -2546,7 +2539,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:21.538438+00:00"
+                "validatedAt": "2026-07-20T14:41:27.528517+00:00"
               },
               "deterministic": true
             },
@@ -2558,9 +2551,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.860033+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.516219+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -2591,7 +2583,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:21.538465+00:00"
+                "validatedAt": "2026-07-20T14:41:27.528530+00:00"
               },
               "deterministic": true
             },
@@ -2603,9 +2595,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.860051+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.516231+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -2658,7 +2649,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:21.538504+00:00"
+                "validatedAt": "2026-07-20T14:41:27.528545+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2670,7 +2661,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.860081+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.516250+00:00"
           },
           "uid": {
             "type": "string",
@@ -2688,7 +2679,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:21.538529+00:00"
+                "validatedAt": "2026-07-20T14:41:27.528555+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2701,7 +2692,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.860101+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.516263+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of static_component is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",

--- a/docs/specifications/api/ai_services.json
+++ b/docs/specifications/api/ai_services.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Ai Services",
     "description": "Query handling through inference routing with production and test modes. Positive and negative quality markers with detailed categorization capture assistant performance. Streaming connections support authenticated access, subscription lifecycles, and feature flags. IP provisioning services allocate infrastructure resources for model workloads across distributed systems.",
-    "version": "2.1.182",
+    "version": "2.1.181",
     "contact": {
       "name": "F5 Distributed Cloud",
       "url": "https://docs.cloud.f5.com"
@@ -2486,7 +2486,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:47.953001+00:00"
+                "validatedAt": "2026-07-20T14:35:20.054519+00:00"
               },
               "deterministic": true
             },
@@ -2527,7 +2527,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:47.953051+00:00"
+                "validatedAt": "2026-07-20T14:35:20.054541+00:00"
               },
               "deterministic": true
             },
@@ -2539,9 +2539,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.497423+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.142285+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "negative_feedback": {
             "allOf": [
@@ -2593,7 +2592,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T12:54:47.953104+00:00"
+                "validatedAt": "2026-07-20T14:35:20.054564+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2626,7 +2625,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:47.953183+00:00"
+                "validatedAt": "2026-07-20T14:35:20.054599+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2695,7 +2694,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:47.953229+00:00"
+                "validatedAt": "2026-07-20T14:35:20.054616+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2735,7 +2734,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:47.953263+00:00"
+                "validatedAt": "2026-07-20T14:35:20.054631+00:00"
               },
               "deterministic": true
             },
@@ -2747,9 +2746,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.497487+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.142325+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -2806,7 +2804,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:47.953305+00:00"
+                "validatedAt": "2026-07-20T14:35:20.054647+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2862,7 +2860,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:47.953360+00:00"
+                "validatedAt": "2026-07-20T14:35:20.054671+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2958,7 +2956,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:47.953438+00:00"
+                "validatedAt": "2026-07-20T14:35:20.054706+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3082,7 +3080,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:47.953488+00:00"
+                "validatedAt": "2026-07-20T14:35:20.054729+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3421,7 +3419,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:47.953524+00:00"
+                "validatedAt": "2026-07-20T14:35:20.054743+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3432,7 +3430,7 @@
             },
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.497595+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.142482+00:00"
           },
           "log_filters": {
             "type": "array",
@@ -3478,7 +3476,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:47.953569+00:00"
+                "validatedAt": "2026-07-20T14:35:20.054762+00:00"
               },
               "deterministic": true
             },
@@ -3490,9 +3488,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.497621+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.142501+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "object_name": {
             "type": "string",
@@ -3509,7 +3506,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:47.953607+00:00"
+                "validatedAt": "2026-07-20T14:35:20.054777+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3534,7 +3531,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:47.953645+00:00"
+                "validatedAt": "2026-07-20T14:35:20.054791+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3559,7 +3556,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:47.953697+00:00"
+                "validatedAt": "2026-07-20T14:35:20.054804+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3570,7 +3567,7 @@
             },
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.497661+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.142523+00:00"
           },
           "type": {
             "allOf": [
@@ -3730,7 +3727,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:47.953749+00:00"
+                "validatedAt": "2026-07-20T14:35:20.054827+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3879,7 +3876,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:47.953786+00:00"
+                "validatedAt": "2026-07-20T14:35:20.054843+00:00"
               },
               "deterministic": true
             },
@@ -3891,9 +3888,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.497728+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.142564+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "title": {
             "type": "string",
@@ -3910,7 +3906,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:47.953818+00:00"
+                "validatedAt": "2026-07-20T14:35:20.054856+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3921,7 +3917,7 @@
             },
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.497747+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.142577+00:00"
           },
           "tooltip": {
             "type": "string",
@@ -3936,7 +3932,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:47.953851+00:00"
+                "validatedAt": "2026-07-20T14:35:20.054869+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4110,7 +4106,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:47.953885+00:00"
+                "validatedAt": "2026-07-20T14:35:20.054883+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4121,7 +4117,7 @@
             },
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.497782+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.142601+00:00"
           },
           "title": {
             "type": "string",
@@ -4138,7 +4134,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:47.953917+00:00"
+                "validatedAt": "2026-07-20T14:35:20.054895+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4149,7 +4145,7 @@
             },
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.497800+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.142614+00:00"
           },
           "url": {
             "type": "string",
@@ -4174,7 +4170,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T12:54:47.953947+00:00"
+                "validatedAt": "2026-07-20T14:35:20.054910+00:00"
               },
               "deterministic": true
             },
@@ -4269,7 +4265,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:47.953989+00:00"
+                "validatedAt": "2026-07-20T14:35:20.054926+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4408,7 +4404,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:47.954022+00:00"
+                "validatedAt": "2026-07-20T14:35:20.054939+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4419,7 +4415,7 @@
             },
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.497865+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.142655+00:00"
           },
           "op": {
             "allOf": [
@@ -4458,7 +4454,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:47.954063+00:00"
+                "validatedAt": "2026-07-20T14:35:20.054959+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4537,7 +4533,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:47.954100+00:00"
+                "validatedAt": "2026-07-20T14:35:20.054974+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4548,7 +4544,7 @@
             },
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.497905+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.142681+00:00"
           },
           "type": {
             "allOf": [
@@ -4618,7 +4614,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:47.954138+00:00"
+                "validatedAt": "2026-07-20T14:35:20.054990+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4643,7 +4639,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:47.954176+00:00"
+                "validatedAt": "2026-07-20T14:35:20.055004+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4668,7 +4664,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:47.954210+00:00"
+                "validatedAt": "2026-07-20T14:35:20.055017+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4693,7 +4689,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:47.954247+00:00"
+                "validatedAt": "2026-07-20T14:35:20.055032+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4718,7 +4714,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:47.954278+00:00"
+                "validatedAt": "2026-07-20T14:35:20.055045+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4743,7 +4739,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:47.954313+00:00"
+                "validatedAt": "2026-07-20T14:35:20.055059+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4946,7 +4942,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:47.954354+00:00"
+                "validatedAt": "2026-07-20T14:35:20.055075+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4985,7 +4981,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:47.954383+00:00"
+                "validatedAt": "2026-07-20T14:35:20.055088+00:00"
               },
               "deterministic": true
             },
@@ -4997,9 +4993,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.498110+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.142731+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "type": {
             "type": "string",
@@ -5016,7 +5011,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:47.954411+00:00"
+                "validatedAt": "2026-07-20T14:35:20.055100+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5094,7 +5089,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:47.954454+00:00"
+                "validatedAt": "2026-07-20T14:35:20.055118+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5119,7 +5114,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:47.954489+00:00"
+                "validatedAt": "2026-07-20T14:35:20.055132+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5144,7 +5139,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:47.954521+00:00"
+                "validatedAt": "2026-07-20T14:35:20.055145+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5169,7 +5164,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:47.954559+00:00"
+                "validatedAt": "2026-07-20T14:35:20.055161+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5279,7 +5274,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:47.954594+00:00"
+                "validatedAt": "2026-07-20T14:35:20.055175+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5304,7 +5299,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:47.954628+00:00"
+                "validatedAt": "2026-07-20T14:35:20.055189+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5367,7 +5362,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:47.954678+00:00"
+                "validatedAt": "2026-07-20T14:35:20.055206+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5516,7 +5511,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:47.954721+00:00"
+                "validatedAt": "2026-07-20T14:35:20.055222+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5528,7 +5523,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.498222+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.142803+00:00"
           },
           "rsp_code": {
             "type": "integer",
@@ -5560,7 +5555,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:47.954781+00:00"
+                "validatedAt": "2026-07-20T14:35:20.055244+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5585,7 +5580,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:47.954827+00:00"
+                "validatedAt": "2026-07-20T14:35:20.055263+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5664,7 +5659,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:47.954868+00:00"
+                "validatedAt": "2026-07-20T14:35:20.055281+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5689,7 +5684,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:47.954902+00:00"
+                "validatedAt": "2026-07-20T14:35:20.055295+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5716,7 +5711,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:47.954926+00:00"
+                "validatedAt": "2026-07-20T14:35:20.055305+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5741,7 +5736,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:47.954964+00:00"
+                "validatedAt": "2026-07-20T14:35:20.055320+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5780,7 +5775,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:47.954992+00:00"
+                "validatedAt": "2026-07-20T14:35:20.055333+00:00"
               },
               "deterministic": true
             },
@@ -5792,9 +5787,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.498295+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.142852+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "state": {
             "type": "string",
@@ -5812,7 +5806,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:47.955022+00:00"
+                "validatedAt": "2026-07-20T14:35:20.055345+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5937,7 +5931,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:47.955080+00:00"
+                "validatedAt": "2026-07-20T14:35:20.055367+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5962,7 +5956,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:47.955119+00:00"
+                "validatedAt": "2026-07-20T14:35:20.055383+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5987,7 +5981,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:47.955158+00:00"
+                "validatedAt": "2026-07-20T14:35:20.055399+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6056,7 +6050,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:47.955196+00:00"
+                "validatedAt": "2026-07-20T14:35:20.055414+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6083,7 +6077,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:47.955220+00:00"
+                "validatedAt": "2026-07-20T14:35:20.055423+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6122,7 +6116,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:47.955246+00:00"
+                "validatedAt": "2026-07-20T14:35:20.055436+00:00"
               },
               "deterministic": true
             },
@@ -6134,9 +6128,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.498380+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.142910+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -6193,7 +6186,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:47.955289+00:00"
+                "validatedAt": "2026-07-20T14:35:20.055451+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6218,7 +6211,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:47.955331+00:00"
+                "validatedAt": "2026-07-20T14:35:20.055464+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6243,7 +6236,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:47.955374+00:00"
+                "validatedAt": "2026-07-20T14:35:20.055479+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6282,7 +6275,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:47.955402+00:00"
+                "validatedAt": "2026-07-20T14:35:20.055491+00:00"
               },
               "deterministic": true
             },
@@ -6294,9 +6287,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.498420+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.142938+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "state": {
             "type": "string",
@@ -6314,7 +6306,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:47.955434+00:00"
+                "validatedAt": "2026-07-20T14:35:20.055504+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6394,7 +6386,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:47.955480+00:00"
+                "validatedAt": "2026-07-20T14:35:20.055521+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6539,7 +6531,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:47.955562+00:00"
+                "validatedAt": "2026-07-20T14:35:20.055551+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6580,7 +6572,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:47.955606+00:00"
+                "validatedAt": "2026-07-20T14:35:20.055568+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6694,7 +6686,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:54:47.955648+00:00"
+                "validatedAt": "2026-07-20T14:35:20.055586+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6706,7 +6698,7 @@
             "maxLength": 26,
             "minLength": 15,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.498521+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.143005+00:00"
           },
           "title": {
             "type": "string",
@@ -6723,7 +6715,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:47.955693+00:00"
+                "validatedAt": "2026-07-20T14:35:20.055599+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6734,7 +6726,7 @@
             },
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.498540+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.143018+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -6800,7 +6792,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:47.955738+00:00"
+                "validatedAt": "2026-07-20T14:35:20.055620+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6828,7 +6820,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:54:47.955770+00:00"
+                "validatedAt": "2026-07-20T14:35:20.055633+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6853,7 +6845,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:47.955807+00:00"
+                "validatedAt": "2026-07-20T14:35:20.055647+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6964,7 +6956,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:47.955848+00:00"
+                "validatedAt": "2026-07-20T14:35:20.055662+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6987,7 +6979,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:47.955883+00:00"
+                "validatedAt": "2026-07-20T14:35:20.055676+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6998,7 +6990,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.498590+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.143051+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -7164,7 +7156,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:47.955928+00:00"
+                "validatedAt": "2026-07-20T14:35:20.055692+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7240,7 +7232,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:47.955973+00:00"
+                "validatedAt": "2026-07-20T14:35:20.055715+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7275,7 +7267,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:47.956014+00:00"
+                "validatedAt": "2026-07-20T14:35:20.055735+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7314,7 +7306,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:47.956053+00:00"
+                "validatedAt": "2026-07-20T14:35:20.055749+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7415,7 +7407,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:47.956097+00:00"
+                "validatedAt": "2026-07-20T14:35:20.055766+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7426,7 +7418,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.498689+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.143109+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -7544,7 +7536,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:47.956153+00:00"
+                "validatedAt": "2026-07-20T14:35:20.055791+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7659,7 +7651,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:54:47.956210+00:00"
+                "validatedAt": "2026-07-20T14:35:20.055813+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7684,7 +7676,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:47.956244+00:00"
+                "validatedAt": "2026-07-20T14:35:20.055826+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7746,7 +7738,7 @@
             "maxLength": 26,
             "minLength": 15,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.498761+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.143157+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -7872,7 +7864,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:40.713543+00:00"
+                "validatedAt": "2026-07-20T14:35:41.173724+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7937,7 +7929,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:40.713603+00:00"
+                "validatedAt": "2026-07-20T14:35:41.173762+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8000,7 +7992,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:44.279377+00:00"
+                "validatedAt": "2026-07-20T14:35:42.464776+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8062,7 +8054,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:44.279446+00:00"
+                "validatedAt": "2026-07-20T14:35:42.464803+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8089,7 +8081,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:44.279497+00:00"
+                "validatedAt": "2026-07-20T14:35:42.464819+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8116,7 +8108,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:44.279553+00:00"
+                "validatedAt": "2026-07-20T14:35:42.464835+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8143,7 +8135,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T12:55:44.279612+00:00"
+                "validatedAt": "2026-07-20T14:35:42.464855+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8207,7 +8199,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:44.279692+00:00"
+                "validatedAt": "2026-07-20T14:35:42.464873+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8269,7 +8261,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T12:55:44.279762+00:00"
+                "validatedAt": "2026-07-20T14:35:42.464890+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8330,7 +8322,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:44.279820+00:00"
+                "validatedAt": "2026-07-20T14:35:42.464906+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8425,7 +8417,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:11.096875+00:00"
+                "validatedAt": "2026-07-20T14:38:16.857410+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8504,7 +8496,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:11.096944+00:00"
+                "validatedAt": "2026-07-20T14:38:16.857436+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8530,7 +8522,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:11.096969+00:00"
+                "validatedAt": "2026-07-20T14:38:16.857447+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8596,7 +8588,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:11.097005+00:00"
+                "validatedAt": "2026-07-20T14:38:16.857462+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8629,7 +8621,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:11.097071+00:00"
+                "validatedAt": "2026-07-20T14:38:16.857490+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8694,7 +8686,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:11.097124+00:00"
+                "validatedAt": "2026-07-20T14:38:16.857505+00:00"
               }
             },
             "x-f5xc-required-for": {

--- a/docs/specifications/api/api.json
+++ b/docs/specifications/api/api.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Api",
     "description": "Structured classification systems with versioning support for contract evolution. Hierarchical groupings segment resources by operational role or security boundaries. Behavioral verification confirms authentication flows and permission constraints. Token and key safeguards protect sensitive credentials. Traffic inspection through connected load balancers and firewalls enables threat detection at network perimeters.",
-    "version": "2.1.182",
+    "version": "2.1.181",
     "contact": {
       "name": "F5 Distributed Cloud",
       "url": "https://docs.cloud.f5.com"
@@ -962,7 +962,7 @@
           },
           {
             "name": "response_format",
-            "description": "The format in which the configuration object is to be fetched. This could be for example\n - in GetSpec form for the contents of object\n - in CreateRequest form to create a new similar object\n - to ReplaceRequest form to replace changeable values\n\nDefault format of returned resource\nResponse should be in CreateRequest format\nResponse should be in ReplaceRequest format\nResponse should be in StatusObject(s) format\nResponse should be in format of GetSpecType\nResponse should have other objects referring to this object\nResponse should have deleted and disabled objects referred by this object.",
+            "description": "The format in which the configuration object is to be fetched. This could be for example\n - in GetSpec form for the contents of object\n - in CreateRequest form to create a new similar object\n - to ReplaceRequest form to replace changeable values\n\nDefault format of returned resource\nResponse should be in CreateRequest format\nResponse should be in ReplaceRequest format\nResponse should be in StatusObject(s) format\nResponse should be in format of GetSpecType\nResponse should have other objects referring to this object\nResponse should have deleted and disabled objects referrred by this object.",
             "in": "query",
             "required": false,
             "x-displayname": "Broken Referred Objects.",
@@ -2103,7 +2103,7 @@
           },
           {
             "name": "response_format",
-            "description": "The format in which the configuration object is to be fetched. This could be for example\n - in GetSpec form for the contents of object\n - in CreateRequest form to create a new similar object\n - to ReplaceRequest form to replace changeable values\n\nDefault format of returned resource\nResponse should be in CreateRequest format\nResponse should be in ReplaceRequest format\nResponse should be in StatusObject(s) format\nResponse should be in format of GetSpecType\nResponse should have other objects referring to this object\nResponse should have deleted and disabled objects referred by this object.",
+            "description": "The format in which the configuration object is to be fetched. This could be for example\n - in GetSpec form for the contents of object\n - in CreateRequest form to create a new similar object\n - to ReplaceRequest form to replace changeable values\n\nDefault format of returned resource\nResponse should be in CreateRequest format\nResponse should be in ReplaceRequest format\nResponse should be in StatusObject(s) format\nResponse should be in format of GetSpecType\nResponse should have other objects referring to this object\nResponse should have deleted and disabled objects referrred by this object.",
             "in": "query",
             "required": false,
             "x-displayname": "Broken Referred Objects.",
@@ -4555,7 +4555,7 @@
           },
           {
             "name": "response_format",
-            "description": "The format in which the configuration object is to be fetched. This could be for example\n - in GetSpec form for the contents of object\n - in CreateRequest form to create a new similar object\n - to ReplaceRequest form to replace changeable values\n\nDefault format of returned resource\nResponse should be in CreateRequest format\nResponse should be in ReplaceRequest format\nResponse should be in StatusObject(s) format\nResponse should be in format of GetSpecType\nResponse should have other objects referring to this object\nResponse should have deleted and disabled objects referred by this object.",
+            "description": "The format in which the configuration object is to be fetched. This could be for example\n - in GetSpec form for the contents of object\n - in CreateRequest form to create a new similar object\n - to ReplaceRequest form to replace changeable values\n\nDefault format of returned resource\nResponse should be in CreateRequest format\nResponse should be in ReplaceRequest format\nResponse should be in StatusObject(s) format\nResponse should be in format of GetSpecType\nResponse should have other objects referring to this object\nResponse should have deleted and disabled objects referrred by this object.",
             "in": "query",
             "required": false,
             "x-displayname": "Broken Referred Objects.",
@@ -5243,7 +5243,7 @@
           },
           {
             "name": "response_format",
-            "description": "The format in which the configuration object is to be fetched. This could be for example\n - in GetSpec form for the contents of object\n - in CreateRequest form to create a new similar object\n - to ReplaceRequest form to replace changeable values\n\nDefault format of returned resource\nResponse should be in StatusObject(s) format\nResponse should be in format of GetSpecType\nResponse should have other objects referring to this object\nResponse should have deleted and disabled objects referred by this object.",
+            "description": "The format in which the configuration object is to be fetched. This could be for example\n - in GetSpec form for the contents of object\n - in CreateRequest form to create a new similar object\n - to ReplaceRequest form to replace changeable values\n\nDefault format of returned resource\nResponse should be in StatusObject(s) format\nResponse should be in format of GetSpecType\nResponse should have other objects referring to this object\nResponse should have deleted and disabled objects referrred by this object.",
             "in": "query",
             "required": false,
             "x-displayname": "Broken Referred Objects.",
@@ -5703,7 +5703,7 @@
           },
           {
             "name": "response_format",
-            "description": "The format in which the configuration object is to be fetched. This could be for example\n - in GetSpec form for the contents of object\n - in CreateRequest form to create a new similar object\n - to ReplaceRequest form to replace changeable values\n\nDefault format of returned resource\nResponse should be in StatusObject(s) format\nResponse should be in format of GetSpecType\nResponse should have other objects referring to this object\nResponse should have deleted and disabled objects referred by this object.",
+            "description": "The format in which the configuration object is to be fetched. This could be for example\n - in GetSpec form for the contents of object\n - in CreateRequest form to create a new similar object\n - to ReplaceRequest form to replace changeable values\n\nDefault format of returned resource\nResponse should be in StatusObject(s) format\nResponse should be in format of GetSpecType\nResponse should have other objects referring to this object\nResponse should have deleted and disabled objects referrred by this object.",
             "in": "query",
             "required": false,
             "x-displayname": "Broken Referred Objects.",
@@ -6615,7 +6615,7 @@
           },
           {
             "name": "response_format",
-            "description": "The format in which the configuration object is to be fetched. This could be for example\n - in GetSpec form for the contents of object\n - in CreateRequest form to create a new similar object\n - to ReplaceRequest form to replace changeable values\n\nDefault format of returned resource\nResponse should be in CreateRequest format\nResponse should be in ReplaceRequest format\nResponse should be in StatusObject(s) format\nResponse should be in format of GetSpecType\nResponse should have other objects referring to this object\nResponse should have deleted and disabled objects referred by this object.",
+            "description": "The format in which the configuration object is to be fetched. This could be for example\n - in GetSpec form for the contents of object\n - in CreateRequest form to create a new similar object\n - to ReplaceRequest form to replace changeable values\n\nDefault format of returned resource\nResponse should be in CreateRequest format\nResponse should be in ReplaceRequest format\nResponse should be in StatusObject(s) format\nResponse should be in format of GetSpecType\nResponse should have other objects referring to this object\nResponse should have deleted and disabled objects referrred by this object.",
             "in": "query",
             "required": false,
             "x-displayname": "Broken Referred Objects.",
@@ -8199,7 +8199,7 @@
           },
           {
             "name": "response_format",
-            "description": "The format in which the configuration object is to be fetched. This could be for example\n - in GetSpec form for the contents of object\n - in CreateRequest form to create a new similar object\n - to ReplaceRequest form to replace changeable values\n\nDefault format of returned resource\nResponse should be in CreateRequest format\nResponse should be in ReplaceRequest format\nResponse should be in StatusObject(s) format\nResponse should be in format of GetSpecType\nResponse should have other objects referring to this object\nResponse should have deleted and disabled objects referred by this object.",
+            "description": "The format in which the configuration object is to be fetched. This could be for example\n - in GetSpec form for the contents of object\n - in CreateRequest form to create a new similar object\n - to ReplaceRequest form to replace changeable values\n\nDefault format of returned resource\nResponse should be in CreateRequest format\nResponse should be in ReplaceRequest format\nResponse should be in StatusObject(s) format\nResponse should be in format of GetSpecType\nResponse should have other objects referring to this object\nResponse should have deleted and disabled objects referrred by this object.",
             "in": "query",
             "required": false,
             "x-displayname": "Broken Referred Objects.",
@@ -11965,7 +11965,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:49.838614+00:00"
+                "validatedAt": "2026-07-20T14:35:20.715207+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12180,7 +12180,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:49.838737+00:00"
+                "validatedAt": "2026-07-20T14:35:20.715256+00:00"
               },
               "deterministic": true
             },
@@ -12273,7 +12273,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:49.838790+00:00"
+                "validatedAt": "2026-07-20T14:35:20.715274+00:00"
               },
               "deterministic": true
             },
@@ -12285,9 +12285,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.528847+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.176023+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -12319,7 +12318,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:49.838836+00:00"
+                "validatedAt": "2026-07-20T14:35:20.715287+00:00"
               },
               "deterministic": true
             },
@@ -12331,9 +12330,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.528868+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.176038+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -12401,7 +12399,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:49.838911+00:00"
+                "validatedAt": "2026-07-20T14:35:20.715321+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12411,9 +12409,9 @@
               "read": false
             },
             "minLength": 26,
-            "format": "fqdn",
+            "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.528890+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.176054+00:00"
           },
           "simple_login": {
             "allOf": [
@@ -12589,7 +12587,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.528965+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.176102+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -12675,7 +12673,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:49.839048+00:00"
+                "validatedAt": "2026-07-20T14:35:20.715377+00:00"
               },
               "deterministic": true
             },
@@ -12757,7 +12755,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:54:49.839088+00:00"
+                "validatedAt": "2026-07-20T14:35:20.715394+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12836,7 +12834,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:54:49.839146+00:00"
+                "validatedAt": "2026-07-20T14:35:20.715418+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12847,7 +12845,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.529025+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.176140+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -12934,7 +12932,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:49.839188+00:00"
+                "validatedAt": "2026-07-20T14:35:20.715436+00:00"
               },
               "deterministic": true
             },
@@ -12946,9 +12944,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.529073+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.176171+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -12979,7 +12976,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:49.839217+00:00"
+                "validatedAt": "2026-07-20T14:35:20.715449+00:00"
               },
               "deterministic": true
             },
@@ -12991,9 +12988,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.529091+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.176184+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -13062,7 +13058,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:49.839271+00:00"
+                "validatedAt": "2026-07-20T14:35:20.715470+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13074,7 +13070,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.529128+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.176209+00:00"
           },
           "uid": {
             "type": "string",
@@ -13091,7 +13087,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:49.839297+00:00"
+                "validatedAt": "2026-07-20T14:35:20.715480+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13104,7 +13100,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.529148+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.176223+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of api_crawler is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -13276,7 +13272,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:49.839357+00:00"
+                "validatedAt": "2026-07-20T14:35:20.715507+00:00"
               },
               "deterministic": true
             },
@@ -13339,7 +13335,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:49.839399+00:00"
+                "validatedAt": "2026-07-20T14:35:20.715523+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13364,7 +13360,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:49.839433+00:00"
+                "validatedAt": "2026-07-20T14:35:20.715536+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13376,7 +13372,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.529199+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.176255+00:00"
           },
           "endpoint_count": {
             "type": "integer",
@@ -13409,7 +13405,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:49.839483+00:00"
+                "validatedAt": "2026-07-20T14:35:20.715555+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13435,7 +13431,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:49.839528+00:00"
+                "validatedAt": "2026-07-20T14:35:20.715572+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13461,7 +13457,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:49.839570+00:00"
+                "validatedAt": "2026-07-20T14:35:20.715590+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13487,7 +13483,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.529245+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.176286+00:00"
           }
         },
         "x-f5xc-description-short": "ScanInfo represents the status and metadata of an API scan.",
@@ -13614,7 +13610,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:49.839629+00:00"
+                "validatedAt": "2026-07-20T14:35:20.715618+00:00"
               },
               "deterministic": true
             },
@@ -13793,7 +13789,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:49.839713+00:00"
+                "validatedAt": "2026-07-20T14:35:20.715646+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13805,7 +13801,7 @@
             "readOnly": true,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.529315+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.176330+00:00"
           },
           "name": {
             "type": "string",
@@ -13838,7 +13834,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:49.839742+00:00"
+                "validatedAt": "2026-07-20T14:35:20.715658+00:00"
               },
               "deterministic": true
             },
@@ -13850,9 +13846,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.529334+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.176343+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -13885,7 +13880,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:49.839770+00:00"
+                "validatedAt": "2026-07-20T14:35:20.715671+00:00"
               },
               "deterministic": true
             },
@@ -13897,9 +13892,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.529352+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.176356+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -13918,7 +13912,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:49.839803+00:00"
+                "validatedAt": "2026-07-20T14:35:20.715684+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13931,7 +13925,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.529371+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.176369+00:00"
           },
           "uid": {
             "type": "string",
@@ -13950,7 +13944,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:49.839829+00:00"
+                "validatedAt": "2026-07-20T14:35:20.715694+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13964,7 +13958,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.529390+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.176383+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -14018,7 +14012,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:49.839866+00:00"
+                "validatedAt": "2026-07-20T14:35:20.715708+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14041,7 +14035,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:49.839901+00:00"
+                "validatedAt": "2026-07-20T14:35:20.715722+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14052,7 +14046,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.529417+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.176401+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -14111,7 +14105,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:49.839948+00:00"
+                "validatedAt": "2026-07-20T14:35:20.715740+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14152,7 +14146,7 @@
                 "confidence": 1.0,
                 "category": "content",
                 "note": "Blindfold envelope encryption (AES-256-GCM + RSA-OAEP) of an RSA-2048 TLS private key produces ~3700 char string:/// URL. 128KB max secret size = ~175KB base64. Discovery reported 1024 which is incorrect.",
-                "validatedAt": "2026-07-20T12:54:49.839986+00:00"
+                "validatedAt": "2026-07-20T14:35:20.715760+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14163,7 +14157,7 @@
             },
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.529445+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.176420+00:00"
           },
           "store_provider": {
             "type": "string",
@@ -14182,7 +14176,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:49.840033+00:00"
+                "validatedAt": "2026-07-20T14:35:20.715780+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14249,7 +14243,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:49.840069+00:00"
+                "validatedAt": "2026-07-20T14:35:20.715794+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14260,7 +14254,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.529472+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.176438+00:00"
           },
           "url": {
             "type": "string",
@@ -14298,7 +14292,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:49.840127+00:00"
+                "validatedAt": "2026-07-20T14:35:20.715823+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -14371,7 +14365,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T12:54:49.840159+00:00"
+                "validatedAt": "2026-07-20T14:35:20.715837+00:00"
               },
               "deterministic": true
             },
@@ -14382,8 +14376,7 @@
               "read": false
             },
             "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "minLength": 1,
-            "format": "fqdn"
+            "minLength": 1
           },
           "last_update_time": {
             "type": "string",
@@ -14400,7 +14393,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:49.840200+00:00"
+                "validatedAt": "2026-07-20T14:35:20.715853+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14426,7 +14419,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:49.840236+00:00"
+                "validatedAt": "2026-07-20T14:35:20.715867+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14437,7 +14430,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.529512+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.176464+00:00"
           },
           "service_name": {
             "type": "string",
@@ -14454,7 +14447,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:49.840275+00:00"
+                "validatedAt": "2026-07-20T14:35:20.715882+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14466,7 +14459,7 @@
           },
           "status": {
             "type": "string",
-            "description": "Status of the condition\n\"Success\" Validation has succeeded. Requested operation was successful.\n\"Failed\" Validation has failed.\n\"Incomplete\" Validation of configuration has failed due to missing configuration.\n\"Installed\" Validation has passed and configuration has been installed in data path or K8s\n\"Down\" Configuration is operationally down. E.g. Down interface\n\"Disabled\" Configuration is administratively disabled i.e. objectmetatype.disable = true.\n\"NotApplicable\" Configuration is not applicable e.g. Tenant service_policy_set(s) in system namespace are not applicable on REs.",
+            "description": "Status of the condition\n\"Success\" Validtion has succeded. Requested operation was successful.\n\"Failed\" Validation has failed.\n\"Incomplete\" Validation of configuration has failed due to missing configuration.\n\"Installed\" Validation has passed and configuration has been installed in data path or K8s\n\"Down\" Configuration is operationally down. E.g. Down interface\n\"Disabled\" Configuration is administratively disabled i.e. objectmetatype.disable = true.\n\"NotApplicable\" Configuration is not applicable e.g. Tenant service_policy_set(s) in system namespace are not applicable on REs.",
             "title": "status",
             "x-displayname": "Status",
             "x-ves-example": "Failed",
@@ -14477,8 +14470,8 @@
             "x-validation-rules": {
               "ves.io.schema.rules.string.in": "[\\\"Success\\\",\\\"Failed\\\",\\\"Incomplete\\\",\\\"Installed\\\",\\\"Down\\\",\\\"Disabled\\\",\\\"NotApplicable\\\"]"
             },
-            "x-f5xc-description-short": "Status of the condition \"Success\" Validation has succeeded.",
-            "x-f5xc-description-medium": "Status of the condition \"Success\" Validation has succeeded. Requested operation was successful. \"Failed\" Validation has failed. \"Incomplete\" Validation of configuration has failed due to missing configuration. \"Installed\" Validation has passed and configuration has been installed in data path or...",
+            "x-f5xc-description-short": "Status of the condition \"Success\" Validtion has succeded.",
+            "x-f5xc-description-medium": "Status of the condition \"Success\" Validtion has succeded. Requested operation was successful. \"Failed\" Validation has failed. \"Incomplete\" Validation of configuration has failed due to missing configuration. \"Installed\" Validation has passed and configuration has been installed in data path or...",
             "maxLength": 1024,
             "x-f5xc-constraints": {
               "constraintType": "string",
@@ -14487,7 +14480,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:49.840311+00:00"
+                "validatedAt": "2026-07-20T14:35:20.715896+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14498,7 +14491,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.529538+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.176482+00:00"
           },
           "type": {
             "type": "string",
@@ -14523,7 +14516,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:49.840346+00:00"
+                "validatedAt": "2026-07-20T14:35:20.715909+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14663,7 +14656,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:49.840387+00:00"
+                "validatedAt": "2026-07-20T14:35:20.715925+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14741,7 +14734,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:49.840416+00:00"
+                "validatedAt": "2026-07-20T14:35:20.715938+00:00"
               },
               "deterministic": true
             },
@@ -14753,9 +14746,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.529586+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.176514+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -14915,7 +14907,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:49.840506+00:00"
+                "validatedAt": "2026-07-20T14:35:20.715979+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -14930,7 +14922,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.529630+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.176543+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -15000,7 +14992,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:49.840544+00:00"
+                "validatedAt": "2026-07-20T14:35:20.715996+00:00"
               },
               "deterministic": true
             },
@@ -15012,9 +15004,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.529671+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.176565+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -15047,7 +15038,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:49.840573+00:00"
+                "validatedAt": "2026-07-20T14:35:20.716009+00:00"
               },
               "deterministic": true
             },
@@ -15059,9 +15050,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.529690+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.176578+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -15159,7 +15149,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:49.840646+00:00"
+                "validatedAt": "2026-07-20T14:35:20.716043+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -15174,7 +15164,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.529718+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.176599+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -15246,7 +15236,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:49.840692+00:00"
+                "validatedAt": "2026-07-20T14:35:20.716060+00:00"
               },
               "deterministic": true
             },
@@ -15258,9 +15248,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.529751+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.176625+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -15293,7 +15282,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:49.840720+00:00"
+                "validatedAt": "2026-07-20T14:35:20.716073+00:00"
               },
               "deterministic": true
             },
@@ -15305,9 +15294,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.529771+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.176638+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -15405,7 +15393,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:49.840794+00:00"
+                "validatedAt": "2026-07-20T14:35:20.716106+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -15420,7 +15408,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.529798+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.176657+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -15490,7 +15478,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:49.840830+00:00"
+                "validatedAt": "2026-07-20T14:35:20.716123+00:00"
               },
               "deterministic": true
             },
@@ -15502,9 +15490,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.529831+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.176680+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -15537,7 +15524,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:49.840857+00:00"
+                "validatedAt": "2026-07-20T14:35:20.716135+00:00"
               },
               "deterministic": true
             },
@@ -15549,9 +15536,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.529849+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.176693+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -15683,7 +15669,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:49.840908+00:00"
+                "validatedAt": "2026-07-20T14:35:20.716154+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15711,7 +15697,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:49.840948+00:00"
+                "validatedAt": "2026-07-20T14:35:20.716169+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15739,7 +15725,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:49.840985+00:00"
+                "validatedAt": "2026-07-20T14:35:20.716183+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15778,7 +15764,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:49.841026+00:00"
+                "validatedAt": "2026-07-20T14:35:20.716198+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15805,7 +15791,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:49.841056+00:00"
+                "validatedAt": "2026-07-20T14:35:20.716208+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15818,7 +15804,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.529919+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.176737+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -15834,7 +15820,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:49.841092+00:00"
+                "validatedAt": "2026-07-20T14:35:20.716222+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15975,7 +15961,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:49.841143+00:00"
+                "validatedAt": "2026-07-20T14:35:20.716240+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15986,7 +15972,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.529960+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.176764+00:00"
           },
           "status": {
             "type": "string",
@@ -16004,7 +15990,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:49.841176+00:00"
+                "validatedAt": "2026-07-20T14:35:20.716253+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16015,7 +16001,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.529979+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.176777+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -16073,7 +16059,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:49.841220+00:00"
+                "validatedAt": "2026-07-20T14:35:20.716270+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16100,7 +16086,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:49.841260+00:00"
+                "validatedAt": "2026-07-20T14:35:20.716285+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16127,7 +16113,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:49.841296+00:00"
+                "validatedAt": "2026-07-20T14:35:20.716299+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16155,7 +16141,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:49.841338+00:00"
+                "validatedAt": "2026-07-20T14:35:20.716315+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16231,7 +16217,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:49.841402+00:00"
+                "validatedAt": "2026-07-20T14:35:20.716339+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16299,7 +16285,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:49.841452+00:00"
+                "validatedAt": "2026-07-20T14:35:20.716357+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16311,7 +16297,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.530065+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.176833+00:00"
           },
           "uid": {
             "type": "string",
@@ -16330,7 +16316,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:49.841477+00:00"
+                "validatedAt": "2026-07-20T14:35:20.716367+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16343,7 +16329,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.530084+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.176846+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -16409,7 +16395,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:49.841508+00:00"
+                "validatedAt": "2026-07-20T14:35:20.716379+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16420,7 +16406,7 @@
             },
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.530104+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.176860+00:00"
           },
           "name": {
             "type": "string",
@@ -16453,7 +16439,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:49.841535+00:00"
+                "validatedAt": "2026-07-20T14:35:20.716392+00:00"
               },
               "deterministic": true
             },
@@ -16465,9 +16451,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.530123+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.176873+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -16500,7 +16485,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:49.841563+00:00"
+                "validatedAt": "2026-07-20T14:35:20.716404+00:00"
               },
               "deterministic": true
             },
@@ -16512,9 +16497,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.530141+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.176886+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "uid": {
             "type": "string",
@@ -16531,7 +16515,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:49.841587+00:00"
+                "validatedAt": "2026-07-20T14:35:20.716414+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16544,7 +16528,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.530160+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.176899+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -16618,7 +16602,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:51.836149+00:00"
+                "validatedAt": "2026-07-20T14:35:21.400094+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16658,7 +16642,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:51.836206+00:00"
+                "validatedAt": "2026-07-20T14:35:21.400116+00:00"
               },
               "deterministic": true
             },
@@ -16670,9 +16654,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.562815+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.211853+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -16704,7 +16687,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:51.836238+00:00"
+                "validatedAt": "2026-07-20T14:35:21.400131+00:00"
               },
               "deterministic": true
             },
@@ -16716,9 +16699,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.562836+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.211867+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Request shape for various API Inventory Requests.",
@@ -16842,7 +16824,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:54:51.836292+00:00"
+                "validatedAt": "2026-07-20T14:35:21.400154+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16888,7 +16870,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:51.836327+00:00"
+                "validatedAt": "2026-07-20T14:35:21.400169+00:00"
               },
               "deterministic": true
             },
@@ -16900,9 +16882,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.562874+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.211893+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -17132,7 +17113,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:51.836381+00:00"
+                "validatedAt": "2026-07-20T14:35:21.400192+00:00"
               },
               "deterministic": true
             },
@@ -17144,9 +17125,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.562937+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.211934+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -17178,7 +17158,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:51.836407+00:00"
+                "validatedAt": "2026-07-20T14:35:21.400205+00:00"
               },
               "deterministic": true
             },
@@ -17190,9 +17170,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.562956+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.211947+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -17412,7 +17391,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.563031+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.211997+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -17560,7 +17539,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:54:51.836547+00:00"
+                "validatedAt": "2026-07-20T14:35:21.400258+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17641,7 +17620,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:54:51.836602+00:00"
+                "validatedAt": "2026-07-20T14:35:21.400280+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17652,7 +17631,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.563090+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.212035+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -17739,7 +17718,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:51.836643+00:00"
+                "validatedAt": "2026-07-20T14:35:21.400298+00:00"
               },
               "deterministic": true
             },
@@ -17751,9 +17730,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.563136+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.212065+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -17784,7 +17762,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:51.836683+00:00"
+                "validatedAt": "2026-07-20T14:35:21.400311+00:00"
               },
               "deterministic": true
             },
@@ -17796,9 +17774,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.563154+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.212078+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -17867,7 +17844,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:51.836737+00:00"
+                "validatedAt": "2026-07-20T14:35:21.400331+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17879,7 +17856,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.563192+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.212104+00:00"
           },
           "uid": {
             "type": "string",
@@ -17896,7 +17873,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:51.836764+00:00"
+                "validatedAt": "2026-07-20T14:35:21.400342+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17909,7 +17886,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.563212+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.212119+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of api_definition is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -18261,7 +18238,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:51.838553+00:00"
+                "validatedAt": "2026-07-20T14:35:21.401105+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18308,7 +18285,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:51.838619+00:00"
+                "validatedAt": "2026-07-20T14:35:21.401140+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18399,7 +18376,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:51.838681+00:00"
+                "validatedAt": "2026-07-20T14:35:21.401167+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -18414,9 +18391,8 @@
               "read": false
             },
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.078748+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.544350+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -18455,7 +18431,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:51.838731+00:00"
+                "validatedAt": "2026-07-20T14:35:21.401191+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -18470,9 +18446,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.564081+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.212700+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -18501,7 +18476,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:51.838784+00:00"
+                "validatedAt": "2026-07-20T14:35:21.401215+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18514,7 +18489,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.564100+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.212714+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a direct reference from one object(the referrer) to another(the referred).",
@@ -18604,7 +18579,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:51.838851+00:00"
+                "validatedAt": "2026-07-20T14:35:21.401245+00:00"
               },
               "byteLength": {
                 "max": 1024,
@@ -18684,7 +18659,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:51.838899+00:00"
+                "validatedAt": "2026-07-20T14:35:21.401267+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18723,7 +18698,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:51.838944+00:00"
+                "validatedAt": "2026-07-20T14:35:21.401288+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18778,7 +18753,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:51.838991+00:00"
+                "validatedAt": "2026-07-20T14:35:21.401310+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18843,7 +18818,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:51.839039+00:00"
+                "validatedAt": "2026-07-20T14:35:21.401333+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18941,7 +18916,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:51.839099+00:00"
+                "validatedAt": "2026-07-20T14:35:21.401359+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18980,7 +18955,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:51.839143+00:00"
+                "validatedAt": "2026-07-20T14:35:21.401381+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19035,7 +19010,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:51.839189+00:00"
+                "validatedAt": "2026-07-20T14:35:21.401403+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19100,7 +19075,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:51.839235+00:00"
+                "validatedAt": "2026-07-20T14:35:21.401424+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19181,7 +19156,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:51.839280+00:00"
+                "validatedAt": "2026-07-20T14:35:21.401446+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19220,7 +19195,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:51.839323+00:00"
+                "validatedAt": "2026-07-20T14:35:21.401467+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19275,7 +19250,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:51.839370+00:00"
+                "validatedAt": "2026-07-20T14:35:21.401489+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19340,7 +19315,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:51.839415+00:00"
+                "validatedAt": "2026-07-20T14:35:21.401511+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19600,7 +19575,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:53.695937+00:00"
+                "validatedAt": "2026-07-20T14:35:22.020050+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19685,7 +19660,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:53.696051+00:00"
+                "validatedAt": "2026-07-20T14:35:22.020099+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19788,7 +19763,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:53.696096+00:00"
+                "validatedAt": "2026-07-20T14:35:22.020119+00:00"
               },
               "deterministic": true
             },
@@ -19800,9 +19775,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.600935+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.244078+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -19834,7 +19808,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:53.696126+00:00"
+                "validatedAt": "2026-07-20T14:35:22.020133+00:00"
               },
               "deterministic": true
             },
@@ -19846,9 +19820,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.600956+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.244092+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -20011,7 +19984,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.601024+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.244135+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -20094,7 +20067,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:53.696247+00:00"
+                "validatedAt": "2026-07-20T14:35:22.020179+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20180,7 +20153,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:54:53.696293+00:00"
+                "validatedAt": "2026-07-20T14:35:22.020199+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20259,7 +20232,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:54:53.696349+00:00"
+                "validatedAt": "2026-07-20T14:35:22.020221+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20270,7 +20243,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.601082+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.244173+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -20357,7 +20330,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:53.696390+00:00"
+                "validatedAt": "2026-07-20T14:35:22.020238+00:00"
               },
               "deterministic": true
             },
@@ -20369,9 +20342,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.601127+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.244203+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -20402,7 +20374,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:53.696417+00:00"
+                "validatedAt": "2026-07-20T14:35:22.020250+00:00"
               },
               "deterministic": true
             },
@@ -20414,9 +20386,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.601146+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.244216+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -20485,7 +20456,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:53.696473+00:00"
+                "validatedAt": "2026-07-20T14:35:22.020271+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20497,7 +20468,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.601183+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.244242+00:00"
           },
           "uid": {
             "type": "string",
@@ -20514,7 +20485,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:53.696500+00:00"
+                "validatedAt": "2026-07-20T14:35:22.020281+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20527,7 +20498,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.601204+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.244256+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of api_discovery is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -20697,7 +20668,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:53.696555+00:00"
+                "validatedAt": "2026-07-20T14:35:22.020305+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20927,7 +20898,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.626697+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.278925+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -21020,7 +20991,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:54:55.458296+00:00"
+                "validatedAt": "2026-07-20T14:35:22.618237+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21098,7 +21069,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:54:55.458368+00:00"
+                "validatedAt": "2026-07-20T14:35:22.618267+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21109,7 +21080,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.626753+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.278960+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -21196,7 +21167,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:55.458415+00:00"
+                "validatedAt": "2026-07-20T14:35:22.618288+00:00"
               },
               "deterministic": true
             },
@@ -21208,9 +21179,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.626800+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.278991+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -21241,7 +21211,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:55.458444+00:00"
+                "validatedAt": "2026-07-20T14:35:22.618302+00:00"
               },
               "deterministic": true
             },
@@ -21253,9 +21223,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.626825+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.279004+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -21324,7 +21293,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:55.458498+00:00"
+                "validatedAt": "2026-07-20T14:35:22.618324+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21336,7 +21305,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.626863+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.279030+00:00"
           },
           "uid": {
             "type": "string",
@@ -21353,7 +21322,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:55.458525+00:00"
+                "validatedAt": "2026-07-20T14:35:22.618335+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21366,7 +21335,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.626883+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.279044+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of api_group is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -21519,7 +21488,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:55.459153+00:00"
+                "validatedAt": "2026-07-20T14:35:22.618596+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21531,7 +21500,7 @@
             "readOnly": true,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.627155+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.279225+00:00"
           },
           "name": {
             "type": "string",
@@ -21564,7 +21533,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:55.459181+00:00"
+                "validatedAt": "2026-07-20T14:35:22.618610+00:00"
               },
               "deterministic": true
             },
@@ -21576,9 +21545,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.627173+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.279237+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -21611,7 +21579,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:55.459209+00:00"
+                "validatedAt": "2026-07-20T14:35:22.618623+00:00"
               },
               "deterministic": true
             },
@@ -21623,9 +21591,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.627191+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.279250+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -21644,7 +21611,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:55.459244+00:00"
+                "validatedAt": "2026-07-20T14:35:22.618636+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21657,7 +21624,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.627209+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.279263+00:00"
           },
           "uid": {
             "type": "string",
@@ -21676,7 +21643,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:55.459271+00:00"
+                "validatedAt": "2026-07-20T14:35:22.618647+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21690,7 +21657,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.627229+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.279277+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -21755,7 +21722,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:55.460060+00:00"
+                "validatedAt": "2026-07-20T14:35:22.618964+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21787,7 +21754,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:55.460109+00:00"
+                "validatedAt": "2026-07-20T14:35:22.619011+00:00"
               },
               "deterministic": true
             },
@@ -21931,7 +21898,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.646125+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.311829+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -22025,7 +21992,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:57.231902+00:00"
+                "validatedAt": "2026-07-20T14:35:23.295612+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22071,7 +22038,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:57.231984+00:00"
+                "validatedAt": "2026-07-20T14:35:23.295651+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22154,7 +22121,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:54:57.232032+00:00"
+                "validatedAt": "2026-07-20T14:35:23.295675+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22233,7 +22200,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:54:57.232092+00:00"
+                "validatedAt": "2026-07-20T14:35:23.295703+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22244,7 +22211,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.646198+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.311873+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -22331,7 +22298,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:57.232137+00:00"
+                "validatedAt": "2026-07-20T14:35:23.295725+00:00"
               },
               "deterministic": true
             },
@@ -22343,9 +22310,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.646246+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.311903+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -22376,7 +22342,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:57.232168+00:00"
+                "validatedAt": "2026-07-20T14:35:23.295741+00:00"
               },
               "deterministic": true
             },
@@ -22388,9 +22354,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.646266+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.311916+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -22459,7 +22424,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:57.232222+00:00"
+                "validatedAt": "2026-07-20T14:35:23.295764+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22471,7 +22436,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.646304+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.311941+00:00"
           },
           "uid": {
             "type": "string",
@@ -22489,7 +22454,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:57.232250+00:00"
+                "validatedAt": "2026-07-20T14:35:23.295775+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22502,7 +22467,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.646324+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.311954+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of api_group_element is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -22659,7 +22624,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:59.152110+00:00"
+                "validatedAt": "2026-07-20T14:35:24.105925+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22670,7 +22635,7 @@
             },
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.668252+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.355071+00:00"
           },
           "value": {
             "allOf": [
@@ -22687,7 +22652,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.668275+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.355087+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -22767,7 +22732,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:59.152216+00:00"
+                "validatedAt": "2026-07-20T14:35:24.105965+00:00"
               },
               "deterministic": true
             },
@@ -23026,7 +22991,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:59.152343+00:00"
+                "validatedAt": "2026-07-20T14:35:24.106011+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23063,7 +23028,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:59.152402+00:00"
+                "validatedAt": "2026-07-20T14:35:24.106042+00:00"
               },
               "deterministic": true
             },
@@ -23271,7 +23236,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:59.152485+00:00"
+                "validatedAt": "2026-07-20T14:35:24.106083+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23402,7 +23367,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:59.152535+00:00"
+                "validatedAt": "2026-07-20T14:35:24.106107+00:00"
               },
               "deterministic": true
             },
@@ -23414,9 +23379,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.668448+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.355194+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -23448,7 +23412,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:59.152566+00:00"
+                "validatedAt": "2026-07-20T14:35:24.106123+00:00"
               },
               "deterministic": true
             },
@@ -23460,9 +23424,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.668466+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.355207+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -23568,7 +23531,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:59.152648+00:00"
+                "validatedAt": "2026-07-20T14:35:24.106162+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23578,9 +23541,9 @@
               "read": false
             },
             "minLength": 26,
-            "format": "fqdn",
+            "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.668502+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.355231+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -23743,7 +23706,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.668568+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.355274+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -23823,7 +23786,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:59.152799+00:00"
+                "validatedAt": "2026-07-20T14:35:24.106226+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23860,7 +23823,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:59.152853+00:00"
+                "validatedAt": "2026-07-20T14:35:24.106254+00:00"
               },
               "deterministic": true
             },
@@ -23998,7 +23961,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:54:59.152906+00:00"
+                "validatedAt": "2026-07-20T14:35:24.106278+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24077,7 +24040,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:54:59.152963+00:00"
+                "validatedAt": "2026-07-20T14:35:24.106303+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24088,7 +24051,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.668661+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.355328+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -24175,7 +24138,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:59.153006+00:00"
+                "validatedAt": "2026-07-20T14:35:24.106324+00:00"
               },
               "deterministic": true
             },
@@ -24187,9 +24150,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.668710+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.355359+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -24220,7 +24182,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:59.153035+00:00"
+                "validatedAt": "2026-07-20T14:35:24.106339+00:00"
               },
               "deterministic": true
             },
@@ -24232,9 +24194,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.668728+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.355372+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -24303,7 +24264,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:59.153089+00:00"
+                "validatedAt": "2026-07-20T14:35:24.106361+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24315,7 +24276,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.668766+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.355397+00:00"
           },
           "uid": {
             "type": "string",
@@ -24332,7 +24293,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:59.153117+00:00"
+                "validatedAt": "2026-07-20T14:35:24.106374+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24345,7 +24306,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.668786+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.355411+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of api_testing is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -24452,7 +24413,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:59.153189+00:00"
+                "validatedAt": "2026-07-20T14:35:24.106410+00:00"
               },
               "deterministic": true
             },
@@ -24483,7 +24444,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:54:59.153235+00:00"
+                "validatedAt": "2026-07-20T14:35:24.106431+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24646,7 +24607,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:59.153307+00:00"
+                "validatedAt": "2026-07-20T14:35:24.106467+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24683,7 +24644,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:54:59.153357+00:00"
+                "validatedAt": "2026-07-20T14:35:24.106495+00:00"
               },
               "deterministic": true
             },
@@ -24949,7 +24910,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:01.244647+00:00"
+                "validatedAt": "2026-07-20T14:35:25.029877+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25114,7 +25075,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.244800+00:00"
+                "validatedAt": "2026-07-20T14:35:25.029920+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25210,7 +25171,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:01.244859+00:00"
+                "validatedAt": "2026-07-20T14:35:25.029948+00:00"
               },
               "deterministic": true
             },
@@ -25222,9 +25183,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.707478+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.408339+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -25255,7 +25215,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:01.244890+00:00"
+                "validatedAt": "2026-07-20T14:35:25.029965+00:00"
               },
               "deterministic": true
             },
@@ -25267,9 +25227,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.707498+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.408353+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "spec": {
             "allOf": [
@@ -25355,7 +25314,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.244931+00:00"
+                "validatedAt": "2026-07-20T14:35:25.029983+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25379,7 +25338,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.244977+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030003+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25415,7 +25374,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:01.245006+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030019+00:00"
               },
               "deterministic": true
             },
@@ -25427,9 +25386,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.707546+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.408378+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "CreateResponse is the response format for the credential's create request.",
@@ -25554,7 +25512,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:01.245057+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030044+00:00"
               },
               "deterministic": true
             },
@@ -25566,9 +25524,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.707587+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.408401+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -25599,7 +25556,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:01.245084+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030059+00:00"
               },
               "deterministic": true
             },
@@ -25611,9 +25568,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.707606+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.408411+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace_roles": {
             "type": "array",
@@ -25657,7 +25613,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.245140+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030083+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25732,7 +25688,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.245205+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030110+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25758,7 +25714,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.245249+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030130+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25860,7 +25816,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.245293+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030149+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25899,7 +25855,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.245338+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030168+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25925,7 +25881,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.245382+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030186+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26087,7 +26043,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:01.245420+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030206+00:00"
               },
               "deterministic": true
             },
@@ -26099,9 +26055,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.707734+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.408472+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -26140,7 +26095,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:01.245454+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030223+00:00"
               },
               "deterministic": true
             },
@@ -26152,9 +26107,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.707754+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.408483+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "GET credential object with a given name.",
@@ -26275,7 +26229,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.245507+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030246+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26300,7 +26254,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.245549+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030264+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26339,7 +26293,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:01.245576+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030279+00:00"
               },
               "deterministic": true
             },
@@ -26351,9 +26305,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.707803+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.408508+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -26384,7 +26337,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:01.245604+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030294+00:00"
               },
               "deterministic": true
             },
@@ -26396,9 +26349,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.707821+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.408519+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace_access": {
             "allOf": [
@@ -26442,7 +26394,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.245636+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030308+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26455,7 +26407,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.707853+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.408537+00:00"
           },
           "user_email": {
             "type": "string",
@@ -26473,7 +26425,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.245684+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030325+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26583,7 +26535,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:01.245776+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030368+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26608,7 +26560,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.245818+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030387+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26631,7 +26583,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.245853+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030404+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26656,7 +26608,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.245897+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030429+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26681,7 +26633,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.245935+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030446+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26728,7 +26680,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:01.245982+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030471+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26752,7 +26704,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.246023+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030489+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26776,7 +26728,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.246067+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030507+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26850,7 +26802,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:55:01.246099+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030539+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26928,7 +26880,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.246145+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030608+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26953,7 +26905,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.246188+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030663+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26992,7 +26944,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:01.246217+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030698+00:00"
               },
               "deterministic": true
             },
@@ -27004,9 +26956,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.707982+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.408602+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -27037,7 +26988,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:01.246244+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030725+00:00"
               },
               "deterministic": true
             },
@@ -27049,9 +27000,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.708001+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.408613+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "type": {
             "allOf": [
@@ -27081,7 +27031,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.246271+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030749+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27094,7 +27044,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.708026+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.408627+00:00"
           },
           "user_email": {
             "type": "string",
@@ -27112,7 +27062,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.246308+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030779+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27183,7 +27133,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:55:01.246338+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030812+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27261,7 +27211,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.246383+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030849+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27286,7 +27236,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.246424+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030880+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27325,7 +27275,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:01.246452+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030909+00:00"
               },
               "deterministic": true
             },
@@ -27337,9 +27287,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.708081+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.408656+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -27370,7 +27319,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:01.246480+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030934+00:00"
               },
               "deterministic": true
             },
@@ -27382,9 +27331,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.708099+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.408666+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace_access": {
             "allOf": [
@@ -27428,7 +27376,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.246511+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030959+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27441,7 +27389,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.708131+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.408684+00:00"
           },
           "user_email": {
             "type": "string",
@@ -27459,7 +27407,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.246549+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030988+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27568,7 +27516,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:01.246612+00:00"
+                "validatedAt": "2026-07-20T14:35:25.031048+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27749,7 +27697,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:01.246682+00:00"
+                "validatedAt": "2026-07-20T14:35:25.031103+00:00"
               },
               "deterministic": true
             },
@@ -27761,9 +27709,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.708202+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.408721+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "RecreateScimTokenRequest is the request format for generating SCIM API credential.",
@@ -27856,7 +27803,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:01.246729+00:00"
+                "validatedAt": "2026-07-20T14:35:25.031144+00:00"
               },
               "deterministic": true
             },
@@ -27868,9 +27815,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.708229+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.408736+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -27909,7 +27855,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:01.246758+00:00"
+                "validatedAt": "2026-07-20T14:35:25.031238+00:00"
               },
               "deterministic": true
             },
@@ -27921,9 +27867,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.708248+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.408750+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -28000,7 +27945,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:01.246788+00:00"
+                "validatedAt": "2026-07-20T14:35:25.031273+00:00"
               },
               "deterministic": true
             },
@@ -28012,9 +27957,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.708267+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.408763+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -28046,7 +27990,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:01.246815+00:00"
+                "validatedAt": "2026-07-20T14:35:25.031300+00:00"
               },
               "deterministic": true
             },
@@ -28058,9 +28002,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.708285+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.408776+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace_access": {
             "allOf": [
@@ -28165,7 +28108,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.246881+00:00"
+                "validatedAt": "2026-07-20T14:35:25.031353+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28204,7 +28147,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:01.246908+00:00"
+                "validatedAt": "2026-07-20T14:35:25.031380+00:00"
               },
               "deterministic": true
             },
@@ -28216,9 +28159,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.708331+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.408807+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Response format for the credential's replace request.",
@@ -28296,7 +28238,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:01.246940+00:00"
+                "validatedAt": "2026-07-20T14:35:25.031411+00:00"
               },
               "deterministic": true
             },
@@ -28308,9 +28250,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.708351+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.408821+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ScimTokenRequest is used for fetching or revoking scim token.",
@@ -28383,7 +28324,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:01.246997+00:00"
+                "validatedAt": "2026-07-20T14:35:25.031466+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28496,7 +28437,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.708389+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.408846+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -28558,7 +28499,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:01.247070+00:00"
+                "validatedAt": "2026-07-20T14:35:25.031530+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28567,8 +28508,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "vk8s_namespace": {
             "type": "string",
@@ -28595,7 +28535,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:01.247130+00:00"
+                "validatedAt": "2026-07-20T14:35:25.031595+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28604,8 +28544,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -28775,7 +28714,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:01.247234+00:00"
+                "validatedAt": "2026-07-20T14:35:25.031677+00:00"
               },
               "deterministic": true
             },
@@ -28787,9 +28726,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.708470+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.408897+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "role": {
             "type": "string",
@@ -28821,7 +28759,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:01.247285+00:00"
+                "validatedAt": "2026-07-20T14:35:25.031710+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28830,8 +28768,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -28924,7 +28861,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:01.247361+00:00"
+                "validatedAt": "2026-07-20T14:35:25.031751+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -28939,7 +28876,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.708504+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.408919+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -29011,7 +28948,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:01.247397+00:00"
+                "validatedAt": "2026-07-20T14:35:25.031770+00:00"
               },
               "deterministic": true
             },
@@ -29023,9 +28960,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.708537+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.408941+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -29058,7 +28994,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:01.247423+00:00"
+                "validatedAt": "2026-07-20T14:35:25.031785+00:00"
               },
               "deterministic": true
             },
@@ -29070,9 +29006,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.708555+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.408953+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "uid": {
             "type": "string",
@@ -29091,7 +29026,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.247447+00:00"
+                "validatedAt": "2026-07-20T14:35:25.031797+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29105,7 +29040,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.708575+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.408966+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectMetaType is metadata(common attributes) of an object that all configuration objects will have.",
@@ -29168,7 +29103,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.247719+00:00"
+                "validatedAt": "2026-07-20T14:35:25.031925+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29196,7 +29131,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.247759+00:00"
+                "validatedAt": "2026-07-20T14:35:25.031942+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29225,7 +29160,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.247800+00:00"
+                "validatedAt": "2026-07-20T14:35:25.031959+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29252,7 +29187,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.247838+00:00"
+                "validatedAt": "2026-07-20T14:35:25.031976+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29281,7 +29216,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.247880+00:00"
+                "validatedAt": "2026-07-20T14:35:25.031994+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29306,7 +29241,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.247922+00:00"
+                "validatedAt": "2026-07-20T14:35:25.032012+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29382,7 +29317,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.247988+00:00"
+                "validatedAt": "2026-07-20T14:35:25.032041+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29420,7 +29355,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:01.248031+00:00"
+                "validatedAt": "2026-07-20T14:35:25.032068+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29432,7 +29367,7 @@
             "maxLength": 6,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.708811+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.409115+00:00"
           },
           "object_index": {
             "type": "integer",
@@ -29492,7 +29427,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.248084+00:00"
+                "validatedAt": "2026-07-20T14:35:25.032090+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29536,7 +29471,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.248122+00:00"
+                "validatedAt": "2026-07-20T14:35:25.032106+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29549,7 +29484,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.708856+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.409143+00:00"
           },
           "trace_info": {
             "type": "string",
@@ -29568,7 +29503,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.248160+00:00"
+                "validatedAt": "2026-07-20T14:35:25.032135+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29595,7 +29530,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.248185+00:00"
+                "validatedAt": "2026-07-20T14:35:25.032175+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29609,7 +29544,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.708881+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.409160+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -29624,7 +29559,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.248221+00:00"
+                "validatedAt": "2026-07-20T14:35:25.032206+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29754,7 +29689,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:18.516495+00:00"
+                "validatedAt": "2026-07-20T14:35:32.441859+00:00"
               },
               "byteLength": {
                 "max": 1024,
@@ -29836,7 +29771,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:18.516535+00:00"
+                "validatedAt": "2026-07-20T14:35:32.441878+00:00"
               },
               "deterministic": true
             },
@@ -29848,9 +29783,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.999706+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.736218+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -29881,7 +29815,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:18.516582+00:00"
+                "validatedAt": "2026-07-20T14:35:32.441893+00:00"
               },
               "deterministic": true
             },
@@ -29893,9 +29827,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.999727+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.736233+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "The API Group ID for the API Groups stats response.",
@@ -30417,7 +30350,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:18.516728+00:00"
+                "validatedAt": "2026-07-20T14:35:32.441933+00:00"
               },
               "deterministic": true
             },
@@ -30429,9 +30362,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.999839+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.736301+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -30463,7 +30395,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:18.516774+00:00"
+                "validatedAt": "2026-07-20T14:35:32.441947+00:00"
               },
               "deterministic": true
             },
@@ -30475,9 +30407,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.999858+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.736315+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -30560,7 +30491,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:18.516828+00:00"
+                "validatedAt": "2026-07-20T14:35:32.441964+00:00"
               },
               "deterministic": true
             },
@@ -30572,9 +30503,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.999884+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.736333+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -30643,7 +30573,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:18.516891+00:00"
+                "validatedAt": "2026-07-20T14:35:32.441984+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30740,7 +30670,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:18.516943+00:00"
+                "validatedAt": "2026-07-20T14:35:32.442006+00:00"
               },
               "deterministic": true
             },
@@ -30752,9 +30682,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.999926+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.736360+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -30811,7 +30740,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:55:18.516976+00:00"
+                "validatedAt": "2026-07-20T14:35:32.442022+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30981,7 +30910,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.000002+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.736409+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -31076,7 +31005,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:55:18.517086+00:00"
+                "validatedAt": "2026-07-20T14:35:32.442070+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31155,7 +31084,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:55:18.517139+00:00"
+                "validatedAt": "2026-07-20T14:35:32.442095+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31166,7 +31095,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.000053+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.736441+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -31253,7 +31182,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:18.517179+00:00"
+                "validatedAt": "2026-07-20T14:35:32.442114+00:00"
               },
               "deterministic": true
             },
@@ -31265,9 +31194,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.000099+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.736472+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -31298,7 +31226,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:18.517207+00:00"
+                "validatedAt": "2026-07-20T14:35:32.442128+00:00"
               },
               "deterministic": true
             },
@@ -31310,9 +31238,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.000118+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.736485+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -31381,7 +31308,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:18.517260+00:00"
+                "validatedAt": "2026-07-20T14:35:32.442149+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31393,7 +31320,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.000156+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.736510+00:00"
           },
           "uid": {
             "type": "string",
@@ -31410,7 +31337,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:18.517287+00:00"
+                "validatedAt": "2026-07-20T14:35:32.442161+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31423,7 +31350,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.000176+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.736524+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of app_api_group is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -31716,7 +31643,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:18.519349+00:00"
+                "validatedAt": "2026-07-20T14:35:32.443151+00:00"
               },
               "deterministic": true
             },
@@ -31870,7 +31797,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:18.519423+00:00"
+                "validatedAt": "2026-07-20T14:35:32.443187+00:00"
               },
               "deterministic": true
             },
@@ -32021,7 +31948,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:18.519496+00:00"
+                "validatedAt": "2026-07-20T14:35:32.443223+00:00"
               },
               "deterministic": true
             },
@@ -32154,7 +32081,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:18.519554+00:00"
+                "validatedAt": "2026-07-20T14:35:32.443253+00:00"
               },
               "deterministic": true
             },
@@ -32295,7 +32222,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:26.923474+00:00"
+                "validatedAt": "2026-07-20T14:35:35.783865+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32373,7 +32300,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:26.923573+00:00"
+                "validatedAt": "2026-07-20T14:35:35.783903+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32384,8 +32311,7 @@
             },
             "x-f5xc-conflicts-with": [
               "any_domain"
-            ],
-            "format": "fqdn"
+            ]
           }
         },
         "x-f5xc-description-short": "API Protection Rule for a specific endpoint.",
@@ -32532,7 +32458,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:26.923638+00:00"
+                "validatedAt": "2026-07-20T14:35:35.783932+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32570,7 +32496,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:26.923740+00:00"
+                "validatedAt": "2026-07-20T14:35:35.783966+00:00"
               },
               "deterministic": true
             },
@@ -32677,7 +32603,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:26.923814+00:00"
+                "validatedAt": "2026-07-20T14:35:35.783999+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32784,7 +32710,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:26.923889+00:00"
+                "validatedAt": "2026-07-20T14:35:35.784033+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32795,8 +32721,7 @@
             },
             "x-f5xc-conflicts-with": [
               "any_domain"
-            ],
-            "format": "fqdn"
+            ]
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -32870,7 +32795,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:26.923938+00:00"
+                "validatedAt": "2026-07-20T14:35:35.784056+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33011,7 +32936,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:26.924010+00:00"
+                "validatedAt": "2026-07-20T14:35:35.784088+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33050,7 +32975,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:26.924068+00:00"
+                "validatedAt": "2026-07-20T14:35:35.784116+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33179,7 +33104,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T12:55:26.924123+00:00"
+                "validatedAt": "2026-07-20T14:35:35.784140+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33700,7 +33625,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:26.924236+00:00"
+                "validatedAt": "2026-07-20T14:35:35.784188+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33817,7 +33742,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:26.924291+00:00"
+                "validatedAt": "2026-07-20T14:35:35.784215+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33924,7 +33849,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:26.924356+00:00"
+                "validatedAt": "2026-07-20T14:35:35.784245+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33963,7 +33888,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:26.924413+00:00"
+                "validatedAt": "2026-07-20T14:35:35.784272+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34015,7 +33940,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:26.924480+00:00"
+                "validatedAt": "2026-07-20T14:35:35.784304+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34026,8 +33951,7 @@
             },
             "x-f5xc-conflicts-with": [
               "any_domain"
-            ],
-            "format": "fqdn"
+            ]
           },
           "validation_mode": {
             "allOf": [
@@ -34256,7 +34180,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:26.924544+00:00"
+                "validatedAt": "2026-07-20T14:35:35.784333+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34446,7 +34370,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:26.924776+00:00"
+                "validatedAt": "2026-07-20T14:35:35.784430+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34521,7 +34445,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:26.924822+00:00"
+                "validatedAt": "2026-07-20T14:35:35.784451+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34844,7 +34768,7 @@
             "maxLength": 26,
             "minLength": 15,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.191781+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:08.912856+00:00",
             "x-f5xc-conflicts-with": [
               "check_not_present",
               "check_present"
@@ -34889,7 +34813,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:26.924918+00:00"
+                "validatedAt": "2026-07-20T14:35:35.784493+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -34904,9 +34828,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.191801+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.912869+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Cookie matcher specifies the name of a single cookie and the criteria to match it.",
@@ -34994,7 +34917,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:26.924967+00:00"
+                "validatedAt": "2026-07-20T14:35:35.784516+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35132,7 +35055,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:26.925017+00:00"
+                "validatedAt": "2026-07-20T14:35:35.784540+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35247,7 +35170,7 @@
             "maxLength": 26,
             "minLength": 15,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.191871+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:08.912915+00:00",
             "x-f5xc-conflicts-with": [
               "check_not_present",
               "check_present"
@@ -35291,7 +35214,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:26.925083+00:00"
+                "validatedAt": "2026-07-20T14:35:35.784572+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -35306,9 +35229,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.191890+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.912928+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "JWT claim matcher specifies the name of a single JWT claim and the criteria for the input request to match it.",
@@ -35437,7 +35359,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:26.925129+00:00"
+                "validatedAt": "2026-07-20T14:35:35.784595+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35483,7 +35405,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:26.925170+00:00"
+                "validatedAt": "2026-07-20T14:35:35.784616+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35521,7 +35443,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:26.925214+00:00"
+                "validatedAt": "2026-07-20T14:35:35.784638+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35616,7 +35538,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:26.925265+00:00"
+                "validatedAt": "2026-07-20T14:35:35.784663+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35689,7 +35611,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:26.925310+00:00"
+                "validatedAt": "2026-07-20T14:35:35.784686+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35726,7 +35648,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:26.925368+00:00"
+                "validatedAt": "2026-07-20T14:35:35.784714+00:00"
               },
               "deterministic": true
             },
@@ -35762,7 +35684,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:26.925410+00:00"
+                "validatedAt": "2026-07-20T14:35:35.784735+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35797,7 +35719,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:26.925453+00:00"
+                "validatedAt": "2026-07-20T14:35:35.784756+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35841,7 +35763,7 @@
       },
       "policyTlsFingerprintMatcherType": {
         "type": "object",
-        "description": "A TLS fingerprint matcher specifies multiple criteria for matching a TLS fingerprint. The set of supported positive match criteria includes a list of known\nclasses of TLS fingerprints and a list of exact values. The match is considered successful if either of these positive criteria are satisfied and the input\nfingerprint is not one of the excluded values.",
+        "description": "A TLS fingerprint matcher specifies multiple criteria for matching a TLS fingerprint. The set of supported positve match criteria includes a list of known\nclasses of TLS fingerprints and a list of exact values. The match is considered successful if either of these positive criteria are satisfied and the input\nfingerprint is not one of the excluded values.",
         "title": "TlsFingerprintMatcherType",
         "x-displayname": "TLS Fingerprint Matcher.",
         "x-ves-proto-message": "ves.io.schema.policy.TlsFingerprintMatcherType",
@@ -35874,7 +35796,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:26.925497+00:00"
+                "validatedAt": "2026-07-20T14:35:35.784779+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35915,7 +35837,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:26.925542+00:00"
+                "validatedAt": "2026-07-20T14:35:35.784802+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35957,7 +35879,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:26.925586+00:00"
+                "validatedAt": "2026-07-20T14:35:35.784823+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35969,7 +35891,7 @@
           }
         },
         "x-f5xc-description-short": "TLS fingerprint matcher specifies multiple criteria for matching a TLS fingerprint.",
-        "x-f5xc-description-medium": "TLS fingerprint matcher specifies multiple criteria for matching a TLS fingerprint. The set of supported positive match criteria includes a list of known classes of TLS fingerprints and a list of exact values. The match is considered successful if either of these positive criteria are satisfied...",
+        "x-f5xc-description-medium": "TLS fingerprint matcher specifies multiple criteria for matching a TLS fingerprint. The set of supported positve match criteria includes a list of known classes of TLS fingerprints and a list of exact values. The match is considered successful if either of these positive criteria are satisfied...",
         "x-f5xc-minimum-configuration": {
           "description": "Minimum configuration for policyTlsFingerprintMatcherType",
           "required_fields": [
@@ -36151,7 +36073,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:26.925624+00:00"
+                "validatedAt": "2026-07-20T14:35:35.784841+00:00"
               },
               "deterministic": true
             },
@@ -36163,9 +36085,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.192004+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.913001+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "path": {
             "type": "string",
@@ -36196,7 +36117,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:26.925692+00:00"
+                "validatedAt": "2026-07-20T14:35:35.784870+00:00"
               },
               "deterministic": true
             },
@@ -36230,7 +36151,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:26.925738+00:00"
+                "validatedAt": "2026-07-20T14:35:35.784888+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36429,7 +36350,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:26.925799+00:00"
+                "validatedAt": "2026-07-20T14:35:35.784915+00:00"
               },
               "deterministic": true
             },
@@ -36441,9 +36362,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.192071+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.913045+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "path": {
             "type": "string",
@@ -36474,7 +36394,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:26.925858+00:00"
+                "validatedAt": "2026-07-20T14:35:35.784944+00:00"
               },
               "deterministic": true
             },
@@ -36508,7 +36428,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:26.925902+00:00"
+                "validatedAt": "2026-07-20T14:35:35.784962+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36713,7 +36633,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:26.925951+00:00"
+                "validatedAt": "2026-07-20T14:35:35.784984+00:00"
               },
               "deterministic": true
             },
@@ -36725,9 +36645,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.192138+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.913088+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "path": {
             "type": "string",
@@ -36758,7 +36677,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:26.926010+00:00"
+                "validatedAt": "2026-07-20T14:35:35.785014+00:00"
               },
               "deterministic": true
             },
@@ -36792,7 +36711,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:26.926053+00:00"
+                "validatedAt": "2026-07-20T14:35:35.785032+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36974,7 +36893,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:26.926099+00:00"
+                "validatedAt": "2026-07-20T14:35:35.785051+00:00"
               },
               "deterministic": true
             },
@@ -36986,13 +36905,12 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.192197+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.913127+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "path": {
             "type": "string",
-            "description": "Path to apply the sensitive data to\nRequired: YES.",
+            "description": "Path to apply the senstive data to\nRequired: YES.",
             "title": "Path",
             "maxLength": 1024,
             "x-displayname": "Request Path.",
@@ -37009,7 +36927,7 @@
               "ves.io.schema.rules.string.max_len": "1024",
               "ves.io.schema.rules.string.templated_http_path": "true"
             },
-            "x-f5xc-description-short": "Path to apply the sensitive data to Required: YES.",
+            "x-f5xc-description-short": "Path to apply the senstive data to Required: YES.",
             "x-f5xc-constraints": {
               "constraintType": "string",
               "category": "discovery",
@@ -37019,7 +36937,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:26.926157+00:00"
+                "validatedAt": "2026-07-20T14:35:35.785080+00:00"
               },
               "deterministic": true
             },
@@ -37053,7 +36971,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:26.926200+00:00"
+                "validatedAt": "2026-07-20T14:35:35.785098+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37178,7 +37096,7 @@
       },
       "schemaLabelSelectorType": {
         "type": "object",
-        "description": "This type can be used to establish a 'selector reference' from one object(called selector) to\na set of other objects(called selectees) based on the value of expressions.\nA label selector is a label query over a set of resources. An empty label selector matches all objects.\nA null label selector matches no objects. Label selector is immutable.\nExpressions is a list of strings of label selection expression.\nEach string has \",\" separated values which are \"AND\" and all strings are logically \"OR\".\nBNF for expression string\n<selector-syntax> ::= <requirement> | <requirement> \",\" <selector-syntax>\n<requirement> ::= [!] KEY [ <set-based-restriction> | <exact-match-restriction> ]\n<set-based-restriction> ::= \"\" | <inclusion-exclusion> <value-set>\n<inclusion-exclusion> ::= <inclusion> | <exclusion>\n<exclusion> ::= \"notin\"\n<inclusion> ::= \"in\"\n<value-set> ::= \"(\" <values> \")\"\n<values> ::= VALUE | VALUE \",\" <values>\n<exact-match-restriction> ::= [\"=\"|\"==\"|\"!=\"] VALUE.",
+        "description": "This type can be used to establish a 'selector reference' from one object(called selector) to\na set of other objects(called selectees) based on the value of expresssions.\nA label selector is a label query over a set of resources. An empty label selector matches all objects.\nA null label selector matches no objects. Label selector is immutable.\nExpressions is a list of strings of label selection expression.\nEach string has \",\" separated values which are \"AND\" and all strings are logically \"OR\".\nBNF for expression string\n<selector-syntax> ::= <requirement> | <requirement> \",\" <selector-syntax>\n<requirement> ::= [!] KEY [ <set-based-restriction> | <exact-match-restriction> ]\n<set-based-restriction> ::= \"\" | <inclusion-exclusion> <value-set>\n<inclusion-exclusion> ::= <inclusion> | <exclusion>\n<exclusion> ::= \"notin\"\n<inclusion> ::= \"in\"\n<value-set> ::= \"(\" <values> \")\"\n<values> ::= VALUE | VALUE \",\" <values>\n<exact-match-restriction> ::= [\"=\"|\"==\"|\"!=\"] VALUE.",
         "title": "LabelSelectorType",
         "x-displayname": "Label Selector.",
         "x-ves-proto-message": "ves.io.schema.LabelSelectorType",
@@ -37220,7 +37138,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:26.926255+00:00"
+                "validatedAt": "2026-07-20T14:35:35.785154+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37232,7 +37150,7 @@
           }
         },
         "x-f5xc-description-short": "Type can be used to establish a 'selector reference' from one object(called selector) to a set of other objects(called selectees) based on the...",
-        "x-f5xc-description-medium": "Type can be used to establish a 'selector reference' from one object(called selector) to a set of other objects(called selectees) based on the value of expressions. A label selector is a label query over a set of resources. An empty label selector matches all objects.",
+        "x-f5xc-description-medium": "Type can be used to establish a 'selector reference' from one object(called selector) to a set of other objects(called selectees) based on the value of expresssions. A label selector is a label query over a set of resources. An empty label selector matches all objects.",
         "x-f5xc-minimum-configuration": {
           "description": "Minimum configuration for schemaLabelSelectorType",
           "required_fields": [
@@ -37293,7 +37211,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:26.926324+00:00"
+                "validatedAt": "2026-07-20T14:35:35.785193+00:00"
               },
               "deterministic": true
             },
@@ -37305,7 +37223,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.192261+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:08.913168+00:00",
             "x-f5xc-description-short": "X-displayName: \"Description\" Human readable description."
           },
           "name": {
@@ -37350,7 +37268,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:26.926375+00:00"
+                "validatedAt": "2026-07-20T14:35:35.785222+00:00"
               },
               "deterministic": true
             },
@@ -37362,9 +37280,8 @@
             },
             "x-f5xc-description-medium": "X-displayName: \"Name\" x-required This is the name of the message. The value of name has to follow DNS-1035 format.",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.078096+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.543944+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "disable": {
             "type": "boolean",
@@ -37531,7 +37448,7 @@
             "maxLength": 26,
             "minLength": 15,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.192308+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:08.913200+00:00",
             "x-f5xc-conflicts-with": [
               "check_not_present",
               "check_present"
@@ -37578,7 +37495,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:26.926438+00:00"
+                "validatedAt": "2026-07-20T14:35:35.785282+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -37593,9 +37510,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.192326+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.913213+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Header matcher specifies the name of a single HTTP header and the criteria for the input request to match it.",
@@ -37671,7 +37587,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:26.926485+00:00"
+                "validatedAt": "2026-07-20T14:35:35.785308+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37783,7 +37699,7 @@
             "maxLength": 26,
             "minLength": 15,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.192375+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:08.913245+00:00",
             "x-f5xc-conflicts-with": [
               "check_not_present",
               "check_present"
@@ -37818,7 +37734,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:26.926548+00:00"
+                "validatedAt": "2026-07-20T14:35:35.785339+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37829,7 +37745,7 @@
             },
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.192393+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.913258+00:00"
           }
         },
         "x-f5xc-description-short": "Query parameter matcher specifies the name of a single query parameter and the criteria for the input request to match it.",
@@ -38006,7 +37922,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:12.322067+00:00"
+                "validatedAt": "2026-07-20T14:36:41.661194+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38093,7 +38009,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T12:58:12.322129+00:00"
+                "validatedAt": "2026-07-20T14:36:41.661216+00:00"
               },
               "deterministic": true
             },
@@ -38131,7 +38047,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:12.322176+00:00"
+                "validatedAt": "2026-07-20T14:36:41.661231+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38627,7 +38543,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:12.322312+00:00"
+                "validatedAt": "2026-07-20T14:36:41.661266+00:00"
               },
               "deterministic": true
             },
@@ -38639,9 +38555,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.294401+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.864609+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -38673,7 +38588,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:12.322350+00:00"
+                "validatedAt": "2026-07-20T14:36:41.661280+00:00"
               },
               "deterministic": true
             },
@@ -38685,9 +38600,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.294422+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.864622+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -38850,7 +38764,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.294490+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.864665+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -38986,7 +38900,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T12:58:12.322511+00:00"
+                "validatedAt": "2026-07-20T14:36:41.661340+00:00"
               },
               "deterministic": true
             },
@@ -39078,7 +38992,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T12:58:12.322552+00:00"
+                "validatedAt": "2026-07-20T14:36:41.661357+00:00"
               },
               "deterministic": true
             },
@@ -39089,8 +39003,7 @@
               "read": false
             },
             "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "minLength": 1,
-            "format": "fqdn"
+            "minLength": 1
           },
           "username": {
             "type": "string",
@@ -39119,7 +39032,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:12.322582+00:00"
+                "validatedAt": "2026-07-20T14:36:41.661371+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39207,7 +39120,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:12.322616+00:00"
+                "validatedAt": "2026-07-20T14:36:41.661387+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39358,7 +39271,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T12:58:12.322673+00:00"
+                "validatedAt": "2026-07-20T14:36:41.661407+00:00"
               },
               "deterministic": true
             },
@@ -39476,7 +39389,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:12.322713+00:00"
+                "validatedAt": "2026-07-20T14:36:41.661423+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39487,7 +39400,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.294624+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.864748+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -39561,7 +39474,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:58:12.322761+00:00"
+                "validatedAt": "2026-07-20T14:36:41.661444+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39640,7 +39553,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:58:12.322815+00:00"
+                "validatedAt": "2026-07-20T14:36:41.661467+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39651,7 +39564,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.294677+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.864777+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -39738,7 +39651,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:12.322857+00:00"
+                "validatedAt": "2026-07-20T14:36:41.661485+00:00"
               },
               "deterministic": true
             },
@@ -39750,9 +39663,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.294723+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.864806+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -39783,7 +39695,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:12.322885+00:00"
+                "validatedAt": "2026-07-20T14:36:41.661498+00:00"
               },
               "deterministic": true
             },
@@ -39795,9 +39707,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.294742+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.864818+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -39866,7 +39777,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:12.322938+00:00"
+                "validatedAt": "2026-07-20T14:36:41.661519+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39878,7 +39789,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.294779+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.864842+00:00"
           },
           "uid": {
             "type": "string",
@@ -39896,7 +39807,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:12.322966+00:00"
+                "validatedAt": "2026-07-20T14:36:41.661529+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39909,7 +39820,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.294798+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.864855+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of code_base_integration is returned in 'List'.",
@@ -40250,7 +40161,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:53.285795+00:00"
+                "validatedAt": "2026-07-20T14:37:46.837222+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40305,7 +40216,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:16.292020+00:00"
+                "validatedAt": "2026-07-20T14:37:55.843358+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40438,7 +40349,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:53.285897+00:00"
+                "validatedAt": "2026-07-20T14:37:46.837256+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40768,7 +40679,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:53.286029+00:00"
+                "validatedAt": "2026-07-20T14:37:46.837299+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41030,7 +40941,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:53.286122+00:00"
+                "validatedAt": "2026-07-20T14:37:46.837341+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41104,7 +41015,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:53.286158+00:00"
+                "validatedAt": "2026-07-20T14:37:46.837359+00:00"
               },
               "deterministic": true
             },
@@ -41116,9 +41027,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.076729+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.543147+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace_regex": {
             "type": "string",
@@ -41134,7 +41044,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:53.286202+00:00"
+                "validatedAt": "2026-07-20T14:37:46.837377+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41419,7 +41329,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:53.286290+00:00"
+                "validatedAt": "2026-07-20T14:37:46.837416+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41598,7 +41508,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:53.286335+00:00"
+                "validatedAt": "2026-07-20T14:37:46.837438+00:00"
               },
               "deterministic": true
             },
@@ -41610,9 +41520,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.076849+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.543218+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -41644,7 +41553,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:53.286362+00:00"
+                "validatedAt": "2026-07-20T14:37:46.837452+00:00"
               },
               "deterministic": true
             },
@@ -41656,9 +41565,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.076868+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.543231+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -41721,7 +41629,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:53.286422+00:00"
+                "validatedAt": "2026-07-20T14:37:46.837483+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41754,7 +41662,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:53.286481+00:00"
+                "validatedAt": "2026-07-20T14:37:46.837511+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41821,7 +41729,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:53.286538+00:00"
+                "validatedAt": "2026-07-20T14:37:46.837544+00:00"
               },
               "deterministic": true
             },
@@ -41833,9 +41741,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.076911+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.543258+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "pods": {
             "type": "array",
@@ -41891,7 +41798,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:53.286615+00:00"
+                "validatedAt": "2026-07-20T14:37:46.837581+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41924,7 +41831,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:53.286688+00:00"
+                "validatedAt": "2026-07-20T14:37:46.837608+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42014,7 +41921,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:53.286723+00:00"
+                "validatedAt": "2026-07-20T14:37:46.837626+00:00"
               },
               "deterministic": true
             },
@@ -42026,9 +41933,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.076969+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.543287+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -42067,7 +41973,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:53.286753+00:00"
+                "validatedAt": "2026-07-20T14:37:46.837641+00:00"
               },
               "deterministic": true
             },
@@ -42079,9 +41985,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.076994+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.543299+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -42139,7 +42044,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:53.286786+00:00"
+                "validatedAt": "2026-07-20T14:37:46.837655+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42310,7 +42215,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.077112+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.543345+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -42394,7 +42299,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:53.286918+00:00"
+                "validatedAt": "2026-07-20T14:37:46.837713+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42707,7 +42612,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:53.287001+00:00"
+                "validatedAt": "2026-07-20T14:37:46.837751+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42890,7 +42795,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:53.287074+00:00"
+                "validatedAt": "2026-07-20T14:37:46.837789+00:00"
               },
               "deterministic": true
             },
@@ -42967,7 +42872,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:53.287104+00:00"
+                "validatedAt": "2026-07-20T14:37:46.837803+00:00"
               },
               "deterministic": true
             },
@@ -42979,9 +42884,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.077250+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.543428+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace_regex": {
             "type": "string",
@@ -43007,7 +42911,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:53.287164+00:00"
+                "validatedAt": "2026-07-20T14:37:46.837832+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43095,7 +42999,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:53.287213+00:00"
+                "validatedAt": "2026-07-20T14:37:46.837859+00:00"
               },
               "deterministic": true
             },
@@ -43107,9 +43011,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.077278+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.543445+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -43296,7 +43199,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:00:53.287267+00:00"
+                "validatedAt": "2026-07-20T14:37:46.837882+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43374,7 +43277,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:00:53.287319+00:00"
+                "validatedAt": "2026-07-20T14:37:46.837906+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43385,7 +43288,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.077351+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.543488+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -43472,7 +43375,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:53.287362+00:00"
+                "validatedAt": "2026-07-20T14:37:46.837926+00:00"
               },
               "deterministic": true
             },
@@ -43484,9 +43387,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.077397+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.543517+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -43517,7 +43419,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:53.287389+00:00"
+                "validatedAt": "2026-07-20T14:37:46.837939+00:00"
               },
               "deterministic": true
             },
@@ -43529,9 +43431,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.077415+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.543529+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -43600,7 +43501,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:53.287442+00:00"
+                "validatedAt": "2026-07-20T14:37:46.837960+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43612,7 +43513,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.077453+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.543552+00:00"
           },
           "uid": {
             "type": "string",
@@ -43629,7 +43530,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:53.287468+00:00"
+                "validatedAt": "2026-07-20T14:37:46.837971+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43642,7 +43543,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.077472+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.543565+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of discovery is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -43710,7 +43611,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:53.287502+00:00"
+                "validatedAt": "2026-07-20T14:37:46.837987+00:00"
               },
               "deterministic": true
             },
@@ -43774,7 +43675,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:00:53.287531+00:00"
+                "validatedAt": "2026-07-20T14:37:46.838001+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43848,7 +43749,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:53.287560+00:00"
+                "validatedAt": "2026-07-20T14:37:46.838016+00:00"
               },
               "deterministic": true
             },
@@ -43860,9 +43761,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.077510+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.543587+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "partition_regex": {
             "type": "string",
@@ -43878,7 +43778,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:53.287600+00:00"
+                "validatedAt": "2026-07-20T14:37:46.838032+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43942,7 +43842,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:53.287626+00:00"
+                "validatedAt": "2026-07-20T14:37:46.838044+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43967,7 +43867,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:53.287670+00:00"
+                "validatedAt": "2026-07-20T14:37:46.838059+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44046,7 +43946,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:53.287704+00:00"
+                "validatedAt": "2026-07-20T14:37:46.838075+00:00"
               },
               "deterministic": true
             },
@@ -44080,7 +43980,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:53.287741+00:00"
+                "validatedAt": "2026-07-20T14:37:46.838091+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44275,7 +44175,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:53.287827+00:00"
+                "validatedAt": "2026-07-20T14:37:46.838128+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44433,7 +44333,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:53.287898+00:00"
+                "validatedAt": "2026-07-20T14:37:46.838161+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44597,7 +44497,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:16.293798+00:00"
+                "validatedAt": "2026-07-20T14:37:55.844207+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44681,7 +44581,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:53.288009+00:00"
+                "validatedAt": "2026-07-20T14:37:46.838213+00:00"
               },
               "deterministic": true
             },
@@ -44732,7 +44632,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:53.288071+00:00"
+                "validatedAt": "2026-07-20T14:37:46.838243+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44740,8 +44640,7 @@
               "create": false,
               "update": false,
               "read": false
-            },
-            "format": "hostname"
+            }
           },
           "trusted_ca_url": {
             "type": "string",
@@ -44773,7 +44672,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:53.288134+00:00"
+                "validatedAt": "2026-07-20T14:37:46.838274+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44866,7 +44765,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:53.288181+00:00"
+                "validatedAt": "2026-07-20T14:37:46.838314+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44979,7 +44878,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:53.288227+00:00"
+                "validatedAt": "2026-07-20T14:37:46.838339+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45017,7 +44916,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:53.288267+00:00"
+                "validatedAt": "2026-07-20T14:37:46.838357+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45042,7 +44941,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:53.288307+00:00"
+                "validatedAt": "2026-07-20T14:37:46.838373+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45180,7 +45079,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:53.289189+00:00"
+                "validatedAt": "2026-07-20T14:37:46.838793+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45425,7 +45324,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:53.289675+00:00"
+                "validatedAt": "2026-07-20T14:37:46.839033+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45548,7 +45447,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:53.290336+00:00"
+                "validatedAt": "2026-07-20T14:37:46.839329+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45660,7 +45559,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:16.291777+00:00"
+                "validatedAt": "2026-07-20T14:37:55.843262+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45715,7 +45614,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:16.291861+00:00"
+                "validatedAt": "2026-07-20T14:37:55.843302+00:00"
               }
             },
             "x-f5xc-required-for": {

--- a/docs/specifications/api/authentication.json
+++ b/docs/specifications/api/authentication.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Authentication",
     "description": "Identity and access management providing APIs for configuring identity providers, access policies, and user credentials. Supports MFA, identity provider integration, and lifecycle operations for credential management across distributed deployments.",
-    "version": "2.1.182",
+    "version": "2.1.181",
     "contact": {
       "name": "F5 Distributed Cloud",
       "url": "https://docs.cloud.f5.com"
@@ -4052,7 +4052,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:01.244647+00:00"
+                "validatedAt": "2026-07-20T14:35:25.029877+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4217,7 +4217,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.244800+00:00"
+                "validatedAt": "2026-07-20T14:35:25.029920+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4313,7 +4313,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:01.244859+00:00"
+                "validatedAt": "2026-07-20T14:35:25.029948+00:00"
               },
               "deterministic": true
             },
@@ -4325,9 +4325,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.707478+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.408339+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -4358,7 +4357,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:01.244890+00:00"
+                "validatedAt": "2026-07-20T14:35:25.029965+00:00"
               },
               "deterministic": true
             },
@@ -4370,9 +4369,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.707498+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.408353+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "spec": {
             "allOf": [
@@ -4458,7 +4456,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.244931+00:00"
+                "validatedAt": "2026-07-20T14:35:25.029983+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4482,7 +4480,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.244977+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030003+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4518,7 +4516,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:01.245006+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030019+00:00"
               },
               "deterministic": true
             },
@@ -4530,9 +4528,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.707546+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.408378+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "CreateResponse is the response format for the credential's create request.",
@@ -4657,7 +4654,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:01.245057+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030044+00:00"
               },
               "deterministic": true
             },
@@ -4669,9 +4666,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.707587+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.408401+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -4702,7 +4698,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:01.245084+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030059+00:00"
               },
               "deterministic": true
             },
@@ -4714,9 +4710,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.707606+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.408411+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace_roles": {
             "type": "array",
@@ -4760,7 +4755,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.245140+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030083+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4835,7 +4830,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.245205+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030110+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4861,7 +4856,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.245249+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030130+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4963,7 +4958,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.245293+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030149+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5002,7 +4997,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.245338+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030168+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5028,7 +5023,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.245382+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030186+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5190,7 +5185,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:01.245420+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030206+00:00"
               },
               "deterministic": true
             },
@@ -5202,9 +5197,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.707734+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.408472+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -5243,7 +5237,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:01.245454+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030223+00:00"
               },
               "deterministic": true
             },
@@ -5255,9 +5249,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.707754+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.408483+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "GET credential object with a given name.",
@@ -5378,7 +5371,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.245507+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030246+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5403,7 +5396,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.245549+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030264+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5442,7 +5435,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:01.245576+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030279+00:00"
               },
               "deterministic": true
             },
@@ -5454,9 +5447,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.707803+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.408508+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -5487,7 +5479,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:01.245604+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030294+00:00"
               },
               "deterministic": true
             },
@@ -5499,9 +5491,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.707821+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.408519+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace_access": {
             "allOf": [
@@ -5545,7 +5536,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.245636+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030308+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5558,7 +5549,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.707853+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.408537+00:00"
           },
           "user_email": {
             "type": "string",
@@ -5576,7 +5567,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.245684+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030325+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5686,7 +5677,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:01.245776+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030368+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5711,7 +5702,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.245818+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030387+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5734,7 +5725,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.245853+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030404+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5759,7 +5750,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.245897+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030429+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5784,7 +5775,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.245935+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030446+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5831,7 +5822,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:01.245982+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030471+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5855,7 +5846,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.246023+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030489+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5879,7 +5870,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.246067+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030507+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5953,7 +5944,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:55:01.246099+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030539+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6031,7 +6022,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.246145+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030608+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6056,7 +6047,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.246188+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030663+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6095,7 +6086,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:01.246217+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030698+00:00"
               },
               "deterministic": true
             },
@@ -6107,9 +6098,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.707982+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.408602+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -6140,7 +6130,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:01.246244+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030725+00:00"
               },
               "deterministic": true
             },
@@ -6152,9 +6142,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.708001+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.408613+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "type": {
             "allOf": [
@@ -6184,7 +6173,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.246271+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030749+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6197,7 +6186,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.708026+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.408627+00:00"
           },
           "user_email": {
             "type": "string",
@@ -6215,7 +6204,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.246308+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030779+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6286,7 +6275,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:55:01.246338+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030812+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6364,7 +6353,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.246383+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030849+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6389,7 +6378,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.246424+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030880+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6428,7 +6417,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:01.246452+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030909+00:00"
               },
               "deterministic": true
             },
@@ -6440,9 +6429,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.708081+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.408656+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -6473,7 +6461,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:01.246480+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030934+00:00"
               },
               "deterministic": true
             },
@@ -6485,9 +6473,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.708099+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.408666+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace_access": {
             "allOf": [
@@ -6531,7 +6518,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.246511+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030959+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6544,7 +6531,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.708131+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.408684+00:00"
           },
           "user_email": {
             "type": "string",
@@ -6562,7 +6549,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.246549+00:00"
+                "validatedAt": "2026-07-20T14:35:25.030988+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6671,7 +6658,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:01.246612+00:00"
+                "validatedAt": "2026-07-20T14:35:25.031048+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6852,7 +6839,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:01.246682+00:00"
+                "validatedAt": "2026-07-20T14:35:25.031103+00:00"
               },
               "deterministic": true
             },
@@ -6864,9 +6851,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.708202+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.408721+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "RecreateScimTokenRequest is the request format for generating SCIM API credential.",
@@ -6959,7 +6945,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:01.246729+00:00"
+                "validatedAt": "2026-07-20T14:35:25.031144+00:00"
               },
               "deterministic": true
             },
@@ -6971,9 +6957,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.708229+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.408736+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -7012,7 +6997,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:01.246758+00:00"
+                "validatedAt": "2026-07-20T14:35:25.031238+00:00"
               },
               "deterministic": true
             },
@@ -7024,9 +7009,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.708248+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.408750+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -7103,7 +7087,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:01.246788+00:00"
+                "validatedAt": "2026-07-20T14:35:25.031273+00:00"
               },
               "deterministic": true
             },
@@ -7115,9 +7099,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.708267+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.408763+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -7149,7 +7132,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:01.246815+00:00"
+                "validatedAt": "2026-07-20T14:35:25.031300+00:00"
               },
               "deterministic": true
             },
@@ -7161,9 +7144,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.708285+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.408776+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace_access": {
             "allOf": [
@@ -7268,7 +7250,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.246881+00:00"
+                "validatedAt": "2026-07-20T14:35:25.031353+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7307,7 +7289,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:01.246908+00:00"
+                "validatedAt": "2026-07-20T14:35:25.031380+00:00"
               },
               "deterministic": true
             },
@@ -7319,9 +7301,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.708331+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.408807+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Response format for the credential's replace request.",
@@ -7399,7 +7380,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:01.246940+00:00"
+                "validatedAt": "2026-07-20T14:35:25.031411+00:00"
               },
               "deterministic": true
             },
@@ -7411,9 +7392,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.708351+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.408821+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ScimTokenRequest is used for fetching or revoking scim token.",
@@ -7486,7 +7466,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:01.246997+00:00"
+                "validatedAt": "2026-07-20T14:35:25.031466+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7599,7 +7579,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.708389+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.408846+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -7661,7 +7641,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:01.247070+00:00"
+                "validatedAt": "2026-07-20T14:35:25.031530+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7670,8 +7650,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "vk8s_namespace": {
             "type": "string",
@@ -7698,7 +7677,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:01.247130+00:00"
+                "validatedAt": "2026-07-20T14:35:25.031595+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7707,8 +7686,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -7808,7 +7786,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:01.247160+00:00"
+                "validatedAt": "2026-07-20T14:35:25.031632+00:00"
               },
               "deterministic": true
             },
@@ -7820,9 +7798,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.708425+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.408869+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -8028,7 +8005,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:01.247234+00:00"
+                "validatedAt": "2026-07-20T14:35:25.031677+00:00"
               },
               "deterministic": true
             },
@@ -8040,9 +8017,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.708470+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.408897+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "role": {
             "type": "string",
@@ -8074,7 +8050,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:01.247285+00:00"
+                "validatedAt": "2026-07-20T14:35:25.031710+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8083,8 +8059,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -8177,7 +8152,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:01.247361+00:00"
+                "validatedAt": "2026-07-20T14:35:25.031751+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -8192,7 +8167,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.708504+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.408919+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -8264,7 +8239,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:01.247397+00:00"
+                "validatedAt": "2026-07-20T14:35:25.031770+00:00"
               },
               "deterministic": true
             },
@@ -8276,9 +8251,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.708537+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.408941+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -8311,7 +8285,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:01.247423+00:00"
+                "validatedAt": "2026-07-20T14:35:25.031785+00:00"
               },
               "deterministic": true
             },
@@ -8323,9 +8297,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.708555+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.408953+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "uid": {
             "type": "string",
@@ -8344,7 +8317,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.247447+00:00"
+                "validatedAt": "2026-07-20T14:35:25.031797+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8358,7 +8331,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.708575+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.408966+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectMetaType is metadata(common attributes) of an object that all configuration objects will have.",
@@ -8421,7 +8394,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.247478+00:00"
+                "validatedAt": "2026-07-20T14:35:25.031811+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8433,7 +8406,7 @@
             "readOnly": true,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.708595+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.408979+00:00"
           },
           "name": {
             "type": "string",
@@ -8466,7 +8439,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:01.247504+00:00"
+                "validatedAt": "2026-07-20T14:35:25.031828+00:00"
               },
               "deterministic": true
             },
@@ -8478,9 +8451,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.708613+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.408992+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -8513,7 +8485,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:01.247530+00:00"
+                "validatedAt": "2026-07-20T14:35:25.031842+00:00"
               },
               "deterministic": true
             },
@@ -8525,9 +8497,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.708631+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.409004+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -8546,7 +8517,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.247562+00:00"
+                "validatedAt": "2026-07-20T14:35:25.031857+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8559,7 +8530,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.708650+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.409017+00:00"
           },
           "uid": {
             "type": "string",
@@ -8578,7 +8549,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.247587+00:00"
+                "validatedAt": "2026-07-20T14:35:25.031869+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8592,7 +8563,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.708677+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.409029+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -8669,7 +8640,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.247632+00:00"
+                "validatedAt": "2026-07-20T14:35:25.031891+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8680,7 +8651,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.708704+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.409047+00:00"
           },
           "status": {
             "type": "string",
@@ -8698,7 +8669,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.247673+00:00"
+                "validatedAt": "2026-07-20T14:35:25.031905+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8709,7 +8680,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.708723+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.409059+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -8767,7 +8738,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.247719+00:00"
+                "validatedAt": "2026-07-20T14:35:25.031925+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8795,7 +8766,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.247759+00:00"
+                "validatedAt": "2026-07-20T14:35:25.031942+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8824,7 +8795,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.247800+00:00"
+                "validatedAt": "2026-07-20T14:35:25.031959+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8851,7 +8822,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.247838+00:00"
+                "validatedAt": "2026-07-20T14:35:25.031976+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8880,7 +8851,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.247880+00:00"
+                "validatedAt": "2026-07-20T14:35:25.031994+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8905,7 +8876,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.247922+00:00"
+                "validatedAt": "2026-07-20T14:35:25.032012+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8981,7 +8952,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.247988+00:00"
+                "validatedAt": "2026-07-20T14:35:25.032041+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9019,7 +8990,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:01.248031+00:00"
+                "validatedAt": "2026-07-20T14:35:25.032068+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9031,7 +9002,7 @@
             "maxLength": 6,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.708811+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.409115+00:00"
           },
           "object_index": {
             "type": "integer",
@@ -9091,7 +9062,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.248084+00:00"
+                "validatedAt": "2026-07-20T14:35:25.032090+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9135,7 +9106,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.248122+00:00"
+                "validatedAt": "2026-07-20T14:35:25.032106+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9148,7 +9119,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.708856+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.409143+00:00"
           },
           "trace_info": {
             "type": "string",
@@ -9167,7 +9138,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.248160+00:00"
+                "validatedAt": "2026-07-20T14:35:25.032135+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9194,7 +9165,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.248185+00:00"
+                "validatedAt": "2026-07-20T14:35:25.032175+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9208,7 +9179,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.708881+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.409160+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -9223,7 +9194,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.248221+00:00"
+                "validatedAt": "2026-07-20T14:35:25.032206+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9320,7 +9291,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.248257+00:00"
+                "validatedAt": "2026-07-20T14:35:25.032239+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9331,7 +9302,7 @@
             },
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.708914+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.409182+00:00"
           },
           "name": {
             "type": "string",
@@ -9364,7 +9335,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:01.248284+00:00"
+                "validatedAt": "2026-07-20T14:35:25.032270+00:00"
               },
               "deterministic": true
             },
@@ -9376,9 +9347,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.708932+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.409194+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -9411,7 +9381,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:01.248310+00:00"
+                "validatedAt": "2026-07-20T14:35:25.032297+00:00"
               },
               "deterministic": true
             },
@@ -9423,9 +9393,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.708950+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.409206+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "uid": {
             "type": "string",
@@ -9442,7 +9411,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:01.248335+00:00"
+                "validatedAt": "2026-07-20T14:35:25.032317+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9455,7 +9424,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.708969+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.409219+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",

--- a/docs/specifications/api/bigip.json
+++ b/docs/specifications/api/bigip.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Bigip",
     "description": "On-premises appliance connector enabling iRule lifecycle operations and data group replication. APM policy coordination, virtual server configuration binding, and CNE linkage. Telemetry aggregation and health status monitoring across hybrid infrastructure deployments.",
-    "version": "2.1.182",
+    "version": "2.1.181",
     "contact": {
       "name": "F5 Distributed Cloud",
       "url": "https://docs.cloud.f5.com"
@@ -2324,7 +2324,7 @@
           },
           {
             "name": "response_format",
-            "description": "The format in which the configuration object is to be fetched. This could be for example\n - in GetSpec form for the contents of object\n - in CreateRequest form to create a new similar object\n - to ReplaceRequest form to replace changeable values\n\nDefault format of returned resource\nResponse should be in CreateRequest format\nResponse should be in ReplaceRequest format\nResponse should be in StatusObject(s) format\nResponse should be in format of GetSpecType\nResponse should have other objects referring to this object\nResponse should have deleted and disabled objects referred by this object.",
+            "description": "The format in which the configuration object is to be fetched. This could be for example\n - in GetSpec form for the contents of object\n - in CreateRequest form to create a new similar object\n - to ReplaceRequest form to replace changeable values\n\nDefault format of returned resource\nResponse should be in CreateRequest format\nResponse should be in ReplaceRequest format\nResponse should be in StatusObject(s) format\nResponse should be in format of GetSpecType\nResponse should have other objects referring to this object\nResponse should have deleted and disabled objects referrred by this object.",
             "in": "query",
             "required": false,
             "x-displayname": "Broken Referred Objects.",
@@ -3467,7 +3467,7 @@
           },
           {
             "name": "response_format",
-            "description": "The format in which the configuration object is to be fetched. This could be for example\n - in GetSpec form for the contents of object\n - in CreateRequest form to create a new similar object\n - to ReplaceRequest form to replace changeable values\n\nDefault format of returned resource\nResponse should be in ReplaceRequest format\nResponse should be in StatusObject(s) format\nResponse should be in format of GetSpecType\nResponse should have other objects referring to this object\nResponse should have deleted and disabled objects referred by this object.",
+            "description": "The format in which the configuration object is to be fetched. This could be for example\n - in GetSpec form for the contents of object\n - in CreateRequest form to create a new similar object\n - to ReplaceRequest form to replace changeable values\n\nDefault format of returned resource\nResponse should be in ReplaceRequest format\nResponse should be in StatusObject(s) format\nResponse should be in format of GetSpecType\nResponse should have other objects referring to this object\nResponse should have deleted and disabled objects referrred by this object.",
             "in": "query",
             "required": false,
             "x-displayname": "Broken Referred Objects.",
@@ -4378,7 +4378,7 @@
           },
           {
             "name": "response_format",
-            "description": "The format in which the configuration object is to be fetched. This could be for example\n - in GetSpec form for the contents of object\n - in CreateRequest form to create a new similar object\n - to ReplaceRequest form to replace changeable values\n\nDefault format of returned resource\nResponse should be in CreateRequest format\nResponse should be in ReplaceRequest format\nResponse should be in format of GetSpecType\nResponse should have other objects referring to this object\nResponse should have deleted and disabled objects referred by this object.",
+            "description": "The format in which the configuration object is to be fetched. This could be for example\n - in GetSpec form for the contents of object\n - in CreateRequest form to create a new similar object\n - to ReplaceRequest form to replace changeable values\n\nDefault format of returned resource\nResponse should be in CreateRequest format\nResponse should be in ReplaceRequest format\nResponse should be in format of GetSpecType\nResponse should have other objects referring to this object\nResponse should have deleted and disabled objects referrred by this object.",
             "in": "query",
             "required": false,
             "x-displayname": "Broken Referred Objects.",
@@ -5515,7 +5515,7 @@
           },
           {
             "name": "response_format",
-            "description": "The format in which the configuration object is to be fetched. This could be for example\n - in GetSpec form for the contents of object\n - in CreateRequest form to create a new similar object\n - to ReplaceRequest form to replace changeable values\n\nDefault format of returned resource\nResponse should be in CreateRequest format\nResponse should be in ReplaceRequest format\nResponse should be in StatusObject(s) format\nResponse should be in format of GetSpecType\nResponse should have other objects referring to this object\nResponse should have deleted and disabled objects referred by this object.",
+            "description": "The format in which the configuration object is to be fetched. This could be for example\n - in GetSpec form for the contents of object\n - in CreateRequest form to create a new similar object\n - to ReplaceRequest form to replace changeable values\n\nDefault format of returned resource\nResponse should be in CreateRequest format\nResponse should be in ReplaceRequest format\nResponse should be in StatusObject(s) format\nResponse should be in format of GetSpecType\nResponse should have other objects referring to this object\nResponse should have deleted and disabled objects referrred by this object.",
             "in": "query",
             "required": false,
             "x-displayname": "Broken Referred Objects.",
@@ -8268,7 +8268,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:05.025097+00:00"
+                "validatedAt": "2026-07-20T14:35:50.767434+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8336,7 +8336,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:05.025169+00:00"
+                "validatedAt": "2026-07-20T14:35:50.767465+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8376,7 +8376,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:05.025233+00:00"
+                "validatedAt": "2026-07-20T14:35:50.767495+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8841,7 +8841,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:05.025321+00:00"
+                "validatedAt": "2026-07-20T14:35:50.767534+00:00"
               },
               "deterministic": true
             },
@@ -8853,9 +8853,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.868807+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.667299+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -8887,7 +8886,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:05.025350+00:00"
+                "validatedAt": "2026-07-20T14:35:50.767549+00:00"
               },
               "deterministic": true
             },
@@ -8899,9 +8898,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.868829+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.667313+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -9153,7 +9151,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.868906+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.667359+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -9250,7 +9248,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:56:05.025472+00:00"
+                "validatedAt": "2026-07-20T14:35:50.767598+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9330,7 +9328,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:56:05.025525+00:00"
+                "validatedAt": "2026-07-20T14:35:50.767622+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9341,7 +9339,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.868959+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.667390+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -9427,7 +9425,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:05.025565+00:00"
+                "validatedAt": "2026-07-20T14:35:50.767642+00:00"
               },
               "deterministic": true
             },
@@ -9439,9 +9437,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.869006+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.667418+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -9472,7 +9469,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:05.025593+00:00"
+                "validatedAt": "2026-07-20T14:35:50.767655+00:00"
               },
               "deterministic": true
             },
@@ -9484,9 +9481,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.869025+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.667431+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -9555,7 +9551,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:05.025646+00:00"
+                "validatedAt": "2026-07-20T14:35:50.767677+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9567,7 +9563,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.869063+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.667454+00:00"
           },
           "uid": {
             "type": "string",
@@ -9584,7 +9580,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:05.025697+00:00"
+                "validatedAt": "2026-07-20T14:35:50.767688+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9597,7 +9593,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.869082+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.667467+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of apm is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -9797,7 +9793,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:05.025758+00:00"
+                "validatedAt": "2026-07-20T14:35:50.767711+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9842,7 +9838,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:05.025806+00:00"
+                "validatedAt": "2026-07-20T14:35:50.767736+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9869,7 +9865,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:05.025841+00:00"
+                "validatedAt": "2026-07-20T14:35:50.767755+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9924,7 +9920,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:05.025882+00:00"
+                "validatedAt": "2026-07-20T14:35:50.767774+00:00"
               },
               "deterministic": true
             },
@@ -9936,9 +9932,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.869152+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.667508+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "start_time": {
             "type": "string",
@@ -9963,7 +9958,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:05.025921+00:00"
+                "validatedAt": "2026-07-20T14:35:50.767791+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9996,7 +9991,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:05.025954+00:00"
+                "validatedAt": "2026-07-20T14:35:50.767806+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10091,7 +10086,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:05.026000+00:00"
+                "validatedAt": "2026-07-20T14:35:50.767824+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10744,7 +10739,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:05.026153+00:00"
+                "validatedAt": "2026-07-20T14:35:50.767887+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11105,7 +11100,7 @@
             "maxLength": 16,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.869427+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.667673+00:00"
           },
           "value": {
             "type": "array",
@@ -11124,7 +11119,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.869448+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.667688+00:00"
           }
         },
         "x-f5xc-description-short": "Metric Type Data contains key/value pair that uniquely identifies the group_by labels specified in the request.",
@@ -11307,7 +11302,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:05.026247+00:00"
+                "validatedAt": "2026-07-20T14:35:50.767924+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11319,7 +11314,7 @@
             "readOnly": true,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.869489+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.667714+00:00"
           },
           "name": {
             "type": "string",
@@ -11352,7 +11347,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:05.026275+00:00"
+                "validatedAt": "2026-07-20T14:35:50.767938+00:00"
               },
               "deterministic": true
             },
@@ -11364,9 +11359,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.869507+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.667727+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -11399,7 +11393,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:05.026301+00:00"
+                "validatedAt": "2026-07-20T14:35:50.767952+00:00"
               },
               "deterministic": true
             },
@@ -11411,9 +11405,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.869525+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.667739+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -11432,7 +11425,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:05.026335+00:00"
+                "validatedAt": "2026-07-20T14:35:50.767966+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11445,7 +11438,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.869544+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.667751+00:00"
           },
           "uid": {
             "type": "string",
@@ -11464,7 +11457,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:05.026359+00:00"
+                "validatedAt": "2026-07-20T14:35:50.767978+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11478,7 +11471,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.869563+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.667764+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -11638,7 +11631,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:05.026428+00:00"
+                "validatedAt": "2026-07-20T14:35:50.768009+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11678,7 +11671,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:05.026490+00:00"
+                "validatedAt": "2026-07-20T14:35:50.768039+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11732,7 +11725,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:05.026549+00:00"
+                "validatedAt": "2026-07-20T14:35:50.768068+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11776,7 +11769,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:05.026600+00:00"
+                "validatedAt": "2026-07-20T14:35:50.768095+00:00"
               },
               "deterministic": true
             },
@@ -11930,7 +11923,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:05.026685+00:00"
+                "validatedAt": "2026-07-20T14:35:50.768129+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12006,7 +11999,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:05.026736+00:00"
+                "validatedAt": "2026-07-20T14:35:50.768154+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12042,7 +12035,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:05.026798+00:00"
+                "validatedAt": "2026-07-20T14:35:50.768184+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12082,7 +12075,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:05.026856+00:00"
+                "validatedAt": "2026-07-20T14:35:50.768213+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12183,7 +12176,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:05.026919+00:00"
+                "validatedAt": "2026-07-20T14:35:50.768249+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12217,7 +12210,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:05.026965+00:00"
+                "validatedAt": "2026-07-20T14:35:50.768270+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12437,7 +12430,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:05.027051+00:00"
+                "validatedAt": "2026-07-20T14:35:50.768309+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12445,8 +12438,7 @@
               "create": true,
               "update": false,
               "read": false
-            },
-            "format": "hostname"
+            }
           },
           "https_port": {
             "type": "integer",
@@ -12566,7 +12558,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:05.027150+00:00"
+                "validatedAt": "2026-07-20T14:35:50.768354+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12626,7 +12618,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:05.027214+00:00"
+                "validatedAt": "2026-07-20T14:35:50.768385+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12634,8 +12626,7 @@
               "create": true,
               "update": false,
               "read": false
-            },
-            "format": "hostname"
+            }
           },
           "reserved_mgmt_subnet": {
             "allOf": [
@@ -12676,7 +12667,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:05.027259+00:00"
+                "validatedAt": "2026-07-20T14:35:50.768404+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12821,7 +12812,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:05.027334+00:00"
+                "validatedAt": "2026-07-20T14:35:50.768439+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12829,8 +12820,7 @@
               "create": true,
               "update": false,
               "read": false
-            },
-            "format": "hostname"
+            }
           }
         },
         "x-f5xc-description-short": "Specification for service nodes, how and where.",
@@ -12885,7 +12875,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:05.027370+00:00"
+                "validatedAt": "2026-07-20T14:35:50.768455+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12908,7 +12898,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:05.027403+00:00"
+                "validatedAt": "2026-07-20T14:35:50.768470+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12919,7 +12909,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.869841+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.667930+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -12980,7 +12970,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:05.027450+00:00"
+                "validatedAt": "2026-07-20T14:35:50.768490+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13021,7 +13011,7 @@
                 "confidence": 1.0,
                 "category": "content",
                 "note": "Blindfold envelope encryption (AES-256-GCM + RSA-OAEP) of an RSA-2048 TLS private key produces ~3700 char string:/// URL. 128KB max secret size = ~175KB base64. Discovery reported 1024 which is incorrect.",
-                "validatedAt": "2026-07-20T12:56:05.027485+00:00"
+                "validatedAt": "2026-07-20T14:35:50.768511+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13032,7 +13022,7 @@
             },
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.869870+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.667948+00:00"
           },
           "store_provider": {
             "type": "string",
@@ -13051,7 +13041,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:05.027529+00:00"
+                "validatedAt": "2026-07-20T14:35:50.768530+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13118,7 +13108,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:05.027565+00:00"
+                "validatedAt": "2026-07-20T14:35:50.768567+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13129,7 +13119,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.869896+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.667965+00:00"
           },
           "url": {
             "type": "string",
@@ -13167,7 +13157,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:05.027622+00:00"
+                "validatedAt": "2026-07-20T14:35:50.768606+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -13242,7 +13232,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T12:56:05.027660+00:00"
+                "validatedAt": "2026-07-20T14:35:50.768623+00:00"
               },
               "deterministic": true
             },
@@ -13253,8 +13243,7 @@
               "read": false
             },
             "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "minLength": 1,
-            "format": "fqdn"
+            "minLength": 1
           },
           "last_update_time": {
             "type": "string",
@@ -13271,7 +13260,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:05.027703+00:00"
+                "validatedAt": "2026-07-20T14:35:50.768641+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13298,7 +13287,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:05.027737+00:00"
+                "validatedAt": "2026-07-20T14:35:50.768655+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13309,7 +13298,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.869936+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.667990+00:00"
           },
           "service_name": {
             "type": "string",
@@ -13326,7 +13315,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:05.027777+00:00"
+                "validatedAt": "2026-07-20T14:35:50.768671+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13359,7 +13348,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:05.027814+00:00"
+                "validatedAt": "2026-07-20T14:35:50.768687+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13370,7 +13359,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.869960+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.668006+00:00"
           },
           "type": {
             "type": "string",
@@ -13395,7 +13384,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:05.027847+00:00"
+                "validatedAt": "2026-07-20T14:35:50.768701+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13539,7 +13528,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:05.027888+00:00"
+                "validatedAt": "2026-07-20T14:35:50.768718+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13666,7 +13655,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:05.027939+00:00"
+                "validatedAt": "2026-07-20T14:35:50.768747+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13744,7 +13733,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:05.027969+00:00"
+                "validatedAt": "2026-07-20T14:35:50.768763+00:00"
               },
               "deterministic": true
             },
@@ -13756,9 +13745,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.870017+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.668040+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -13913,7 +13901,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:05.028035+00:00"
+                "validatedAt": "2026-07-20T14:35:50.768790+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13924,7 +13912,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.870064+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.668069+00:00"
           }
         },
         "x-f5xc-description-short": "Metric data contains timestamp and the value.",
@@ -14020,7 +14008,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:05.028109+00:00"
+                "validatedAt": "2026-07-20T14:35:50.768829+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -14035,7 +14023,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.870092+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.668087+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -14105,7 +14093,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:05.028147+00:00"
+                "validatedAt": "2026-07-20T14:35:50.768848+00:00"
               },
               "deterministic": true
             },
@@ -14117,9 +14105,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.870125+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.668108+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -14152,7 +14139,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:05.028174+00:00"
+                "validatedAt": "2026-07-20T14:35:50.768862+00:00"
               },
               "deterministic": true
             },
@@ -14164,9 +14151,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.870143+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.668120+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -14266,7 +14252,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:05.028246+00:00"
+                "validatedAt": "2026-07-20T14:35:50.768897+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -14281,7 +14267,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.870171+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.668137+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -14353,7 +14339,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:05.028282+00:00"
+                "validatedAt": "2026-07-20T14:35:50.768916+00:00"
               },
               "deterministic": true
             },
@@ -14365,9 +14351,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.870204+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.668157+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -14400,7 +14385,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:05.028307+00:00"
+                "validatedAt": "2026-07-20T14:35:50.768929+00:00"
               },
               "deterministic": true
             },
@@ -14412,9 +14397,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.870221+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.668169+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -14514,7 +14498,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:05.028378+00:00"
+                "validatedAt": "2026-07-20T14:35:50.768965+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -14529,7 +14513,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.870249+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.668186+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -14599,7 +14583,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:05.028414+00:00"
+                "validatedAt": "2026-07-20T14:35:50.768983+00:00"
               },
               "deterministic": true
             },
@@ -14611,9 +14595,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.870282+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.668206+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -14646,7 +14629,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:05.028439+00:00"
+                "validatedAt": "2026-07-20T14:35:50.768997+00:00"
               },
               "deterministic": true
             },
@@ -14658,9 +14641,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.870300+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.668219+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -14738,7 +14720,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:05.028482+00:00"
+                "validatedAt": "2026-07-20T14:35:50.769019+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14911,7 +14893,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:05.028533+00:00"
+                "validatedAt": "2026-07-20T14:35:50.769041+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14939,7 +14921,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:05.028572+00:00"
+                "validatedAt": "2026-07-20T14:35:50.769058+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14967,7 +14949,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:05.028610+00:00"
+                "validatedAt": "2026-07-20T14:35:50.769073+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15006,7 +14988,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:05.028648+00:00"
+                "validatedAt": "2026-07-20T14:35:50.769090+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15033,7 +15015,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:05.028681+00:00"
+                "validatedAt": "2026-07-20T14:35:50.769101+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15046,7 +15028,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.870377+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.668264+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -15062,7 +15044,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:05.028716+00:00"
+                "validatedAt": "2026-07-20T14:35:50.769115+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15207,7 +15189,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:05.028763+00:00"
+                "validatedAt": "2026-07-20T14:35:50.769135+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15218,7 +15200,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.870416+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.668289+00:00"
           },
           "status": {
             "type": "string",
@@ -15236,7 +15218,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:05.028796+00:00"
+                "validatedAt": "2026-07-20T14:35:50.769149+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15247,7 +15229,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.870435+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.668301+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -15307,7 +15289,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:05.028839+00:00"
+                "validatedAt": "2026-07-20T14:35:50.769166+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15334,7 +15316,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:05.028879+00:00"
+                "validatedAt": "2026-07-20T14:35:50.769182+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15361,7 +15343,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:05.028918+00:00"
+                "validatedAt": "2026-07-20T14:35:50.769198+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15389,7 +15371,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:05.028961+00:00"
+                "validatedAt": "2026-07-20T14:35:50.769217+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15465,7 +15447,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:05.029024+00:00"
+                "validatedAt": "2026-07-20T14:35:50.769242+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15533,7 +15515,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:05.029074+00:00"
+                "validatedAt": "2026-07-20T14:35:50.769263+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15545,7 +15527,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.870521+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.668354+00:00"
           },
           "uid": {
             "type": "string",
@@ -15564,7 +15546,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:05.029098+00:00"
+                "validatedAt": "2026-07-20T14:35:50.769274+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15577,7 +15559,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.870540+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.668367+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -15668,7 +15650,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:05.029165+00:00"
+                "validatedAt": "2026-07-20T14:35:50.769306+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15715,7 +15697,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:56:05.029214+00:00"
+                "validatedAt": "2026-07-20T14:35:50.769328+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15726,7 +15708,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.870573+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.668387+00:00"
           },
           "disable_ocsp_stapling": {
             "allOf": [
@@ -15927,7 +15909,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:56:05.029270+00:00"
+                "validatedAt": "2026-07-20T14:35:50.769352+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15938,7 +15920,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.870614+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.668412+00:00"
           },
           "previous_value": {
             "type": "string",
@@ -15956,7 +15938,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:05.029308+00:00"
+                "validatedAt": "2026-07-20T14:35:50.769368+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15994,7 +15976,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:05.029342+00:00"
+                "validatedAt": "2026-07-20T14:35:50.769383+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16005,7 +15987,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.870644+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.668432+00:00"
           }
         },
         "x-f5xc-description-short": "Trend value contains trend value, trend sentiment and trend calculation description and window size.",
@@ -16130,7 +16112,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:05.029373+00:00"
+                "validatedAt": "2026-07-20T14:35:50.769396+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16141,7 +16123,7 @@
             },
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.870673+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.668445+00:00"
           },
           "name": {
             "type": "string",
@@ -16174,7 +16156,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:05.029400+00:00"
+                "validatedAt": "2026-07-20T14:35:50.769409+00:00"
               },
               "deterministic": true
             },
@@ -16186,9 +16168,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.870692+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.668457+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -16221,7 +16202,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:05.029427+00:00"
+                "validatedAt": "2026-07-20T14:35:50.769423+00:00"
               },
               "deterministic": true
             },
@@ -16233,9 +16214,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.870711+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.668469+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "uid": {
             "type": "string",
@@ -16252,7 +16232,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:05.029451+00:00"
+                "validatedAt": "2026-07-20T14:35:50.769434+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16265,7 +16245,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.870730+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.668481+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -16397,7 +16377,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:05.029504+00:00"
+                "validatedAt": "2026-07-20T14:35:50.769462+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -16411,8 +16391,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -16451,7 +16430,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:05.029551+00:00"
+                "validatedAt": "2026-07-20T14:35:50.769488+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -16466,9 +16445,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.870760+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.668499+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -16497,7 +16475,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:05.029603+00:00"
+                "validatedAt": "2026-07-20T14:35:50.769513+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16510,7 +16488,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.870779+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.668512+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a direct reference from one object(the referrer) to another(the referred).",
@@ -16626,7 +16604,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:05.029651+00:00"
+                "validatedAt": "2026-07-20T14:35:50.769534+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16669,7 +16647,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:05.029702+00:00"
+                "validatedAt": "2026-07-20T14:35:50.769552+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16714,7 +16692,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:05.029749+00:00"
+                "validatedAt": "2026-07-20T14:35:50.769571+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16740,7 +16718,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:05.029789+00:00"
+                "validatedAt": "2026-07-20T14:35:50.769587+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16766,7 +16744,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:05.029826+00:00"
+                "validatedAt": "2026-07-20T14:35:50.769603+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16789,7 +16767,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:05.029863+00:00"
+                "validatedAt": "2026-07-20T14:35:50.769618+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17017,7 +16995,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:05.029908+00:00"
+                "validatedAt": "2026-07-20T14:35:50.769636+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17093,7 +17071,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:05.029984+00:00"
+                "validatedAt": "2026-07-20T14:35:50.769676+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17194,7 +17172,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:05.030030+00:00"
+                "validatedAt": "2026-07-20T14:35:50.769701+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17320,7 +17298,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:05.030085+00:00"
+                "validatedAt": "2026-07-20T14:35:50.769730+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17520,7 +17498,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:05.030167+00:00"
+                "validatedAt": "2026-07-20T14:35:50.769769+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17937,7 +17915,7 @@
         "properties": {
           "code": {
             "type": "string",
-            "description": "IRule code content, this content will be base64 encoded for preserving formatting.",
+            "description": "IRule code content, this content will be base64 encoded for preserving formating.",
             "minLength": 1,
             "maxLength": 1048576,
             "x-displayname": "IRule code.",
@@ -17949,7 +17927,7 @@
               "ves.io.schema.rules.string.max_bytes": "1048576",
               "ves.io.schema.rules.string.min_bytes": "1"
             },
-            "x-f5xc-description-short": "IRule code content, this content will be base64 encoded for preserving formatting.",
+            "x-f5xc-description-short": "IRule code content, this content will be base64 encoded for preserving formating.",
             "x-f5xc-constraints": {
               "constraintType": "string",
               "category": "discovery",
@@ -17963,7 +17941,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:06.981644+00:00"
+                "validatedAt": "2026-07-20T14:35:51.527631+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17993,7 +17971,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:06.981745+00:00"
+                "validatedAt": "2026-07-20T14:35:51.527663+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18021,7 +17999,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:06.981801+00:00"
+                "validatedAt": "2026-07-20T14:35:51.527679+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18117,7 +18095,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:06.981856+00:00"
+                "validatedAt": "2026-07-20T14:35:51.527700+00:00"
               },
               "deterministic": true
             },
@@ -18129,9 +18107,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.915223+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.700623+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -18163,7 +18140,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:06.981901+00:00"
+                "validatedAt": "2026-07-20T14:35:51.527715+00:00"
               },
               "deterministic": true
             },
@@ -18175,9 +18152,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.915243+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.700636+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -18340,7 +18316,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.915312+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.700677+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -18402,7 +18378,7 @@
         "properties": {
           "code": {
             "type": "string",
-            "description": "IRule code content, this content will be base64 encoded for preserving formatting.",
+            "description": "IRule code content, this content will be base64 encoded for preserving formating.",
             "minLength": 1,
             "maxLength": 1048576,
             "x-displayname": "IRule code.",
@@ -18414,7 +18390,7 @@
               "ves.io.schema.rules.string.max_bytes": "1048576",
               "ves.io.schema.rules.string.min_bytes": "1"
             },
-            "x-f5xc-description-short": "IRule code content, this content will be base64 encoded for preserving formatting.",
+            "x-f5xc-description-short": "IRule code content, this content will be base64 encoded for preserving formating.",
             "x-f5xc-constraints": {
               "constraintType": "string",
               "category": "discovery",
@@ -18428,7 +18404,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:06.982093+00:00"
+                "validatedAt": "2026-07-20T14:35:51.527771+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18458,7 +18434,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:06.982152+00:00"
+                "validatedAt": "2026-07-20T14:35:51.527799+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18486,7 +18462,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:06.982188+00:00"
+                "validatedAt": "2026-07-20T14:35:51.527814+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18569,7 +18545,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:56:06.982234+00:00"
+                "validatedAt": "2026-07-20T14:35:51.527835+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18648,7 +18624,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:56:06.982293+00:00"
+                "validatedAt": "2026-07-20T14:35:51.527859+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18659,7 +18635,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.915386+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.700721+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -18746,7 +18722,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:06.982333+00:00"
+                "validatedAt": "2026-07-20T14:35:51.527879+00:00"
               },
               "deterministic": true
             },
@@ -18758,9 +18734,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.915431+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.700750+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -18791,7 +18766,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:06.982360+00:00"
+                "validatedAt": "2026-07-20T14:35:51.527892+00:00"
               },
               "deterministic": true
             },
@@ -18803,9 +18778,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.915450+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.700762+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -18874,7 +18848,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:06.982412+00:00"
+                "validatedAt": "2026-07-20T14:35:51.527913+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18886,7 +18860,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.915488+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.700787+00:00"
           },
           "uid": {
             "type": "string",
@@ -18903,7 +18877,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:06.982438+00:00"
+                "validatedAt": "2026-07-20T14:35:51.527923+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18916,7 +18890,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.915508+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.700800+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of bigip_irule is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -19064,7 +19038,7 @@
         "properties": {
           "code": {
             "type": "string",
-            "description": "IRule code content, this content will be base64 encoded for preserving formatting.",
+            "description": "IRule code content, this content will be base64 encoded for preserving formating.",
             "minLength": 1,
             "maxLength": 1048576,
             "x-displayname": "IRule code.",
@@ -19076,7 +19050,7 @@
               "ves.io.schema.rules.string.max_bytes": "1048576",
               "ves.io.schema.rules.string.min_bytes": "1"
             },
-            "x-f5xc-description-short": "IRule code content, this content will be base64 encoded for preserving formatting.",
+            "x-f5xc-description-short": "IRule code content, this content will be base64 encoded for preserving formating.",
             "x-f5xc-constraints": {
               "constraintType": "string",
               "category": "discovery",
@@ -19090,7 +19064,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:06.982502+00:00"
+                "validatedAt": "2026-07-20T14:35:51.527954+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19120,7 +19094,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:06.982559+00:00"
+                "validatedAt": "2026-07-20T14:35:51.527981+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19148,7 +19122,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:06.982594+00:00"
+                "validatedAt": "2026-07-20T14:35:51.527996+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19298,7 +19272,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:06.983336+00:00"
+                "validatedAt": "2026-07-20T14:35:51.528312+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19310,7 +19284,7 @@
             "readOnly": true,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.915905+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.701044+00:00"
           },
           "name": {
             "type": "string",
@@ -19343,7 +19317,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:06.983363+00:00"
+                "validatedAt": "2026-07-20T14:35:51.528325+00:00"
               },
               "deterministic": true
             },
@@ -19355,9 +19329,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.915924+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.701056+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -19390,7 +19363,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:06.983390+00:00"
+                "validatedAt": "2026-07-20T14:35:51.528338+00:00"
               },
               "deterministic": true
             },
@@ -19402,9 +19375,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.915942+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.701068+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -19423,7 +19395,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:06.983422+00:00"
+                "validatedAt": "2026-07-20T14:35:51.528352+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19436,7 +19408,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.915960+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.701080+00:00"
           },
           "uid": {
             "type": "string",
@@ -19455,7 +19427,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:06.983448+00:00"
+                "validatedAt": "2026-07-20T14:35:51.528363+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19469,7 +19441,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.915979+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.701092+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -19613,7 +19585,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:09.035123+00:00"
+                "validatedAt": "2026-07-20T14:35:52.431098+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19806,7 +19778,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.945889+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.738202+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -19935,7 +19907,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:09.035296+00:00"
+                "validatedAt": "2026-07-20T14:35:52.431161+00:00"
               },
               "deterministic": true
             },
@@ -19947,9 +19919,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.945933+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.738227+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Request of GET Security Config Spec API.",
@@ -20025,7 +19996,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:56:09.035343+00:00"
+                "validatedAt": "2026-07-20T14:35:52.431185+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20104,7 +20075,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:56:09.035400+00:00"
+                "validatedAt": "2026-07-20T14:35:52.431213+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20115,7 +20086,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.945978+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.738254+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -20202,7 +20173,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:09.035442+00:00"
+                "validatedAt": "2026-07-20T14:35:52.431234+00:00"
               },
               "deterministic": true
             },
@@ -20214,9 +20185,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.946024+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.738283+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -20247,7 +20217,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:09.035471+00:00"
+                "validatedAt": "2026-07-20T14:35:52.431250+00:00"
               },
               "deterministic": true
             },
@@ -20259,9 +20229,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.946043+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.738295+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -20330,7 +20299,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:09.035526+00:00"
+                "validatedAt": "2026-07-20T14:35:52.431273+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20342,7 +20311,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.946081+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.738319+00:00"
           },
           "uid": {
             "type": "string",
@@ -20360,7 +20329,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:09.035552+00:00"
+                "validatedAt": "2026-07-20T14:35:52.431285+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20373,7 +20342,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.946101+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.738332+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of bigip_virtual_server is returned in 'List'.",
@@ -21084,7 +21053,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:09.035781+00:00"
+                "validatedAt": "2026-07-20T14:35:52.431379+00:00"
               },
               "deterministic": true
             },
@@ -21222,7 +21191,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:09.035834+00:00"
+                "validatedAt": "2026-07-20T14:35:52.431407+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21454,7 +21423,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:09.035901+00:00"
+                "validatedAt": "2026-07-20T14:35:52.431439+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21492,7 +21461,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:09.035966+00:00"
+                "validatedAt": "2026-07-20T14:35:52.431475+00:00"
               },
               "deterministic": true
             },
@@ -21667,7 +21636,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:09.036025+00:00"
+                "validatedAt": "2026-07-20T14:35:52.431506+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21743,7 +21712,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:09.036083+00:00"
+                "validatedAt": "2026-07-20T14:35:52.431536+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21753,9 +21722,9 @@
               "read": false
             },
             "minLength": 26,
-            "format": "fqdn",
+            "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.946368+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.738488+00:00"
           },
           "simple_login": {
             "allOf": [
@@ -21905,7 +21874,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:09.036160+00:00"
+                "validatedAt": "2026-07-20T14:35:52.431573+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21944,7 +21913,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:09.036217+00:00"
+                "validatedAt": "2026-07-20T14:35:52.431603+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22467,7 +22436,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:09.036323+00:00"
+                "validatedAt": "2026-07-20T14:35:52.431654+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22586,7 +22555,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:09.036378+00:00"
+                "validatedAt": "2026-07-20T14:35:52.431683+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22695,7 +22664,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:09.036443+00:00"
+                "validatedAt": "2026-07-20T14:35:52.431716+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22734,7 +22703,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:09.036501+00:00"
+                "validatedAt": "2026-07-20T14:35:52.431745+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22786,7 +22755,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:09.036566+00:00"
+                "validatedAt": "2026-07-20T14:35:52.431778+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22797,8 +22766,7 @@
             },
             "x-f5xc-conflicts-with": [
               "any_domain"
-            ],
-            "format": "fqdn"
+            ]
           },
           "validation_mode": {
             "allOf": [
@@ -22898,7 +22866,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:09.036624+00:00"
+                "validatedAt": "2026-07-20T14:35:52.431812+00:00"
               },
               "deterministic": true
             },
@@ -22992,7 +22960,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:09.036680+00:00"
+                "validatedAt": "2026-07-20T14:35:52.431837+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23258,7 +23226,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:09.037518+00:00"
+                "validatedAt": "2026-07-20T14:35:52.432348+00:00"
               },
               "deterministic": true
             },
@@ -23270,7 +23238,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.946998+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.738861+00:00"
           },
           "name": {
             "type": "string",
@@ -23314,7 +23282,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:09.037568+00:00"
+                "validatedAt": "2026-07-20T14:35:52.432379+00:00"
               },
               "deterministic": true
             },
@@ -23324,8 +23292,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "MessageMetaType is metadata (common attributes) of a message that only certain messages have.",
@@ -23447,7 +23414,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:09.038797+00:00"
+                "validatedAt": "2026-07-20T14:35:52.432993+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23480,7 +23447,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:09.038860+00:00"
+                "validatedAt": "2026-07-20T14:35:52.433025+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23502,7 +23469,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:09.038903+00:00"
+                "validatedAt": "2026-07-20T14:35:52.433043+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23616,7 +23583,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:09.038977+00:00"
+                "validatedAt": "2026-07-20T14:35:52.433079+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24130,7 +24097,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:47.801798+00:00"
+                "validatedAt": "2026-07-20T14:36:56.364690+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24166,7 +24133,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:47.801851+00:00"
+                "validatedAt": "2026-07-20T14:36:56.364721+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24357,7 +24324,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:47.801922+00:00"
+                "validatedAt": "2026-07-20T14:36:56.364745+00:00"
               },
               "deterministic": true
             },
@@ -24369,9 +24336,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.196429+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.712981+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -24403,7 +24369,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:47.801969+00:00"
+                "validatedAt": "2026-07-20T14:36:56.364760+00:00"
               },
               "deterministic": true
             },
@@ -24415,9 +24381,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.196450+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.712995+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -24677,7 +24642,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:47.802101+00:00"
+                "validatedAt": "2026-07-20T14:36:56.364807+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24713,7 +24678,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:47.802148+00:00"
+                "validatedAt": "2026-07-20T14:36:56.364830+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24805,7 +24770,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:47.802199+00:00"
+                "validatedAt": "2026-07-20T14:36:56.364854+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24842,7 +24807,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:47.802243+00:00"
+                "validatedAt": "2026-07-20T14:36:56.364875+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24879,7 +24844,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:47.802286+00:00"
+                "validatedAt": "2026-07-20T14:36:56.364897+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24916,7 +24881,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:47.802330+00:00"
+                "validatedAt": "2026-07-20T14:36:56.364924+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24953,7 +24918,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:47.802374+00:00"
+                "validatedAt": "2026-07-20T14:36:56.364946+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24990,7 +24955,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:47.802418+00:00"
+                "validatedAt": "2026-07-20T14:36:56.364967+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25027,7 +24992,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:47.802461+00:00"
+                "validatedAt": "2026-07-20T14:36:56.364989+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25107,7 +25072,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:47.802506+00:00"
+                "validatedAt": "2026-07-20T14:36:56.365011+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25144,7 +25109,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:47.802550+00:00"
+                "validatedAt": "2026-07-20T14:36:56.365033+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25181,7 +25146,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:47.802592+00:00"
+                "validatedAt": "2026-07-20T14:36:56.365054+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25218,7 +25183,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:47.802634+00:00"
+                "validatedAt": "2026-07-20T14:36:56.365076+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25255,7 +25220,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:47.802688+00:00"
+                "validatedAt": "2026-07-20T14:36:56.365098+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25292,7 +25257,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:47.802731+00:00"
+                "validatedAt": "2026-07-20T14:36:56.365119+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25329,7 +25294,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:47.802773+00:00"
+                "validatedAt": "2026-07-20T14:36:56.365140+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25418,7 +25383,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:58:47.802818+00:00"
+                "validatedAt": "2026-07-20T14:36:56.365159+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25499,7 +25464,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:58:47.802876+00:00"
+                "validatedAt": "2026-07-20T14:36:56.365184+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25510,7 +25475,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.196686+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.713129+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -25597,7 +25562,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:47.802917+00:00"
+                "validatedAt": "2026-07-20T14:36:56.365201+00:00"
               },
               "deterministic": true
             },
@@ -25609,9 +25574,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.196733+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.713158+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -25642,7 +25606,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:47.802944+00:00"
+                "validatedAt": "2026-07-20T14:36:56.365214+00:00"
               },
               "deterministic": true
             },
@@ -25654,9 +25618,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.196752+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.713170+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -25709,7 +25672,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:47.802985+00:00"
+                "validatedAt": "2026-07-20T14:36:56.365230+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25721,7 +25684,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.196783+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.713190+00:00"
           },
           "uid": {
             "type": "string",
@@ -25739,7 +25702,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:47.803012+00:00"
+                "validatedAt": "2026-07-20T14:36:56.365242+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25752,7 +25715,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.196803+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.713203+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of application_profiles is returned in 'List'.",
@@ -25958,7 +25921,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:47.803072+00:00"
+                "validatedAt": "2026-07-20T14:36:56.365273+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25994,7 +25957,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:47.803114+00:00"
+                "validatedAt": "2026-07-20T14:36:56.365300+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26087,7 +26050,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:47.803162+00:00"
+                "validatedAt": "2026-07-20T14:36:56.365323+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26124,7 +26087,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:47.803204+00:00"
+                "validatedAt": "2026-07-20T14:36:56.365344+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26200,7 +26163,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:47.803247+00:00"
+                "validatedAt": "2026-07-20T14:36:56.365366+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26237,7 +26200,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:47.803289+00:00"
+                "validatedAt": "2026-07-20T14:36:56.365388+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26344,7 +26307,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:47.803340+00:00"
+                "validatedAt": "2026-07-20T14:36:56.365414+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26382,7 +26345,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:47.803383+00:00"
+                "validatedAt": "2026-07-20T14:36:56.365436+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26479,7 +26442,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:47.803472+00:00"
+                "validatedAt": "2026-07-20T14:36:56.365476+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26517,7 +26480,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:47.803513+00:00"
+                "validatedAt": "2026-07-20T14:36:56.365497+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26554,7 +26517,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:47.803558+00:00"
+                "validatedAt": "2026-07-20T14:36:56.365520+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26591,7 +26554,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:47.803600+00:00"
+                "validatedAt": "2026-07-20T14:36:56.365542+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26677,7 +26640,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:47.803652+00:00"
+                "validatedAt": "2026-07-20T14:36:56.365567+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26740,7 +26703,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:47.803711+00:00"
+                "validatedAt": "2026-07-20T14:36:56.365590+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26790,7 +26753,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:47.803757+00:00"
+                "validatedAt": "2026-07-20T14:36:56.365613+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28267,7 +28230,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:00.220578+00:00"
+                "validatedAt": "2026-07-20T14:37:01.647602+00:00"
               },
               "deterministic": true
             },
@@ -28279,9 +28242,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.664312+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:13.122584+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -28313,7 +28275,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:00.220616+00:00"
+                "validatedAt": "2026-07-20T14:37:01.647621+00:00"
               },
               "deterministic": true
             },
@@ -28325,9 +28287,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.664334+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:13.122598+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -28492,7 +28453,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.664402+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:13.122640+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -28599,7 +28560,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:00.220769+00:00"
+                "validatedAt": "2026-07-20T14:37:01.647683+00:00"
               },
               "deterministic": true
             },
@@ -28810,7 +28771,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:00.220835+00:00"
+                "validatedAt": "2026-07-20T14:37:01.647717+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28877,7 +28838,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T12:59:00.220894+00:00"
+                "validatedAt": "2026-07-20T14:37:01.647748+00:00"
               },
               "deterministic": true
             },
@@ -28918,7 +28879,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T12:59:00.220927+00:00"
+                "validatedAt": "2026-07-20T14:37:01.647769+00:00"
               },
               "deterministic": true
             },
@@ -29027,7 +28988,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:00.220990+00:00"
+                "validatedAt": "2026-07-20T14:37:01.647801+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29164,7 +29125,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:59:00.221038+00:00"
+                "validatedAt": "2026-07-20T14:37:01.647823+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29245,7 +29206,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:59:00.221093+00:00"
+                "validatedAt": "2026-07-20T14:37:01.647855+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29256,7 +29217,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.664548+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:13.122744+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -29343,7 +29304,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:00.221135+00:00"
+                "validatedAt": "2026-07-20T14:37:01.647877+00:00"
               },
               "deterministic": true
             },
@@ -29355,9 +29316,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.664595+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:13.122774+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -29388,7 +29348,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:00.221162+00:00"
+                "validatedAt": "2026-07-20T14:37:01.647891+00:00"
               },
               "deterministic": true
             },
@@ -29400,9 +29360,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.664613+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:13.122786+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -29471,7 +29430,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:00.221214+00:00"
+                "validatedAt": "2026-07-20T14:37:01.647915+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29483,7 +29442,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.664652+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:13.122811+00:00"
           },
           "uid": {
             "type": "string",
@@ -29501,7 +29460,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:00.221240+00:00"
+                "validatedAt": "2026-07-20T14:37:01.647926+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29514,7 +29473,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.664681+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:13.122825+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of bigip_http_proxy is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -29594,7 +29553,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:00.221291+00:00"
+                "validatedAt": "2026-07-20T14:37:01.647954+00:00"
               },
               "deterministic": true
             },
@@ -29726,7 +29685,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:00.221347+00:00"
+                "validatedAt": "2026-07-20T14:37:01.647980+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29764,7 +29723,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:00.221376+00:00"
+                "validatedAt": "2026-07-20T14:37:01.647994+00:00"
               },
               "deterministic": true
             },
@@ -30121,7 +30080,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:00.221499+00:00"
+                "validatedAt": "2026-07-20T14:37:01.648045+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30156,7 +30115,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:00.221560+00:00"
+                "validatedAt": "2026-07-20T14:37:01.648073+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30250,7 +30209,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:00.221594+00:00"
+                "validatedAt": "2026-07-20T14:37:01.648090+00:00"
               },
               "deterministic": true
             },
@@ -30296,7 +30255,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:00.221668+00:00"
+                "validatedAt": "2026-07-20T14:37:01.648119+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30392,7 +30351,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:00.221737+00:00"
+                "validatedAt": "2026-07-20T14:37:01.648149+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30602,7 +30561,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:00.221812+00:00"
+                "validatedAt": "2026-07-20T14:37:01.648181+00:00"
               },
               "deterministic": true
             },
@@ -30648,7 +30607,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:00.221874+00:00"
+                "validatedAt": "2026-07-20T14:37:01.648209+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30684,7 +30643,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:00.221932+00:00"
+                "validatedAt": "2026-07-20T14:37:01.648235+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30831,7 +30790,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:00.222005+00:00"
+                "validatedAt": "2026-07-20T14:37:01.648268+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31056,7 +31015,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:00.222085+00:00"
+                "validatedAt": "2026-07-20T14:37:01.648304+00:00"
               },
               "deterministic": true
             },
@@ -31102,7 +31061,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:00.222145+00:00"
+                "validatedAt": "2026-07-20T14:37:01.648332+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31138,7 +31097,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:00.222201+00:00"
+                "validatedAt": "2026-07-20T14:37:01.648359+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31313,7 +31272,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:00.222410+00:00"
+                "validatedAt": "2026-07-20T14:37:01.648453+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31456,7 +31415,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:00.222472+00:00"
+                "validatedAt": "2026-07-20T14:37:01.648481+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31607,7 +31566,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:00.222529+00:00"
+                "validatedAt": "2026-07-20T14:37:01.648534+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31697,7 +31656,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:00.222586+00:00"
+                "validatedAt": "2026-07-20T14:37:01.648570+00:00"
               },
               "deterministic": true
             },
@@ -31707,8 +31666,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "format": "hostname"
+            "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$"
           },
           "refresh_interval": {
             "type": "integer",
@@ -32053,7 +32011,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:00.224572+00:00"
+                "validatedAt": "2026-07-20T14:37:01.649462+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32217,7 +32175,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:00.224791+00:00"
+                "validatedAt": "2026-07-20T14:37:01.649569+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32297,7 +32255,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:00.224887+00:00"
+                "validatedAt": "2026-07-20T14:37:01.649616+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32424,7 +32382,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:00.225023+00:00"
+                "validatedAt": "2026-07-20T14:37:01.649683+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32748,7 +32706,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:00.225093+00:00"
+                "validatedAt": "2026-07-20T14:37:01.649718+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32891,7 +32849,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:00.225136+00:00"
+                "validatedAt": "2026-07-20T14:37:01.649738+00:00"
               },
               "deterministic": true
             },
@@ -32938,7 +32896,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:00.225197+00:00"
+                "validatedAt": "2026-07-20T14:37:01.649766+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33292,7 +33250,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:00.225286+00:00"
+                "validatedAt": "2026-07-20T14:37:01.649804+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33327,7 +33285,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:00.225342+00:00"
+                "validatedAt": "2026-07-20T14:37:01.649831+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33508,7 +33466,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:00.225397+00:00"
+                "validatedAt": "2026-07-20T14:37:01.649857+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33921,7 +33879,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:00.225507+00:00"
+                "validatedAt": "2026-07-20T14:37:01.649899+00:00"
               },
               "deterministic": true
             },
@@ -33933,9 +33891,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.666677+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:13.124025+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "origin_servers": {
             "allOf": [
@@ -33976,7 +33933,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:59:00.225544+00:00"
+                "validatedAt": "2026-07-20T14:37:01.649916+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34005,7 +33962,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:59:00.225574+00:00"
+                "validatedAt": "2026-07-20T14:37:01.649930+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34582,7 +34539,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:29.158139+00:00"
+                "validatedAt": "2026-07-20T14:37:13.164855+00:00"
               },
               "deterministic": true
             },
@@ -34594,7 +34551,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.462799+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:13.908187+00:00"
           },
           "irule": {
             "type": "string",
@@ -34621,7 +34578,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:29.158193+00:00"
+                "validatedAt": "2026-07-20T14:37:13.164880+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34718,7 +34675,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:29.158231+00:00"
+                "validatedAt": "2026-07-20T14:37:13.164898+00:00"
               },
               "deterministic": true
             },
@@ -34730,9 +34687,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.462833+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:13.908208+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -34764,7 +34720,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:29.158260+00:00"
+                "validatedAt": "2026-07-20T14:37:13.164910+00:00"
               },
               "deterministic": true
             },
@@ -34776,9 +34732,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.462851+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:13.908220+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -35009,7 +34964,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:29.158392+00:00"
+                "validatedAt": "2026-07-20T14:37:13.164964+00:00"
               },
               "deterministic": true
             },
@@ -35021,7 +34976,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.462925+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:13.908265+00:00"
           },
           "irule": {
             "type": "string",
@@ -35048,7 +35003,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:29.158444+00:00"
+                "validatedAt": "2026-07-20T14:37:13.164987+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35132,7 +35087,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:59:29.158490+00:00"
+                "validatedAt": "2026-07-20T14:37:13.165007+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35212,7 +35167,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:59:29.158543+00:00"
+                "validatedAt": "2026-07-20T14:37:13.165029+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35223,7 +35178,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.462978+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:13.908296+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -35310,7 +35265,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:29.158584+00:00"
+                "validatedAt": "2026-07-20T14:37:13.165047+00:00"
               },
               "deterministic": true
             },
@@ -35322,9 +35277,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.463024+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:13.908324+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -35355,7 +35309,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:29.158612+00:00"
+                "validatedAt": "2026-07-20T14:37:13.165060+00:00"
               },
               "deterministic": true
             },
@@ -35367,9 +35321,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.463042+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:13.908337+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -35422,7 +35375,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:29.158650+00:00"
+                "validatedAt": "2026-07-20T14:37:13.165075+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35434,7 +35387,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.463073+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:13.908357+00:00"
           },
           "uid": {
             "type": "string",
@@ -35451,7 +35404,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:29.158687+00:00"
+                "validatedAt": "2026-07-20T14:37:13.165085+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35464,7 +35417,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.463092+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:13.908369+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of irule is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -35641,7 +35594,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:29.158767+00:00"
+                "validatedAt": "2026-07-20T14:37:13.165119+00:00"
               },
               "deterministic": true
             },
@@ -35653,7 +35606,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.463128+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:13.908391+00:00"
           },
           "irule": {
             "type": "string",
@@ -35680,7 +35633,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:29.158846+00:00"
+                "validatedAt": "2026-07-20T14:37:13.165146+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36267,7 +36220,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:26.955609+00:00"
+                "validatedAt": "2026-07-20T14:37:35.797472+00:00"
               },
               "deterministic": true
             },
@@ -36279,9 +36232,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.613353+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.175605+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -36313,7 +36265,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:26.955646+00:00"
+                "validatedAt": "2026-07-20T14:37:35.797490+00:00"
               },
               "deterministic": true
             },
@@ -36325,9 +36277,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.613373+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.175619+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -36625,7 +36576,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:00:26.955828+00:00"
+                "validatedAt": "2026-07-20T14:37:35.797536+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36706,7 +36657,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:00:26.955886+00:00"
+                "validatedAt": "2026-07-20T14:37:35.797559+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36717,7 +36668,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.613481+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.175684+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -36804,7 +36755,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:26.955927+00:00"
+                "validatedAt": "2026-07-20T14:37:35.797578+00:00"
               },
               "deterministic": true
             },
@@ -36816,9 +36767,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.613527+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.175713+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -36849,7 +36799,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:26.955958+00:00"
+                "validatedAt": "2026-07-20T14:37:35.797591+00:00"
               },
               "deterministic": true
             },
@@ -36861,9 +36811,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.613545+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.175726+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -36916,7 +36865,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:26.955999+00:00"
+                "validatedAt": "2026-07-20T14:37:35.797607+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36928,7 +36877,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.613576+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.175746+00:00"
           },
           "uid": {
             "type": "string",
@@ -36945,7 +36894,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:26.956027+00:00"
+                "validatedAt": "2026-07-20T14:37:35.797618+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36958,7 +36907,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.613596+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.175759+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of data_group is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",

--- a/docs/specifications/api/billing_and_usage.json
+++ b/docs/specifications/api/billing_and_usage.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Billing And Usage",
     "description": "Subscription lifecycle with plan transitions and billing states. Payment method hierarchies supporting primary and secondary configurations. Invoice generation with PDF downloads and custom listing. Resource quotas per namespace with limit definitions and consumption metrics. Contact types for billing notifications and tenant deletion workflows.",
-    "version": "2.1.182",
+    "version": "2.1.181",
     "contact": {
       "name": "F5 Distributed Cloud",
       "url": "https://docs.cloud.f5.com"
@@ -5737,7 +5737,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:14.514291+00:00"
+                "validatedAt": "2026-07-20T14:35:54.572513+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5764,7 +5764,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:14.514362+00:00"
+                "validatedAt": "2026-07-20T14:35:54.572536+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5775,7 +5775,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.035463+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.849584+00:00"
           }
         },
         "x-f5xc-description-short": "Billing Metric Data represents billing metric metadata like unit as well as converted metric value.",
@@ -5838,7 +5838,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:14.514431+00:00"
+                "validatedAt": "2026-07-20T14:35:54.572556+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5871,7 +5871,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:14.514487+00:00"
+                "validatedAt": "2026-07-20T14:35:54.572573+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5998,7 +5998,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:14.514576+00:00"
+                "validatedAt": "2026-07-20T14:35:54.572595+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6090,7 +6090,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:14.514630+00:00"
+                "validatedAt": "2026-07-20T14:35:54.572616+00:00"
               },
               "deterministic": true
             },
@@ -6102,9 +6102,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.035532+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.849622+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "service": {
             "type": "string",
@@ -6122,7 +6121,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:14.514677+00:00"
+                "validatedAt": "2026-07-20T14:35:54.572630+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6217,7 +6216,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:14.514734+00:00"
+                "validatedAt": "2026-07-20T14:35:54.572651+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6228,7 +6227,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.035572+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.849646+00:00"
           }
         },
         "x-f5xc-description-short": "Value returned for a Billing Metrics query.",
@@ -6284,7 +6283,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:24.617985+00:00"
+                "validatedAt": "2026-07-20T14:38:46.636098+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6407,7 +6406,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:24.618062+00:00"
+                "validatedAt": "2026-07-20T14:38:46.636124+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6432,7 +6431,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:24.618100+00:00"
+                "validatedAt": "2026-07-20T14:38:46.636139+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6471,7 +6470,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:24.618136+00:00"
+                "validatedAt": "2026-07-20T14:38:46.636156+00:00"
               },
               "deterministic": true
             },
@@ -6483,9 +6482,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.454260+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.243793+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "period_end": {
             "type": "string",
@@ -6504,7 +6502,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:24.618174+00:00"
+                "validatedAt": "2026-07-20T14:38:46.636171+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6531,7 +6529,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:24.618241+00:00"
+                "validatedAt": "2026-07-20T14:38:46.636188+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6557,7 +6555,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.454294+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.243815+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -6708,7 +6706,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:47.183906+00:00"
+                "validatedAt": "2026-07-20T14:39:41.229276+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6733,7 +6731,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:47.183980+00:00"
+                "validatedAt": "2026-07-20T14:39:41.229302+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6758,7 +6756,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:47.184030+00:00"
+                "validatedAt": "2026-07-20T14:39:41.229317+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6796,7 +6794,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:47.184090+00:00"
+                "validatedAt": "2026-07-20T14:39:41.229333+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6821,7 +6819,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:47.184143+00:00"
+                "validatedAt": "2026-07-20T14:39:41.229348+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6847,7 +6845,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:47.184198+00:00"
+                "validatedAt": "2026-07-20T14:39:41.229365+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6872,7 +6870,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:47.184231+00:00"
+                "validatedAt": "2026-07-20T14:39:41.229379+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6897,7 +6895,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:47.184268+00:00"
+                "validatedAt": "2026-07-20T14:39:41.229394+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6922,7 +6920,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:47.184303+00:00"
+                "validatedAt": "2026-07-20T14:39:41.229409+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7023,7 +7021,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:47.184347+00:00"
+                "validatedAt": "2026-07-20T14:39:41.229431+00:00"
               },
               "deterministic": true
             },
@@ -7035,15 +7033,14 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.643923+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:19.340917+00:00",
             "x-ves-validation-rules": {
               "ves.io.schema.rules.string.const": "system"
             },
             "x-validation-rules": {
               "ves.io.schema.rules.string.const": "system"
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "role": {
             "allOf": [
@@ -7076,7 +7073,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:05:47.184388+00:00"
+                "validatedAt": "2026-07-20T14:39:41.229451+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7152,7 +7149,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:47.184419+00:00"
+                "validatedAt": "2026-07-20T14:39:41.229466+00:00"
               },
               "deterministic": true
             },
@@ -7164,9 +7161,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.643959+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.340940+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -7234,7 +7230,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:47.184447+00:00"
+                "validatedAt": "2026-07-20T14:39:41.229481+00:00"
               },
               "deterministic": true
             },
@@ -7246,9 +7242,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.643980+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.340954+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -7280,7 +7275,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:47.184474+00:00"
+                "validatedAt": "2026-07-20T14:39:41.229494+00:00"
               },
               "deterministic": true
             },
@@ -7292,15 +7287,14 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.643998+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:19.340966+00:00",
             "x-ves-validation-rules": {
               "ves.io.schema.rules.string.const": "system"
             },
             "x-validation-rules": {
               "ves.io.schema.rules.string.const": "system"
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Changes a payment method role to primary.",
@@ -7411,7 +7405,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:47.184501+00:00"
+                "validatedAt": "2026-07-20T14:39:41.229509+00:00"
               },
               "deterministic": true
             },
@@ -7423,9 +7417,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.644019+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.340979+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -7457,7 +7450,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:47.184527+00:00"
+                "validatedAt": "2026-07-20T14:39:41.229522+00:00"
               },
               "deterministic": true
             },
@@ -7469,15 +7462,14 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.644038+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:19.340992+00:00",
             "x-ves-validation-rules": {
               "ves.io.schema.rules.string.const": "system"
             },
             "x-validation-rules": {
               "ves.io.schema.rules.string.const": "system"
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Changes a payment method role (from/to primary or backup).",
@@ -7547,7 +7539,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:47.184554+00:00"
+                "validatedAt": "2026-07-20T14:39:41.229537+00:00"
               },
               "deterministic": true
             },
@@ -7559,9 +7551,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.644058+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.341005+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -7593,7 +7584,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:47.184582+00:00"
+                "validatedAt": "2026-07-20T14:39:41.229551+00:00"
               },
               "deterministic": true
             },
@@ -7605,15 +7596,14 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.644076+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:19.341017+00:00",
             "x-ves-validation-rules": {
               "ves.io.schema.rules.string.const": "system"
             },
             "x-validation-rules": {
               "ves.io.schema.rules.string.const": "system"
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Changes a payment method role to secondary.",
@@ -7734,7 +7724,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:58.056195+00:00"
+                "validatedAt": "2026-07-20T14:39:45.586493+00:00"
               },
               "deterministic": true
             },
@@ -7746,15 +7736,14 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.774129+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:19.515699+00:00",
             "x-ves-validation-rules": {
               "ves.io.schema.rules.string.const": "system"
             },
             "x-validation-rules": {
               "ves.io.schema.rules.string.const": "system"
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "new_plan": {
             "type": "string",
@@ -7772,7 +7761,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:58.056258+00:00"
+                "validatedAt": "2026-07-20T14:39:45.586514+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7852,7 +7841,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:58.056303+00:00"
+                "validatedAt": "2026-07-20T14:39:45.586528+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7987,7 +7976,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:58.056390+00:00"
+                "validatedAt": "2026-07-20T14:39:45.586555+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8028,7 +8017,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:58.056462+00:00"
+                "validatedAt": "2026-07-20T14:39:45.586576+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8067,7 +8056,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:58.056509+00:00"
+                "validatedAt": "2026-07-20T14:39:45.586593+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8079,7 +8068,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.774216+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.515750+00:00"
           },
           "payment_address": {
             "allOf": [
@@ -8110,7 +8099,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:58.056556+00:00"
+                "validatedAt": "2026-07-20T14:39:45.586614+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8154,7 +8143,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:58.056619+00:00"
+                "validatedAt": "2026-07-20T14:39:45.586640+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8180,7 +8169,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:58.056673+00:00"
+                "validatedAt": "2026-07-20T14:39:45.586658+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8272,7 +8261,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:58.056728+00:00"
+                "validatedAt": "2026-07-20T14:39:45.586682+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8297,7 +8286,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:58.056764+00:00"
+                "validatedAt": "2026-07-20T14:39:45.586698+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8322,7 +8311,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:58.056795+00:00"
+                "validatedAt": "2026-07-20T14:39:45.586712+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8360,7 +8349,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:58.056835+00:00"
+                "validatedAt": "2026-07-20T14:39:45.586729+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8385,7 +8374,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:58.056869+00:00"
+                "validatedAt": "2026-07-20T14:39:45.586744+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8411,7 +8400,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:58.056909+00:00"
+                "validatedAt": "2026-07-20T14:39:45.586762+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8436,7 +8425,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:58.056942+00:00"
+                "validatedAt": "2026-07-20T14:39:45.586777+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8461,7 +8450,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:58.056980+00:00"
+                "validatedAt": "2026-07-20T14:39:45.586794+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8486,7 +8475,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:58.057017+00:00"
+                "validatedAt": "2026-07-20T14:39:45.586810+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8595,7 +8584,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:26.517684+00:00"
+                "validatedAt": "2026-07-20T14:39:56.678268+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8618,7 +8607,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:26.517742+00:00"
+                "validatedAt": "2026-07-20T14:39:56.678292+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8629,7 +8618,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.195935+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.912393+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -8855,7 +8844,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:26.517815+00:00"
+                "validatedAt": "2026-07-20T14:39:56.678319+00:00"
               },
               "deterministic": true
             },
@@ -8867,9 +8856,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.196003+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.912433+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -8901,7 +8889,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:26.517856+00:00"
+                "validatedAt": "2026-07-20T14:39:56.678333+00:00"
               },
               "deterministic": true
             },
@@ -8913,9 +8901,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.196022+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.912445+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -9245,7 +9232,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.196145+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.912517+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -9510,7 +9497,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:06:26.518136+00:00"
+                "validatedAt": "2026-07-20T14:39:56.678405+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9588,7 +9575,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:06:26.518194+00:00"
+                "validatedAt": "2026-07-20T14:39:56.678428+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9599,7 +9586,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.196251+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.912578+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -9686,7 +9673,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:26.518237+00:00"
+                "validatedAt": "2026-07-20T14:39:56.678447+00:00"
               },
               "deterministic": true
             },
@@ -9698,9 +9685,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.196298+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.912604+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -9731,7 +9717,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:26.518266+00:00"
+                "validatedAt": "2026-07-20T14:39:56.678460+00:00"
               },
               "deterministic": true
             },
@@ -9743,9 +9729,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.196317+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.912616+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -9814,7 +9799,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:26.518320+00:00"
+                "validatedAt": "2026-07-20T14:39:56.678480+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9826,7 +9811,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.196354+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.912639+00:00"
           },
           "uid": {
             "type": "string",
@@ -9843,7 +9828,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:26.518347+00:00"
+                "validatedAt": "2026-07-20T14:39:56.678491+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9856,7 +9841,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.196380+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.912651+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of quota is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -9948,7 +9933,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:26.518399+00:00"
+                "validatedAt": "2026-07-20T14:39:56.678511+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10195,7 +10180,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T13:06:26.518473+00:00"
+                "validatedAt": "2026-07-20T14:39:56.678539+00:00"
               },
               "deterministic": true
             },
@@ -10206,8 +10191,7 @@
               "read": false
             },
             "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "minLength": 1,
-            "format": "fqdn"
+            "minLength": 1
           },
           "last_update_time": {
             "type": "string",
@@ -10224,7 +10208,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:26.518515+00:00"
+                "validatedAt": "2026-07-20T14:39:56.678556+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10251,7 +10235,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:26.518550+00:00"
+                "validatedAt": "2026-07-20T14:39:56.678569+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10262,7 +10246,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.196471+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.912702+00:00"
           },
           "service_name": {
             "type": "string",
@@ -10279,7 +10263,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:26.518590+00:00"
+                "validatedAt": "2026-07-20T14:39:56.678585+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10312,7 +10296,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:26.518635+00:00"
+                "validatedAt": "2026-07-20T14:39:56.678601+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10323,7 +10307,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.196497+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.912718+00:00"
           },
           "type": {
             "type": "string",
@@ -10348,7 +10332,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:26.518679+00:00"
+                "validatedAt": "2026-07-20T14:39:56.678614+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10488,7 +10472,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:26.518724+00:00"
+                "validatedAt": "2026-07-20T14:39:56.678631+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10566,7 +10550,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:26.518754+00:00"
+                "validatedAt": "2026-07-20T14:39:56.678645+00:00"
               },
               "deterministic": true
             },
@@ -10578,9 +10562,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.196546+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.912747+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -10740,7 +10723,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:26.518853+00:00"
+                "validatedAt": "2026-07-20T14:39:56.678689+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -10755,7 +10738,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.196590+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.912771+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -10825,7 +10808,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:26.518892+00:00"
+                "validatedAt": "2026-07-20T14:39:56.678707+00:00"
               },
               "deterministic": true
             },
@@ -10837,9 +10820,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.196623+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.912791+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -10872,7 +10854,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:26.518919+00:00"
+                "validatedAt": "2026-07-20T14:39:56.678720+00:00"
               },
               "deterministic": true
             },
@@ -10884,9 +10866,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.196642+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.912803+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -10984,7 +10965,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:26.518996+00:00"
+                "validatedAt": "2026-07-20T14:39:56.678756+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -10999,7 +10980,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.196678+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.912819+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -11071,7 +11052,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:26.519034+00:00"
+                "validatedAt": "2026-07-20T14:39:56.678773+00:00"
               },
               "deterministic": true
             },
@@ -11083,9 +11064,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.196711+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.912839+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -11118,7 +11098,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:26.519061+00:00"
+                "validatedAt": "2026-07-20T14:39:56.678786+00:00"
               },
               "deterministic": true
             },
@@ -11130,9 +11110,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.196730+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.912851+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -11193,7 +11172,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:26.519092+00:00"
+                "validatedAt": "2026-07-20T14:39:56.678799+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11205,7 +11184,7 @@
             "readOnly": true,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.196750+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.912863+00:00"
           },
           "name": {
             "type": "string",
@@ -11238,7 +11217,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:26.519118+00:00"
+                "validatedAt": "2026-07-20T14:39:56.678812+00:00"
               },
               "deterministic": true
             },
@@ -11250,9 +11229,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.196768+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.912874+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -11285,7 +11263,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:26.519144+00:00"
+                "validatedAt": "2026-07-20T14:39:56.678824+00:00"
               },
               "deterministic": true
             },
@@ -11297,9 +11275,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.196787+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.912886+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -11318,7 +11295,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:26.519176+00:00"
+                "validatedAt": "2026-07-20T14:39:56.678837+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11331,7 +11308,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.196805+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.912898+00:00"
           },
           "uid": {
             "type": "string",
@@ -11350,7 +11327,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:26.519201+00:00"
+                "validatedAt": "2026-07-20T14:39:56.678847+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11364,7 +11341,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.196824+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.912910+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -11462,7 +11439,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:26.519277+00:00"
+                "validatedAt": "2026-07-20T14:39:56.678881+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -11477,7 +11454,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.196851+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.912926+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -11547,7 +11524,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:26.519315+00:00"
+                "validatedAt": "2026-07-20T14:39:56.678897+00:00"
               },
               "deterministic": true
             },
@@ -11559,9 +11536,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.196884+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.912946+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -11594,7 +11570,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:26.519342+00:00"
+                "validatedAt": "2026-07-20T14:39:56.678910+00:00"
               },
               "deterministic": true
             },
@@ -11606,9 +11582,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.196902+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.912958+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -11669,7 +11644,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:26.519386+00:00"
+                "validatedAt": "2026-07-20T14:39:56.678928+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11697,7 +11672,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:26.519425+00:00"
+                "validatedAt": "2026-07-20T14:39:56.678943+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11725,7 +11700,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:26.519462+00:00"
+                "validatedAt": "2026-07-20T14:39:56.678958+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11764,7 +11739,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:26.519503+00:00"
+                "validatedAt": "2026-07-20T14:39:56.678974+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11791,7 +11766,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:26.519529+00:00"
+                "validatedAt": "2026-07-20T14:39:56.678984+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11804,7 +11779,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.196956+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.912990+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -11820,7 +11795,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:26.519563+00:00"
+                "validatedAt": "2026-07-20T14:39:56.678998+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11961,7 +11936,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:26.519612+00:00"
+                "validatedAt": "2026-07-20T14:39:56.679016+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11972,7 +11947,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.196995+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.913013+00:00"
           },
           "status": {
             "type": "string",
@@ -11990,7 +11965,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:26.519646+00:00"
+                "validatedAt": "2026-07-20T14:39:56.679029+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12001,7 +11976,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.197013+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.913025+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -12059,7 +12034,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:26.519698+00:00"
+                "validatedAt": "2026-07-20T14:39:56.679047+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12086,7 +12061,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:26.519739+00:00"
+                "validatedAt": "2026-07-20T14:39:56.679062+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12113,7 +12088,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:26.519775+00:00"
+                "validatedAt": "2026-07-20T14:39:56.679076+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12141,7 +12116,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:26.519816+00:00"
+                "validatedAt": "2026-07-20T14:39:56.679092+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12217,7 +12192,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:26.519879+00:00"
+                "validatedAt": "2026-07-20T14:39:56.679116+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12285,7 +12260,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:26.519929+00:00"
+                "validatedAt": "2026-07-20T14:39:56.679137+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12297,7 +12272,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.197099+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.913075+00:00"
           },
           "uid": {
             "type": "string",
@@ -12316,7 +12291,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:26.519955+00:00"
+                "validatedAt": "2026-07-20T14:39:56.679147+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12329,7 +12304,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.197117+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.913087+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -12395,7 +12370,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:26.519987+00:00"
+                "validatedAt": "2026-07-20T14:39:56.679160+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12406,7 +12381,7 @@
             },
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.197137+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.913099+00:00"
           },
           "name": {
             "type": "string",
@@ -12439,7 +12414,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:26.520014+00:00"
+                "validatedAt": "2026-07-20T14:39:56.679173+00:00"
               },
               "deterministic": true
             },
@@ -12451,9 +12426,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.197155+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.913111+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -12486,7 +12460,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:26.520042+00:00"
+                "validatedAt": "2026-07-20T14:39:56.679185+00:00"
               },
               "deterministic": true
             },
@@ -12498,9 +12472,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.197173+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.913122+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "uid": {
             "type": "string",
@@ -12517,7 +12490,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:26.520066+00:00"
+                "validatedAt": "2026-07-20T14:39:56.679195+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12530,7 +12503,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.197192+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.913134+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -13082,7 +13055,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:58.353035+00:00"
+                "validatedAt": "2026-07-20T14:40:56.491708+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13110,7 +13083,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:58.353098+00:00"
+                "validatedAt": "2026-07-20T14:40:56.491735+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13138,7 +13111,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:58.353142+00:00"
+                "validatedAt": "2026-07-20T14:40:56.491753+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13197,7 +13170,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:58.353225+00:00"
+                "validatedAt": "2026-07-20T14:40:56.491779+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13236,7 +13209,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:58.353277+00:00"
+                "validatedAt": "2026-07-20T14:40:56.491791+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13249,7 +13222,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.582363+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.903092+00:00"
           }
         },
         "x-f5xc-description-short": "Response to call to GET list of tenant subscriptions.",
@@ -13314,7 +13287,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:58.353325+00:00"
+                "validatedAt": "2026-07-20T14:40:56.491811+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13370,7 +13343,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:58.353380+00:00"
+                "validatedAt": "2026-07-20T14:40:56.491832+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13398,7 +13371,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:58.353429+00:00"
+                "validatedAt": "2026-07-20T14:40:56.491851+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13439,7 +13412,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:58.353467+00:00"
+                "validatedAt": "2026-07-20T14:40:56.491868+00:00"
               },
               "deterministic": true
             },
@@ -13451,9 +13424,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.582419+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:22.903126+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "plan_name": {
             "type": "string",
@@ -13470,7 +13442,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:58.353506+00:00"
+                "validatedAt": "2026-07-20T14:40:56.491885+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13495,7 +13467,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:58.353548+00:00"
+                "validatedAt": "2026-07-20T14:40:56.491902+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13537,7 +13509,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:58.353601+00:00"
+                "validatedAt": "2026-07-20T14:40:56.491923+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14567,7 +14539,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:32.188510+00:00"
+                "validatedAt": "2026-07-20T14:41:31.280317+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14592,7 +14564,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:32.188571+00:00"
+                "validatedAt": "2026-07-20T14:41:31.280341+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14619,7 +14591,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:32.188613+00:00"
+                "validatedAt": "2026-07-20T14:41:31.280358+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14695,7 +14667,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:32.188735+00:00"
+                "validatedAt": "2026-07-20T14:41:31.280386+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14722,7 +14694,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:32.188797+00:00"
+                "validatedAt": "2026-07-20T14:41:31.280402+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14748,7 +14720,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.978670+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.712441+00:00"
           },
           "unit_name": {
             "type": "string",
@@ -14765,7 +14737,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:32.188864+00:00"
+                "validatedAt": "2026-07-20T14:41:31.280418+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14790,7 +14762,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:32.188930+00:00"
+                "validatedAt": "2026-07-20T14:41:31.280435+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14815,7 +14787,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:32.188968+00:00"
+                "validatedAt": "2026-07-20T14:41:31.280449+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14925,7 +14897,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:32.189028+00:00"
+                "validatedAt": "2026-07-20T14:41:31.280471+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14936,7 +14908,7 @@
             },
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.978728+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.712475+00:00"
           }
         },
         "x-f5xc-description-short": "Coupon details, discount type, amount and name.",
@@ -15033,7 +15005,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:32.189068+00:00"
+                "validatedAt": "2026-07-20T14:41:31.280487+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15066,7 +15038,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:32.189114+00:00"
+                "validatedAt": "2026-07-20T14:41:31.280503+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15093,7 +15065,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:32.189155+00:00"
+                "validatedAt": "2026-07-20T14:41:31.280518+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15135,7 +15107,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:32.189209+00:00"
+                "validatedAt": "2026-07-20T14:41:31.280538+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15160,7 +15132,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:32.189245+00:00"
+                "validatedAt": "2026-07-20T14:41:31.280553+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15230,7 +15202,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:32.189278+00:00"
+                "validatedAt": "2026-07-20T14:41:31.280565+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15269,7 +15241,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:32.189315+00:00"
+                "validatedAt": "2026-07-20T14:41:31.280581+00:00"
               },
               "deterministic": true
             },
@@ -15281,15 +15253,14 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.978798+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:24.712516+00:00",
             "x-ves-validation-rules": {
               "ves.io.schema.rules.string.const": "system"
             },
             "x-validation-rules": {
               "ves.io.schema.rules.string.const": "system"
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "to": {
             "type": "string",
@@ -15308,7 +15279,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:32.189340+00:00"
+                "validatedAt": "2026-07-20T14:41:31.280592+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15389,7 +15360,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:32.189390+00:00"
+                "validatedAt": "2026-07-20T14:41:31.280611+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15416,7 +15387,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:32.189427+00:00"
+                "validatedAt": "2026-07-20T14:41:31.280625+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15511,7 +15482,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:32.189471+00:00"
+                "validatedAt": "2026-07-20T14:41:31.280644+00:00"
               },
               "deterministic": true
             },
@@ -15523,15 +15494,14 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.978853+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:24.712548+00:00",
             "x-ves-validation-rules": {
               "ves.io.schema.rules.string.const": "system"
             },
             "x-validation-rules": {
               "ves.io.schema.rules.string.const": "system"
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query": {
             "type": "string",
@@ -15550,7 +15520,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:10:32.189512+00:00"
+                "validatedAt": "2026-07-20T14:41:31.280662+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15680,7 +15650,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:32.189556+00:00"
+                "validatedAt": "2026-07-20T14:41:31.280681+00:00"
               },
               "deterministic": true
             },
@@ -15692,15 +15662,14 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.978888+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:24.712569+00:00",
             "x-ves-validation-rules": {
               "ves.io.schema.rules.string.const": "system"
             },
             "x-validation-rules": {
               "ves.io.schema.rules.string.const": "system"
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Request message to GET mon thly usage details.",
@@ -15810,7 +15779,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:32.189602+00:00"
+                "validatedAt": "2026-07-20T14:41:31.280699+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15849,7 +15818,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:32.189630+00:00"
+                "validatedAt": "2026-07-20T14:41:31.280711+00:00"
               },
               "deterministic": true
             },
@@ -15861,15 +15830,14 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.978922+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:24.712590+00:00",
             "x-ves-validation-rules": {
               "ves.io.schema.rules.string.const": "system"
             },
             "x-validation-rules": {
               "ves.io.schema.rules.string.const": "system"
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "to": {
             "type": "string",
@@ -15888,7 +15856,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:32.189668+00:00"
+                "validatedAt": "2026-07-20T14:41:31.280721+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16005,7 +15973,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:32.189729+00:00"
+                "validatedAt": "2026-07-20T14:41:31.280740+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16030,7 +15998,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:32.189768+00:00"
+                "validatedAt": "2026-07-20T14:41:31.280756+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16057,7 +16025,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:32.189808+00:00"
+                "validatedAt": "2026-07-20T14:41:31.280771+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16084,7 +16052,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:32.189848+00:00"
+                "validatedAt": "2026-07-20T14:41:31.280786+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16151,7 +16119,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:32.189888+00:00"
+                "validatedAt": "2026-07-20T14:41:31.280802+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16202,7 +16170,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:32.189948+00:00"
+                "validatedAt": "2026-07-20T14:41:31.280825+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16233,7 +16201,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:32.189989+00:00"
+                "validatedAt": "2026-07-20T14:41:31.280841+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16272,7 +16240,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:32.190017+00:00"
+                "validatedAt": "2026-07-20T14:41:31.280853+00:00"
               },
               "deterministic": true
             },
@@ -16284,9 +16252,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.979012+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.712641+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "object_name": {
             "type": "string",
@@ -16304,7 +16271,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:32.190055+00:00"
+                "validatedAt": "2026-07-20T14:41:31.280868+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16346,7 +16313,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:32.190106+00:00"
+                "validatedAt": "2026-07-20T14:41:31.280888+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16371,7 +16338,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:32.190142+00:00"
+                "validatedAt": "2026-07-20T14:41:31.280903+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16396,7 +16363,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:32.190180+00:00"
+                "validatedAt": "2026-07-20T14:41:31.280917+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16471,7 +16438,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:10:35.612454+00:00"
+                "validatedAt": "2026-07-20T14:41:32.467377+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16510,7 +16477,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:35.612492+00:00"
+                "validatedAt": "2026-07-20T14:41:32.467394+00:00"
               },
               "deterministic": true
             },
@@ -16522,9 +16489,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.014392+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.778858+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -16629,7 +16595,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:35.612551+00:00"
+                "validatedAt": "2026-07-20T14:41:32.467416+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16811,7 +16777,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:10:35.612681+00:00"
+                "validatedAt": "2026-07-20T14:41:32.467450+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16822,7 +16788,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.014466+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.778901+00:00"
           },
           "flat_price": {
             "type": "integer",
@@ -16884,7 +16850,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:35.612769+00:00"
+                "validatedAt": "2026-07-20T14:41:32.467474+00:00"
               },
               "deterministic": true
             },
@@ -16896,9 +16862,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.014497+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.778921+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "renewal_period_unit": {
             "allOf": [
@@ -16944,7 +16909,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:35.612839+00:00"
+                "validatedAt": "2026-07-20T14:41:32.467491+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16982,7 +16947,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:35.612889+00:00"
+                "validatedAt": "2026-07-20T14:41:32.467505+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16993,7 +16958,7 @@
             },
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.014543+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.778948+00:00"
           },
           "transition_flow": {
             "allOf": [

--- a/docs/specifications/api/blindfold.json
+++ b/docs/specifications/api/blindfold.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Blindfold",
     "description": "Public key retrieval and secret policy enforcement for encrypted data handling. Policy rules govern access with configurable matching and transformation actions. VoltShare integration provides decryption services, access counting, and audit log aggregation. Namespace-scoped policies enable fine-grained control over sensitive information with administrative overrides.",
-    "version": "2.1.182",
+    "version": "2.1.181",
     "contact": {
       "name": "F5 Distributed Cloud",
       "url": "https://docs.cloud.f5.com"
@@ -7343,7 +7343,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:21.681631+00:00"
+                "validatedAt": "2026-07-20T14:37:57.845569+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7389,7 +7389,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:21.681716+00:00"
+                "validatedAt": "2026-07-20T14:37:57.845596+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7427,7 +7427,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:21.681783+00:00"
+                "validatedAt": "2026-07-20T14:37:57.845636+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7639,7 +7639,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:21.681860+00:00"
+                "validatedAt": "2026-07-20T14:37:57.845666+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7728,7 +7728,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:21.681953+00:00"
+                "validatedAt": "2026-07-20T14:37:57.845703+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7953,7 +7953,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:21.682032+00:00"
+                "validatedAt": "2026-07-20T14:37:57.845733+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7979,7 +7979,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:21.682076+00:00"
+                "validatedAt": "2026-07-20T14:37:57.845751+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8004,7 +8004,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:21.682110+00:00"
+                "validatedAt": "2026-07-20T14:37:57.845765+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8016,7 +8016,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.533373+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.847633+00:00"
           }
         },
         "x-f5xc-description-short": "F5XC Secret Management uses asymmetric cryptography for securing secrets.",
@@ -8088,7 +8088,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:21.682147+00:00"
+                "validatedAt": "2026-07-20T14:37:57.845786+00:00"
               },
               "deterministic": true
             },
@@ -8100,9 +8100,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.533395+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.847647+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -8133,7 +8132,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:21.682179+00:00"
+                "validatedAt": "2026-07-20T14:37:57.845801+00:00"
               },
               "deterministic": true
             },
@@ -8145,9 +8144,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.533414+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.847658+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "policy_id": {
             "type": "string",
@@ -8176,7 +8174,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:21.682220+00:00"
+                "validatedAt": "2026-07-20T14:37:57.845818+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8216,7 +8214,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:21.682263+00:00"
+                "validatedAt": "2026-07-20T14:37:57.845834+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8228,7 +8226,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.533446+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.847678+00:00"
           }
         },
         "x-f5xc-description-short": "Policy_data contains the information about the secret policy and all the secret policy rules for the policy.",
@@ -8305,7 +8303,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:01:21.682302+00:00"
+                "validatedAt": "2026-07-20T14:37:57.845856+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8365,7 +8363,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.589614+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.881133+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Avg Aggregation Data\" Average Aggregation data.",
@@ -8417,7 +8415,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:25.643411+00:00"
+                "validatedAt": "2026-07-20T14:37:59.370800+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8493,7 +8491,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:25.643488+00:00"
+                "validatedAt": "2026-07-20T14:37:59.370824+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8566,7 +8564,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:25.643549+00:00"
+                "validatedAt": "2026-07-20T14:37:59.370840+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8605,7 +8603,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T13:01:25.643625+00:00"
+                "validatedAt": "2026-07-20T14:37:59.370862+00:00"
               },
               "deterministic": true
             },
@@ -8699,7 +8697,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:25.643710+00:00"
+                "validatedAt": "2026-07-20T14:37:59.370882+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8824,7 +8822,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:25.643761+00:00"
+                "validatedAt": "2026-07-20T14:37:59.370902+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8847,7 +8845,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:25.643789+00:00"
+                "validatedAt": "2026-07-20T14:37:59.370913+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8858,7 +8856,7 @@
             },
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.589747+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.881201+00:00"
           },
           "order_by": {
             "allOf": [
@@ -9004,7 +9002,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:25.643847+00:00"
+                "validatedAt": "2026-07-20T14:37:59.370935+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9028,7 +9026,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:25.643873+00:00"
+                "validatedAt": "2026-07-20T14:37:59.370946+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9039,7 +9037,7 @@
             },
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.589804+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.881234+00:00"
           },
           "order_by": {
             "allOf": [
@@ -9107,7 +9105,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:25.643911+00:00"
+                "validatedAt": "2026-07-20T14:37:59.370961+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9131,7 +9129,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:25.643938+00:00"
+                "validatedAt": "2026-07-20T14:37:59.370972+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9142,7 +9140,7 @@
             },
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.589837+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.881255+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Field Sub Field Aggregation Bucket\" Field sub aggregation bucket containing field values and the number of logs.",
@@ -9196,7 +9194,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:25.643974+00:00"
+                "validatedAt": "2026-07-20T14:37:59.370985+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9269,7 +9267,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:25.644012+00:00"
+                "validatedAt": "2026-07-20T14:37:59.371001+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9293,7 +9291,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:25.644039+00:00"
+                "validatedAt": "2026-07-20T14:37:59.371011+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9304,7 +9302,7 @@
             },
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.589880+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.881280+00:00"
           },
           "sub_aggs": {
             "type": "object",
@@ -9416,7 +9414,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.589909+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.881297+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Max Aggregation Data\" Max Aggregation data.",
@@ -9515,7 +9513,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.589939+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.881314+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Min Aggregation Data\" Min Aggregation data.",
@@ -9567,7 +9565,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:25.644105+00:00"
+                "validatedAt": "2026-07-20T14:37:59.371037+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9720,7 +9718,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:25.644163+00:00"
+                "validatedAt": "2026-07-20T14:37:59.371059+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9829,7 +9827,7 @@
             "maxLength": 16,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.590014+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.881358+00:00"
           },
           "value": {
             "type": "number",
@@ -9845,7 +9843,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.590032+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.881369+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Percentile Aggregation Data\" Percentile Aggregation data.",
@@ -9898,7 +9896,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:25.644223+00:00"
+                "validatedAt": "2026-07-20T14:37:59.371082+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10045,7 +10043,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:25.644288+00:00"
+                "validatedAt": "2026-07-20T14:37:59.371107+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10070,7 +10068,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:25.644325+00:00"
+                "validatedAt": "2026-07-20T14:37:59.371122+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10095,7 +10093,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:25.644359+00:00"
+                "validatedAt": "2026-07-20T14:37:59.371135+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10121,7 +10119,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:25.644398+00:00"
+                "validatedAt": "2026-07-20T14:37:59.371151+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10253,7 +10251,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:25.644439+00:00"
+                "validatedAt": "2026-07-20T14:37:59.371167+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10264,7 +10262,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.590124+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.881421+00:00"
           }
         },
         "x-f5xc-description-short": "VoltShare Access metric is tagged with labels mentioned in MetricLabel.",
@@ -10374,7 +10372,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:25.644487+00:00"
+                "validatedAt": "2026-07-20T14:37:59.371186+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10385,7 +10383,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.590151+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.881438+00:00"
           }
         },
         "x-f5xc-description-short": "Value returned for a VoltShare Access Metrics query.",
@@ -10517,7 +10515,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:01:25.644538+00:00"
+                "validatedAt": "2026-07-20T14:37:59.371207+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10528,7 +10526,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.590173+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.881451+00:00"
           },
           "previous_value": {
             "type": "string",
@@ -10543,7 +10541,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:25.644579+00:00"
+                "validatedAt": "2026-07-20T14:37:59.371223+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10579,7 +10577,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:25.644615+00:00"
+                "validatedAt": "2026-07-20T14:37:59.371238+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10590,7 +10588,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.590205+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.881471+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Trend Value\" Trend value contains trend value, trend sentiment and trend calculation description and window size.",
@@ -10670,7 +10668,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:25.644675+00:00"
+                "validatedAt": "2026-07-20T14:37:59.371258+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10710,7 +10708,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:25.644711+00:00"
+                "validatedAt": "2026-07-20T14:37:59.371274+00:00"
               },
               "deterministic": true
             },
@@ -10722,9 +10720,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.590241+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.881492+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query": {
             "type": "string",
@@ -10744,7 +10741,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:01:25.644754+00:00"
+                "validatedAt": "2026-07-20T14:37:59.371292+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10777,7 +10774,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:25.644795+00:00"
+                "validatedAt": "2026-07-20T14:37:59.371308+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10860,7 +10857,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:25.644840+00:00"
+                "validatedAt": "2026-07-20T14:37:59.371325+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10945,7 +10942,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:25.644884+00:00"
+                "validatedAt": "2026-07-20T14:37:59.371342+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10974,7 +10971,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:01:25.644919+00:00"
+                "validatedAt": "2026-07-20T14:37:59.371358+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11014,7 +11011,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:25.644950+00:00"
+                "validatedAt": "2026-07-20T14:37:59.371373+00:00"
               },
               "deterministic": true
             },
@@ -11026,9 +11023,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.590312+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.881532+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query": {
             "type": "string",
@@ -11048,7 +11044,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:01:25.644990+00:00"
+                "validatedAt": "2026-07-20T14:37:59.371390+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11112,7 +11108,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:25.645037+00:00"
+                "validatedAt": "2026-07-20T14:37:59.371408+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11246,7 +11242,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:25.645089+00:00"
+                "validatedAt": "2026-07-20T14:37:59.371428+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11275,7 +11271,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:25.645126+00:00"
+                "validatedAt": "2026-07-20T14:37:59.371443+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11369,7 +11365,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:25.645156+00:00"
+                "validatedAt": "2026-07-20T14:37:59.371457+00:00"
               },
               "deterministic": true
             },
@@ -11381,9 +11377,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.590388+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.881576+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "scroll_id": {
             "type": "string",
@@ -11401,7 +11396,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:25.645191+00:00"
+                "validatedAt": "2026-07-20T14:37:59.371471+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11474,7 +11469,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:25.645240+00:00"
+                "validatedAt": "2026-07-20T14:37:59.371491+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11521,7 +11516,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:25.645293+00:00"
+                "validatedAt": "2026-07-20T14:37:59.371512+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11585,7 +11580,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:25.645337+00:00"
+                "validatedAt": "2026-07-20T14:37:59.371529+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11676,7 +11671,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:25.645395+00:00"
+                "validatedAt": "2026-07-20T14:37:59.371552+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11717,7 +11712,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:25.645436+00:00"
+                "validatedAt": "2026-07-20T14:37:59.371567+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11743,7 +11738,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:25.645474+00:00"
+                "validatedAt": "2026-07-20T14:37:59.371582+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11819,7 +11814,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:25.645529+00:00"
+                "validatedAt": "2026-07-20T14:37:59.371608+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11845,7 +11840,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:25.645571+00:00"
+                "validatedAt": "2026-07-20T14:37:59.371625+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11939,7 +11934,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:25.645641+00:00"
+                "validatedAt": "2026-07-20T14:37:59.371657+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12017,7 +12012,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:25.645698+00:00"
+                "validatedAt": "2026-07-20T14:37:59.371676+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12054,7 +12049,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T13:01:25.645746+00:00"
+                "validatedAt": "2026-07-20T14:37:59.371695+00:00"
               },
               "deterministic": true
             },
@@ -12140,7 +12135,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:25.645813+00:00"
+                "validatedAt": "2026-07-20T14:37:59.371728+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -12185,7 +12180,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:25.645867+00:00"
+                "validatedAt": "2026-07-20T14:37:59.371754+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12257,7 +12252,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:25.645910+00:00"
+                "validatedAt": "2026-07-20T14:37:59.371771+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12331,7 +12326,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:25.645964+00:00"
+                "validatedAt": "2026-07-20T14:37:59.371793+00:00"
               },
               "deterministic": true
             },
@@ -12343,9 +12338,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.590570+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.881681+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "start_time": {
             "type": "string",
@@ -12370,7 +12364,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:25.646004+00:00"
+                "validatedAt": "2026-07-20T14:37:59.371809+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12403,7 +12397,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:25.646037+00:00"
+                "validatedAt": "2026-07-20T14:37:59.371822+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12496,7 +12490,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:25.646082+00:00"
+                "validatedAt": "2026-07-20T14:37:59.371840+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12561,7 +12555,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:48.438850+00:00"
+                "validatedAt": "2026-07-20T14:38:07.960564+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12668,7 +12662,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:17.790007+00:00"
+                "validatedAt": "2026-07-20T14:40:16.055562+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12691,7 +12685,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:17.790076+00:00"
+                "validatedAt": "2026-07-20T14:40:16.055584+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12702,7 +12696,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.133740+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.757829+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -12758,7 +12752,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:17.790116+00:00"
+                "validatedAt": "2026-07-20T14:40:16.055599+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12857,7 +12851,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:17.790161+00:00"
+                "validatedAt": "2026-07-20T14:40:16.055619+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13044,7 +13038,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:17.790238+00:00"
+                "validatedAt": "2026-07-20T14:40:16.055643+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13085,7 +13079,7 @@
                 "confidence": 1.0,
                 "category": "content",
                 "note": "Blindfold envelope encryption (AES-256-GCM + RSA-OAEP) of an RSA-2048 TLS private key produces ~3700 char string:/// URL. 128KB max secret size = ~175KB base64. Discovery reported 1024 which is incorrect.",
-                "validatedAt": "2026-07-20T13:07:17.790286+00:00"
+                "validatedAt": "2026-07-20T14:40:16.055667+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13096,7 +13090,7 @@
             },
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.133823+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.757877+00:00"
           },
           "store_provider": {
             "type": "string",
@@ -13115,7 +13109,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:17.790330+00:00"
+                "validatedAt": "2026-07-20T14:40:16.055686+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13182,7 +13176,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:17.790367+00:00"
+                "validatedAt": "2026-07-20T14:40:16.055700+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13193,7 +13187,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.133850+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.757894+00:00"
           },
           "url": {
             "type": "string",
@@ -13231,7 +13225,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:17.790431+00:00"
+                "validatedAt": "2026-07-20T14:40:16.055730+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -13304,7 +13298,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T13:07:17.790466+00:00"
+                "validatedAt": "2026-07-20T14:40:16.055745+00:00"
               },
               "deterministic": true
             },
@@ -13315,8 +13309,7 @@
               "read": false
             },
             "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "minLength": 1,
-            "format": "fqdn"
+            "minLength": 1
           },
           "last_update_time": {
             "type": "string",
@@ -13333,7 +13326,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:17.790507+00:00"
+                "validatedAt": "2026-07-20T14:40:16.055762+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13360,7 +13353,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:17.790541+00:00"
+                "validatedAt": "2026-07-20T14:40:16.055775+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13371,7 +13364,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.133891+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.757919+00:00"
           },
           "service_name": {
             "type": "string",
@@ -13388,7 +13381,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:17.790580+00:00"
+                "validatedAt": "2026-07-20T14:40:16.055791+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13421,7 +13414,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:17.790617+00:00"
+                "validatedAt": "2026-07-20T14:40:16.055805+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13432,7 +13425,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.133916+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.757936+00:00"
           },
           "type": {
             "type": "string",
@@ -13457,7 +13450,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:17.790651+00:00"
+                "validatedAt": "2026-07-20T14:40:16.055818+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13597,7 +13590,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:17.790705+00:00"
+                "validatedAt": "2026-07-20T14:40:16.055834+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13720,7 +13713,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:17.790761+00:00"
+                "validatedAt": "2026-07-20T14:40:16.055860+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13828,7 +13821,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:17.790836+00:00"
+                "validatedAt": "2026-07-20T14:40:16.055893+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13938,7 +13931,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:17.790875+00:00"
+                "validatedAt": "2026-07-20T14:40:16.055911+00:00"
               },
               "deterministic": true
             },
@@ -13950,9 +13943,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.134008+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.757990+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -14086,7 +14078,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:17.790933+00:00"
+                "validatedAt": "2026-07-20T14:40:16.055936+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14312,7 +14304,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:17.791022+00:00"
+                "validatedAt": "2026-07-20T14:40:16.055976+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -14327,7 +14319,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.134080+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.758033+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -14397,7 +14389,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:17.791063+00:00"
+                "validatedAt": "2026-07-20T14:40:16.055993+00:00"
               },
               "deterministic": true
             },
@@ -14409,9 +14401,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.134113+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.758054+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -14444,7 +14435,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:17.791090+00:00"
+                "validatedAt": "2026-07-20T14:40:16.056006+00:00"
               },
               "deterministic": true
             },
@@ -14456,9 +14447,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.134131+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.758066+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -14556,7 +14546,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:17.791163+00:00"
+                "validatedAt": "2026-07-20T14:40:16.056039+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -14571,7 +14561,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.134159+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.758084+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -14643,7 +14633,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:17.791200+00:00"
+                "validatedAt": "2026-07-20T14:40:16.056057+00:00"
               },
               "deterministic": true
             },
@@ -14655,9 +14645,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.134192+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.758104+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -14690,7 +14679,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:17.791227+00:00"
+                "validatedAt": "2026-07-20T14:40:16.056070+00:00"
               },
               "deterministic": true
             },
@@ -14702,9 +14691,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.134211+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.758117+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -14765,7 +14753,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:17.791259+00:00"
+                "validatedAt": "2026-07-20T14:40:16.056082+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14777,7 +14765,7 @@
             "readOnly": true,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.134231+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.758130+00:00"
           },
           "name": {
             "type": "string",
@@ -14810,7 +14798,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:17.791285+00:00"
+                "validatedAt": "2026-07-20T14:40:16.056094+00:00"
               },
               "deterministic": true
             },
@@ -14822,9 +14810,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.134250+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.758142+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -14857,7 +14844,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:17.791313+00:00"
+                "validatedAt": "2026-07-20T14:40:16.056107+00:00"
               },
               "deterministic": true
             },
@@ -14869,9 +14856,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.134267+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.758154+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -14890,7 +14876,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:17.791346+00:00"
+                "validatedAt": "2026-07-20T14:40:16.056120+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14903,7 +14889,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.134286+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.758167+00:00"
           },
           "uid": {
             "type": "string",
@@ -14922,7 +14908,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:17.791371+00:00"
+                "validatedAt": "2026-07-20T14:40:16.056130+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14936,7 +14922,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.134306+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.758179+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -15034,7 +15020,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:17.791445+00:00"
+                "validatedAt": "2026-07-20T14:40:16.056163+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -15049,7 +15035,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.134334+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.758197+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -15119,7 +15105,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:17.791481+00:00"
+                "validatedAt": "2026-07-20T14:40:16.056180+00:00"
               },
               "deterministic": true
             },
@@ -15131,9 +15117,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.134367+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.758217+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -15166,7 +15151,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:17.791508+00:00"
+                "validatedAt": "2026-07-20T14:40:16.056193+00:00"
               },
               "deterministic": true
             },
@@ -15178,9 +15163,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.134385+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.758229+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -15497,7 +15481,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:17.791574+00:00"
+                "validatedAt": "2026-07-20T14:40:16.056221+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15564,7 +15548,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:17.791617+00:00"
+                "validatedAt": "2026-07-20T14:40:16.056238+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15592,7 +15576,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:17.791665+00:00"
+                "validatedAt": "2026-07-20T14:40:16.056253+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15620,7 +15604,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:17.791703+00:00"
+                "validatedAt": "2026-07-20T14:40:16.056268+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15659,7 +15643,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:17.791743+00:00"
+                "validatedAt": "2026-07-20T14:40:16.056284+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15686,7 +15670,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:17.791768+00:00"
+                "validatedAt": "2026-07-20T14:40:16.056294+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15699,7 +15683,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.134503+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.758299+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -15715,7 +15699,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:17.791802+00:00"
+                "validatedAt": "2026-07-20T14:40:16.056307+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15856,7 +15840,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:17.791855+00:00"
+                "validatedAt": "2026-07-20T14:40:16.056327+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15867,7 +15851,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.134544+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.758324+00:00"
           },
           "status": {
             "type": "string",
@@ -15885,7 +15869,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:17.791889+00:00"
+                "validatedAt": "2026-07-20T14:40:16.056340+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15896,7 +15880,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.134563+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.758336+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -15954,7 +15938,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:17.791934+00:00"
+                "validatedAt": "2026-07-20T14:40:16.056357+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15981,7 +15965,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:17.791973+00:00"
+                "validatedAt": "2026-07-20T14:40:16.056372+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16008,7 +15992,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:17.792010+00:00"
+                "validatedAt": "2026-07-20T14:40:16.056387+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16036,7 +16020,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:17.792052+00:00"
+                "validatedAt": "2026-07-20T14:40:16.056403+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16112,7 +16096,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:17.792116+00:00"
+                "validatedAt": "2026-07-20T14:40:16.056427+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16180,7 +16164,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:17.792166+00:00"
+                "validatedAt": "2026-07-20T14:40:16.056445+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16192,7 +16176,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.134649+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.758389+00:00"
           },
           "uid": {
             "type": "string",
@@ -16211,7 +16195,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:17.792192+00:00"
+                "validatedAt": "2026-07-20T14:40:16.056455+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16224,7 +16208,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.134677+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.758401+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -16313,7 +16297,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:17.792259+00:00"
+                "validatedAt": "2026-07-20T14:40:16.056486+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16360,7 +16344,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:07:17.792308+00:00"
+                "validatedAt": "2026-07-20T14:40:16.056506+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16371,7 +16355,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.134711+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.758422+00:00"
           },
           "disable_ocsp_stapling": {
             "allOf": [
@@ -16494,7 +16478,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:17.792361+00:00"
+                "validatedAt": "2026-07-20T14:40:16.056530+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16702,7 +16686,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:17.792455+00:00"
+                "validatedAt": "2026-07-20T14:40:16.056571+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16798,7 +16782,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:17.792515+00:00"
+                "validatedAt": "2026-07-20T14:40:16.056598+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16940,7 +16924,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:17.792572+00:00"
+                "validatedAt": "2026-07-20T14:40:16.056623+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17175,7 +17159,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:17.792672+00:00"
+                "validatedAt": "2026-07-20T14:40:16.056663+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17187,8 +17171,7 @@
             "x-f5xc-conflicts-with": [
               "disable_sni",
               "use_host_header_as_sni"
-            ],
-            "format": "hostname"
+            ]
           },
           "use_host_header_as_sni": {
             "allOf": [
@@ -17324,7 +17307,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:17.792725+00:00"
+                "validatedAt": "2026-07-20T14:40:16.056686+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17461,7 +17444,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:17.792764+00:00"
+                "validatedAt": "2026-07-20T14:40:16.056702+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17472,7 +17455,7 @@
             },
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.134947+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.758565+00:00"
           },
           "name": {
             "type": "string",
@@ -17505,7 +17488,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:17.792793+00:00"
+                "validatedAt": "2026-07-20T14:40:16.056715+00:00"
               },
               "deterministic": true
             },
@@ -17517,9 +17500,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.134966+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.758577+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -17552,7 +17534,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:17.792821+00:00"
+                "validatedAt": "2026-07-20T14:40:16.056727+00:00"
               },
               "deterministic": true
             },
@@ -17564,9 +17546,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.134985+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.758590+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "uid": {
             "type": "string",
@@ -17583,7 +17564,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:17.792846+00:00"
+                "validatedAt": "2026-07-20T14:40:16.056738+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17596,7 +17577,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.135004+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.758602+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -17876,7 +17857,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:17.792931+00:00"
+                "validatedAt": "2026-07-20T14:40:16.056775+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17995,7 +17976,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:17.792967+00:00"
+                "validatedAt": "2026-07-20T14:40:16.056791+00:00"
               },
               "deterministic": true
             },
@@ -18007,9 +17988,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.135087+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.758652+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -18041,7 +18021,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:17.792994+00:00"
+                "validatedAt": "2026-07-20T14:40:16.056804+00:00"
               },
               "deterministic": true
             },
@@ -18053,9 +18033,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.135105+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.758665+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -18218,7 +18197,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.135170+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.758705+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -18323,7 +18302,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:17.793133+00:00"
+                "validatedAt": "2026-07-20T14:40:16.056860+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18429,7 +18408,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:07:17.793178+00:00"
+                "validatedAt": "2026-07-20T14:40:16.056879+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18508,7 +18487,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:07:17.793229+00:00"
+                "validatedAt": "2026-07-20T14:40:16.056901+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18519,7 +18498,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.135241+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.758748+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -18607,7 +18586,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:17.793269+00:00"
+                "validatedAt": "2026-07-20T14:40:16.056918+00:00"
               },
               "deterministic": true
             },
@@ -18619,9 +18598,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.135285+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.758776+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -18652,7 +18630,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:17.793296+00:00"
+                "validatedAt": "2026-07-20T14:40:16.056930+00:00"
               },
               "deterministic": true
             },
@@ -18664,9 +18642,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.135304+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.758788+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -18735,7 +18712,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:17.793347+00:00"
+                "validatedAt": "2026-07-20T14:40:16.056950+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18747,7 +18724,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.135341+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.758812+00:00"
           },
           "uid": {
             "type": "string",
@@ -18765,7 +18742,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:17.793373+00:00"
+                "validatedAt": "2026-07-20T14:40:16.056961+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18778,7 +18755,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.135360+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.758824+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of secret_management_access is returned in 'List'.",
@@ -18969,7 +18946,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:17.793446+00:00"
+                "validatedAt": "2026-07-20T14:40:16.056994+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19141,7 +19118,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:19.867065+00:00"
+                "validatedAt": "2026-07-20T14:40:16.844401+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19153,7 +19130,7 @@
             "readOnly": true,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.171934+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.782214+00:00"
           },
           "name": {
             "type": "string",
@@ -19186,7 +19163,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:19.867140+00:00"
+                "validatedAt": "2026-07-20T14:40:16.844426+00:00"
               },
               "deterministic": true
             },
@@ -19198,9 +19175,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.171956+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.782228+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -19233,7 +19209,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:19.867172+00:00"
+                "validatedAt": "2026-07-20T14:40:16.844440+00:00"
               },
               "deterministic": true
             },
@@ -19245,9 +19221,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.171975+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.782241+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -19266,7 +19241,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:19.867207+00:00"
+                "validatedAt": "2026-07-20T14:40:16.844454+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19279,7 +19254,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.171994+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.782253+00:00"
           },
           "uid": {
             "type": "string",
@@ -19298,7 +19273,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:19.867244+00:00"
+                "validatedAt": "2026-07-20T14:40:16.844465+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19312,7 +19287,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.172014+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.782266+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -19381,7 +19356,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:19.867931+00:00"
+                "validatedAt": "2026-07-20T14:40:16.844751+00:00"
               },
               "deterministic": true
             },
@@ -19393,7 +19368,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.172219+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.782396+00:00"
           },
           "name": {
             "type": "string",
@@ -19437,7 +19412,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:19.867983+00:00"
+                "validatedAt": "2026-07-20T14:40:16.844777+00:00"
               },
               "deterministic": true
             },
@@ -19447,8 +19422,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "MessageMetaType is metadata (common attributes) of a message that only certain messages have.",
@@ -19522,7 +19496,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:19.869188+00:00"
+                "validatedAt": "2026-07-20T14:40:16.845275+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19625,7 +19599,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:19.869239+00:00"
+                "validatedAt": "2026-07-20T14:40:16.845295+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19652,7 +19626,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:19.869279+00:00"
+                "validatedAt": "2026-07-20T14:40:16.845310+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19788,7 +19762,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:19.869336+00:00"
+                "validatedAt": "2026-07-20T14:40:16.845332+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20063,7 +20037,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:19.869466+00:00"
+                "validatedAt": "2026-07-20T14:40:16.845388+00:00"
               },
               "deterministic": true
             },
@@ -20075,9 +20049,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.172944+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.782854+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -20109,7 +20082,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:19.869493+00:00"
+                "validatedAt": "2026-07-20T14:40:16.845401+00:00"
               },
               "deterministic": true
             },
@@ -20121,9 +20094,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.172963+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.782867+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -20288,7 +20260,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.173028+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.782908+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -20377,7 +20349,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:19.869620+00:00"
+                "validatedAt": "2026-07-20T14:40:16.845453+00:00"
               },
               "deterministic": true
             },
@@ -20463,7 +20435,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:07:19.869669+00:00"
+                "validatedAt": "2026-07-20T14:40:16.845470+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20544,7 +20516,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:07:19.869722+00:00"
+                "validatedAt": "2026-07-20T14:40:16.845491+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20555,7 +20527,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.173085+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.782944+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -20642,7 +20614,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:19.869763+00:00"
+                "validatedAt": "2026-07-20T14:40:16.845508+00:00"
               },
               "deterministic": true
             },
@@ -20654,9 +20626,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.173130+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.782972+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -20687,7 +20658,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:19.869790+00:00"
+                "validatedAt": "2026-07-20T14:40:16.845521+00:00"
               },
               "deterministic": true
             },
@@ -20699,9 +20670,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.173149+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.782985+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "system_metadata": {
             "allOf": [
@@ -20732,7 +20702,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:19.869828+00:00"
+                "validatedAt": "2026-07-20T14:40:16.845535+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20744,7 +20714,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.173173+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.783001+00:00"
           },
           "uid": {
             "type": "string",
@@ -20761,7 +20731,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:19.869854+00:00"
+                "validatedAt": "2026-07-20T14:40:16.845546+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20774,7 +20744,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.173192+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.783014+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -20859,7 +20829,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:07:19.869915+00:00"
+                "validatedAt": "2026-07-20T14:40:16.845563+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20940,7 +20910,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:07:19.869984+00:00"
+                "validatedAt": "2026-07-20T14:40:16.845584+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20951,7 +20921,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.173235+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.783040+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -21038,7 +21008,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:19.870025+00:00"
+                "validatedAt": "2026-07-20T14:40:16.845602+00:00"
               },
               "deterministic": true
             },
@@ -21050,9 +21020,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.173280+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.783069+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -21083,7 +21052,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:19.870053+00:00"
+                "validatedAt": "2026-07-20T14:40:16.845614+00:00"
               },
               "deterministic": true
             },
@@ -21095,9 +21064,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.173299+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.783081+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -21166,7 +21134,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:19.870107+00:00"
+                "validatedAt": "2026-07-20T14:40:16.845634+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21178,7 +21146,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.173337+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.783105+00:00"
           },
           "uid": {
             "type": "string",
@@ -21195,7 +21163,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:19.870133+00:00"
+                "validatedAt": "2026-07-20T14:40:16.845644+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21208,7 +21176,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.173356+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.783117+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of secret_policy is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -21299,7 +21267,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:19.870166+00:00"
+                "validatedAt": "2026-07-20T14:40:16.845658+00:00"
               },
               "deterministic": true
             },
@@ -21311,9 +21279,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.173376+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.783130+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -21352,7 +21319,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:19.870195+00:00"
+                "validatedAt": "2026-07-20T14:40:16.845672+00:00"
               },
               "deterministic": true
             },
@@ -21364,9 +21331,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.173394+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.783143+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Input message of the 'RecoverPolicy' RPC.",
@@ -21424,7 +21390,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:19.870230+00:00"
+                "validatedAt": "2026-07-20T14:40:16.845686+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21435,7 +21401,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.173414+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.783155+00:00"
           }
         },
         "x-f5xc-description-short": "Response message of the 'RecoverPolicy' RPC.",
@@ -21670,7 +21636,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:19.870300+00:00"
+                "validatedAt": "2026-07-20T14:40:16.845717+00:00"
               },
               "deterministic": true
             },
@@ -21755,7 +21721,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:19.870331+00:00"
+                "validatedAt": "2026-07-20T14:40:16.845731+00:00"
               },
               "deterministic": true
             },
@@ -21767,9 +21733,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.173473+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.783191+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -21808,7 +21773,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:19.870361+00:00"
+                "validatedAt": "2026-07-20T14:40:16.845745+00:00"
               },
               "deterministic": true
             },
@@ -21820,9 +21785,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.173491+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.783203+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Input message of the 'DeletePolicy' RPC.",
@@ -21880,7 +21844,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:19.870396+00:00"
+                "validatedAt": "2026-07-20T14:40:16.845759+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21891,7 +21855,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.173511+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.783216+00:00"
           }
         },
         "x-f5xc-description-short": "Response message of the 'DeletePolicy' RPC.",
@@ -22051,7 +22015,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:26.141199+00:00"
+                "validatedAt": "2026-07-20T14:40:19.443815+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22097,7 +22061,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:26.141246+00:00"
+                "validatedAt": "2026-07-20T14:40:19.443839+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22186,7 +22150,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:26.142924+00:00"
+                "validatedAt": "2026-07-20T14:40:19.444575+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22322,7 +22286,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:26.142996+00:00"
+                "validatedAt": "2026-07-20T14:40:19.444606+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22452,7 +22416,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:26.143066+00:00"
+                "validatedAt": "2026-07-20T14:40:19.444637+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22727,7 +22691,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:26.143128+00:00"
+                "validatedAt": "2026-07-20T14:40:19.444661+00:00"
               },
               "deterministic": true
             },
@@ -22739,9 +22703,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.291897+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.868964+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -22773,7 +22736,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:26.143156+00:00"
+                "validatedAt": "2026-07-20T14:40:19.444674+00:00"
               },
               "deterministic": true
             },
@@ -22785,9 +22748,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.291916+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.868976+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -22950,7 +22912,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.291982+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.869017+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -23045,7 +23007,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:07:26.143269+00:00"
+                "validatedAt": "2026-07-20T14:40:19.444718+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23124,7 +23086,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:07:26.143321+00:00"
+                "validatedAt": "2026-07-20T14:40:19.444739+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23135,7 +23097,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.292031+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.869049+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -23222,7 +23184,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:26.143361+00:00"
+                "validatedAt": "2026-07-20T14:40:19.444757+00:00"
               },
               "deterministic": true
             },
@@ -23234,9 +23196,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.292076+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.869077+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -23267,7 +23228,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:26.143389+00:00"
+                "validatedAt": "2026-07-20T14:40:19.444768+00:00"
               },
               "deterministic": true
             },
@@ -23279,9 +23240,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.292094+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.869090+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -23350,7 +23310,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:26.143441+00:00"
+                "validatedAt": "2026-07-20T14:40:19.444788+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23362,7 +23322,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.292132+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.869114+00:00"
           },
           "uid": {
             "type": "string",
@@ -23380,7 +23340,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:26.143467+00:00"
+                "validatedAt": "2026-07-20T14:40:19.444798+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23393,7 +23353,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.292150+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.869127+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of secret_policy_rule is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -23653,7 +23613,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:18.508770+00:00"
+                "validatedAt": "2026-07-20T14:41:48.552386+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23687,7 +23647,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:18.508819+00:00"
+                "validatedAt": "2026-07-20T14:41:48.552410+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23772,7 +23732,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:18.508866+00:00"
+                "validatedAt": "2026-07-20T14:41:48.552429+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23806,7 +23766,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:18.508911+00:00"
+                "validatedAt": "2026-07-20T14:41:48.552451+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23889,7 +23849,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:18.508979+00:00"
+                "validatedAt": "2026-07-20T14:41:48.552482+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23933,7 +23893,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:18.509043+00:00"
+                "validatedAt": "2026-07-20T14:41:48.552510+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24016,7 +23976,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:18.509093+00:00"
+                "validatedAt": "2026-07-20T14:41:48.552529+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24050,7 +24010,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:18.509137+00:00"
+                "validatedAt": "2026-07-20T14:41:48.552551+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24270,7 +24230,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:18.509200+00:00"
+                "validatedAt": "2026-07-20T14:41:48.552580+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24360,7 +24320,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:18.509235+00:00"
+                "validatedAt": "2026-07-20T14:41:48.552596+00:00"
               },
               "deterministic": true
             },
@@ -24372,9 +24332,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.722972+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.662692+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -24406,7 +24365,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:18.509262+00:00"
+                "validatedAt": "2026-07-20T14:41:48.552610+00:00"
               },
               "deterministic": true
             },
@@ -24418,9 +24377,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.722991+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.662705+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -24583,7 +24541,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.723057+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.662746+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -24678,7 +24636,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:11:18.509375+00:00"
+                "validatedAt": "2026-07-20T14:41:48.552655+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24757,7 +24715,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:11:18.509425+00:00"
+                "validatedAt": "2026-07-20T14:41:48.552677+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24768,7 +24726,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.723108+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.662776+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -24856,7 +24814,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:18.509464+00:00"
+                "validatedAt": "2026-07-20T14:41:48.552695+00:00"
               },
               "deterministic": true
             },
@@ -24868,9 +24826,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.723153+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.662804+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -24901,7 +24858,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:18.509490+00:00"
+                "validatedAt": "2026-07-20T14:41:48.552709+00:00"
               },
               "deterministic": true
             },
@@ -24913,9 +24870,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.723172+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.662816+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -24984,7 +24940,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:18.509542+00:00"
+                "validatedAt": "2026-07-20T14:41:48.552729+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24996,7 +24952,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.723209+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.662840+00:00"
           },
           "uid": {
             "type": "string",
@@ -25014,7 +24970,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:18.509569+00:00"
+                "validatedAt": "2026-07-20T14:41:48.552740+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25027,7 +24983,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.723228+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.662853+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of voltshare_admin_policy is returned in 'List'.",
@@ -25430,7 +25386,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:18.509694+00:00"
+                "validatedAt": "2026-07-20T14:41:48.552788+00:00"
               }
             },
             "x-f5xc-required-for": {

--- a/docs/specifications/api/bot_and_threat_defense.json
+++ b/docs/specifications/api/bot_and_threat_defense.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Bot And Threat Defense",
     "description": "Behavioral fingerprinting identifies automated clients through request patterns, mouse movements, and JavaScript execution. Threat categories classify attacks by type including credential stuffing, scraping, and denial-of-service. Defense instances apply per-namespace policies with configurable sensitivity thresholds and challenge actions. Provisioning handles integration credentials for third-party threat intelligence feeds.",
-    "version": "2.1.182",
+    "version": "2.1.181",
     "contact": {
       "name": "F5 Distributed Cloud",
       "url": "https://docs.cloud.f5.com"
@@ -5019,7 +5019,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:16.379996+00:00"
+                "validatedAt": "2026-07-20T14:35:55.280086+00:00"
               },
               "deterministic": true
             },
@@ -5031,9 +5031,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.047871+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.889439+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -5065,7 +5064,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:16.380034+00:00"
+                "validatedAt": "2026-07-20T14:35:55.280105+00:00"
               },
               "deterministic": true
             },
@@ -5077,9 +5076,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.047891+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.889452+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -5149,7 +5147,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:16.380106+00:00"
+                "validatedAt": "2026-07-20T14:35:55.280139+00:00"
               },
               "deterministic": true
             },
@@ -5175,7 +5173,7 @@
             "maxLength": 4,
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.047920+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.889471+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -5551,7 +5549,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:16.380270+00:00"
+                "validatedAt": "2026-07-20T14:35:55.280195+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5587,7 +5585,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:16.380336+00:00"
+                "validatedAt": "2026-07-20T14:35:55.280226+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5595,8 +5593,7 @@
               "create": true,
               "update": false,
               "read": false
-            },
-            "format": "hostname"
+            }
           },
           "ingress": {
             "type": "array",
@@ -5631,7 +5628,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:16.380385+00:00"
+                "validatedAt": "2026-07-20T14:35:55.280251+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5721,7 +5718,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:16.380449+00:00"
+                "validatedAt": "2026-07-20T14:35:55.280280+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5732,8 +5729,7 @@
             },
             "x-f5xc-conflicts-with": [
               "ip_address"
-            ],
-            "format": "hostname"
+            ]
           },
           "ip_address": {
             "type": "string",
@@ -5760,7 +5756,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:16.380503+00:00"
+                "validatedAt": "2026-07-20T14:35:55.280308+00:00"
               },
               "deterministic": true
             },
@@ -5789,7 +5785,7 @@
             "maxLength": 4,
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.048064+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.889559+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -5866,7 +5862,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:56:16.380551+00:00"
+                "validatedAt": "2026-07-20T14:35:55.280329+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5947,7 +5943,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:56:16.380607+00:00"
+                "validatedAt": "2026-07-20T14:35:55.280354+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5958,7 +5954,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.048109+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.889586+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -6046,7 +6042,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:16.380648+00:00"
+                "validatedAt": "2026-07-20T14:35:55.280372+00:00"
               },
               "deterministic": true
             },
@@ -6058,9 +6054,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.048155+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.889615+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -6091,7 +6086,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:16.380687+00:00"
+                "validatedAt": "2026-07-20T14:35:55.280386+00:00"
               },
               "deterministic": true
             },
@@ -6103,9 +6098,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.048174+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.889628+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -6158,7 +6152,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:16.380727+00:00"
+                "validatedAt": "2026-07-20T14:35:55.280402+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6170,7 +6164,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.048205+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.889648+00:00"
           },
           "uid": {
             "type": "string",
@@ -6188,7 +6182,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:16.380752+00:00"
+                "validatedAt": "2026-07-20T14:35:55.280413+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6201,7 +6195,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.048226+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.889661+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of bot_defense_app_infrastructure is returned in 'List'.",
@@ -6512,7 +6506,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:16.380808+00:00"
+                "validatedAt": "2026-07-20T14:35:55.280435+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6524,7 +6518,7 @@
             "readOnly": true,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.048288+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.889700+00:00"
           },
           "name": {
             "type": "string",
@@ -6557,7 +6551,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:16.380834+00:00"
+                "validatedAt": "2026-07-20T14:35:55.280448+00:00"
               },
               "deterministic": true
             },
@@ -6569,9 +6563,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.048307+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.889712+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -6604,7 +6597,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:16.380860+00:00"
+                "validatedAt": "2026-07-20T14:35:55.280461+00:00"
               },
               "deterministic": true
             },
@@ -6616,9 +6609,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.048325+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.889725+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -6637,7 +6629,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:16.380893+00:00"
+                "validatedAt": "2026-07-20T14:35:55.280475+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6650,7 +6642,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.048344+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.889737+00:00"
           },
           "uid": {
             "type": "string",
@@ -6669,7 +6661,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:16.380918+00:00"
+                "validatedAt": "2026-07-20T14:35:55.280486+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6683,7 +6675,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.048363+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.889750+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -6739,7 +6731,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:16.380955+00:00"
+                "validatedAt": "2026-07-20T14:35:55.280501+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6762,7 +6754,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:16.380990+00:00"
+                "validatedAt": "2026-07-20T14:35:55.280515+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6773,7 +6765,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.048390+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.889767+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -6905,7 +6897,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:16.381031+00:00"
+                "validatedAt": "2026-07-20T14:35:55.280532+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6985,7 +6977,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:16.381058+00:00"
+                "validatedAt": "2026-07-20T14:35:55.280546+00:00"
               },
               "deterministic": true
             },
@@ -6997,9 +6989,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.048434+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.889794+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -7163,7 +7154,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:16.381151+00:00"
+                "validatedAt": "2026-07-20T14:35:55.280588+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -7178,7 +7169,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.048477+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.889821+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -7248,7 +7239,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:16.381188+00:00"
+                "validatedAt": "2026-07-20T14:35:55.280605+00:00"
               },
               "deterministic": true
             },
@@ -7260,9 +7251,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.048510+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.889842+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -7295,7 +7285,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:16.381215+00:00"
+                "validatedAt": "2026-07-20T14:35:55.280619+00:00"
               },
               "deterministic": true
             },
@@ -7307,9 +7297,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.048528+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.889854+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -7409,7 +7398,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:16.381287+00:00"
+                "validatedAt": "2026-07-20T14:35:55.280654+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -7424,7 +7413,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.048556+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.889872+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -7496,7 +7485,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:16.381322+00:00"
+                "validatedAt": "2026-07-20T14:35:55.280671+00:00"
               },
               "deterministic": true
             },
@@ -7508,9 +7497,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.048589+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.889893+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -7543,7 +7531,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:16.381347+00:00"
+                "validatedAt": "2026-07-20T14:35:55.280684+00:00"
               },
               "deterministic": true
             },
@@ -7555,9 +7543,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.048607+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.889905+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -7657,7 +7644,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:16.381418+00:00"
+                "validatedAt": "2026-07-20T14:35:55.280719+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -7672,7 +7659,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.048635+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.889923+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -7742,7 +7729,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:16.381453+00:00"
+                "validatedAt": "2026-07-20T14:35:55.280736+00:00"
               },
               "deterministic": true
             },
@@ -7754,9 +7741,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.048677+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.889944+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -7789,7 +7775,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:16.381478+00:00"
+                "validatedAt": "2026-07-20T14:35:55.280749+00:00"
               },
               "deterministic": true
             },
@@ -7801,9 +7787,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.048697+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.889956+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -7882,7 +7867,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:16.381524+00:00"
+                "validatedAt": "2026-07-20T14:35:55.280767+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7893,7 +7878,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.048723+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.889973+00:00"
           },
           "status": {
             "type": "string",
@@ -7911,7 +7896,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:16.381558+00:00"
+                "validatedAt": "2026-07-20T14:35:55.280782+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7922,7 +7907,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.048741+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.889985+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -7982,7 +7967,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:16.381601+00:00"
+                "validatedAt": "2026-07-20T14:35:55.280799+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8009,7 +7994,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:16.381641+00:00"
+                "validatedAt": "2026-07-20T14:35:55.280815+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8036,7 +8021,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:16.381686+00:00"
+                "validatedAt": "2026-07-20T14:35:55.280830+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8064,7 +8049,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:16.381729+00:00"
+                "validatedAt": "2026-07-20T14:35:55.280847+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8140,7 +8125,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:16.381792+00:00"
+                "validatedAt": "2026-07-20T14:35:55.280871+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8208,7 +8193,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:16.381841+00:00"
+                "validatedAt": "2026-07-20T14:35:55.280891+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8220,7 +8205,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.048827+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.890038+00:00"
           },
           "uid": {
             "type": "string",
@@ -8239,7 +8224,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:16.381866+00:00"
+                "validatedAt": "2026-07-20T14:35:55.280901+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8252,7 +8237,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.048846+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.890050+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -8320,7 +8305,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:16.381899+00:00"
+                "validatedAt": "2026-07-20T14:35:55.280915+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8331,7 +8316,7 @@
             },
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.048866+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.890063+00:00"
           },
           "name": {
             "type": "string",
@@ -8364,7 +8349,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:16.381925+00:00"
+                "validatedAt": "2026-07-20T14:35:55.280928+00:00"
               },
               "deterministic": true
             },
@@ -8376,9 +8361,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.048884+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.890076+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -8411,7 +8395,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:16.381951+00:00"
+                "validatedAt": "2026-07-20T14:35:55.280941+00:00"
               },
               "deterministic": true
             },
@@ -8423,9 +8407,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.048903+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.890088+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "uid": {
             "type": "string",
@@ -8442,7 +8425,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:16.381975+00:00"
+                "validatedAt": "2026-07-20T14:35:55.280951+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8455,7 +8438,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.048922+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.890100+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -8774,7 +8757,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:07:58.508043+00:00"
+                "validatedAt": "2026-07-20T14:40:31.827931+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8853,7 +8836,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:07:58.508092+00:00"
+                "validatedAt": "2026-07-20T14:40:31.827954+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8864,7 +8847,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.877534+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.394606+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -8952,7 +8935,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:58.508132+00:00"
+                "validatedAt": "2026-07-20T14:40:31.827972+00:00"
               },
               "deterministic": true
             },
@@ -8964,9 +8947,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.877579+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.394634+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -8997,7 +8979,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:58.508160+00:00"
+                "validatedAt": "2026-07-20T14:40:31.827986+00:00"
               },
               "deterministic": true
             },
@@ -9009,9 +8991,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.877597+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.394668+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -9064,7 +9045,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:58.508199+00:00"
+                "validatedAt": "2026-07-20T14:40:31.828002+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9076,7 +9057,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.877628+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.394690+00:00"
           },
           "uid": {
             "type": "string",
@@ -9094,7 +9075,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:58.508225+00:00"
+                "validatedAt": "2026-07-20T14:40:31.828013+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9107,7 +9088,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.877647+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.394703+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of shape_bot_defense_instance is returned in 'List'.",
@@ -9179,7 +9160,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T13:09:13.332241+00:00"
+                "validatedAt": "2026-07-20T14:41:02.024577+00:00"
               },
               "deterministic": true
             },
@@ -9190,8 +9171,7 @@
               "read": false
             },
             "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "minLength": 1,
-            "format": "fqdn"
+            "minLength": 1
           },
           "last_update_time": {
             "type": "string",
@@ -9208,7 +9188,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:13.332289+00:00"
+                "validatedAt": "2026-07-20T14:41:02.024594+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9235,7 +9215,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:13.332337+00:00"
+                "validatedAt": "2026-07-20T14:41:02.024608+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9246,7 +9226,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.790710+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.174966+00:00"
           },
           "service_name": {
             "type": "string",
@@ -9263,7 +9243,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:13.332395+00:00"
+                "validatedAt": "2026-07-20T14:41:02.024624+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9296,7 +9276,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:13.332457+00:00"
+                "validatedAt": "2026-07-20T14:41:02.024640+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9307,7 +9287,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.790736+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.174981+00:00"
           },
           "type": {
             "type": "string",
@@ -9332,7 +9312,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:13.332512+00:00"
+                "validatedAt": "2026-07-20T14:41:02.024654+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9404,7 +9384,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:13.332976+00:00"
+                "validatedAt": "2026-07-20T14:41:02.024839+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9416,7 +9396,7 @@
             "readOnly": true,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.790985+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.175121+00:00"
           },
           "name": {
             "type": "string",
@@ -9449,7 +9429,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:13.333004+00:00"
+                "validatedAt": "2026-07-20T14:41:02.024852+00:00"
               },
               "deterministic": true
             },
@@ -9461,9 +9441,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.791004+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:23.175132+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -9496,7 +9475,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:13.333031+00:00"
+                "validatedAt": "2026-07-20T14:41:02.024865+00:00"
               },
               "deterministic": true
             },
@@ -9508,9 +9487,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.791023+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:23.175143+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -9529,7 +9507,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:13.333065+00:00"
+                "validatedAt": "2026-07-20T14:41:02.024879+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9542,7 +9520,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.791042+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.175154+00:00"
           },
           "uid": {
             "type": "string",
@@ -9561,7 +9539,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:13.333092+00:00"
+                "validatedAt": "2026-07-20T14:41:02.024889+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9575,7 +9553,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.791062+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.175165+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -9638,7 +9616,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:13.333272+00:00"
+                "validatedAt": "2026-07-20T14:41:02.024968+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9666,7 +9644,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:13.333312+00:00"
+                "validatedAt": "2026-07-20T14:41:02.024985+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9694,7 +9672,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:13.333349+00:00"
+                "validatedAt": "2026-07-20T14:41:02.024999+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9733,7 +9711,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:13.333389+00:00"
+                "validatedAt": "2026-07-20T14:41:02.025015+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9760,7 +9738,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:13.333415+00:00"
+                "validatedAt": "2026-07-20T14:41:02.025025+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9773,7 +9751,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.791198+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.175240+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -9789,7 +9767,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:13.333449+00:00"
+                "validatedAt": "2026-07-20T14:41:02.025039+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10079,7 +10057,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:13.334021+00:00"
+                "validatedAt": "2026-07-20T14:41:02.025272+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10273,7 +10251,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.791561+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.175439+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -10367,7 +10345,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:13.334138+00:00"
+                "validatedAt": "2026-07-20T14:41:02.025321+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10426,7 +10404,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:13.334184+00:00"
+                "validatedAt": "2026-07-20T14:41:02.025339+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10453,7 +10431,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:13.334224+00:00"
+                "validatedAt": "2026-07-20T14:41:02.025355+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10540,7 +10518,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:09:13.334268+00:00"
+                "validatedAt": "2026-07-20T14:41:02.025374+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10621,7 +10599,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:09:13.334316+00:00"
+                "validatedAt": "2026-07-20T14:41:02.025395+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10632,7 +10610,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.791648+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.175484+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -10719,7 +10697,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:13.334355+00:00"
+                "validatedAt": "2026-07-20T14:41:02.025413+00:00"
               },
               "deterministic": true
             },
@@ -10731,9 +10709,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.791702+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:23.175508+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -10764,7 +10741,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:13.334382+00:00"
+                "validatedAt": "2026-07-20T14:41:02.025426+00:00"
               },
               "deterministic": true
             },
@@ -10776,9 +10753,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.791721+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:23.175519+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -10847,7 +10823,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:13.334432+00:00"
+                "validatedAt": "2026-07-20T14:41:02.025446+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10859,7 +10835,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.791758+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.175539+00:00"
           },
           "uid": {
             "type": "string",
@@ -10876,7 +10852,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:13.334457+00:00"
+                "validatedAt": "2026-07-20T14:41:02.025456+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10889,7 +10865,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.791778+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.175551+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of tpm_api_key is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -11074,7 +11050,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:13.334509+00:00"
+                "validatedAt": "2026-07-20T14:41:02.025477+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11101,7 +11077,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:13.334549+00:00"
+                "validatedAt": "2026-07-20T14:41:02.025493+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11435,7 +11411,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:17.152150+00:00"
+                "validatedAt": "2026-07-20T14:41:03.437014+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11612,7 +11588,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.847745+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.288488+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -11690,7 +11666,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:17.152265+00:00"
+                "validatedAt": "2026-07-20T14:41:03.437058+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11716,7 +11692,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:17.152305+00:00"
+                "validatedAt": "2026-07-20T14:41:03.437074+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11742,7 +11718,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:17.152343+00:00"
+                "validatedAt": "2026-07-20T14:41:03.437089+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11768,7 +11744,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:17.152380+00:00"
+                "validatedAt": "2026-07-20T14:41:03.437103+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11827,7 +11803,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:17.152439+00:00"
+                "validatedAt": "2026-07-20T14:41:03.437130+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11915,7 +11891,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:09:17.152484+00:00"
+                "validatedAt": "2026-07-20T14:41:03.437150+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11996,7 +11972,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:09:17.152534+00:00"
+                "validatedAt": "2026-07-20T14:41:03.437170+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12007,7 +11983,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.847837+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.288540+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -12094,7 +12070,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:17.152573+00:00"
+                "validatedAt": "2026-07-20T14:41:03.437188+00:00"
               },
               "deterministic": true
             },
@@ -12106,9 +12082,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.847883+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:23.288567+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -12139,7 +12114,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:17.152602+00:00"
+                "validatedAt": "2026-07-20T14:41:03.437200+00:00"
               },
               "deterministic": true
             },
@@ -12151,9 +12126,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.847901+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:23.288579+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -12222,7 +12196,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:17.152663+00:00"
+                "validatedAt": "2026-07-20T14:41:03.437220+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12234,7 +12208,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.847938+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.288601+00:00"
           },
           "uid": {
             "type": "string",
@@ -12251,7 +12225,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:17.152691+00:00"
+                "validatedAt": "2026-07-20T14:41:03.437231+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12264,7 +12238,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.847958+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.288613+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of tpm_category is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -12850,7 +12824,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.872728+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.316554+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -12926,7 +12900,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:19.006694+00:00"
+                "validatedAt": "2026-07-20T14:41:04.106892+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12953,7 +12927,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:19.006737+00:00"
+                "validatedAt": "2026-07-20T14:41:04.106908+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13037,7 +13011,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:09:19.006782+00:00"
+                "validatedAt": "2026-07-20T14:41:04.106927+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13118,7 +13092,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:09:19.006833+00:00"
+                "validatedAt": "2026-07-20T14:41:04.106949+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13129,7 +13103,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.872794+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.316588+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -13216,7 +13190,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:19.006872+00:00"
+                "validatedAt": "2026-07-20T14:41:04.106966+00:00"
               },
               "deterministic": true
             },
@@ -13228,9 +13202,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.872840+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:23.316614+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -13261,7 +13234,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:19.006899+00:00"
+                "validatedAt": "2026-07-20T14:41:04.106979+00:00"
               },
               "deterministic": true
             },
@@ -13273,9 +13246,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.872858+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:23.316624+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -13344,7 +13316,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:19.006950+00:00"
+                "validatedAt": "2026-07-20T14:41:04.106999+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13356,7 +13328,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.872896+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.316645+00:00"
           },
           "uid": {
             "type": "string",
@@ -13373,7 +13345,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:19.006975+00:00"
+                "validatedAt": "2026-07-20T14:41:04.107010+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13386,7 +13358,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.872915+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.316657+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of tpm_manager is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -13563,7 +13535,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:23.851755+00:00"
+                "validatedAt": "2026-07-20T14:41:05.814623+00:00"
               },
               "deterministic": true
             },
@@ -13575,9 +13547,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.908033+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:23.404021+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "serial": {
             "type": "string",
@@ -13601,7 +13572,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:23.851804+00:00"
+                "validatedAt": "2026-07-20T14:41:05.814644+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13633,7 +13604,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:23.851858+00:00"
+                "validatedAt": "2026-07-20T14:41:05.814660+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13665,7 +13636,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:23.851911+00:00"
+                "validatedAt": "2026-07-20T14:41:05.814676+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13676,7 +13647,7 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.908068+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.404043+00:00"
           }
         },
         "x-f5xc-description-short": "DeviceInfo defines device parameters like Serial-Number to include in the TPM provisioning data.",
@@ -13748,7 +13719,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:23.851981+00:00"
+                "validatedAt": "2026-07-20T14:41:05.814697+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13828,7 +13799,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.908106+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.404067+00:00"
           }
         },
         "x-f5xc-description-short": "PreauthResponse defines the preauthorization response.",
@@ -13934,7 +13905,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:23.852065+00:00"
+                "validatedAt": "2026-07-20T14:41:05.814718+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13972,7 +13943,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:23.852122+00:00"
+                "validatedAt": "2026-07-20T14:41:05.814736+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14005,7 +13976,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:23.852152+00:00"
+                "validatedAt": "2026-07-20T14:41:05.814748+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14051,7 +14022,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:23.852193+00:00"
+                "validatedAt": "2026-07-20T14:41:05.814764+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14084,7 +14055,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:23.852235+00:00"
+                "validatedAt": "2026-07-20T14:41:05.814782+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14153,7 +14124,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:23.852278+00:00"
+                "validatedAt": "2026-07-20T14:41:05.814799+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14179,7 +14150,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:23.852320+00:00"
+                "validatedAt": "2026-07-20T14:41:05.814816+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14205,7 +14176,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:23.852354+00:00"
+                "validatedAt": "2026-07-20T14:41:05.814829+00:00"
               }
             },
             "x-f5xc-required-for": {

--- a/docs/specifications/api/cdn.json
+++ b/docs/specifications/api/cdn.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Cdn",
     "description": "Content delivery networks with edge caching, geographic distribution, and cache management. Supports custom rules, asset purge operations, and performance analytics. Enables worldwide asset distribution, optimization, and delivery monitoring across regions and protocols.",
-    "version": "2.1.182",
+    "version": "2.1.181",
     "contact": {
       "name": "F5 Distributed Cloud",
       "url": "https://docs.cloud.f5.com"
@@ -6403,7 +6403,7 @@
           },
           {
             "name": "response_format",
-            "description": "The format in which the configuration object is to be fetched. This could be for example\n - in GetSpec form for the contents of object\n - in CreateRequest form to create a new similar object\n - to ReplaceRequest form to replace changeable values\n\nDefault format of returned resource\nResponse should be in CreateRequest format\nResponse should be in StatusObject(s) format\nResponse should be in format of GetSpecType\nResponse should have other objects referring to this object\nResponse should have deleted and disabled objects referred by this object.",
+            "description": "The format in which the configuration object is to be fetched. This could be for example\n - in GetSpec form for the contents of object\n - in CreateRequest form to create a new similar object\n - to ReplaceRequest form to replace changeable values\n\nDefault format of returned resource\nResponse should be in CreateRequest format\nResponse should be in StatusObject(s) format\nResponse should be in format of GetSpecType\nResponse should have other objects referring to this object\nResponse should have deleted and disabled objects referrred by this object.",
             "in": "query",
             "required": false,
             "x-displayname": "Broken Referred Objects.",
@@ -7606,7 +7606,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.997051+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067444+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7630,7 +7630,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:29.997097+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067463+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7725,7 +7725,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.997142+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067484+00:00"
               },
               "deterministic": true
             },
@@ -7737,9 +7737,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.248552+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.961526+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -7771,7 +7770,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.997172+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067500+00:00"
               },
               "deterministic": true
             },
@@ -7783,9 +7782,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.248573+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.961540+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "path": {
             "type": "string",
@@ -7816,7 +7814,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.997266+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067538+00:00"
               },
               "deterministic": true
             },
@@ -7959,7 +7957,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.997340+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067571+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8022,7 +8020,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.997421+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067611+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8062,7 +8060,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.997454+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067627+00:00"
               },
               "deterministic": true
             },
@@ -8074,9 +8072,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.248636+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.961582+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -8108,7 +8105,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.997483+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067640+00:00"
               },
               "deterministic": true
             },
@@ -8120,9 +8117,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.248661+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.961595+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "user_id": {
             "type": "string",
@@ -8146,7 +8142,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.997540+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067670+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8245,7 +8241,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.997573+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067686+00:00"
               },
               "deterministic": true
             },
@@ -8257,9 +8253,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.248696+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.961617+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "rule": {
             "allOf": [
@@ -8356,7 +8351,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.997631+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067717+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8423,7 +8418,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.997677+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067732+00:00"
               },
               "deterministic": true
             },
@@ -8435,9 +8430,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.248749+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.961652+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -8469,7 +8463,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.997705+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067750+00:00"
               },
               "deterministic": true
             },
@@ -8481,9 +8475,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.248768+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.961665+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tls_fingerprint_matcher": {
             "allOf": [
@@ -8588,7 +8581,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:29.997761+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067772+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8701,7 +8694,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.997807+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067793+00:00"
               },
               "deterministic": true
             },
@@ -8713,9 +8706,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.248830+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.961705+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -8747,7 +8739,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.997836+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067807+00:00"
               },
               "deterministic": true
             },
@@ -8759,9 +8751,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.248848+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.961718+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "path": {
             "type": "string",
@@ -8792,7 +8783,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.997902+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067838+00:00"
               },
               "deterministic": true
             },
@@ -8981,7 +8972,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.997944+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067857+00:00"
               },
               "deterministic": true
             },
@@ -8993,9 +8984,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.248903+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.961753+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -9027,7 +9017,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.997971+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067869+00:00"
               },
               "deterministic": true
             },
@@ -9039,9 +9029,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.248922+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.961766+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "path": {
             "type": "string",
@@ -9072,7 +9061,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.998031+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067898+00:00"
               },
               "deterministic": true
             },
@@ -9238,7 +9227,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.998070+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067915+00:00"
               },
               "deterministic": true
             },
@@ -9250,9 +9239,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.248971+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.961798+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -9284,7 +9272,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.998097+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067928+00:00"
               },
               "deterministic": true
             },
@@ -9296,9 +9284,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.248989+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.961811+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "path": {
             "type": "string",
@@ -9329,7 +9316,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.998157+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067957+00:00"
               },
               "deterministic": true
             },
@@ -9472,7 +9459,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.998224+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067987+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9535,7 +9522,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.998300+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068020+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9591,7 +9578,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.998335+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068036+00:00"
               },
               "deterministic": true
             },
@@ -9603,9 +9590,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.249058+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.961855+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -9637,7 +9623,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.998363+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068049+00:00"
               },
               "deterministic": true
             },
@@ -9649,9 +9635,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.249076+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.961868+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "sec_event_name": {
             "type": "string",
@@ -9668,7 +9653,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:29.998404+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068065+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9707,7 +9692,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.998451+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068087+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9755,7 +9740,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.998512+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068114+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9858,7 +9843,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.998543+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068129+00:00"
               },
               "deterministic": true
             },
@@ -9870,9 +9855,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.249129+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.961903+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "rule": {
             "allOf": [
@@ -9968,7 +9952,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.998608+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068157+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9980,7 +9964,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.249164+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.961926+00:00"
           },
           "exclude_bot_names": {
             "type": "array",
@@ -10011,7 +9995,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.998662+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068180+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10050,7 +10034,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.998711+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068202+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10089,7 +10073,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.998758+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068224+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10129,7 +10113,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.998787+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068237+00:00"
               },
               "deterministic": true
             },
@@ -10141,9 +10125,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.249202+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.961952+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -10175,7 +10158,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.998815+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068250+00:00"
               },
               "deterministic": true
             },
@@ -10187,9 +10170,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.249220+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.961965+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "req_path": {
             "type": "string",
@@ -10213,7 +10195,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.998870+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068275+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10247,7 +10229,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.998942+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068309+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10348,7 +10330,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.998978+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068325+00:00"
               },
               "deterministic": true
             },
@@ -10360,9 +10342,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.249259+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.961992+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "waf_exclusion_policy": {
             "allOf": [
@@ -10472,7 +10453,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.999014+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068341+00:00"
               },
               "deterministic": true
             },
@@ -10484,9 +10465,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.249293+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.962014+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -10517,7 +10497,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.999041+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068353+00:00"
               },
               "deterministic": true
             },
@@ -10529,9 +10509,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.249311+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.962027+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "request_data": {
             "allOf": [
@@ -10619,7 +10598,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:29.999082+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068369+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10647,7 +10626,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:29.999119+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068383+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10675,7 +10654,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:29.999154+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068397+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10776,7 +10755,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.999204+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068420+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10788,7 +10767,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.249379+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.962071+00:00"
           }
         },
         "x-f5xc-description-short": "Metric label filter can be specified to query specific metrics based on label match.",
@@ -10937,7 +10916,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.999251+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068443+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10977,7 +10956,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.999282+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068458+00:00"
               },
               "deterministic": true
             },
@@ -10989,9 +10968,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.249408+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.962091+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "GET a list of virtual hosts in all the namespaces matching filter provided in the request.",
@@ -11176,7 +11154,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:29.999342+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068482+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11216,7 +11194,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.999370+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068495+00:00"
               },
               "deterministic": true
             },
@@ -11228,9 +11206,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.249452+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.962120+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query": {
             "type": "string",
@@ -11250,7 +11227,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T12:55:29.999412+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068514+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11283,7 +11260,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:29.999452+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068530+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11368,7 +11345,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:29.999496+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068548+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11441,7 +11418,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:29.999536+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068563+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11515,7 +11492,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.999590+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068587+00:00"
               },
               "deterministic": true
             },
@@ -11527,9 +11504,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.249521+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.962165+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "start_time": {
             "type": "string",
@@ -11554,7 +11530,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:29.999629+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068602+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11587,7 +11563,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:29.999670+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068615+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11680,7 +11656,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:29.999717+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068633+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11747,7 +11723,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:29.999750+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068646+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11775,7 +11751,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:29.999787+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068660+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11803,7 +11779,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:29.999822+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068677+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11890,7 +11866,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:29.999866+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068694+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11919,7 +11895,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T12:55:29.999902+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068714+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11959,7 +11935,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.999930+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068728+00:00"
               },
               "deterministic": true
             },
@@ -11971,9 +11947,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.249611+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.962222+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query": {
             "type": "string",
@@ -11993,7 +11968,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T12:55:29.999972+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068747+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12049,7 +12024,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.000013+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068763+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12082,7 +12057,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.000054+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068779+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12218,7 +12193,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.000108+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068799+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12247,7 +12222,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.000147+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068814+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12343,7 +12318,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.000176+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068828+00:00"
               },
               "deterministic": true
             },
@@ -12355,9 +12330,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.249704+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.962275+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "scroll_id": {
             "type": "string",
@@ -12375,7 +12349,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.000213+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068843+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12464,7 +12438,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.000257+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068878+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12504,7 +12478,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.000285+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068906+00:00"
               },
               "deterministic": true
             },
@@ -12516,9 +12490,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.249746+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.962303+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query": {
             "type": "string",
@@ -12538,7 +12511,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T12:55:30.000325+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068927+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12571,7 +12544,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.000365+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068946+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12656,7 +12629,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.000408+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068965+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12743,7 +12716,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.000453+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068985+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12772,7 +12745,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T12:55:30.000486+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069002+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12812,7 +12785,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.000513+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069016+00:00"
               },
               "deterministic": true
             },
@@ -12824,9 +12797,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.249814+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.962348+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query": {
             "type": "string",
@@ -12846,7 +12818,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T12:55:30.000553+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069034+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12902,7 +12874,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.000593+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069050+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12935,7 +12907,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.000633+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069067+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13071,7 +13043,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.000697+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069090+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13100,7 +13072,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.000736+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069105+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13196,7 +13168,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.000767+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069119+00:00"
               },
               "deterministic": true
             },
@@ -13208,9 +13180,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.249895+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.962402+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "scroll_id": {
             "type": "string",
@@ -13228,7 +13199,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.000804+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069133+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13317,7 +13288,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.000847+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069151+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13357,7 +13328,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.000875+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069164+00:00"
               },
               "deterministic": true
             },
@@ -13369,9 +13340,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.249935+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.962429+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query": {
             "type": "string",
@@ -13391,7 +13361,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T12:55:30.000915+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069184+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13424,7 +13394,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.000954+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069199+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13509,7 +13479,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.000996+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069216+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13596,7 +13566,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.001041+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069233+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13625,7 +13595,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T12:55:30.001074+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069248+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13665,7 +13635,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.001102+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069262+00:00"
               },
               "deterministic": true
             },
@@ -13677,9 +13647,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.250003+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.962474+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query": {
             "type": "string",
@@ -13699,7 +13668,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T12:55:30.001143+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069279+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13755,7 +13724,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.001183+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069295+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13788,7 +13757,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.001224+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069311+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13924,7 +13893,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.001277+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069331+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13953,7 +13922,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.001316+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069345+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14049,7 +14018,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.001346+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069359+00:00"
               },
               "deterministic": true
             },
@@ -14061,9 +14030,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.250084+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.962527+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "scroll_id": {
             "type": "string",
@@ -14081,7 +14049,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.001383+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069373+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14148,7 +14116,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.001424+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069389+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14177,7 +14145,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:55:30.001471+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069409+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14188,7 +14156,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.250117+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.962549+00:00"
           },
           "id": {
             "type": "string",
@@ -14214,7 +14182,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.001498+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069420+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14239,7 +14207,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.001532+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069433+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14272,7 +14240,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.001573+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069449+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14343,7 +14311,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.001618+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069469+00:00"
               },
               "deterministic": true
             },
@@ -14355,9 +14323,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.250162+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.962579+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "references": {
             "type": "array",
@@ -14398,7 +14365,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.001674+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069488+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14545,7 +14512,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.001728+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069509+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15101,7 +15068,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.001830+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069548+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15451,7 +15418,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.001920+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069589+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15589,7 +15556,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.001980+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069612+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15744,7 +15711,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.002059+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069647+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15823,7 +15790,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.002131+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069741+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15834,8 +15801,7 @@
             },
             "x-f5xc-conflicts-with": [
               "any_domain"
-            ],
-            "format": "fqdn"
+            ]
           }
         },
         "x-f5xc-description-short": "API Protection Rule for a specific endpoint.",
@@ -15987,7 +15953,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.002184+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069804+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16025,7 +15991,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.002245+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069849+00:00"
               },
               "deterministic": true
             },
@@ -16134,7 +16100,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.002314+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069883+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16241,7 +16207,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.002389+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069916+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16252,8 +16218,7 @@
             },
             "x-f5xc-conflicts-with": [
               "any_domain"
-            ],
-            "format": "fqdn"
+            ]
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -16376,7 +16341,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.002437+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069940+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16519,7 +16484,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.002508+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069972+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16558,7 +16523,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.002565+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069999+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16660,7 +16625,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.002626+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070030+00:00"
               },
               "deterministic": true
             },
@@ -16767,7 +16732,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T12:55:30.002674+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070049+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17298,7 +17263,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.002780+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070093+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17417,7 +17382,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.002834+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070122+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17526,7 +17491,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.002897+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070152+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17565,7 +17530,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.002953+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070178+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17617,7 +17582,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.003017+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070207+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17628,8 +17593,7 @@
             },
             "x-f5xc-conflicts-with": [
               "any_domain"
-            ],
-            "format": "fqdn"
+            ]
           },
           "validation_mode": {
             "allOf": [
@@ -17721,7 +17685,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.003065+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070231+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17804,7 +17768,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.003129+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070256+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17856,7 +17820,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.003171+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070273+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17894,7 +17858,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.003212+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070291+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17963,7 +17927,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.003280+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070323+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18220,7 +18184,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.003346+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070355+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18401,7 +18365,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.003424+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070388+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18472,7 +18436,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.003485+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070423+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -18486,8 +18450,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "presence": {
             "type": "boolean",
@@ -18532,7 +18495,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.003554+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070457+00:00"
               },
               "byteLength": {
                 "max": 256
@@ -18611,7 +18574,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.003588+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070469+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18623,7 +18586,7 @@
             "readOnly": true,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.250997+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.963121+00:00"
           },
           "name": {
             "type": "string",
@@ -18656,7 +18619,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.003616+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070482+00:00"
               },
               "deterministic": true
             },
@@ -18668,9 +18631,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.251017+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.963135+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -18703,7 +18665,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.003644+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070496+00:00"
               },
               "deterministic": true
             },
@@ -18715,9 +18677,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.251035+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.963148+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -18736,7 +18697,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.003686+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070509+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18749,7 +18710,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.251054+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.963161+00:00"
           },
           "uid": {
             "type": "string",
@@ -18768,7 +18729,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.003713+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070519+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18782,7 +18743,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.251074+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.963175+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -18840,7 +18801,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.251095+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.963189+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Avg Aggregation Data\" Average Aggregation data.",
@@ -18894,7 +18855,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.003774+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070538+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18972,7 +18933,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.003819+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070552+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19011,7 +18972,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T12:55:30.003866+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070571+00:00"
               },
               "deterministic": true
             },
@@ -19107,7 +19068,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.003919+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070589+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19170,7 +19131,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.003955+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070603+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19193,7 +19154,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.003983+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070617+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19204,7 +19165,7 @@
             },
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.251180+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.963246+00:00"
           },
           "order_by": {
             "allOf": [
@@ -19354,7 +19315,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.004047+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070640+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19378,7 +19339,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.004073+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070651+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19389,7 +19350,7 @@
             },
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.251235+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.963283+00:00"
           },
           "order_by": {
             "allOf": [
@@ -19459,7 +19420,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.004113+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070666+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19483,7 +19444,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.004139+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070677+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19494,7 +19455,7 @@
             },
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.251268+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.963306+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Field Sub Field Aggregation Bucket\" Field sub aggregation bucket containing field values and the number of logs.",
@@ -19550,7 +19511,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.004176+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070691+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19625,7 +19586,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.004216+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070706+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19649,7 +19610,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.004243+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070717+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19660,7 +19621,7 @@
             },
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.251311+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.963334+00:00"
           },
           "sub_aggs": {
             "type": "object",
@@ -19728,7 +19689,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.251339+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.963353+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Max Aggregation Data\" Max Aggregation data.",
@@ -19831,7 +19792,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.251367+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.963372+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Min Aggregation Data\" Min Aggregation data.",
@@ -19885,7 +19846,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.004313+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070742+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20042,7 +20003,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.004375+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070764+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20155,7 +20116,7 @@
             "maxLength": 16,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.251442+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.963421+00:00"
           },
           "value": {
             "type": "number",
@@ -20171,7 +20132,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.251460+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.963434+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Percentile Aggregation Data\" Percentile Aggregation data.",
@@ -20226,7 +20187,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.004440+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070791+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20390,7 +20351,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.004501+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070816+00:00"
               },
               "deterministic": true
             },
@@ -20402,9 +20363,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.251510+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.963466+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "sec_event_type": {
             "type": "string",
@@ -20421,7 +20381,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.004546+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070831+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20446,7 +20406,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.004589+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070847+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20471,7 +20431,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.004627+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070861+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20496,7 +20456,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.004682+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070875+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20633,7 +20593,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.004727+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070911+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20644,7 +20604,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.251570+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.963505+00:00"
           }
         },
         "x-f5xc-description-short": "Label based filtering for Security Events metrics. Security Events metrics are tagged with labels mentioned in MetricLabel.",
@@ -20758,7 +20718,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.004779+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070935+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20769,7 +20729,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.251596+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.963524+00:00"
           }
         },
         "x-f5xc-description-short": "Value returned for a Security Events Metrics query.",
@@ -20848,7 +20808,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.004850+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070970+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20939,7 +20899,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.004902+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070997+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20977,7 +20937,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.004949+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071021+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21014,7 +20974,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.004996+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071046+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21051,7 +21011,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.005042+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071068+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21141,7 +21101,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.005108+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071101+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21258,7 +21218,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.005192+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071136+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21361,7 +21321,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.005244+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071162+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21438,7 +21398,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.005287+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071183+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21509,7 +21469,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.005329+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071200+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21836,7 +21796,7 @@
             "maxLength": 26,
             "minLength": 15,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.251817+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:08.963660+00:00",
             "x-f5xc-conflicts-with": [
               "check_not_present",
               "check_present"
@@ -21881,7 +21841,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.005427+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071247+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -21896,9 +21856,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.251837+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.963674+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Cookie matcher specifies the name of a single cookie and the criteria to match it.",
@@ -22327,7 +22286,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.005474+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071270+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22469,7 +22428,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.005521+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071292+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22549,7 +22508,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.005568+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071314+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22665,7 +22624,7 @@
             "maxLength": 26,
             "minLength": 15,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.251916+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:08.963725+00:00",
             "x-f5xc-conflicts-with": [
               "check_not_present",
               "check_present"
@@ -22709,7 +22668,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.005632+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071345+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -22724,9 +22683,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.251934+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.963738+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "JWT claim matcher specifies the name of a single JWT claim and the criteria for the input request to match it.",
@@ -22859,7 +22817,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.005685+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071367+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22905,7 +22863,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.005728+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071388+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22943,7 +22901,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.005771+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071409+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23040,7 +22998,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.005821+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071432+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23115,7 +23073,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.005866+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071454+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23152,7 +23110,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.005919+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071481+00:00"
               },
               "deterministic": true
             },
@@ -23188,7 +23146,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.005958+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071501+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23223,7 +23181,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.006001+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071521+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23359,7 +23317,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.006076+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071554+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23371,8 +23329,7 @@
             "x-f5xc-conflicts-with": [
               "any_domain",
               "suffix_value"
-            ],
-            "format": "hostname"
+            ]
           },
           "expiration_timestamp": {
             "type": "string",
@@ -23393,7 +23350,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.006119+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071571+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23447,7 +23404,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.006167+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071594+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23483,7 +23440,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.006228+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071621+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23526,7 +23483,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.006287+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071649+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23571,7 +23528,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.006349+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071677+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23583,8 +23540,7 @@
             "x-f5xc-conflicts-with": [
               "any_domain",
               "exact_value"
-            ],
-            "format": "hostname"
+            ]
           },
           "waf_skip_processing": {
             "allOf": [
@@ -23680,7 +23636,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.006395+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071700+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23721,7 +23677,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.006438+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071722+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23763,7 +23719,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.006482+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071743+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24029,7 +23985,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.006525+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071765+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24102,7 +24058,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.006592+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071797+00:00"
               },
               "deterministic": true
             },
@@ -24114,7 +24070,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.252121+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.963860+00:00"
           },
           "name": {
             "type": "string",
@@ -24158,7 +24114,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.006642+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071822+00:00"
               },
               "deterministic": true
             },
@@ -24168,8 +24124,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "MessageMetaType is metadata (common attributes) of a message that only certain messages have.",
@@ -24355,7 +24310,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:55:30.006699+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071843+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24366,7 +24321,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.252153+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.963880+00:00"
           },
           "previous_value": {
             "type": "string",
@@ -24381,7 +24336,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.006738+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071858+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24417,7 +24372,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.006775+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071874+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24428,7 +24383,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.252185+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.963903+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Trend Value\" Trend value contains trend value, trend sentiment and trend calculation description and window size.",
@@ -24537,7 +24492,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.006812+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071890+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25159,7 +25114,7 @@
             "maxLength": 26,
             "minLength": 15,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.252328+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:08.963995+00:00",
             "x-f5xc-conflicts-with": [
               "check_not_present",
               "check_present"
@@ -25206,7 +25161,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.006949+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071949+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -25221,9 +25176,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.252347+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.964008+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Header matcher specifies the name of a single HTTP header and the criteria for the input request to match it.",
@@ -25301,7 +25255,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.006993+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071971+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25415,7 +25369,7 @@
             "maxLength": 26,
             "minLength": 15,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.252395+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:08.964039+00:00",
             "x-f5xc-conflicts-with": [
               "check_not_present",
               "check_present"
@@ -25450,7 +25404,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.007056+00:00"
+                "validatedAt": "2026-07-20T14:35:37.072000+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25461,7 +25415,7 @@
             },
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.252413+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.964052+00:00"
           }
         },
         "x-f5xc-description-short": "Query parameter matcher specifies the name of a single query parameter and the criteria for the input request to match it.",
@@ -25550,7 +25504,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.007107+00:00"
+                "validatedAt": "2026-07-20T14:35:37.072027+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -25564,8 +25518,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -25604,7 +25557,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.007155+00:00"
+                "validatedAt": "2026-07-20T14:35:37.072052+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -25619,9 +25572,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.252441+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.964071+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -25650,7 +25602,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.007207+00:00"
+                "validatedAt": "2026-07-20T14:35:37.072077+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25663,7 +25615,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.252460+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.964084+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a direct reference from one object(the referrer) to another(the referred).",
@@ -25928,7 +25880,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:35.072442+00:00"
+                "validatedAt": "2026-07-20T14:35:39.091566+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26067,7 +26019,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.732943+00:00"
+                "validatedAt": "2026-07-20T14:36:06.993734+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26158,7 +26110,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.733029+00:00"
+                "validatedAt": "2026-07-20T14:36:06.993769+00:00"
               },
               "deterministic": true
             },
@@ -26170,9 +26122,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.570810+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.282307+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-example": "[EMAIL, CC]",
@@ -26304,7 +26255,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.733096+00:00"
+                "validatedAt": "2026-07-20T14:36:06.993794+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26329,7 +26280,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.733158+00:00"
+                "validatedAt": "2026-07-20T14:36:06.993810+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26394,7 +26345,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.733211+00:00"
+                "validatedAt": "2026-07-20T14:36:06.993830+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26610,7 +26561,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.733276+00:00"
+                "validatedAt": "2026-07-20T14:36:06.993856+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26731,7 +26682,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.733348+00:00"
+                "validatedAt": "2026-07-20T14:36:06.993885+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26755,7 +26706,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.733388+00:00"
+                "validatedAt": "2026-07-20T14:36:06.993917+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26880,7 +26831,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.733436+00:00"
+                "validatedAt": "2026-07-20T14:36:06.993949+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26904,7 +26855,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.733475+00:00"
+                "validatedAt": "2026-07-20T14:36:06.993967+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27254,7 +27205,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.733562+00:00"
+                "validatedAt": "2026-07-20T14:36:06.994003+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27294,7 +27245,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.733595+00:00"
+                "validatedAt": "2026-07-20T14:36:06.994022+00:00"
               },
               "deterministic": true
             },
@@ -27306,9 +27257,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.571112+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.282485+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query": {
             "type": "array",
@@ -27343,7 +27293,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.733644+00:00"
+                "validatedAt": "2026-07-20T14:36:06.994043+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27456,7 +27406,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.733714+00:00"
+                "validatedAt": "2026-07-20T14:36:06.994074+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27586,7 +27536,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.733759+00:00"
+                "validatedAt": "2026-07-20T14:36:06.994093+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27623,7 +27573,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T12:56:45.733798+00:00"
+                "validatedAt": "2026-07-20T14:36:06.994112+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27663,7 +27613,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.733829+00:00"
+                "validatedAt": "2026-07-20T14:36:06.994127+00:00"
               },
               "deterministic": true
             },
@@ -27675,9 +27625,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.571190+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.282533+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query": {
             "type": "array",
@@ -27703,7 +27652,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.733871+00:00"
+                "validatedAt": "2026-07-20T14:36:06.994150+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27744,7 +27693,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.733913+00:00"
+                "validatedAt": "2026-07-20T14:36:06.994167+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27808,7 +27757,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.733956+00:00"
+                "validatedAt": "2026-07-20T14:36:06.994185+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27870,7 +27819,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.733989+00:00"
+                "validatedAt": "2026-07-20T14:36:06.994198+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28214,7 +28163,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.734088+00:00"
+                "validatedAt": "2026-07-20T14:36:06.994241+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28294,7 +28243,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.734132+00:00"
+                "validatedAt": "2026-07-20T14:36:06.994260+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28395,7 +28344,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.734187+00:00"
+                "validatedAt": "2026-07-20T14:36:06.994281+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28613,7 +28562,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.734259+00:00"
+                "validatedAt": "2026-07-20T14:36:06.994309+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28637,7 +28586,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.734303+00:00"
+                "validatedAt": "2026-07-20T14:36:06.994328+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29300,7 +29249,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.734456+00:00"
+                "validatedAt": "2026-07-20T14:36:06.994389+00:00"
               },
               "deterministic": true
             },
@@ -29312,9 +29261,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.571619+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.282785+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -29346,7 +29294,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.734485+00:00"
+                "validatedAt": "2026-07-20T14:36:06.994403+00:00"
               },
               "deterministic": true
             },
@@ -29358,9 +29306,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.571639+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.282798+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -29531,7 +29478,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.734529+00:00"
+                "validatedAt": "2026-07-20T14:36:06.994422+00:00"
               },
               "deterministic": true
             },
@@ -29543,9 +29490,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.571696+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.282828+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Request of GET Security Config Spec API.",
@@ -29711,7 +29657,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.571763+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.282869+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -29853,7 +29799,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.734646+00:00"
+                "validatedAt": "2026-07-20T14:36:06.994469+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29878,7 +29824,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.734692+00:00"
+                "validatedAt": "2026-07-20T14:36:06.994483+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29903,7 +29849,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.734728+00:00"
+                "validatedAt": "2026-07-20T14:36:06.994498+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29929,7 +29875,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.734765+00:00"
+                "validatedAt": "2026-07-20T14:36:06.994513+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29954,7 +29900,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.734806+00:00"
+                "validatedAt": "2026-07-20T14:36:06.994530+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29978,7 +29924,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.734841+00:00"
+                "validatedAt": "2026-07-20T14:36:06.994545+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30002,7 +29948,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.734881+00:00"
+                "validatedAt": "2026-07-20T14:36:06.994561+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30028,7 +29974,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.734917+00:00"
+                "validatedAt": "2026-07-20T14:36:06.994573+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30053,7 +29999,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.734958+00:00"
+                "validatedAt": "2026-07-20T14:36:06.994589+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30078,7 +30024,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.734997+00:00"
+                "validatedAt": "2026-07-20T14:36:06.994605+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30103,7 +30049,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.735031+00:00"
+                "validatedAt": "2026-07-20T14:36:06.994619+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30128,7 +30074,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.735066+00:00"
+                "validatedAt": "2026-07-20T14:36:06.994633+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30153,7 +30099,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.735109+00:00"
+                "validatedAt": "2026-07-20T14:36:06.994651+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30178,7 +30124,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.735144+00:00"
+                "validatedAt": "2026-07-20T14:36:06.994666+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30204,7 +30150,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.735181+00:00"
+                "validatedAt": "2026-07-20T14:36:06.994681+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30229,7 +30175,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.735221+00:00"
+                "validatedAt": "2026-07-20T14:36:06.994697+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30254,7 +30200,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.735257+00:00"
+                "validatedAt": "2026-07-20T14:36:06.994713+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30279,7 +30225,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.735298+00:00"
+                "validatedAt": "2026-07-20T14:36:06.994729+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30304,7 +30250,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.735340+00:00"
+                "validatedAt": "2026-07-20T14:36:06.994745+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30331,7 +30277,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.735376+00:00"
+                "validatedAt": "2026-07-20T14:36:06.994760+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30356,7 +30302,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.735412+00:00"
+                "validatedAt": "2026-07-20T14:36:06.994774+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30381,7 +30327,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.735450+00:00"
+                "validatedAt": "2026-07-20T14:36:06.994790+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30406,7 +30352,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.735484+00:00"
+                "validatedAt": "2026-07-20T14:36:06.994804+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30447,7 +30393,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T12:56:45.735535+00:00"
+                "validatedAt": "2026-07-20T14:36:06.994829+00:00"
               },
               "deterministic": true
             },
@@ -30473,7 +30419,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.735572+00:00"
+                "validatedAt": "2026-07-20T14:36:06.994844+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30498,7 +30444,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.735611+00:00"
+                "validatedAt": "2026-07-20T14:36:06.994860+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30522,7 +30468,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.735651+00:00"
+                "validatedAt": "2026-07-20T14:36:06.994877+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30546,7 +30492,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.735704+00:00"
+                "validatedAt": "2026-07-20T14:36:06.994895+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30571,7 +30517,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.735749+00:00"
+                "validatedAt": "2026-07-20T14:36:06.994912+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30596,7 +30542,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.735789+00:00"
+                "validatedAt": "2026-07-20T14:36:06.994929+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30626,7 +30572,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.735819+00:00"
+                "validatedAt": "2026-07-20T14:36:06.994944+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30651,7 +30597,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.735857+00:00"
+                "validatedAt": "2026-07-20T14:36:06.994960+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30970,7 +30916,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.735921+00:00"
+                "validatedAt": "2026-07-20T14:36:06.994986+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31007,7 +30953,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.735966+00:00"
+                "validatedAt": "2026-07-20T14:36:06.995010+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31084,7 +31030,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.736025+00:00"
+                "validatedAt": "2026-07-20T14:36:06.995036+00:00"
               },
               "deterministic": true
             },
@@ -31096,9 +31042,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.572062+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.283051+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "start_time": {
             "type": "string",
@@ -31123,7 +31068,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.736065+00:00"
+                "validatedAt": "2026-07-20T14:36:06.995053+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31150,7 +31095,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.736097+00:00"
+                "validatedAt": "2026-07-20T14:36:06.995066+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31223,7 +31168,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:56:45.736129+00:00"
+                "validatedAt": "2026-07-20T14:36:06.995083+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31250,7 +31195,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.736159+00:00"
+                "validatedAt": "2026-07-20T14:36:06.995096+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31398,7 +31343,7 @@
             "maxLength": 16,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.572132+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.283093+00:00"
           },
           "value": {
             "type": "string",
@@ -31413,7 +31358,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.736217+00:00"
+                "validatedAt": "2026-07-20T14:36:06.995121+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31424,7 +31369,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.572153+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.283107+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -31497,7 +31442,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.572181+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.283126+00:00"
           }
         },
         "x-f5xc-description-short": "CDN Metrics response series. Each series instance has data for a combination of group-by tag values.",
@@ -31562,7 +31507,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T12:56:45.736286+00:00"
+                "validatedAt": "2026-07-20T14:36:06.995152+00:00"
               },
               "deterministic": true
             },
@@ -31586,7 +31531,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.736318+00:00"
+                "validatedAt": "2026-07-20T14:36:06.995165+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31597,7 +31542,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.572210+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.283144+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -31719,7 +31664,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:56:45.736361+00:00"
+                "validatedAt": "2026-07-20T14:36:06.995186+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31800,7 +31745,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:56:45.736413+00:00"
+                "validatedAt": "2026-07-20T14:36:06.995210+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31811,7 +31756,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.572255+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.283171+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -31898,7 +31843,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.736453+00:00"
+                "validatedAt": "2026-07-20T14:36:06.995230+00:00"
               },
               "deterministic": true
             },
@@ -31910,9 +31855,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.572300+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.283199+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -31943,7 +31887,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.736481+00:00"
+                "validatedAt": "2026-07-20T14:36:06.995245+00:00"
               },
               "deterministic": true
             },
@@ -31955,9 +31899,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.572318+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.283211+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -32026,7 +31969,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.736535+00:00"
+                "validatedAt": "2026-07-20T14:36:06.995266+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32038,7 +31981,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.572356+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.283235+00:00"
           },
           "uid": {
             "type": "string",
@@ -32056,7 +31999,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.736560+00:00"
+                "validatedAt": "2026-07-20T14:36:06.995277+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32069,7 +32012,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.572376+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.283248+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of cdn_loadbalancer is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -32981,7 +32924,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.736792+00:00"
+                "validatedAt": "2026-07-20T14:36:06.995366+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33045,7 +32988,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.736827+00:00"
+                "validatedAt": "2026-07-20T14:36:06.995381+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33069,7 +33012,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.736857+00:00"
+                "validatedAt": "2026-07-20T14:36:06.995394+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33095,7 +33038,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.572609+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.283387+00:00"
           }
         },
         "x-f5xc-description-short": "CDN status is per site and it indicates the status of the CDN service for the LB on the site.",
@@ -33175,7 +33118,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.736892+00:00"
+                "validatedAt": "2026-07-20T14:36:06.995412+00:00"
               },
               "deterministic": true
             },
@@ -33187,9 +33130,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.572630+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.283415+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -33228,7 +33170,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.736922+00:00"
+                "validatedAt": "2026-07-20T14:36:06.995428+00:00"
               },
               "deterministic": true
             },
@@ -33240,9 +33182,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.572648+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.283430+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "service_op_id": {
             "type": "integer",
@@ -33340,7 +33281,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:56:45.736970+00:00"
+                "validatedAt": "2026-07-20T14:36:06.995451+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33435,7 +33376,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.737027+00:00"
+                "validatedAt": "2026-07-20T14:36:06.995482+00:00"
               },
               "deterministic": true
             },
@@ -33451,8 +33392,7 @@
               "url"
             ],
             "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "minLength": 1,
-            "format": "fqdn"
+            "minLength": 1
           },
           "pattern": {
             "type": "string",
@@ -33484,7 +33424,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.737086+00:00"
+                "validatedAt": "2026-07-20T14:36:06.995512+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33557,7 +33497,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T12:56:45.737123+00:00"
+                "validatedAt": "2026-07-20T14:36:06.995530+00:00"
               },
               "deterministic": true
             },
@@ -33718,7 +33658,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.737179+00:00"
+                "validatedAt": "2026-07-20T14:36:06.995556+00:00"
               },
               "deterministic": true
             },
@@ -33730,9 +33670,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.572759+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.283515+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -33771,7 +33710,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.737208+00:00"
+                "validatedAt": "2026-07-20T14:36:06.995571+00:00"
               },
               "deterministic": true
             },
@@ -33783,9 +33722,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.572778+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.283532+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "time_range": {
             "allOf": [
@@ -33877,7 +33815,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:56:45.737242+00:00"
+                "validatedAt": "2026-07-20T14:36:06.995588+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33942,7 +33880,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.737284+00:00"
+                "validatedAt": "2026-07-20T14:36:06.995607+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33968,7 +33906,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.737323+00:00"
+                "validatedAt": "2026-07-20T14:36:06.995624+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34000,7 +33938,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.737365+00:00"
+                "validatedAt": "2026-07-20T14:36:06.995642+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34045,7 +33983,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.737410+00:00"
+                "validatedAt": "2026-07-20T14:36:06.995662+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34070,7 +34008,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.737445+00:00"
+                "validatedAt": "2026-07-20T14:36:06.995678+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34094,7 +34032,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.737476+00:00"
+                "validatedAt": "2026-07-20T14:36:06.995691+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34125,7 +34063,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.737516+00:00"
+                "validatedAt": "2026-07-20T14:36:06.995715+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34226,7 +34164,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.737570+00:00"
+                "validatedAt": "2026-07-20T14:36:06.995739+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34237,7 +34175,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.572886+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.283599+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -34298,7 +34236,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.737613+00:00"
+                "validatedAt": "2026-07-20T14:36:06.995759+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34327,7 +34265,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.737662+00:00"
+                "validatedAt": "2026-07-20T14:36:06.995784+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34433,7 +34371,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.737733+00:00"
+                "validatedAt": "2026-07-20T14:36:06.995872+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34468,7 +34406,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.737773+00:00"
+                "validatedAt": "2026-07-20T14:36:06.995895+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34574,7 +34512,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.572964+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:10.283647+00:00",
             "x-f5xc-conflicts-with": [
               "any_domain"
             ]
@@ -34622,7 +34560,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.737842+00:00"
+                "validatedAt": "2026-07-20T14:36:06.995937+00:00"
               },
               "deterministic": true
             },
@@ -34670,7 +34608,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.737888+00:00"
+                "validatedAt": "2026-07-20T14:36:06.995963+00:00"
               },
               "source": "minimum_configs",
               "enumValues": [
@@ -34806,7 +34744,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.737952+00:00"
+                "validatedAt": "2026-07-20T14:36:06.995994+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35002,7 +34940,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.738013+00:00"
+                "validatedAt": "2026-07-20T14:36:06.996025+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35078,7 +35016,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.738058+00:00"
+                "validatedAt": "2026-07-20T14:36:06.996049+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35122,7 +35060,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.738110+00:00"
+                "validatedAt": "2026-07-20T14:36:06.996079+00:00"
               },
               "deterministic": true
             },
@@ -35208,7 +35146,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.573106+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:10.283734+00:00",
             "x-f5xc-conflicts-with": [
               "any_domain"
             ]
@@ -35484,7 +35422,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.738293+00:00"
+                "validatedAt": "2026-07-20T14:36:06.996163+00:00"
               },
               "deterministic": true
             },
@@ -35496,9 +35434,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.573236+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.283818+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Response of DELETE DoS Auto-Mitigation Rule API.",
@@ -35851,7 +35788,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.738452+00:00"
+                "validatedAt": "2026-07-20T14:36:06.996233+00:00"
               },
               "deterministic": true
             },
@@ -36034,7 +35971,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.738513+00:00"
+                "validatedAt": "2026-07-20T14:36:06.996260+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36154,7 +36091,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.738574+00:00"
+                "validatedAt": "2026-07-20T14:36:06.996290+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36340,7 +36277,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T12:56:45.738621+00:00"
+                "validatedAt": "2026-07-20T14:36:06.996322+00:00"
               },
               "deterministic": true
             },
@@ -36429,7 +36366,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.573428+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:10.283933+00:00",
             "x-f5xc-conflicts-with": [
               "any_domain"
             ]
@@ -36583,7 +36520,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.738697+00:00"
+                "validatedAt": "2026-07-20T14:36:06.996354+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36673,7 +36610,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.738746+00:00"
+                "validatedAt": "2026-07-20T14:36:06.996379+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36717,7 +36654,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.738796+00:00"
+                "validatedAt": "2026-07-20T14:36:06.996407+00:00"
               },
               "deterministic": true
             },
@@ -36803,7 +36740,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.573506+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:10.283981+00:00",
             "x-f5xc-conflicts-with": [
               "any_domain"
             ]
@@ -37029,7 +36966,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.738966+00:00"
+                "validatedAt": "2026-07-20T14:36:06.996476+00:00"
               },
               "deterministic": true
             },
@@ -37063,7 +37000,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.739003+00:00"
+                "validatedAt": "2026-07-20T14:36:06.996492+00:00"
               },
               "deterministic": true
             },
@@ -37143,7 +37080,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.739053+00:00"
+                "validatedAt": "2026-07-20T14:36:06.996513+00:00"
               },
               "format": "fqdn",
               "deterministic": true
@@ -37166,8 +37103,7 @@
             },
             "x-f5xc-conflicts-with": [
               "any_domain"
-            ],
-            "format": "fqdn"
+            ]
           }
         },
         "x-f5xc-description-short": "X-displayName: \"API Group Protection Rule\" API Protection Rule for a group or a base URL.",
@@ -37249,7 +37185,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.739098+00:00"
+                "validatedAt": "2026-07-20T14:36:06.996538+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37327,7 +37263,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.656270+00:00"
+                "validatedAt": "2026-07-20T14:37:00.601485+00:00"
               }
             }
           },
@@ -37363,7 +37299,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.656311+00:00"
+                "validatedAt": "2026-07-20T14:37:00.601507+00:00"
               }
             }
           }
@@ -37435,7 +37371,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.739180+00:00"
+                "validatedAt": "2026-07-20T14:36:06.996575+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37544,7 +37480,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.739236+00:00"
+                "validatedAt": "2026-07-20T14:36:06.996602+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37879,7 +37815,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.739324+00:00"
+                "validatedAt": "2026-07-20T14:36:06.996644+00:00"
               },
               "deterministic": true
             },
@@ -38017,7 +37953,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.739373+00:00"
+                "validatedAt": "2026-07-20T14:36:06.996670+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38253,7 +38189,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.739701+00:00"
+                "validatedAt": "2026-07-20T14:36:06.996828+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38335,7 +38271,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.739744+00:00"
+                "validatedAt": "2026-07-20T14:36:06.996852+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38481,7 +38417,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.739817+00:00"
+                "validatedAt": "2026-07-20T14:36:06.996885+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38550,7 +38486,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.739886+00:00"
+                "validatedAt": "2026-07-20T14:36:06.996917+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38561,8 +38497,7 @@
             },
             "x-f5xc-conflicts-with": [
               "any_domain"
-            ],
-            "format": "fqdn"
+            ]
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -38635,7 +38570,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.739933+00:00"
+                "validatedAt": "2026-07-20T14:36:06.996941+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38781,7 +38716,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.739991+00:00"
+                "validatedAt": "2026-07-20T14:36:06.996971+00:00"
               },
               "deterministic": true
             },
@@ -38958,7 +38893,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.740093+00:00"
+                "validatedAt": "2026-07-20T14:36:06.997023+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39182,7 +39117,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.740380+00:00"
+                "validatedAt": "2026-07-20T14:36:06.997163+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39400,7 +39335,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.740445+00:00"
+                "validatedAt": "2026-07-20T14:36:06.997194+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39644,7 +39579,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.740866+00:00"
+                "validatedAt": "2026-07-20T14:36:06.997388+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39793,7 +39728,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.740936+00:00"
+                "validatedAt": "2026-07-20T14:36:06.997422+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39831,7 +39766,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.740991+00:00"
+                "validatedAt": "2026-07-20T14:36:06.997451+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39938,7 +39873,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.741063+00:00"
+                "validatedAt": "2026-07-20T14:36:06.997484+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39949,8 +39884,7 @@
             },
             "x-f5xc-conflicts-with": [
               "any_domain"
-            ],
-            "format": "fqdn"
+            ]
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -40032,7 +39966,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.741108+00:00"
+                "validatedAt": "2026-07-20T14:36:06.997509+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40119,7 +40053,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.741456+00:00"
+                "validatedAt": "2026-07-20T14:36:06.997661+00:00"
               },
               "deterministic": true
             },
@@ -40361,7 +40295,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.741522+00:00"
+                "validatedAt": "2026-07-20T14:36:06.997690+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40538,7 +40472,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.741597+00:00"
+                "validatedAt": "2026-07-20T14:36:06.997727+00:00"
               },
               "deterministic": true
             },
@@ -40667,7 +40601,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.741669+00:00"
+                "validatedAt": "2026-07-20T14:36:06.997752+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40693,7 +40627,7 @@
             "maxLength": 26,
             "minLength": 15,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.574753+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.284768+00:00"
           },
           "name": {
             "type": "string",
@@ -40733,7 +40667,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.741706+00:00"
+                "validatedAt": "2026-07-20T14:36:06.997769+00:00"
               },
               "deterministic": true
             },
@@ -40745,9 +40679,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.574773+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.284783+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "uid": {
             "type": "string",
@@ -40766,7 +40699,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.741732+00:00"
+                "validatedAt": "2026-07-20T14:36:06.997781+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40779,7 +40712,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.574792+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.284796+00:00"
           }
         },
         "x-f5xc-description-short": "DoS Mitigation Object to auto-configure rules to block attackers.",
@@ -40866,7 +40799,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.741768+00:00"
+                "validatedAt": "2026-07-20T14:36:06.997799+00:00"
               },
               "deterministic": true
             },
@@ -40912,7 +40845,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.741838+00:00"
+                "validatedAt": "2026-07-20T14:36:06.997830+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41027,7 +40960,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.742245+00:00"
+                "validatedAt": "2026-07-20T14:36:06.998032+00:00"
               },
               "deterministic": true
             },
@@ -41067,7 +41000,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.742301+00:00"
+                "validatedAt": "2026-07-20T14:36:06.998059+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41108,7 +41041,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.742368+00:00"
+                "validatedAt": "2026-07-20T14:36:06.998093+00:00"
               },
               "byteLength": {
                 "max": 256,
@@ -41193,7 +41126,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.743141+00:00"
+                "validatedAt": "2026-07-20T14:36:06.998400+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41283,7 +41216,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.743201+00:00"
+                "validatedAt": "2026-07-20T14:36:06.998431+00:00"
               },
               "deterministic": true
             },
@@ -41293,8 +41226,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "format": "hostname"
+            "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$"
           },
           "refresh_interval": {
             "type": "integer",
@@ -41390,7 +41322,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.743266+00:00"
+                "validatedAt": "2026-07-20T14:36:06.998462+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41587,7 +41519,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.743354+00:00"
+                "validatedAt": "2026-07-20T14:36:06.998503+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41599,8 +41531,7 @@
             "x-f5xc-conflicts-with": [
               "disable_sni",
               "use_host_header_as_sni"
-            ],
-            "format": "hostname"
+            ]
           },
           "tls_config": {
             "allOf": [
@@ -41617,7 +41548,7 @@
                 "confidence": 0.99,
                 "category": "tls",
                 "note": "Required when use_tls is selected — API returns 400 if nil",
-                "validatedAt": "2026-07-20T12:56:45.743371+00:00"
+                "validatedAt": "2026-07-20T14:36:06.998512+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41840,7 +41771,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.743468+00:00"
+                "validatedAt": "2026-07-20T14:36:06.998556+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41958,7 +41889,7 @@
             "maxLength": 26,
             "minLength": 15,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.575691+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:10.285354+00:00",
             "x-f5xc-conflicts-with": [
               "check_not_present",
               "check_present"
@@ -42005,7 +41936,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.743944+00:00"
+                "validatedAt": "2026-07-20T14:36:06.998786+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -42020,9 +41951,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.575711+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.285367+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Argument matcher specifies the name of a single argument in the body and the criteria to match it.",
@@ -42183,7 +42113,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.744245+00:00"
+                "validatedAt": "2026-07-20T14:36:06.998958+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42223,7 +42153,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.744305+00:00"
+                "validatedAt": "2026-07-20T14:36:06.998991+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42235,8 +42165,7 @@
             "x-f5xc-conflicts-with": [
               "any_domain",
               "suffix_value"
-            ],
-            "format": "hostname"
+            ]
           },
           "graphql_settings": {
             "allOf": [
@@ -42330,7 +42259,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.744377+00:00"
+                "validatedAt": "2026-07-20T14:36:06.999026+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42342,8 +42271,7 @@
             "x-f5xc-conflicts-with": [
               "any_domain",
               "exact_value"
-            ],
-            "format": "hostname"
+            ]
           }
         },
         "x-f5xc-description-short": "Section defines various configuration OPTIONS for GraphQL inspection.",
@@ -42600,7 +42528,7 @@
             "maxLength": 26,
             "minLength": 15,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.575986+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:10.285537+00:00",
             "x-f5xc-conflicts-with": [
               "check_not_present",
               "check_present"
@@ -42647,7 +42575,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.744496+00:00"
+                "validatedAt": "2026-07-20T14:36:06.999188+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -42662,9 +42590,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.576004+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.285550+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Header matcher specifies the name of a single HTTP header and the criteria for the input request to match it.",
@@ -42735,7 +42662,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.744523+00:00"
+                "validatedAt": "2026-07-20T14:36:06.999240+00:00"
               },
               "deterministic": true
             },
@@ -42747,9 +42674,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.576025+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.285564+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Name of the cookie field\" Specifies the name of the cookie field.",
@@ -42816,7 +42742,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.744551+00:00"
+                "validatedAt": "2026-07-20T14:36:06.999285+00:00"
               },
               "deterministic": true
             },
@@ -42828,9 +42754,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.576046+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.285578+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Name of the field\" Specifies the name of the field.",
@@ -42883,7 +42808,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.744624+00:00"
+                "validatedAt": "2026-07-20T14:36:06.999336+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42894,7 +42819,7 @@
             },
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.576082+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.285601+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Key name of the query parameter\" Specifies the key name of the query parameter.",
@@ -43091,7 +43016,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.744992+00:00"
+                "validatedAt": "2026-07-20T14:36:06.999526+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43137,7 +43062,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.745034+00:00"
+                "validatedAt": "2026-07-20T14:36:06.999548+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43215,7 +43140,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.745318+00:00"
+                "validatedAt": "2026-07-20T14:36:06.999698+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43241,7 +43166,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.576307+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.285741+00:00"
           }
         },
         "x-f5xc-description-short": "Block request and respond with custom content.",
@@ -43387,7 +43312,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.745399+00:00"
+                "validatedAt": "2026-07-20T14:36:06.999735+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43428,7 +43353,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.745463+00:00"
+                "validatedAt": "2026-07-20T14:36:06.999766+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43597,7 +43522,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.745504+00:00"
+                "validatedAt": "2026-07-20T14:36:06.999784+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43712,7 +43637,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.745573+00:00"
+                "validatedAt": "2026-07-20T14:36:06.999819+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43724,8 +43649,7 @@
             "x-f5xc-conflicts-with": [
               "any_domain",
               "suffix_value"
-            ],
-            "format": "hostname"
+            ]
           },
           "metadata": {
             "allOf": [
@@ -43803,7 +43727,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.745643+00:00"
+                "validatedAt": "2026-07-20T14:36:06.999887+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43815,8 +43739,7 @@
             "x-f5xc-conflicts-with": [
               "any_domain",
               "exact_value"
-            ],
-            "format": "hostname"
+            ]
           }
         },
         "x-f5xc-description-short": "Simple Data Guard rule specifies a simple set of match conditions to enable data guard protection.",
@@ -43873,7 +43796,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.746167+00:00"
+                "validatedAt": "2026-07-20T14:36:07.000172+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43896,7 +43819,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.746200+00:00"
+                "validatedAt": "2026-07-20T14:36:07.000186+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43907,7 +43830,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.576532+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.285879+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -44568,7 +44491,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.746376+00:00"
+                "validatedAt": "2026-07-20T14:36:07.000259+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44707,7 +44630,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.746430+00:00"
+                "validatedAt": "2026-07-20T14:36:07.000281+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44748,7 +44671,7 @@
                 "confidence": 1.0,
                 "category": "content",
                 "note": "Blindfold envelope encryption (AES-256-GCM + RSA-OAEP) of an RSA-2048 TLS private key produces ~3700 char string:/// URL. 128KB max secret size = ~175KB base64. Discovery reported 1024 which is incorrect.",
-                "validatedAt": "2026-07-20T12:56:45.746466+00:00"
+                "validatedAt": "2026-07-20T14:36:07.000303+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44759,7 +44682,7 @@
             },
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.576693+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.285991+00:00"
           },
           "store_provider": {
             "type": "string",
@@ -44778,7 +44701,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.746511+00:00"
+                "validatedAt": "2026-07-20T14:36:07.000323+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46061,7 +45984,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.746721+00:00"
+                "validatedAt": "2026-07-20T14:36:07.000407+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -46076,9 +45999,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.576972+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.286161+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "regex_values": {
             "type": "array",
@@ -46116,7 +46038,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.746763+00:00"
+                "validatedAt": "2026-07-20T14:36:07.000429+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46142,7 +46064,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.576998+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.286178+00:00"
           }
         },
         "x-f5xc-description-short": "Bot Defense Transaction Result Condition.",
@@ -46212,7 +46134,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.746813+00:00"
+                "validatedAt": "2026-07-20T14:36:07.000455+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46248,7 +46170,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.746858+00:00"
+                "validatedAt": "2026-07-20T14:36:07.000478+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46361,7 +46283,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.746897+00:00"
+                "validatedAt": "2026-07-20T14:36:07.000496+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46372,7 +46294,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.577040+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.286201+00:00"
           },
           "url": {
             "type": "string",
@@ -46410,7 +46332,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.746953+00:00"
+                "validatedAt": "2026-07-20T14:36:07.000528+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -46485,7 +46407,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T12:56:45.746985+00:00"
+                "validatedAt": "2026-07-20T14:36:07.000545+00:00"
               },
               "deterministic": true
             },
@@ -46496,8 +46418,7 @@
               "read": false
             },
             "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "minLength": 1,
-            "format": "fqdn"
+            "minLength": 1
           },
           "last_update_time": {
             "type": "string",
@@ -46514,7 +46435,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.747028+00:00"
+                "validatedAt": "2026-07-20T14:36:07.000562+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46541,7 +46462,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.747062+00:00"
+                "validatedAt": "2026-07-20T14:36:07.000577+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46552,7 +46473,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.577080+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.286227+00:00"
           },
           "service_name": {
             "type": "string",
@@ -46569,7 +46490,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.747102+00:00"
+                "validatedAt": "2026-07-20T14:36:07.000594+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46602,7 +46523,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.747140+00:00"
+                "validatedAt": "2026-07-20T14:36:07.000611+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46613,7 +46534,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.577106+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.286244+00:00"
           },
           "type": {
             "type": "string",
@@ -46638,7 +46559,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.747174+00:00"
+                "validatedAt": "2026-07-20T14:36:07.000627+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46896,7 +46817,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.747270+00:00"
+                "validatedAt": "2026-07-20T14:36:07.000673+00:00"
               },
               "deterministic": true
             },
@@ -46908,9 +46829,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.577190+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.286296+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "samesite_lax": {
             "allOf": [
@@ -47047,7 +46967,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.747325+00:00"
+                "validatedAt": "2026-07-20T14:36:07.000697+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47079,7 +46999,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.747368+00:00"
+                "validatedAt": "2026-07-20T14:36:07.000715+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47125,7 +47045,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.747416+00:00"
+                "validatedAt": "2026-07-20T14:36:07.000741+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47173,7 +47093,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.747460+00:00"
+                "validatedAt": "2026-07-20T14:36:07.000765+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47215,7 +47135,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.747505+00:00"
+                "validatedAt": "2026-07-20T14:36:07.000783+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47252,7 +47172,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.747556+00:00"
+                "validatedAt": "2026-07-20T14:36:07.000811+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47449,7 +47369,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.747621+00:00"
+                "validatedAt": "2026-07-20T14:36:07.000846+00:00"
               },
               "deterministic": true
             },
@@ -47530,7 +47450,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.747692+00:00"
+                "validatedAt": "2026-07-20T14:36:07.000875+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47542,8 +47462,7 @@
             "x-f5xc-conflicts-with": [
               "regex_value",
               "suffix_value"
-            ],
-            "format": "hostname"
+            ]
           },
           "regex_value": {
             "type": "string",
@@ -47574,7 +47493,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.747755+00:00"
+                "validatedAt": "2026-07-20T14:36:07.000904+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47619,7 +47538,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.747818+00:00"
+                "validatedAt": "2026-07-20T14:36:07.000934+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47631,8 +47550,7 @@
             "x-f5xc-conflicts-with": [
               "exact_value",
               "regex_value"
-            ],
-            "format": "hostname"
+            ]
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -47763,7 +47681,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.747863+00:00"
+                "validatedAt": "2026-07-20T14:36:07.000952+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47890,7 +47808,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.747912+00:00"
+                "validatedAt": "2026-07-20T14:36:07.000978+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47993,7 +47911,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.747968+00:00"
+                "validatedAt": "2026-07-20T14:36:07.001008+00:00"
               },
               "deterministic": true
             },
@@ -48005,9 +47923,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.577369+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.286407+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "secret_value": {
             "allOf": [
@@ -48046,7 +47963,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.748027+00:00"
+                "validatedAt": "2026-07-20T14:36:07.001037+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48057,7 +47974,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.577394+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:10.286424+00:00",
             "x-f5xc-conflicts-with": [
               "secret_value"
             ]
@@ -48272,7 +48189,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.748058+00:00"
+                "validatedAt": "2026-07-20T14:36:07.001053+00:00"
               },
               "deterministic": true
             },
@@ -48284,9 +48201,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.577417+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.286438+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -48492,7 +48408,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.748316+00:00"
+                "validatedAt": "2026-07-20T14:36:07.001190+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -48507,7 +48423,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.577496+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.286490+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -48577,7 +48493,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.748356+00:00"
+                "validatedAt": "2026-07-20T14:36:07.001209+00:00"
               },
               "deterministic": true
             },
@@ -48589,9 +48505,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.577528+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.286511+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -48624,7 +48539,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.748385+00:00"
+                "validatedAt": "2026-07-20T14:36:07.001225+00:00"
               },
               "deterministic": true
             },
@@ -48636,9 +48551,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.577547+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.286524+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -48738,7 +48652,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.748459+00:00"
+                "validatedAt": "2026-07-20T14:36:07.001263+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -48753,7 +48667,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.577575+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.286542+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -48825,7 +48739,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.748498+00:00"
+                "validatedAt": "2026-07-20T14:36:07.001282+00:00"
               },
               "deterministic": true
             },
@@ -48837,9 +48751,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.577608+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.286563+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -48872,7 +48785,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.748526+00:00"
+                "validatedAt": "2026-07-20T14:36:07.001297+00:00"
               },
               "deterministic": true
             },
@@ -48884,9 +48797,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.577626+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.286576+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -48986,7 +48898,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.748601+00:00"
+                "validatedAt": "2026-07-20T14:36:07.001335+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -49001,7 +48913,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.577660+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.286593+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -49071,7 +48983,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.748641+00:00"
+                "validatedAt": "2026-07-20T14:36:07.001354+00:00"
               },
               "deterministic": true
             },
@@ -49083,9 +48995,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.577695+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.286614+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -49118,7 +49029,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.748678+00:00"
+                "validatedAt": "2026-07-20T14:36:07.001368+00:00"
               },
               "deterministic": true
             },
@@ -49130,9 +49041,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.577714+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.286626+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -49303,7 +49213,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.748731+00:00"
+                "validatedAt": "2026-07-20T14:36:07.001390+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49331,7 +49241,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.748772+00:00"
+                "validatedAt": "2026-07-20T14:36:07.001406+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49359,7 +49269,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.748809+00:00"
+                "validatedAt": "2026-07-20T14:36:07.001423+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49398,7 +49308,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.748851+00:00"
+                "validatedAt": "2026-07-20T14:36:07.001440+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49425,7 +49335,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.748877+00:00"
+                "validatedAt": "2026-07-20T14:36:07.001452+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49438,7 +49348,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.577785+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.286670+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -49454,7 +49364,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.748912+00:00"
+                "validatedAt": "2026-07-20T14:36:07.001468+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49599,7 +49509,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.748962+00:00"
+                "validatedAt": "2026-07-20T14:36:07.001489+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49610,7 +49520,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.577825+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.286695+00:00"
           },
           "status": {
             "type": "string",
@@ -49628,7 +49538,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.748997+00:00"
+                "validatedAt": "2026-07-20T14:36:07.001504+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49639,7 +49549,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.577843+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.286708+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -49699,7 +49609,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.749042+00:00"
+                "validatedAt": "2026-07-20T14:36:07.001524+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49726,7 +49636,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.749082+00:00"
+                "validatedAt": "2026-07-20T14:36:07.001564+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49753,7 +49663,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.749120+00:00"
+                "validatedAt": "2026-07-20T14:36:07.001583+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49781,7 +49691,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.749163+00:00"
+                "validatedAt": "2026-07-20T14:36:07.001602+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49857,7 +49767,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.749230+00:00"
+                "validatedAt": "2026-07-20T14:36:07.001641+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49925,7 +49835,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.749280+00:00"
+                "validatedAt": "2026-07-20T14:36:07.001663+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49937,7 +49847,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.577930+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.286761+00:00"
           },
           "uid": {
             "type": "string",
@@ -49956,7 +49866,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.749308+00:00"
+                "validatedAt": "2026-07-20T14:36:07.001676+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49969,7 +49879,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.577949+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.286774+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -50060,7 +49970,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.749378+00:00"
+                "validatedAt": "2026-07-20T14:36:07.001711+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50107,7 +50017,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:56:45.749427+00:00"
+                "validatedAt": "2026-07-20T14:36:07.001735+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50118,7 +50028,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.577981+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.286795+00:00"
           },
           "disable_ocsp_stapling": {
             "allOf": [
@@ -50273,7 +50183,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.749596+00:00"
+                "validatedAt": "2026-07-20T14:36:07.001810+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50284,7 +50194,7 @@
             },
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.578074+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.286855+00:00"
           },
           "name": {
             "type": "string",
@@ -50317,7 +50227,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.749624+00:00"
+                "validatedAt": "2026-07-20T14:36:07.001825+00:00"
               },
               "deterministic": true
             },
@@ -50329,9 +50239,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.578092+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.286867+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -50364,7 +50273,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.749651+00:00"
+                "validatedAt": "2026-07-20T14:36:07.001840+00:00"
               },
               "deterministic": true
             },
@@ -50376,9 +50285,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.578111+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.286879+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "uid": {
             "type": "string",
@@ -50395,7 +50303,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.749686+00:00"
+                "validatedAt": "2026-07-20T14:36:07.001851+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50408,7 +50316,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.578129+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.286892+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -50531,7 +50439,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.749735+00:00"
+                "validatedAt": "2026-07-20T14:36:07.001876+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50567,7 +50475,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.749779+00:00"
+                "validatedAt": "2026-07-20T14:36:07.001900+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50625,7 +50533,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.749829+00:00"
+                "validatedAt": "2026-07-20T14:36:07.001943+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50698,7 +50606,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.749892+00:00"
+                "validatedAt": "2026-07-20T14:36:07.002000+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50741,7 +50649,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.749934+00:00"
+                "validatedAt": "2026-07-20T14:36:07.002024+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50781,7 +50689,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.749980+00:00"
+                "validatedAt": "2026-07-20T14:36:07.002049+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50928,7 +50836,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.750142+00:00"
+                "validatedAt": "2026-07-20T14:36:07.002133+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50987,7 +50895,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.750190+00:00"
+                "validatedAt": "2026-07-20T14:36:07.002159+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51033,7 +50941,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.750232+00:00"
+                "validatedAt": "2026-07-20T14:36:07.002182+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51077,7 +50985,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.750275+00:00"
+                "validatedAt": "2026-07-20T14:36:07.002205+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51115,7 +51023,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.750317+00:00"
+                "validatedAt": "2026-07-20T14:36:07.002229+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51219,7 +51127,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.750433+00:00"
+                "validatedAt": "2026-07-20T14:36:07.002289+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51378,7 +51286,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.750647+00:00"
+                "validatedAt": "2026-07-20T14:36:07.002412+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51476,7 +51384,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.750712+00:00"
+                "validatedAt": "2026-07-20T14:36:07.002439+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51569,7 +51477,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.750768+00:00"
+                "validatedAt": "2026-07-20T14:36:07.002462+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51604,7 +51512,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.750823+00:00"
+                "validatedAt": "2026-07-20T14:36:07.002491+00:00"
               },
               "deterministic": true
             },
@@ -51700,7 +51608,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.750876+00:00"
+                "validatedAt": "2026-07-20T14:36:07.002517+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51820,7 +51728,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.750921+00:00"
+                "validatedAt": "2026-07-20T14:36:07.002540+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51952,7 +51860,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.750973+00:00"
+                "validatedAt": "2026-07-20T14:36:07.002566+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52168,7 +52076,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.751065+00:00"
+                "validatedAt": "2026-07-20T14:36:07.002609+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52290,7 +52198,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.751116+00:00"
+                "validatedAt": "2026-07-20T14:36:07.002635+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52579,7 +52487,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.751206+00:00"
+                "validatedAt": "2026-07-20T14:36:07.002671+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52758,7 +52666,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.751308+00:00"
+                "validatedAt": "2026-07-20T14:36:07.002711+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52878,7 +52786,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.751342+00:00"
+                "validatedAt": "2026-07-20T14:36:07.002729+00:00"
               },
               "deterministic": true
             },
@@ -53080,7 +52988,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.751383+00:00"
+                "validatedAt": "2026-07-20T14:36:07.002749+00:00"
               },
               "deterministic": true
             },
@@ -53092,9 +53000,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.578835+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.287326+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "operator": {
             "allOf": [
@@ -53288,7 +53195,7 @@
             "maxLength": 16,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.578901+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.287367+00:00"
           },
           "operator": {
             "allOf": [
@@ -53355,7 +53262,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.751453+00:00"
+                "validatedAt": "2026-07-20T14:36:07.002777+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53378,7 +53285,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.751495+00:00"
+                "validatedAt": "2026-07-20T14:36:07.002795+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53401,7 +53308,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.751536+00:00"
+                "validatedAt": "2026-07-20T14:36:07.002812+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53424,7 +53331,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.751578+00:00"
+                "validatedAt": "2026-07-20T14:36:07.002833+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53447,7 +53354,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.751620+00:00"
+                "validatedAt": "2026-07-20T14:36:07.002851+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53470,7 +53377,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.751665+00:00"
+                "validatedAt": "2026-07-20T14:36:07.002867+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53493,7 +53400,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.751704+00:00"
+                "validatedAt": "2026-07-20T14:36:07.002883+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53516,7 +53423,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.751744+00:00"
+                "validatedAt": "2026-07-20T14:36:07.002900+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53539,7 +53446,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.751785+00:00"
+                "validatedAt": "2026-07-20T14:36:07.002917+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53608,7 +53515,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.751815+00:00"
+                "validatedAt": "2026-07-20T14:36:07.002930+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53619,7 +53526,7 @@
             },
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.578987+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.287420+00:00"
           },
           "operator": {
             "allOf": [
@@ -53701,7 +53608,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.751864+00:00"
+                "validatedAt": "2026-07-20T14:36:07.002950+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53823,7 +53730,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.751924+00:00"
+                "validatedAt": "2026-07-20T14:36:07.002974+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53866,7 +53773,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.751974+00:00"
+                "validatedAt": "2026-07-20T14:36:07.003000+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54070,7 +53977,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.752041+00:00"
+                "validatedAt": "2026-07-20T14:36:07.003033+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54200,7 +54107,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.752102+00:00"
+                "validatedAt": "2026-07-20T14:36:07.003080+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54236,7 +54143,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.752147+00:00"
+                "validatedAt": "2026-07-20T14:36:07.003104+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54456,7 +54363,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.752230+00:00"
+                "validatedAt": "2026-07-20T14:36:07.003146+00:00"
               },
               "deterministic": true
             },
@@ -54580,7 +54487,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.752288+00:00"
+                "validatedAt": "2026-07-20T14:36:07.003174+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54842,7 +54749,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.752376+00:00"
+                "validatedAt": "2026-07-20T14:36:07.003212+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54966,7 +54873,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.752436+00:00"
+                "validatedAt": "2026-07-20T14:36:07.003241+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55336,7 +55243,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.752521+00:00"
+                "validatedAt": "2026-07-20T14:36:07.003280+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55479,7 +55386,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.752585+00:00"
+                "validatedAt": "2026-07-20T14:36:07.003311+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55515,7 +55422,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.752630+00:00"
+                "validatedAt": "2026-07-20T14:36:07.003335+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55749,7 +55656,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.752735+00:00"
+                "validatedAt": "2026-07-20T14:36:07.003379+00:00"
               },
               "deterministic": true
             },
@@ -55873,7 +55780,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.752793+00:00"
+                "validatedAt": "2026-07-20T14:36:07.003406+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55898,7 +55805,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.752835+00:00"
+                "validatedAt": "2026-07-20T14:36:07.003424+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56160,7 +56067,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.752924+00:00"
+                "validatedAt": "2026-07-20T14:36:07.003463+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56312,7 +56219,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.753001+00:00"
+                "validatedAt": "2026-07-20T14:36:07.003498+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56508,7 +56415,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.753056+00:00"
+                "validatedAt": "2026-07-20T14:36:07.003525+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56555,7 +56462,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.753105+00:00"
+                "validatedAt": "2026-07-20T14:36:07.003549+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56593,7 +56500,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.753151+00:00"
+                "validatedAt": "2026-07-20T14:36:07.003573+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56634,7 +56541,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.753199+00:00"
+                "validatedAt": "2026-07-20T14:36:07.003598+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56755,7 +56662,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.753244+00:00"
+                "validatedAt": "2026-07-20T14:36:07.003621+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57145,7 +57052,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.753334+00:00"
+                "validatedAt": "2026-07-20T14:36:07.003660+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57275,7 +57182,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.753397+00:00"
+                "validatedAt": "2026-07-20T14:36:07.003688+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57311,7 +57218,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.753443+00:00"
+                "validatedAt": "2026-07-20T14:36:07.003711+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57531,7 +57438,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.753526+00:00"
+                "validatedAt": "2026-07-20T14:36:07.003750+00:00"
               },
               "deterministic": true
             },
@@ -57655,7 +57562,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.753585+00:00"
+                "validatedAt": "2026-07-20T14:36:07.003777+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57917,7 +57824,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.753681+00:00"
+                "validatedAt": "2026-07-20T14:36:07.003816+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58041,7 +57948,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.753744+00:00"
+                "validatedAt": "2026-07-20T14:36:07.003845+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58242,7 +58149,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.753805+00:00"
+                "validatedAt": "2026-07-20T14:36:07.003870+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58276,7 +58183,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.753852+00:00"
+                "validatedAt": "2026-07-20T14:36:07.003889+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58483,7 +58390,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.753915+00:00"
+                "validatedAt": "2026-07-20T14:36:07.003920+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58493,9 +58400,9 @@
               "read": false
             },
             "minLength": 26,
-            "format": "fqdn",
+            "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.580238+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.288187+00:00"
           },
           "simple_login": {
             "allOf": [
@@ -58582,7 +58489,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.753967+00:00"
+                "validatedAt": "2026-07-20T14:36:07.003947+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58915,7 +58822,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.754052+00:00"
+                "validatedAt": "2026-07-20T14:36:07.003980+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58938,7 +58845,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.754099+00:00"
+                "validatedAt": "2026-07-20T14:36:07.003998+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58975,7 +58882,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.754149+00:00"
+                "validatedAt": "2026-07-20T14:36:07.004018+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59095,7 +59002,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.754247+00:00"
+                "validatedAt": "2026-07-20T14:36:07.004062+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59227,7 +59134,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.754280+00:00"
+                "validatedAt": "2026-07-20T14:36:07.004078+00:00"
               },
               "deterministic": true
             },
@@ -59239,9 +59146,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.580399+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.288287+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "type": {
             "type": "string",
@@ -59258,7 +59164,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.754312+00:00"
+                "validatedAt": "2026-07-20T14:36:07.004091+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59281,7 +59187,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.754345+00:00"
+                "validatedAt": "2026-07-20T14:36:07.004106+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59292,7 +59198,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.580425+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.288304+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -59348,7 +59254,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.754391+00:00"
+                "validatedAt": "2026-07-20T14:36:07.004127+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59373,7 +59279,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.754439+00:00"
+                "validatedAt": "2026-07-20T14:36:07.004147+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59426,7 +59332,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.754488+00:00"
+                "validatedAt": "2026-07-20T14:36:07.004166+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59535,7 +59441,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.754570+00:00"
+                "validatedAt": "2026-07-20T14:36:07.004203+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59628,7 +59534,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.754625+00:00"
+                "validatedAt": "2026-07-20T14:36:07.004225+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59640,7 +59546,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.580501+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.288351+00:00"
           },
           "service_domain": {
             "type": "string",
@@ -59657,7 +59563,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:45.754675+00:00"
+                "validatedAt": "2026-07-20T14:36:07.004243+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59841,7 +59747,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.754781+00:00"
+                "validatedAt": "2026-07-20T14:36:07.004295+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59959,7 +59865,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:45.754838+00:00"
+                "validatedAt": "2026-07-20T14:36:07.004326+00:00"
               },
               "deterministic": true
             },
@@ -60079,7 +59985,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:47.927264+00:00"
+                "validatedAt": "2026-07-20T14:36:07.900862+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60114,7 +60020,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:47.927400+00:00"
+                "validatedAt": "2026-07-20T14:36:07.900896+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60193,7 +60099,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:47.927511+00:00"
+                "validatedAt": "2026-07-20T14:36:07.900921+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60231,7 +60137,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:47.927599+00:00"
+                "validatedAt": "2026-07-20T14:36:07.900946+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60280,7 +60186,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:47.927677+00:00"
+                "validatedAt": "2026-07-20T14:36:07.900971+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60366,7 +60272,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:47.927746+00:00"
+                "validatedAt": "2026-07-20T14:36:07.900995+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60402,7 +60308,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:47.927828+00:00"
+                "validatedAt": "2026-07-20T14:36:07.901023+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60542,7 +60448,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:47.927913+00:00"
+                "validatedAt": "2026-07-20T14:36:07.901054+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -60557,9 +60463,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.730565+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.404285+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "operator": {
             "allOf": [
@@ -60703,7 +60608,7 @@
             "maxLength": 16,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.730612+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.404313+00:00"
           },
           "operator": {
             "allOf": [
@@ -60774,7 +60679,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:47.927985+00:00"
+                "validatedAt": "2026-07-20T14:36:07.901076+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60809,7 +60714,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:47.928039+00:00"
+                "validatedAt": "2026-07-20T14:36:07.901092+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60844,7 +60749,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:47.928093+00:00"
+                "validatedAt": "2026-07-20T14:36:07.901108+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60879,7 +60784,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:47.928142+00:00"
+                "validatedAt": "2026-07-20T14:36:07.901123+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60914,7 +60819,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:47.928193+00:00"
+                "validatedAt": "2026-07-20T14:36:07.901138+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60949,7 +60854,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:47.928237+00:00"
+                "validatedAt": "2026-07-20T14:36:07.901152+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60984,7 +60889,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:47.928282+00:00"
+                "validatedAt": "2026-07-20T14:36:07.901166+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61032,7 +60937,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:47.928360+00:00"
+                "validatedAt": "2026-07-20T14:36:07.901194+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61067,7 +60972,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:47.928408+00:00"
+                "validatedAt": "2026-07-20T14:36:07.901209+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61167,7 +61072,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:47.928476+00:00"
+                "validatedAt": "2026-07-20T14:36:07.901235+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61270,7 +61175,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:47.928537+00:00"
+                "validatedAt": "2026-07-20T14:36:07.901255+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61524,7 +61429,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:47.928607+00:00"
+                "validatedAt": "2026-07-20T14:36:07.901278+00:00"
               },
               "deterministic": true
             },
@@ -61536,9 +61441,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.730793+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.404418+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -61570,7 +61474,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:47.928642+00:00"
+                "validatedAt": "2026-07-20T14:36:07.901291+00:00"
               },
               "deterministic": true
             },
@@ -61582,9 +61486,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.730814+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.404431+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -61867,7 +61770,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:56:47.928783+00:00"
+                "validatedAt": "2026-07-20T14:36:07.901332+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61948,7 +61851,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:56:47.928848+00:00"
+                "validatedAt": "2026-07-20T14:36:07.901355+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61959,7 +61862,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.730915+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.404493+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -62046,7 +61949,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:47.928898+00:00"
+                "validatedAt": "2026-07-20T14:36:07.901373+00:00"
               },
               "deterministic": true
             },
@@ -62058,9 +61961,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.730960+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.404522+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -62091,7 +61993,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:47.928932+00:00"
+                "validatedAt": "2026-07-20T14:36:07.901386+00:00"
               },
               "deterministic": true
             },
@@ -62103,9 +62005,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.730979+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.404535+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -62158,7 +62059,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:47.928983+00:00"
+                "validatedAt": "2026-07-20T14:36:07.901402+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62170,7 +62071,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.731011+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.404556+00:00"
           },
           "uid": {
             "type": "string",
@@ -62187,7 +62088,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:47.929014+00:00"
+                "validatedAt": "2026-07-20T14:36:07.901412+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62200,7 +62101,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.731030+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.404570+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of cdn_cache_rule is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -62765,7 +62666,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:57.704987+00:00"
+                "validatedAt": "2026-07-20T14:36:11.877958+00:00"
               },
               "deterministic": true
             },
@@ -62777,9 +62678,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.997618+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.572068+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -62811,7 +62711,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:57.705025+00:00"
+                "validatedAt": "2026-07-20T14:36:11.877978+00:00"
               },
               "deterministic": true
             },
@@ -62823,9 +62723,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.997639+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.572082+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -62976,7 +62875,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.997709+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.572120+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -63072,7 +62971,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:56:57.705158+00:00"
+                "validatedAt": "2026-07-20T14:36:11.878027+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63153,7 +63052,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:56:57.705235+00:00"
+                "validatedAt": "2026-07-20T14:36:11.878054+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63164,7 +63063,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.997761+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.572150+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -63251,7 +63150,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:57.705298+00:00"
+                "validatedAt": "2026-07-20T14:36:11.878074+00:00"
               },
               "deterministic": true
             },
@@ -63263,9 +63162,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.997806+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.572179+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -63296,7 +63194,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:57.705345+00:00"
+                "validatedAt": "2026-07-20T14:36:11.878089+00:00"
               },
               "deterministic": true
             },
@@ -63308,9 +63206,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.997824+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.572191+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -63379,7 +63276,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:57.705436+00:00"
+                "validatedAt": "2026-07-20T14:36:11.878111+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63391,7 +63288,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.997861+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.572214+00:00"
           },
           "uid": {
             "type": "string",
@@ -63409,7 +63306,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:57.705465+00:00"
+                "validatedAt": "2026-07-20T14:36:11.878123+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63422,7 +63319,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.997882+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.572227+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of cdn_purge_command is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -63489,7 +63386,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:57.705509+00:00"
+                "validatedAt": "2026-07-20T14:36:11.878141+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63515,7 +63412,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:57.705557+00:00"
+                "validatedAt": "2026-07-20T14:36:11.878159+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63547,7 +63444,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:57.705610+00:00"
+                "validatedAt": "2026-07-20T14:36:11.878179+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63586,7 +63483,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:57.705647+00:00"
+                "validatedAt": "2026-07-20T14:36:11.878194+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63617,7 +63514,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:57.705698+00:00"
+                "validatedAt": "2026-07-20T14:36:11.878211+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63642,7 +63539,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:57.705733+00:00"
+                "validatedAt": "2026-07-20T14:36:11.878224+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63667,7 +63564,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:57.705763+00:00"
+                "validatedAt": "2026-07-20T14:36:11.878237+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63698,7 +63595,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:57.705804+00:00"
+                "validatedAt": "2026-07-20T14:36:11.878254+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63894,7 +63791,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:57.707431+00:00"
+                "validatedAt": "2026-07-20T14:36:11.878951+00:00"
               },
               "deterministic": true
             },
@@ -63910,8 +63807,7 @@
               "url_path"
             ],
             "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "minLength": 1,
-            "format": "fqdn"
+            "minLength": 1
           },
           "pattern": {
             "type": "string",
@@ -63940,7 +63836,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:57.707489+00:00"
+                "validatedAt": "2026-07-20T14:36:11.878979+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64010,7 +63906,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:57.707533+00:00"
+                "validatedAt": "2026-07-20T14:36:11.879001+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64144,7 +64040,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:57.707592+00:00"
+                "validatedAt": "2026-07-20T14:36:11.879033+00:00"
               },
               "deterministic": true
             },
@@ -64160,8 +64056,7 @@
               "url_path"
             ],
             "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "minLength": 1,
-            "format": "fqdn"
+            "minLength": 1
           },
           "pattern": {
             "type": "string",
@@ -64190,7 +64085,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:57.707645+00:00"
+                "validatedAt": "2026-07-20T14:36:11.879059+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64260,7 +64155,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:57.707698+00:00"
+                "validatedAt": "2026-07-20T14:36:11.879077+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64357,7 +64252,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:01.290609+00:00"
+                "validatedAt": "2026-07-20T14:36:13.193654+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64392,7 +64287,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:01.290648+00:00"
+                "validatedAt": "2026-07-20T14:36:13.193670+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64427,7 +64322,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:01.290705+00:00"
+                "validatedAt": "2026-07-20T14:36:13.193685+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64462,7 +64357,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:01.290743+00:00"
+                "validatedAt": "2026-07-20T14:36:13.193700+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64497,7 +64392,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:01.290785+00:00"
+                "validatedAt": "2026-07-20T14:36:13.193716+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64532,7 +64427,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:01.290819+00:00"
+                "validatedAt": "2026-07-20T14:36:13.193729+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64567,7 +64462,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:01.290854+00:00"
+                "validatedAt": "2026-07-20T14:36:13.193743+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64613,7 +64508,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:01.290913+00:00"
+                "validatedAt": "2026-07-20T14:36:13.193771+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64648,7 +64543,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:01.290951+00:00"
+                "validatedAt": "2026-07-20T14:36:13.193786+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64729,7 +64624,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:01.291128+00:00"
+                "validatedAt": "2026-07-20T14:36:13.193859+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64764,7 +64659,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:01.291167+00:00"
+                "validatedAt": "2026-07-20T14:36:13.193874+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64799,7 +64694,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:01.291206+00:00"
+                "validatedAt": "2026-07-20T14:36:13.193889+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64834,7 +64729,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:01.291246+00:00"
+                "validatedAt": "2026-07-20T14:36:13.193905+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64869,7 +64764,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:01.291286+00:00"
+                "validatedAt": "2026-07-20T14:36:13.193920+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64904,7 +64799,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:01.291322+00:00"
+                "validatedAt": "2026-07-20T14:36:13.193934+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64939,7 +64834,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:01.291356+00:00"
+                "validatedAt": "2026-07-20T14:36:13.193947+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64985,7 +64880,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:01.291415+00:00"
+                "validatedAt": "2026-07-20T14:36:13.193975+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65020,7 +64915,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:01.291452+00:00"
+                "validatedAt": "2026-07-20T14:36:13.193990+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65101,7 +64996,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:01.291728+00:00"
+                "validatedAt": "2026-07-20T14:36:13.194105+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65136,7 +65031,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:01.291767+00:00"
+                "validatedAt": "2026-07-20T14:36:13.194121+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65171,7 +65066,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:01.291806+00:00"
+                "validatedAt": "2026-07-20T14:36:13.194136+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65206,7 +65101,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:01.291845+00:00"
+                "validatedAt": "2026-07-20T14:36:13.194151+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65241,7 +65136,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:01.291886+00:00"
+                "validatedAt": "2026-07-20T14:36:13.194167+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65276,7 +65171,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:01.291921+00:00"
+                "validatedAt": "2026-07-20T14:36:13.194180+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65311,7 +65206,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:01.291954+00:00"
+                "validatedAt": "2026-07-20T14:36:13.194194+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65357,7 +65252,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:01.292014+00:00"
+                "validatedAt": "2026-07-20T14:36:13.194226+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65392,7 +65287,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:01.292053+00:00"
+                "validatedAt": "2026-07-20T14:36:13.194243+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65467,7 +65362,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.652693+00:00"
+                "validatedAt": "2026-07-20T14:37:00.599935+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65492,7 +65387,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.652753+00:00"
+                "validatedAt": "2026-07-20T14:37:00.599957+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65863,7 +65758,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.653386+00:00"
+                "validatedAt": "2026-07-20T14:37:00.600214+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65990,7 +65885,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.653436+00:00"
+                "validatedAt": "2026-07-20T14:37:00.600239+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66233,7 +66128,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T12:58:57.653528+00:00"
+                "validatedAt": "2026-07-20T14:37:00.600278+00:00"
               },
               "deterministic": true
             },
@@ -66632,7 +66527,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.655343+00:00"
+                "validatedAt": "2026-07-20T14:37:00.601061+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66714,7 +66609,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.462447+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.970762+00:00"
           },
           "http_methods": {
             "type": "array",
@@ -66738,7 +66633,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.655399+00:00"
+                "validatedAt": "2026-07-20T14:37:00.601085+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66869,7 +66764,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:58:57.658945+00:00"
+                "validatedAt": "2026-07-20T14:37:00.602760+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67148,7 +67043,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.659088+00:00"
+                "validatedAt": "2026-07-20T14:37:00.602819+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67191,7 +67086,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.659136+00:00"
+                "validatedAt": "2026-07-20T14:37:00.602843+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67229,7 +67124,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.659180+00:00"
+                "validatedAt": "2026-07-20T14:37:00.602865+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67274,7 +67169,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.659227+00:00"
+                "validatedAt": "2026-07-20T14:37:00.602889+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67312,7 +67207,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.659271+00:00"
+                "validatedAt": "2026-07-20T14:37:00.602912+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67356,7 +67251,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.659318+00:00"
+                "validatedAt": "2026-07-20T14:37:00.602936+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67394,7 +67289,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.659364+00:00"
+                "validatedAt": "2026-07-20T14:37:00.602960+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67439,7 +67334,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.659410+00:00"
+                "validatedAt": "2026-07-20T14:37:00.602984+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67612,7 +67507,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.659459+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603009+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67623,7 +67518,7 @@
             },
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.464142+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.971780+00:00"
           },
           "value": {
             "allOf": [
@@ -67640,7 +67535,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.464162+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.971793+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -67702,7 +67597,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.659527+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603039+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67740,7 +67635,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.659573+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603065+00:00"
               },
               "deterministic": true
             },
@@ -67910,7 +67805,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.659622+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603086+00:00"
               },
               "deterministic": true
             },
@@ -67922,9 +67817,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.464228+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.971834+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -67955,7 +67849,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.659650+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603100+00:00"
               },
               "deterministic": true
             },
@@ -67967,9 +67861,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.464247+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.971846+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -68088,7 +67981,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.659713+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603128+00:00"
               },
               "deterministic": true
             },
@@ -68776,7 +68669,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.659864+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603195+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68909,7 +68802,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.659906+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603214+00:00"
               },
               "deterministic": true
             },
@@ -68921,9 +68814,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.464398+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.971938+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -68955,7 +68847,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.659935+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603228+00:00"
               },
               "deterministic": true
             },
@@ -68967,9 +68859,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.464416+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.971951+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -69041,7 +68932,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.659964+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603242+00:00"
               },
               "deterministic": true
             },
@@ -69053,9 +68944,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.464437+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.971964+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -69087,7 +68977,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.659991+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603256+00:00"
               },
               "deterministic": true
             },
@@ -69099,9 +68989,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.464455+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.971977+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Request shape for GET API Endpoints For Groups.",
@@ -69177,7 +69066,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.660050+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603279+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69252,7 +69141,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.660096+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603302+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69292,7 +69181,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.660124+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603317+00:00"
               },
               "deterministic": true
             },
@@ -69304,9 +69193,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.464496+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.972003+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -69338,7 +69226,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.660151+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603330+00:00"
               },
               "deterministic": true
             },
@@ -69350,9 +69238,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.464515+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.972015+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query_type": {
             "allOf": [
@@ -69657,7 +69544,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.464610+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.972074+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -69783,7 +69670,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.660302+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603388+00:00"
               },
               "deterministic": true
             },
@@ -69795,9 +69682,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.464649+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.972098+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Request of GET Security Config Spec API.",
@@ -69877,7 +69763,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.660349+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603412+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69956,7 +69842,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.660393+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603434+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -70348,7 +70234,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:58:57.660502+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603477+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -70429,7 +70315,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:58:57.660555+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603500+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -70440,7 +70326,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.464791+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.972179+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -70527,7 +70413,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.660597+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603518+00:00"
               },
               "deterministic": true
             },
@@ -70539,9 +70425,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.464836+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.972207+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -70572,7 +70457,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.660624+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603531+00:00"
               },
               "deterministic": true
             },
@@ -70584,9 +70469,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.464855+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.972219+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -70655,7 +70539,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.660689+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603553+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -70667,7 +70551,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.464892+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.972243+00:00"
           },
           "uid": {
             "type": "string",
@@ -70685,7 +70569,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.660716+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603564+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -70698,7 +70582,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.464912+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.972256+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of http_loadbalancer is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -70807,7 +70691,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.660787+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603597+00:00"
               },
               "deterministic": true
             },
@@ -70839,7 +70723,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.660833+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603616+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -70919,7 +70803,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.660879+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603638+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71010,7 +70894,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.661045+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603716+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71220,7 +71104,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.661123+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603749+00:00"
               },
               "deterministic": true
             },
@@ -71266,7 +71150,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.661186+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603779+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71302,7 +71186,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.661244+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603806+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71451,7 +71335,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.661319+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603840+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71714,7 +71598,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.661403+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603874+00:00"
               },
               "deterministic": true,
               "source": "minimum_configs",
@@ -71763,7 +71647,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.661463+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603904+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71799,7 +71683,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.661521+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603932+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -72707,7 +72591,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.661684+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603997+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -72781,7 +72665,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.661739+00:00"
+                "validatedAt": "2026-07-20T14:37:00.604022+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -72824,7 +72708,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.661787+00:00"
+                "validatedAt": "2026-07-20T14:37:00.604048+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -72861,7 +72745,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.661831+00:00"
+                "validatedAt": "2026-07-20T14:37:00.604071+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -72906,7 +72790,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.661875+00:00"
+                "validatedAt": "2026-07-20T14:37:00.604094+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -72944,7 +72828,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.661919+00:00"
+                "validatedAt": "2026-07-20T14:37:00.604116+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -72988,7 +72872,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.661966+00:00"
+                "validatedAt": "2026-07-20T14:37:00.604139+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -73025,7 +72909,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.662012+00:00"
+                "validatedAt": "2026-07-20T14:37:00.604163+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -73070,7 +72954,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.662057+00:00"
+                "validatedAt": "2026-07-20T14:37:00.604185+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -73159,7 +73043,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T12:58:57.662100+00:00"
+                "validatedAt": "2026-07-20T14:37:00.604205+00:00"
               },
               "deterministic": true
             },
@@ -73417,7 +73301,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.662167+00:00"
+                "validatedAt": "2026-07-20T14:37:00.604237+00:00"
               },
               "deterministic": true
             },
@@ -73555,7 +73439,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.662233+00:00"
+                "validatedAt": "2026-07-20T14:37:00.604269+00:00"
               },
               "deterministic": true
             },
@@ -73742,7 +73626,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.662307+00:00"
+                "validatedAt": "2026-07-20T14:37:00.604303+00:00"
               },
               "deterministic": true
             },
@@ -73778,7 +73662,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.662364+00:00"
+                "validatedAt": "2026-07-20T14:37:00.604330+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -73790,8 +73674,7 @@
             "x-f5xc-conflicts-with": [
               "auto_host_rewrite",
               "disable_host_rewrite"
-            ],
-            "format": "hostname"
+            ]
           },
           "http_method": {
             "allOf": [
@@ -73854,7 +73737,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.662416+00:00"
+                "validatedAt": "2026-07-20T14:37:00.604354+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74005,7 +73888,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.662469+00:00"
+                "validatedAt": "2026-07-20T14:37:00.604380+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74092,7 +73975,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.662515+00:00"
+                "validatedAt": "2026-07-20T14:37:00.604402+00:00"
               },
               "deterministic": true
             },
@@ -74104,9 +73987,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.465650+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.972707+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -74145,7 +74027,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.662545+00:00"
+                "validatedAt": "2026-07-20T14:37:00.604417+00:00"
               },
               "deterministic": true
             },
@@ -74157,9 +74039,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.465677+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.972719+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "rps_threshold": {
             "type": "integer",
@@ -74534,7 +74415,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.662677+00:00"
+                "validatedAt": "2026-07-20T14:37:00.604469+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74574,7 +74455,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.662706+00:00"
+                "validatedAt": "2026-07-20T14:37:00.604482+00:00"
               },
               "deterministic": true
             },
@@ -74586,9 +74467,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.465778+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.972784+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -74620,7 +74500,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.662734+00:00"
+                "validatedAt": "2026-07-20T14:37:00.604496+00:00"
               },
               "deterministic": true
             },
@@ -74632,9 +74512,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.465796+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.972797+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Request shape for Update API Endpoints Schemas.",
@@ -74778,7 +74657,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.663347+00:00"
+                "validatedAt": "2026-07-20T14:37:00.604764+00:00"
               },
               "deterministic": true
             },
@@ -74822,7 +74701,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.663416+00:00"
+                "validatedAt": "2026-07-20T14:37:00.604793+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75478,7 +75357,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.663610+00:00"
+                "validatedAt": "2026-07-20T14:37:00.604862+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75572,7 +75451,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.663670+00:00"
+                "validatedAt": "2026-07-20T14:37:00.604882+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75681,7 +75560,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.663728+00:00"
+                "validatedAt": "2026-07-20T14:37:00.604902+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75909,7 +75788,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.663803+00:00"
+                "validatedAt": "2026-07-20T14:37:00.604928+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -76052,7 +75931,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.663869+00:00"
+                "validatedAt": "2026-07-20T14:37:00.604957+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -76213,7 +76092,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T12:58:57.663924+00:00"
+                "validatedAt": "2026-07-20T14:37:00.604979+00:00"
               },
               "deterministic": true
             },
@@ -76224,8 +76103,7 @@
               "read": false
             },
             "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "minLength": 1,
-            "format": "fqdn"
+            "minLength": 1
           },
           "inside_network": {
             "allOf": [
@@ -76721,7 +76599,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.664178+00:00"
+                "validatedAt": "2026-07-20T14:37:00.605091+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -76828,7 +76706,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T12:58:57.664223+00:00"
+                "validatedAt": "2026-07-20T14:37:00.605109+00:00"
               },
               "deterministic": true
             },
@@ -76839,8 +76717,7 @@
               "read": false
             },
             "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "minLength": 1,
-            "format": "fqdn"
+            "minLength": 1
           },
           "private_network": {
             "allOf": [
@@ -77063,7 +76940,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.666084+00:00"
+                "validatedAt": "2026-07-20T14:37:00.605937+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -77200,7 +77077,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.666148+00:00"
+                "validatedAt": "2026-07-20T14:37:00.605965+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -77309,7 +77186,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.667561+00:00"
+                "validatedAt": "2026-07-20T14:37:00.606612+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -77487,7 +77364,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.667632+00:00"
+                "validatedAt": "2026-07-20T14:37:00.606644+00:00"
               },
               "deterministic": true
             },
@@ -77497,8 +77374,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "path": {
             "type": "string",
@@ -77519,7 +77395,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:58:57.667679+00:00"
+                "validatedAt": "2026-07-20T14:37:00.606661+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -77694,7 +77570,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.667763+00:00"
+                "validatedAt": "2026-07-20T14:37:00.606698+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -77816,7 +77692,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.667839+00:00"
+                "validatedAt": "2026-07-20T14:37:00.606732+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -77853,7 +77729,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.667884+00:00"
+                "validatedAt": "2026-07-20T14:37:00.606754+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -77944,7 +77820,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.667951+00:00"
+                "validatedAt": "2026-07-20T14:37:00.606786+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78045,7 +77921,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.668024+00:00"
+                "validatedAt": "2026-07-20T14:37:00.606819+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78135,7 +78011,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.668083+00:00"
+                "validatedAt": "2026-07-20T14:37:00.606842+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78170,7 +78046,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.668145+00:00"
+                "validatedAt": "2026-07-20T14:37:00.606870+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78209,7 +78085,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.668205+00:00"
+                "validatedAt": "2026-07-20T14:37:00.606899+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78245,7 +78121,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.668249+00:00"
+                "validatedAt": "2026-07-20T14:37:00.606917+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78298,7 +78174,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.668316+00:00"
+                "validatedAt": "2026-07-20T14:37:00.606947+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78434,7 +78310,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.668400+00:00"
+                "validatedAt": "2026-07-20T14:37:00.606985+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78702,7 +78578,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.669396+00:00"
+                "validatedAt": "2026-07-20T14:37:00.607418+00:00"
               },
               "deterministic": true
             },
@@ -78714,9 +78590,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.468438+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.974398+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "overwrite": {
             "type": "boolean",
@@ -78770,7 +78645,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.669455+00:00"
+                "validatedAt": "2026-07-20T14:37:00.607445+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78781,7 +78656,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.468469+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:12.974418+00:00",
             "x-f5xc-conflicts-with": [
               "secret_value"
             ]
@@ -78905,7 +78780,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.468572+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:12.974493+00:00",
             "x-f5xc-conflicts-with": [
               "any_domain"
             ]
@@ -79173,7 +79048,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.670949+00:00"
+                "validatedAt": "2026-07-20T14:37:00.608140+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -79207,7 +79082,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.671009+00:00"
+                "validatedAt": "2026-07-20T14:37:00.608168+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -79427,7 +79302,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.671126+00:00"
+                "validatedAt": "2026-07-20T14:37:00.608217+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -79476,7 +79351,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.671174+00:00"
+                "validatedAt": "2026-07-20T14:37:00.608241+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -79607,7 +79482,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.671247+00:00"
+                "validatedAt": "2026-07-20T14:37:00.608273+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -79618,8 +79493,7 @@
             },
             "x-f5xc-conflicts-with": [
               "ignore_domain"
-            ],
-            "format": "hostname"
+            ]
           },
           "add_expiry": {
             "type": "string",
@@ -79642,7 +79516,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.671306+00:00"
+                "validatedAt": "2026-07-20T14:37:00.608300+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -79712,7 +79586,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.671369+00:00"
+                "validatedAt": "2026-07-20T14:37:00.608329+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -79958,7 +79832,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.671469+00:00"
+                "validatedAt": "2026-07-20T14:37:00.608399+00:00"
               },
               "deterministic": true
             },
@@ -79970,9 +79844,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.469251+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.974918+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "overwrite": {
             "type": "boolean",
@@ -80081,7 +79954,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.671538+00:00"
+                "validatedAt": "2026-07-20T14:37:00.608453+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -80092,7 +79965,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.469301+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:12.974949+00:00",
             "x-f5xc-conflicts-with": [
               "ignore_value",
               "secret_value"
@@ -80483,7 +80356,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.673422+00:00"
+                "validatedAt": "2026-07-20T14:37:00.609392+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -80582,7 +80455,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.673773+00:00"
+                "validatedAt": "2026-07-20T14:37:00.609555+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -80735,7 +80608,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.673843+00:00"
+                "validatedAt": "2026-07-20T14:37:00.609589+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -80830,7 +80703,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.673911+00:00"
+                "validatedAt": "2026-07-20T14:37:00.609623+00:00"
               },
               "byteLength": {
                 "max": 1024,
@@ -80900,7 +80773,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.674144+00:00"
+                "validatedAt": "2026-07-20T14:37:00.609731+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -80939,7 +80812,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.470329+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.975601+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -80993,7 +80866,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:58:57.674185+00:00"
+                "validatedAt": "2026-07-20T14:37:00.609751+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81021,7 +80894,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.674215+00:00"
+                "validatedAt": "2026-07-20T14:37:00.609766+00:00"
               },
               "deterministic": true
             },
@@ -81045,7 +80918,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.674253+00:00"
+                "validatedAt": "2026-07-20T14:37:00.609782+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81068,7 +80941,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.674289+00:00"
+                "validatedAt": "2026-07-20T14:37:00.609797+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81079,7 +80952,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.470371+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.975626+00:00"
           },
           "status": {
             "type": "string",
@@ -81095,7 +80968,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.674325+00:00"
+                "validatedAt": "2026-07-20T14:37:00.609813+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81106,7 +80979,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.470390+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.975639+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -81165,7 +81038,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:58:57.674359+00:00"
+                "validatedAt": "2026-07-20T14:37:00.609828+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81203,7 +81076,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.674390+00:00"
+                "validatedAt": "2026-07-20T14:37:00.609843+00:00"
               },
               "deterministic": true
             },
@@ -81215,9 +81088,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.470417+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.975656+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "nlb_cname": {
             "type": "string",
@@ -81233,7 +81105,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.674428+00:00"
+                "validatedAt": "2026-07-20T14:37:00.609859+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81256,7 +81128,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.674468+00:00"
+                "validatedAt": "2026-07-20T14:37:00.609875+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81279,7 +81151,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.674503+00:00"
+                "validatedAt": "2026-07-20T14:37:00.609890+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81290,7 +81162,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.470449+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.975676+00:00"
           },
           "target_group_status": {
             "type": "array",
@@ -81362,7 +81234,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:58:57.674554+00:00"
+                "validatedAt": "2026-07-20T14:37:00.609913+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81415,7 +81287,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.674596+00:00"
+                "validatedAt": "2026-07-20T14:37:00.609933+00:00"
               },
               "deterministic": true
             },
@@ -81427,9 +81299,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.470489+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.975701+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "protocol": {
             "type": "string",
@@ -81444,7 +81315,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.674632+00:00"
+                "validatedAt": "2026-07-20T14:37:00.609948+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81467,7 +81338,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.674676+00:00"
+                "validatedAt": "2026-07-20T14:37:00.609963+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81478,7 +81349,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.470514+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.975717+00:00"
           },
           "status": {
             "type": "string",
@@ -81494,7 +81365,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.674712+00:00"
+                "validatedAt": "2026-07-20T14:37:00.609978+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81505,7 +81376,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.470534+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.975729+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -81576,7 +81447,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.674767+00:00"
+                "validatedAt": "2026-07-20T14:37:00.610005+00:00"
               },
               "deterministic": true
             },
@@ -81728,7 +81599,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:58:57.674815+00:00"
+                "validatedAt": "2026-07-20T14:37:00.610026+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81756,7 +81627,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:58:57.674846+00:00"
+                "validatedAt": "2026-07-20T14:37:00.610041+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -82083,7 +81954,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.674968+00:00"
+                "validatedAt": "2026-07-20T14:37:00.610097+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -82226,7 +82097,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.675010+00:00"
+                "validatedAt": "2026-07-20T14:37:00.610116+00:00"
               },
               "deterministic": true
             },
@@ -82273,7 +82144,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.675072+00:00"
+                "validatedAt": "2026-07-20T14:37:00.610147+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -82627,7 +82498,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.675166+00:00"
+                "validatedAt": "2026-07-20T14:37:00.610187+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -82662,7 +82533,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.675224+00:00"
+                "validatedAt": "2026-07-20T14:37:00.610215+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -82843,7 +82714,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.675279+00:00"
+                "validatedAt": "2026-07-20T14:37:00.610242+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83175,7 +83046,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.675641+00:00"
+                "validatedAt": "2026-07-20T14:37:00.610401+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83380,7 +83251,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.675723+00:00"
+                "validatedAt": "2026-07-20T14:37:00.610433+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83423,7 +83294,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.675769+00:00"
+                "validatedAt": "2026-07-20T14:37:00.610457+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83509,7 +83380,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.675820+00:00"
+                "validatedAt": "2026-07-20T14:37:00.610482+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83842,7 +83713,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.675922+00:00"
+                "validatedAt": "2026-07-20T14:37:00.610527+00:00"
               },
               "deterministic": true,
               "source": "minimum_configs",
@@ -83986,7 +83857,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.675986+00:00"
+                "validatedAt": "2026-07-20T14:37:00.610556+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -84327,7 +84198,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.676087+00:00"
+                "validatedAt": "2026-07-20T14:37:00.610600+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -84452,7 +84323,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.676144+00:00"
+                "validatedAt": "2026-07-20T14:37:00.610627+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -84634,7 +84505,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.676211+00:00"
+                "validatedAt": "2026-07-20T14:37:00.610658+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -85126,7 +84997,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.676299+00:00"
+                "validatedAt": "2026-07-20T14:37:00.610698+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -85136,9 +85007,9 @@
               "read": false
             },
             "minLength": 26,
-            "format": "fqdn",
+            "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.471498+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.976295+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -85438,7 +85309,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.676383+00:00"
+                "validatedAt": "2026-07-20T14:37:00.610735+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -85656,7 +85527,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.676455+00:00"
+                "validatedAt": "2026-07-20T14:37:00.610768+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -85699,7 +85570,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.676502+00:00"
+                "validatedAt": "2026-07-20T14:37:00.610791+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -85785,7 +85656,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.676554+00:00"
+                "validatedAt": "2026-07-20T14:37:00.610816+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -86132,7 +86003,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.676678+00:00"
+                "validatedAt": "2026-07-20T14:37:00.610865+00:00"
               },
               "deterministic": true,
               "source": "minimum_configs",
@@ -86276,7 +86147,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.676741+00:00"
+                "validatedAt": "2026-07-20T14:37:00.610893+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -86301,7 +86172,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.676783+00:00"
+                "validatedAt": "2026-07-20T14:37:00.610910+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -86661,7 +86532,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.676902+00:00"
+                "validatedAt": "2026-07-20T14:37:00.610959+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -86786,7 +86657,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.676959+00:00"
+                "validatedAt": "2026-07-20T14:37:00.610986+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -86982,7 +86853,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.677030+00:00"
+                "validatedAt": "2026-07-20T14:37:00.611017+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -87726,7 +87597,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.677128+00:00"
+                "validatedAt": "2026-07-20T14:37:00.611058+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -87931,7 +87802,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.677197+00:00"
+                "validatedAt": "2026-07-20T14:37:00.611090+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -87974,7 +87845,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.677243+00:00"
+                "validatedAt": "2026-07-20T14:37:00.611113+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -88060,7 +87931,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.677294+00:00"
+                "validatedAt": "2026-07-20T14:37:00.611138+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -88393,7 +88264,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.677394+00:00"
+                "validatedAt": "2026-07-20T14:37:00.611182+00:00"
               },
               "deterministic": true,
               "source": "minimum_configs",
@@ -88537,7 +88408,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.677456+00:00"
+                "validatedAt": "2026-07-20T14:37:00.611211+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -88878,7 +88749,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.677559+00:00"
+                "validatedAt": "2026-07-20T14:37:00.611253+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89003,7 +88874,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.677617+00:00"
+                "validatedAt": "2026-07-20T14:37:00.611281+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89185,7 +89056,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.677694+00:00"
+                "validatedAt": "2026-07-20T14:37:00.611311+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89845,7 +89716,7 @@
                 "confidence": 0.99,
                 "category": "networking",
                 "note": "Asymmetry: port enforces [1,65535], health_check_port allows 0",
-                "validatedAt": "2026-07-20T12:58:57.677754+00:00"
+                "validatedAt": "2026-07-20T14:37:00.611335+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89882,7 +89753,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.677803+00:00"
+                "validatedAt": "2026-07-20T14:37:00.611361+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89992,7 +89863,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.677863+00:00"
+                "validatedAt": "2026-07-20T14:37:00.611389+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -90057,7 +89928,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.677895+00:00"
+                "validatedAt": "2026-07-20T14:37:00.611404+00:00"
               },
               "deterministic": true
             },
@@ -90265,7 +90136,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.678200+00:00"
+                "validatedAt": "2026-07-20T14:37:00.611537+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -90369,7 +90240,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.678263+00:00"
+                "validatedAt": "2026-07-20T14:37:00.611567+00:00"
               }
             },
             "x-f5xc-required-for": {

--- a/docs/specifications/api/ce_management.json
+++ b/docs/specifications/api/ce_management.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Ce Management",
     "description": "Customer edge node lifecycle through secure enrollment tokens and downloadable deployment images. Network connectivity options span exclusive, common, and administrative pathways with DHCP address pools supporting both IPv4 and IPv6. Bulk grouping consolidates configuration across distributed locations. Compatibility verification runs before software updates, with rollout tracking for version progression across the infrastructure.",
-    "version": "2.1.182",
+    "version": "2.1.181",
     "contact": {
       "name": "F5 Distributed Cloud",
       "url": "https://docs.cloud.f5.com"
@@ -4513,7 +4513,7 @@
           },
           {
             "name": "response_format",
-            "description": "The format in which the configuration object is to be fetched. This could be for example\n - in GetSpec form for the contents of object\n - in CreateRequest form to create a new similar object\n - to ReplaceRequest form to replace changeable values\n\nDefault format of returned resource\nResponse should be in CreateRequest format\nResponse should be in ReplaceRequest format\nResponse should be in format of GetSpecType\nResponse should have other objects referring to this object\nResponse should have deleted and disabled objects referred by this object.",
+            "description": "The format in which the configuration object is to be fetched. This could be for example\n - in GetSpec form for the contents of object\n - in CreateRequest form to create a new similar object\n - to ReplaceRequest form to replace changeable values\n\nDefault format of returned resource\nResponse should be in CreateRequest format\nResponse should be in ReplaceRequest format\nResponse should be in format of GetSpecType\nResponse should have other objects referring to this object\nResponse should have deleted and disabled objects referrred by this object.",
             "in": "query",
             "required": false,
             "x-displayname": "Broken Referred Objects.",
@@ -7735,7 +7735,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.093062+00:00"
+                "validatedAt": "2026-07-20T14:38:05.948113+00:00"
               },
               "deterministic": true
             },
@@ -7747,9 +7747,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.843534+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.040516+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -7781,7 +7780,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.093097+00:00"
+                "validatedAt": "2026-07-20T14:38:05.948130+00:00"
               },
               "deterministic": true
             },
@@ -7793,9 +7792,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.843555+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.040529+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -7867,7 +7865,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.093126+00:00"
+                "validatedAt": "2026-07-20T14:38:05.948144+00:00"
               },
               "deterministic": true
             },
@@ -7879,9 +7877,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.843575+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.040542+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "network_device": {
             "allOf": [
@@ -8005,7 +8002,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.093223+00:00"
+                "validatedAt": "2026-07-20T14:38:05.948191+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8042,7 +8039,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.093285+00:00"
+                "validatedAt": "2026-07-20T14:38:05.948222+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8203,7 +8200,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.093361+00:00"
+                "validatedAt": "2026-07-20T14:38:05.948258+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8214,8 +8211,7 @@
             },
             "x-f5xc-conflicts-with": [
               "mgmt_ip"
-            ],
-            "format": "hostname"
+            ]
           },
           "mgmt_ip": {
             "type": "string",
@@ -8241,7 +8237,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.093415+00:00"
+                "validatedAt": "2026-07-20T14:38:05.948307+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8321,7 +8317,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.093480+00:00"
+                "validatedAt": "2026-07-20T14:38:05.948343+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8356,7 +8352,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:43.093524+00:00"
+                "validatedAt": "2026-07-20T14:38:05.948361+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8395,7 +8391,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.093575+00:00"
+                "validatedAt": "2026-07-20T14:38:05.948389+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8452,7 +8448,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.093624+00:00"
+                "validatedAt": "2026-07-20T14:38:05.948414+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8514,7 +8510,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:43.093689+00:00"
+                "validatedAt": "2026-07-20T14:38:05.948437+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8609,7 +8605,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.093758+00:00"
+                "validatedAt": "2026-07-20T14:38:05.948469+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8620,8 +8616,7 @@
             },
             "x-f5xc-conflicts-with": [
               "mgmt_ip"
-            ],
-            "format": "hostname"
+            ]
           },
           "mgmt_ip": {
             "type": "string",
@@ -8647,7 +8642,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.093812+00:00"
+                "validatedAt": "2026-07-20T14:38:05.948494+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8687,7 +8682,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.093878+00:00"
+                "validatedAt": "2026-07-20T14:38:05.948524+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8698,8 +8693,7 @@
             },
             "x-f5xc-conflicts-with": [
               "nfs_endpoint_ip"
-            ],
-            "format": "hostname"
+            ]
           },
           "nfs_endpoint_ip": {
             "type": "string",
@@ -8725,7 +8719,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.093937+00:00"
+                "validatedAt": "2026-07-20T14:38:05.948550+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8848,7 +8842,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.094010+00:00"
+                "validatedAt": "2026-07-20T14:38:05.948583+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8892,7 +8886,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.094058+00:00"
+                "validatedAt": "2026-07-20T14:38:05.948607+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8998,7 +8992,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.094107+00:00"
+                "validatedAt": "2026-07-20T14:38:05.948631+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9117,7 +9111,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.094197+00:00"
+                "validatedAt": "2026-07-20T14:38:05.948672+00:00"
               },
               "deterministic": true
             },
@@ -9129,9 +9123,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.843828+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.040680+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -9207,7 +9200,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.094244+00:00"
+                "validatedAt": "2026-07-20T14:38:05.948695+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9281,7 +9274,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.094288+00:00"
+                "validatedAt": "2026-07-20T14:38:05.948717+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9362,7 +9355,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.094336+00:00"
+                "validatedAt": "2026-07-20T14:38:05.948740+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9423,7 +9416,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:43.094382+00:00"
+                "validatedAt": "2026-07-20T14:38:05.948758+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9495,7 +9488,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.094428+00:00"
+                "validatedAt": "2026-07-20T14:38:05.948780+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9642,7 +9635,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.094517+00:00"
+                "validatedAt": "2026-07-20T14:38:05.948820+00:00"
               },
               "deterministic": true
             },
@@ -9654,7 +9647,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.843925+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.040733+00:00"
           },
           "hpe_storage": {
             "allOf": [
@@ -9736,7 +9729,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.094586+00:00"
+                "validatedAt": "2026-07-20T14:38:05.948851+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9774,7 +9767,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.094650+00:00"
+                "validatedAt": "2026-07-20T14:38:05.948880+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9783,8 +9776,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "storage_device": {
             "type": "string",
@@ -9820,7 +9812,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.094724+00:00"
+                "validatedAt": "2026-07-20T14:38:05.948909+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9902,7 +9894,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.094769+00:00"
+                "validatedAt": "2026-07-20T14:38:05.948932+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10080,7 +10072,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.094847+00:00"
+                "validatedAt": "2026-07-20T14:38:05.948967+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10165,7 +10157,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.094894+00:00"
+                "validatedAt": "2026-07-20T14:38:05.948990+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10334,7 +10326,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.844101+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.040830+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -10429,7 +10421,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:01:43.095008+00:00"
+                "validatedAt": "2026-07-20T14:38:05.949034+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10507,7 +10499,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:01:43.095062+00:00"
+                "validatedAt": "2026-07-20T14:38:05.949058+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10518,7 +10510,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.844155+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.040860+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -10605,7 +10597,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.095103+00:00"
+                "validatedAt": "2026-07-20T14:38:05.949077+00:00"
               },
               "deterministic": true
             },
@@ -10617,9 +10609,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.844204+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.040888+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -10650,7 +10641,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.095131+00:00"
+                "validatedAt": "2026-07-20T14:38:05.949090+00:00"
               },
               "deterministic": true
             },
@@ -10662,9 +10653,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.844224+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.040900+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -10733,7 +10723,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:43.095182+00:00"
+                "validatedAt": "2026-07-20T14:38:05.949110+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10745,7 +10735,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.844264+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.040923+00:00"
           },
           "uid": {
             "type": "string",
@@ -10762,7 +10752,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:43.095208+00:00"
+                "validatedAt": "2026-07-20T14:38:05.949120+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10775,7 +10765,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.844285+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.040935+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of fleet is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -10855,7 +10845,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.095253+00:00"
+                "validatedAt": "2026-07-20T14:38:05.949142+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11016,7 +11006,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:43.095296+00:00"
+                "validatedAt": "2026-07-20T14:38:05.949159+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11090,7 +11080,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.095361+00:00"
+                "validatedAt": "2026-07-20T14:38:05.949189+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11135,7 +11125,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:43.095404+00:00"
+                "validatedAt": "2026-07-20T14:38:05.949206+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11187,7 +11177,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.095466+00:00"
+                "validatedAt": "2026-07-20T14:38:05.949234+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11216,7 +11206,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:43.095506+00:00"
+                "validatedAt": "2026-07-20T14:38:05.949249+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11255,7 +11245,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:43.095549+00:00"
+                "validatedAt": "2026-07-20T14:38:05.949266+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11281,7 +11271,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:43.095589+00:00"
+                "validatedAt": "2026-07-20T14:38:05.949281+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11313,7 +11303,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:43.095630+00:00"
+                "validatedAt": "2026-07-20T14:38:05.949297+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11355,7 +11345,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:43.095682+00:00"
+                "validatedAt": "2026-07-20T14:38:05.949314+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11613,7 +11603,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:43.095756+00:00"
+                "validatedAt": "2026-07-20T14:38:05.949342+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11725,7 +11715,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.095829+00:00"
+                "validatedAt": "2026-07-20T14:38:05.949374+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11833,7 +11823,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.844522+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.041063+00:00"
           }
         },
         "x-f5xc-description-short": "Most recently observed status of fleet object.",
@@ -11903,7 +11893,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.095928+00:00"
+                "validatedAt": "2026-07-20T14:38:05.949418+00:00"
               },
               "deterministic": true,
               "format": "uri"
@@ -11976,7 +11966,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.095988+00:00"
+                "validatedAt": "2026-07-20T14:38:05.949445+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12008,7 +11998,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.096049+00:00"
+                "validatedAt": "2026-07-20T14:38:05.949471+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12061,7 +12051,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.096118+00:00"
+                "validatedAt": "2026-07-20T14:38:05.949504+00:00"
               },
               "deterministic": true
             },
@@ -12073,7 +12063,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.844572+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.041091+00:00"
           },
           "destroy_on_delete": {
             "type": "boolean",
@@ -12131,7 +12121,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.096176+00:00"
+                "validatedAt": "2026-07-20T14:38:05.949530+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12158,7 +12148,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:43.096213+00:00"
+                "validatedAt": "2026-07-20T14:38:05.949545+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12185,7 +12175,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:43.096250+00:00"
+                "validatedAt": "2026-07-20T14:38:05.949559+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12218,7 +12208,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.096310+00:00"
+                "validatedAt": "2026-07-20T14:38:05.949587+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12251,7 +12241,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.096359+00:00"
+                "validatedAt": "2026-07-20T14:38:05.949612+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12284,7 +12274,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.096420+00:00"
+                "validatedAt": "2026-07-20T14:38:05.949640+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12318,7 +12308,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.096478+00:00"
+                "validatedAt": "2026-07-20T14:38:05.949667+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12351,7 +12341,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.096536+00:00"
+                "validatedAt": "2026-07-20T14:38:05.949694+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12486,7 +12476,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.096607+00:00"
+                "validatedAt": "2026-07-20T14:38:05.949725+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12557,7 +12547,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:43.096644+00:00"
+                "validatedAt": "2026-07-20T14:38:05.949740+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12591,7 +12581,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.096712+00:00"
+                "validatedAt": "2026-07-20T14:38:05.949769+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12723,7 +12713,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.096809+00:00"
+                "validatedAt": "2026-07-20T14:38:05.949811+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12770,7 +12760,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.096877+00:00"
+                "validatedAt": "2026-07-20T14:38:05.949841+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12803,7 +12793,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.096936+00:00"
+                "validatedAt": "2026-07-20T14:38:05.949868+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12811,8 +12801,7 @@
               "create": false,
               "update": false,
               "read": false
-            },
-            "format": "hostname"
+            }
           },
           "username": {
             "type": "string",
@@ -12848,7 +12837,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.096988+00:00"
+                "validatedAt": "2026-07-20T14:38:05.949894+00:00"
               },
               "deterministic": true
             },
@@ -12957,7 +12946,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.097057+00:00"
+                "validatedAt": "2026-07-20T14:38:05.949923+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12990,7 +12979,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.097117+00:00"
+                "validatedAt": "2026-07-20T14:38:05.949950+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13041,7 +13030,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.097184+00:00"
+                "validatedAt": "2026-07-20T14:38:05.949980+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13052,8 +13041,7 @@
             },
             "x-f5xc-conflicts-with": [
               "data_lif_ip"
-            ],
-            "format": "hostname"
+            ]
           },
           "data_lif_ip": {
             "type": "string",
@@ -13080,7 +13068,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.097242+00:00"
+                "validatedAt": "2026-07-20T14:38:05.950006+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13138,7 +13126,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:43.097290+00:00"
+                "validatedAt": "2026-07-20T14:38:05.950024+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13164,7 +13152,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:43.097330+00:00"
+                "validatedAt": "2026-07-20T14:38:05.950039+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13201,7 +13189,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.097394+00:00"
+                "validatedAt": "2026-07-20T14:38:05.950070+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13212,8 +13200,7 @@
             },
             "x-f5xc-conflicts-with": [
               "management_lif_ip"
-            ],
-            "format": "hostname"
+            ]
           },
           "management_lif_ip": {
             "type": "string",
@@ -13240,7 +13227,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.097452+00:00"
+                "validatedAt": "2026-07-20T14:38:05.950098+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13269,7 +13256,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:43.097494+00:00"
+                "validatedAt": "2026-07-20T14:38:05.950115+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13308,7 +13295,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:43.097530+00:00"
+                "validatedAt": "2026-07-20T14:38:05.950129+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13346,7 +13333,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.097574+00:00"
+                "validatedAt": "2026-07-20T14:38:05.950151+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13381,7 +13368,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:43.097618+00:00"
+                "validatedAt": "2026-07-20T14:38:05.950169+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13407,7 +13394,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:43.097665+00:00"
+                "validatedAt": "2026-07-20T14:38:05.950185+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13444,7 +13431,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.097713+00:00"
+                "validatedAt": "2026-07-20T14:38:05.950207+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13478,7 +13465,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.097774+00:00"
+                "validatedAt": "2026-07-20T14:38:05.950235+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13522,7 +13509,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.097823+00:00"
+                "validatedAt": "2026-07-20T14:38:05.950259+00:00"
               },
               "deterministic": true
             },
@@ -13631,7 +13618,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.097887+00:00"
+                "validatedAt": "2026-07-20T14:38:05.950287+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13682,7 +13669,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.097953+00:00"
+                "validatedAt": "2026-07-20T14:38:05.950317+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13693,8 +13680,7 @@
             },
             "x-f5xc-conflicts-with": [
               "data_lif_ip"
-            ],
-            "format": "hostname"
+            ]
           },
           "data_lif_ip": {
             "type": "string",
@@ -13721,7 +13707,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.098009+00:00"
+                "validatedAt": "2026-07-20T14:38:05.950342+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13761,7 +13747,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.098069+00:00"
+                "validatedAt": "2026-07-20T14:38:05.950369+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13867,7 +13853,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.098170+00:00"
+                "validatedAt": "2026-07-20T14:38:05.950411+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13878,8 +13864,7 @@
             },
             "x-f5xc-conflicts-with": [
               "management_lif_ip"
-            ],
-            "format": "hostname"
+            ]
           },
           "management_lif_ip": {
             "type": "string",
@@ -13906,7 +13891,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.098228+00:00"
+                "validatedAt": "2026-07-20T14:38:05.950437+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13964,7 +13949,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:43.098268+00:00"
+                "validatedAt": "2026-07-20T14:38:05.950453+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14002,7 +13987,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.098310+00:00"
+                "validatedAt": "2026-07-20T14:38:05.950474+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14037,7 +14022,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:43.098356+00:00"
+                "validatedAt": "2026-07-20T14:38:05.950493+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14074,7 +14059,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.098415+00:00"
+                "validatedAt": "2026-07-20T14:38:05.950521+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14111,7 +14096,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.098460+00:00"
+                "validatedAt": "2026-07-20T14:38:05.950543+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14145,7 +14130,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.098520+00:00"
+                "validatedAt": "2026-07-20T14:38:05.950571+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14205,7 +14190,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.098572+00:00"
+                "validatedAt": "2026-07-20T14:38:05.950598+00:00"
               },
               "deterministic": true
             },
@@ -14407,7 +14392,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.098671+00:00"
+                "validatedAt": "2026-07-20T14:38:05.950639+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14521,7 +14506,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:43.098726+00:00"
+                "validatedAt": "2026-07-20T14:38:05.950660+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14715,7 +14700,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:43.098775+00:00"
+                "validatedAt": "2026-07-20T14:38:05.950678+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14727,7 +14712,7 @@
             "readOnly": true,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.845116+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.041398+00:00"
           },
           "name": {
             "type": "string",
@@ -14760,7 +14745,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.098803+00:00"
+                "validatedAt": "2026-07-20T14:38:05.950692+00:00"
               },
               "deterministic": true
             },
@@ -14772,9 +14757,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.845136+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.041409+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -14807,7 +14791,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.098830+00:00"
+                "validatedAt": "2026-07-20T14:38:05.950705+00:00"
               },
               "deterministic": true
             },
@@ -14819,9 +14803,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.845154+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.041421+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -14840,7 +14823,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:43.098863+00:00"
+                "validatedAt": "2026-07-20T14:38:05.950718+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14853,7 +14836,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.845173+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.041433+00:00"
           },
           "uid": {
             "type": "string",
@@ -14872,7 +14855,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:43.098889+00:00"
+                "validatedAt": "2026-07-20T14:38:05.950728+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14886,7 +14869,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.845192+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.041445+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -14940,7 +14923,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:43.098925+00:00"
+                "validatedAt": "2026-07-20T14:38:05.950742+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14963,7 +14946,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:43.098958+00:00"
+                "validatedAt": "2026-07-20T14:38:05.950756+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14974,7 +14957,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.845219+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.041461+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -15033,7 +15016,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:43.099001+00:00"
+                "validatedAt": "2026-07-20T14:38:05.950773+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15074,7 +15057,7 @@
                 "confidence": 1.0,
                 "category": "content",
                 "note": "Blindfold envelope encryption (AES-256-GCM + RSA-OAEP) of an RSA-2048 TLS private key produces ~3700 char string:/// URL. 128KB max secret size = ~175KB base64. Discovery reported 1024 which is incorrect.",
-                "validatedAt": "2026-07-20T13:01:43.099037+00:00"
+                "validatedAt": "2026-07-20T14:38:05.950794+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15085,7 +15068,7 @@
             },
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.845247+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.041478+00:00"
           },
           "store_provider": {
             "type": "string",
@@ -15104,7 +15087,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:43.099083+00:00"
+                "validatedAt": "2026-07-20T14:38:05.950813+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15171,7 +15154,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:43.099118+00:00"
+                "validatedAt": "2026-07-20T14:38:05.950828+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15182,7 +15165,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.845274+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.041494+00:00"
           },
           "url": {
             "type": "string",
@@ -15220,7 +15203,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.099172+00:00"
+                "validatedAt": "2026-07-20T14:38:05.950857+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -15293,7 +15276,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T13:01:43.099204+00:00"
+                "validatedAt": "2026-07-20T14:38:05.950871+00:00"
               },
               "deterministic": true
             },
@@ -15304,8 +15287,7 @@
               "read": false
             },
             "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "minLength": 1,
-            "format": "fqdn"
+            "minLength": 1
           },
           "last_update_time": {
             "type": "string",
@@ -15322,7 +15304,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:43.099244+00:00"
+                "validatedAt": "2026-07-20T14:38:05.950886+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15349,7 +15331,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:43.099277+00:00"
+                "validatedAt": "2026-07-20T14:38:05.950899+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15360,7 +15342,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.845313+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.041518+00:00"
           },
           "service_name": {
             "type": "string",
@@ -15377,7 +15359,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:43.099315+00:00"
+                "validatedAt": "2026-07-20T14:38:05.950914+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15410,7 +15392,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:43.099351+00:00"
+                "validatedAt": "2026-07-20T14:38:05.950929+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15421,7 +15403,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.845338+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.041533+00:00"
           },
           "type": {
             "type": "string",
@@ -15446,7 +15428,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:43.099383+00:00"
+                "validatedAt": "2026-07-20T14:38:05.950942+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15586,7 +15568,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:43.099424+00:00"
+                "validatedAt": "2026-07-20T14:38:05.950958+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15664,7 +15646,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.099451+00:00"
+                "validatedAt": "2026-07-20T14:38:05.950984+00:00"
               },
               "deterministic": true
             },
@@ -15676,9 +15658,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.845386+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.041561+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -15961,7 +15942,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.099528+00:00"
+                "validatedAt": "2026-07-20T14:38:05.951024+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16053,7 +16034,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.099593+00:00"
+                "validatedAt": "2026-07-20T14:38:05.951055+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16125,7 +16106,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.099642+00:00"
+                "validatedAt": "2026-07-20T14:38:05.951080+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16219,7 +16200,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.099716+00:00"
+                "validatedAt": "2026-07-20T14:38:05.951111+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16291,7 +16272,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.099759+00:00"
+                "validatedAt": "2026-07-20T14:38:05.951133+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16458,7 +16439,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.099836+00:00"
+                "validatedAt": "2026-07-20T14:38:05.951172+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -16473,7 +16454,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.845525+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.041640+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -16543,7 +16524,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.099873+00:00"
+                "validatedAt": "2026-07-20T14:38:05.951189+00:00"
               },
               "deterministic": true
             },
@@ -16555,9 +16536,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.845558+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.041660+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -16590,7 +16570,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.099899+00:00"
+                "validatedAt": "2026-07-20T14:38:05.951203+00:00"
               },
               "deterministic": true
             },
@@ -16602,9 +16582,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.845577+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.041671+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -16702,7 +16681,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.099971+00:00"
+                "validatedAt": "2026-07-20T14:38:05.951238+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -16717,7 +16696,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.845605+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.041688+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -16789,7 +16768,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.100009+00:00"
+                "validatedAt": "2026-07-20T14:38:05.951255+00:00"
               },
               "deterministic": true
             },
@@ -16801,9 +16780,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.845637+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.041708+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -16836,7 +16814,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.100033+00:00"
+                "validatedAt": "2026-07-20T14:38:05.951268+00:00"
               },
               "deterministic": true
             },
@@ -16848,9 +16826,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.845663+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.041720+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -16948,7 +16925,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.100103+00:00"
+                "validatedAt": "2026-07-20T14:38:05.951303+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -16963,7 +16940,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.845692+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.041736+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -17033,7 +17010,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.100140+00:00"
+                "validatedAt": "2026-07-20T14:38:05.951320+00:00"
               },
               "deterministic": true
             },
@@ -17045,9 +17022,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.845725+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.041756+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -17080,7 +17056,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.100166+00:00"
+                "validatedAt": "2026-07-20T14:38:05.951333+00:00"
               },
               "deterministic": true
             },
@@ -17092,9 +17068,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.845743+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.041767+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -17313,7 +17288,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.100216+00:00"
+                "validatedAt": "2026-07-20T14:38:05.951357+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17377,7 +17352,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.100262+00:00"
+                "validatedAt": "2026-07-20T14:38:05.951380+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17444,7 +17419,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:43.100305+00:00"
+                "validatedAt": "2026-07-20T14:38:05.951397+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17472,7 +17447,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:43.100343+00:00"
+                "validatedAt": "2026-07-20T14:38:05.951413+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17500,7 +17475,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:43.100379+00:00"
+                "validatedAt": "2026-07-20T14:38:05.951428+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17539,7 +17514,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:43.100417+00:00"
+                "validatedAt": "2026-07-20T14:38:05.951443+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17566,7 +17541,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:43.100443+00:00"
+                "validatedAt": "2026-07-20T14:38:05.951454+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17579,7 +17554,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.845841+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.041824+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -17595,7 +17570,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:43.100477+00:00"
+                "validatedAt": "2026-07-20T14:38:05.951468+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17736,7 +17711,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:43.100524+00:00"
+                "validatedAt": "2026-07-20T14:38:05.951487+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17747,7 +17722,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.845881+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.041848+00:00"
           },
           "status": {
             "type": "string",
@@ -17765,7 +17740,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:43.100557+00:00"
+                "validatedAt": "2026-07-20T14:38:05.951500+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17776,7 +17751,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.845899+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.041859+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -17834,7 +17809,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:43.100598+00:00"
+                "validatedAt": "2026-07-20T14:38:05.951517+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17861,7 +17836,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:43.100637+00:00"
+                "validatedAt": "2026-07-20T14:38:05.951533+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17888,7 +17863,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:43.100681+00:00"
+                "validatedAt": "2026-07-20T14:38:05.951548+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17916,7 +17891,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:43.100722+00:00"
+                "validatedAt": "2026-07-20T14:38:05.951564+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17992,7 +17967,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:43.100784+00:00"
+                "validatedAt": "2026-07-20T14:38:05.951589+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18060,7 +18035,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:43.100836+00:00"
+                "validatedAt": "2026-07-20T14:38:05.951609+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18072,7 +18047,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.845986+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.041909+00:00"
           },
           "uid": {
             "type": "string",
@@ -18091,7 +18066,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:43.100861+00:00"
+                "validatedAt": "2026-07-20T14:38:05.951620+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18104,7 +18079,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.846005+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.041921+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -18170,7 +18145,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:43.100892+00:00"
+                "validatedAt": "2026-07-20T14:38:05.951633+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18181,7 +18156,7 @@
             },
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.846024+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.041933+00:00"
           },
           "name": {
             "type": "string",
@@ -18214,7 +18189,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.100919+00:00"
+                "validatedAt": "2026-07-20T14:38:05.951646+00:00"
               },
               "deterministic": true
             },
@@ -18226,9 +18201,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.846042+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.041945+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -18261,7 +18235,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.100946+00:00"
+                "validatedAt": "2026-07-20T14:38:05.951659+00:00"
               },
               "deterministic": true
             },
@@ -18273,9 +18247,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.846061+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.041957+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "uid": {
             "type": "string",
@@ -18292,7 +18265,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:43.100971+00:00"
+                "validatedAt": "2026-07-20T14:38:05.951669+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18305,7 +18278,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.846079+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.041968+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -18452,7 +18425,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.101023+00:00"
+                "validatedAt": "2026-07-20T14:38:05.951694+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18745,7 +18718,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:43.101109+00:00"
+                "validatedAt": "2026-07-20T14:38:05.951725+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18778,7 +18751,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.101155+00:00"
+                "validatedAt": "2026-07-20T14:38:05.951748+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18887,7 +18860,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.101210+00:00"
+                "validatedAt": "2026-07-20T14:38:05.951774+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18921,7 +18894,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.101250+00:00"
+                "validatedAt": "2026-07-20T14:38:05.951794+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19040,7 +19013,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.101328+00:00"
+                "validatedAt": "2026-07-20T14:38:05.951829+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19073,7 +19046,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.101371+00:00"
+                "validatedAt": "2026-07-20T14:38:05.951851+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19231,7 +19204,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.101456+00:00"
+                "validatedAt": "2026-07-20T14:38:05.951888+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19377,7 +19350,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.101503+00:00"
+                "validatedAt": "2026-07-20T14:38:05.951911+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19670,7 +19643,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:43.101587+00:00"
+                "validatedAt": "2026-07-20T14:38:05.951942+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19703,7 +19676,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.101630+00:00"
+                "validatedAt": "2026-07-20T14:38:05.951964+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19812,7 +19785,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.101694+00:00"
+                "validatedAt": "2026-07-20T14:38:05.951989+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19846,7 +19819,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.101736+00:00"
+                "validatedAt": "2026-07-20T14:38:05.952009+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19965,7 +19938,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.101813+00:00"
+                "validatedAt": "2026-07-20T14:38:05.952043+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19998,7 +19971,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.101856+00:00"
+                "validatedAt": "2026-07-20T14:38:05.952065+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20156,7 +20129,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.101941+00:00"
+                "validatedAt": "2026-07-20T14:38:05.952102+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20295,7 +20268,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.101987+00:00"
+                "validatedAt": "2026-07-20T14:38:05.952124+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20586,7 +20559,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.102079+00:00"
+                "validatedAt": "2026-07-20T14:38:05.952161+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20695,7 +20668,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.102136+00:00"
+                "validatedAt": "2026-07-20T14:38:05.952187+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20729,7 +20702,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.102183+00:00"
+                "validatedAt": "2026-07-20T14:38:05.952209+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20848,7 +20821,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.102263+00:00"
+                "validatedAt": "2026-07-20T14:38:05.952243+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20881,7 +20854,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.102309+00:00"
+                "validatedAt": "2026-07-20T14:38:05.952265+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21039,7 +21012,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.102392+00:00"
+                "validatedAt": "2026-07-20T14:38:05.952301+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21166,7 +21139,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.102449+00:00"
+                "validatedAt": "2026-07-20T14:38:05.952330+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -21180,8 +21153,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -21220,7 +21192,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.102500+00:00"
+                "validatedAt": "2026-07-20T14:38:05.952356+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -21235,9 +21207,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.846854+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.042411+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -21266,7 +21237,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.102559+00:00"
+                "validatedAt": "2026-07-20T14:38:05.952381+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21279,7 +21250,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.846873+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.042423+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a direct reference from one object(the referrer) to another(the referred).",
@@ -21698,7 +21669,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:43.102692+00:00"
+                "validatedAt": "2026-07-20T14:38:05.952430+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21873,7 +21844,7 @@
             "maxLength": 7,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.458970+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.221909+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -22227,7 +22198,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:19.753448+00:00"
+                "validatedAt": "2026-07-20T14:39:30.821846+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22278,7 +22249,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:19.753517+00:00"
+                "validatedAt": "2026-07-20T14:39:30.821878+00:00"
               },
               "deterministic": true
             },
@@ -22352,7 +22323,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:19.753573+00:00"
+                "validatedAt": "2026-07-20T14:39:30.821905+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22387,7 +22358,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:19.753627+00:00"
+                "validatedAt": "2026-07-20T14:39:30.821931+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22505,7 +22476,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:19.753695+00:00"
+                "validatedAt": "2026-07-20T14:39:30.821958+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22755,7 +22726,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:19.753784+00:00"
+                "validatedAt": "2026-07-20T14:39:30.821993+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22794,7 +22765,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:19.753843+00:00"
+                "validatedAt": "2026-07-20T14:39:30.822020+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22863,7 +22834,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:19.753894+00:00"
+                "validatedAt": "2026-07-20T14:39:30.822042+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22914,7 +22885,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:19.753952+00:00"
+                "validatedAt": "2026-07-20T14:39:30.822070+00:00"
               },
               "deterministic": true
             },
@@ -23048,7 +23019,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:19.754010+00:00"
+                "validatedAt": "2026-07-20T14:39:30.822095+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23082,7 +23053,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:19.754065+00:00"
+                "validatedAt": "2026-07-20T14:39:30.822121+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23200,7 +23171,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:19.754121+00:00"
+                "validatedAt": "2026-07-20T14:39:30.822146+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23344,7 +23315,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:19.754195+00:00"
+                "validatedAt": "2026-07-20T14:39:30.822178+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23450,7 +23421,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:19.754274+00:00"
+                "validatedAt": "2026-07-20T14:39:30.822211+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23507,7 +23478,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:05:19.754319+00:00"
+                "validatedAt": "2026-07-20T14:39:30.822229+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23609,7 +23580,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:19.754382+00:00"
+                "validatedAt": "2026-07-20T14:39:30.822258+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23667,7 +23638,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:19.754448+00:00"
+                "validatedAt": "2026-07-20T14:39:30.822287+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23762,7 +23733,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:19.754483+00:00"
+                "validatedAt": "2026-07-20T14:39:30.822302+00:00"
               },
               "deterministic": true
             },
@@ -23774,9 +23745,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.152986+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.877853+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -23808,7 +23778,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:19.754512+00:00"
+                "validatedAt": "2026-07-20T14:39:30.822315+00:00"
               },
               "deterministic": true
             },
@@ -23820,9 +23790,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.153006+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.877866+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -23916,7 +23885,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:19.754574+00:00"
+                "validatedAt": "2026-07-20T14:39:30.822343+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24092,7 +24061,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:19.754671+00:00"
+                "validatedAt": "2026-07-20T14:39:30.822379+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24149,7 +24118,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:05:19.754710+00:00"
+                "validatedAt": "2026-07-20T14:39:30.822397+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24290,7 +24259,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T13:05:19.754759+00:00"
+                "validatedAt": "2026-07-20T14:39:30.822418+00:00"
               },
               "deterministic": true
             },
@@ -24483,7 +24452,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.153202+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.877987+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -24596,7 +24565,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:19.754882+00:00"
+                "validatedAt": "2026-07-20T14:39:30.822467+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24685,7 +24654,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:19.754931+00:00"
+                "validatedAt": "2026-07-20T14:39:30.822487+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24888,7 +24857,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:05:19.755002+00:00"
+                "validatedAt": "2026-07-20T14:39:30.822516+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24924,7 +24893,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:19.755048+00:00"
+                "validatedAt": "2026-07-20T14:39:30.822538+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25004,7 +24973,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:19.755099+00:00"
+                "validatedAt": "2026-07-20T14:39:30.822562+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25151,7 +25120,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:19.755196+00:00"
+                "validatedAt": "2026-07-20T14:39:30.822605+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25395,7 +25364,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:19.755260+00:00"
+                "validatedAt": "2026-07-20T14:39:30.822634+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25466,7 +25435,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:19.755320+00:00"
+                "validatedAt": "2026-07-20T14:39:30.822662+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25675,7 +25644,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T13:05:19.755369+00:00"
+                "validatedAt": "2026-07-20T14:39:30.822683+00:00"
               },
               "deterministic": true
             },
@@ -25755,7 +25724,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:19.755426+00:00"
+                "validatedAt": "2026-07-20T14:39:30.822710+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25809,7 +25778,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T13:05:19.755459+00:00"
+                "validatedAt": "2026-07-20T14:39:30.822725+00:00"
               },
               "deterministic": true
             },
@@ -25892,7 +25861,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:19.755515+00:00"
+                "validatedAt": "2026-07-20T14:39:30.822751+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25932,7 +25901,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T13:05:19.755543+00:00"
+                "validatedAt": "2026-07-20T14:39:30.822765+00:00"
               },
               "deterministic": true
             },
@@ -26034,7 +26003,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:19.755594+00:00"
+                "validatedAt": "2026-07-20T14:39:30.822790+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26082,7 +26051,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:19.755639+00:00"
+                "validatedAt": "2026-07-20T14:39:30.822808+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26187,7 +26156,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:05:19.755703+00:00"
+                "validatedAt": "2026-07-20T14:39:30.822831+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26263,7 +26232,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:19.755767+00:00"
+                "validatedAt": "2026-07-20T14:39:30.822859+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26430,7 +26399,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:05:19.755827+00:00"
+                "validatedAt": "2026-07-20T14:39:30.822883+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26509,7 +26478,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:05:19.755878+00:00"
+                "validatedAt": "2026-07-20T14:39:30.822905+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26520,7 +26489,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.153660+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.878258+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -26607,7 +26576,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:19.755920+00:00"
+                "validatedAt": "2026-07-20T14:39:30.822922+00:00"
               },
               "deterministic": true
             },
@@ -26619,9 +26588,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.153708+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.878286+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -26652,7 +26620,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:19.755947+00:00"
+                "validatedAt": "2026-07-20T14:39:30.822935+00:00"
               },
               "deterministic": true
             },
@@ -26664,9 +26632,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.153727+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.878299+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -26735,7 +26702,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:19.755998+00:00"
+                "validatedAt": "2026-07-20T14:39:30.822955+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26747,7 +26714,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.153765+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.878323+00:00"
           },
           "uid": {
             "type": "string",
@@ -26765,7 +26732,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:19.756023+00:00"
+                "validatedAt": "2026-07-20T14:39:30.822965+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26778,7 +26745,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.153784+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.878336+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of network_interface is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -27195,7 +27162,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:19.756099+00:00"
+                "validatedAt": "2026-07-20T14:39:30.822996+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27781,7 +27748,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:19.756199+00:00"
+                "validatedAt": "2026-07-20T14:39:30.823038+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27820,7 +27787,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:19.756254+00:00"
+                "validatedAt": "2026-07-20T14:39:30.823065+00:00"
               },
               "deterministic": true
             },
@@ -27930,7 +27897,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.153965+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.878445+00:00"
           }
         },
         "x-f5xc-description-short": "Most recently observed status of object.",
@@ -28022,7 +27989,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:19.756349+00:00"
+                "validatedAt": "2026-07-20T14:39:30.823105+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28059,7 +28026,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:05:19.756384+00:00"
+                "validatedAt": "2026-07-20T14:39:30.823121+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28211,7 +28178,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.369939+00:00"
+                "validatedAt": "2026-07-20T14:40:11.336580+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28222,7 +28189,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.887858+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.538039+00:00"
           },
           "status": {
             "type": "string",
@@ -28240,7 +28207,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.369973+00:00"
+                "validatedAt": "2026-07-20T14:40:11.336593+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28251,7 +28218,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.887876+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.538051+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -28323,7 +28290,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.370100+00:00"
+                "validatedAt": "2026-07-20T14:40:11.336645+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28350,7 +28317,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.370143+00:00"
+                "validatedAt": "2026-07-20T14:40:11.336662+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28413,7 +28380,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:05.370185+00:00"
+                "validatedAt": "2026-07-20T14:40:11.336682+00:00"
               },
               "deterministic": true
             },
@@ -28425,9 +28392,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.887955+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.538100+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "passport": {
             "allOf": [
@@ -28458,7 +28424,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.370229+00:00"
+                "validatedAt": "2026-07-20T14:40:11.336700+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28560,7 +28526,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:05.370266+00:00"
+                "validatedAt": "2026-07-20T14:40:11.336716+00:00"
               },
               "deterministic": true
             },
@@ -28572,9 +28538,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.887994+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.538124+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -28612,7 +28577,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:05.370298+00:00"
+                "validatedAt": "2026-07-20T14:40:11.336732+00:00"
               },
               "deterministic": true
             },
@@ -28624,9 +28589,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.888013+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.538137+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "token": {
             "type": "string",
@@ -28652,7 +28616,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:07:05.370339+00:00"
+                "validatedAt": "2026-07-20T14:40:11.336750+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28714,7 +28678,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.370371+00:00"
+                "validatedAt": "2026-07-20T14:40:11.336764+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28939,7 +28903,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.370435+00:00"
+                "validatedAt": "2026-07-20T14:40:11.336789+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28950,7 +28914,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.888090+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.538183+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -29001,7 +28965,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.370482+00:00"
+                "validatedAt": "2026-07-20T14:40:11.336807+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29024,7 +28988,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.370526+00:00"
+                "validatedAt": "2026-07-20T14:40:11.336826+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29093,7 +29057,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.370569+00:00"
+                "validatedAt": "2026-07-20T14:40:11.336844+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29385,7 +29349,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.370723+00:00"
+                "validatedAt": "2026-07-20T14:40:11.336891+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29411,7 +29375,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.370763+00:00"
+                "validatedAt": "2026-07-20T14:40:11.336907+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29438,7 +29402,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.370798+00:00"
+                "validatedAt": "2026-07-20T14:40:11.336922+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29450,7 +29414,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.888215+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.538257+00:00"
           },
           "hostname": {
             "type": "string",
@@ -29482,7 +29446,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T13:07:05.370834+00:00"
+                "validatedAt": "2026-07-20T14:40:11.336945+00:00"
               },
               "deterministic": true
             },
@@ -29493,8 +29457,7 @@
               "read": false
             },
             "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "minLength": 1,
-            "format": "fqdn"
+            "minLength": 1
           },
           "hw_info": {
             "allOf": [
@@ -29525,7 +29488,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.370877+00:00"
+                "validatedAt": "2026-07-20T14:40:11.336963+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29599,7 +29562,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.370927+00:00"
+                "validatedAt": "2026-07-20T14:40:11.336982+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29625,7 +29588,7 @@
             "maxLength": 8,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.888282+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.538298+00:00"
           },
           "sw_info": {
             "allOf": [
@@ -29663,7 +29626,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T13:07:05.370975+00:00"
+                "validatedAt": "2026-07-20T14:40:11.337002+00:00"
               },
               "deterministic": true
             },
@@ -29690,7 +29653,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.371006+00:00"
+                "validatedAt": "2026-07-20T14:40:11.337014+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29767,7 +29730,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.371045+00:00"
+                "validatedAt": "2026-07-20T14:40:11.337036+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29793,7 +29756,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.371086+00:00"
+                "validatedAt": "2026-07-20T14:40:11.337052+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29820,7 +29783,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.371123+00:00"
+                "validatedAt": "2026-07-20T14:40:11.337067+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29847,7 +29810,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.371164+00:00"
+                "validatedAt": "2026-07-20T14:40:11.337085+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29932,7 +29895,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:07:05.371211+00:00"
+                "validatedAt": "2026-07-20T14:40:11.337106+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30011,7 +29974,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:07:05.371263+00:00"
+                "validatedAt": "2026-07-20T14:40:11.337129+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30022,7 +29985,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.888373+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.538352+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -30109,7 +30072,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:05.371301+00:00"
+                "validatedAt": "2026-07-20T14:40:11.337147+00:00"
               },
               "deterministic": true
             },
@@ -30121,9 +30084,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.888418+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.538381+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -30154,7 +30116,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:05.371328+00:00"
+                "validatedAt": "2026-07-20T14:40:11.337161+00:00"
               },
               "deterministic": true
             },
@@ -30166,9 +30128,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.888437+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.538392+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "object": {
             "allOf": [
@@ -30234,7 +30195,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.371369+00:00"
+                "validatedAt": "2026-07-20T14:40:11.337178+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30246,7 +30207,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.888474+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.538416+00:00"
           },
           "uid": {
             "type": "string",
@@ -30263,7 +30224,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.371395+00:00"
+                "validatedAt": "2026-07-20T14:40:11.337189+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30276,7 +30237,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.888493+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.538429+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of registration is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -30365,7 +30326,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:05.371428+00:00"
+                "validatedAt": "2026-07-20T14:40:11.337204+00:00"
               },
               "deterministic": true
             },
@@ -30377,9 +30338,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.888514+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.538442+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "state": {
             "allOf": [
@@ -30477,7 +30437,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.888553+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.538467+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -30657,7 +30617,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.371491+00:00"
+                "validatedAt": "2026-07-20T14:40:11.337229+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30712,7 +30672,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.371555+00:00"
+                "validatedAt": "2026-07-20T14:40:11.337256+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30832,7 +30792,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:05.371673+00:00"
+                "validatedAt": "2026-07-20T14:40:11.337304+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30872,7 +30832,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:05.371740+00:00"
+                "validatedAt": "2026-07-20T14:40:11.337336+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30906,7 +30866,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:05.371804+00:00"
+                "validatedAt": "2026-07-20T14:40:11.337367+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31201,7 +31161,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.371861+00:00"
+                "validatedAt": "2026-07-20T14:40:11.337389+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31321,7 +31281,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:05.371926+00:00"
+                "validatedAt": "2026-07-20T14:40:11.337420+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31355,7 +31315,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:05.371986+00:00"
+                "validatedAt": "2026-07-20T14:40:11.337449+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31395,7 +31355,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:05.372016+00:00"
+                "validatedAt": "2026-07-20T14:40:11.337463+00:00"
               },
               "deterministic": true
             },
@@ -31407,9 +31367,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.888724+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.538566+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "request_body": {
             "allOf": [
@@ -31517,7 +31476,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:05.372454+00:00"
+                "validatedAt": "2026-07-20T14:40:11.337676+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -31532,7 +31491,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.888973+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.538722+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -31604,7 +31563,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:05.372490+00:00"
+                "validatedAt": "2026-07-20T14:40:11.337694+00:00"
               },
               "deterministic": true
             },
@@ -31616,9 +31575,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.889006+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.538743+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -31651,7 +31609,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:05.372517+00:00"
+                "validatedAt": "2026-07-20T14:40:11.337707+00:00"
               },
               "deterministic": true
             },
@@ -31663,9 +31621,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.889024+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.538755+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "uid": {
             "type": "string",
@@ -31684,7 +31641,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.372542+00:00"
+                "validatedAt": "2026-07-20T14:40:11.337718+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31698,7 +31655,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.889044+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.538768+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectMetaType is metadata(common attributes) of an object that all configuration objects will have.",
@@ -31739,7 +31696,7 @@
       },
       "schemaSiteToSiteTunnelType": {
         "type": "string",
-        "description": "Tunnel encapsulation to be used between sites\n\nTunnel can operate in both IPsec and SSL, with IPsec being preferred over SSL.\nTunnel is of type IPsec\nTunnel is of type SSL.",
+        "description": "Tunnel encapsulation to be used between sites\n\nTunnel can operate in both IPsec and SSL, with IPsec being prefered over SSL.\nTunnel is of type IPsec\nTunnel is of type SSL.",
         "title": "Site to site tunnel type",
         "enum": [
           "SITE_TO_SITE_TUNNEL_IPSEC_OR_SSL",
@@ -31749,8 +31706,8 @@
         "default": "SITE_TO_SITE_TUNNEL_IPSEC_OR_SSL",
         "x-displayname": "Tunnel type.",
         "x-ves-proto-enum": "ves.io.schema.SiteToSiteTunnelType",
-        "x-f5xc-description-short": "Tunnel encapsulation to be used between sites Tunnel can operate in both IPsec and SSL, with IPsec being preferred over SSL.",
-        "x-f5xc-description-medium": "Tunnel encapsulation to be used between sites Tunnel can operate in both IPsec and SSL, with IPsec being preferred over SSL. Tunnel is of type IPsec Tunnel is of type SSL.",
+        "x-f5xc-description-short": "Tunnel encapsulation to be used between sites Tunnel can operate in both IPsec and SSL, with IPsec being prefered over SSL.",
+        "x-f5xc-description-medium": "Tunnel encapsulation to be used between sites Tunnel can operate in both IPsec and SSL, with IPsec being prefered over SSL. Tunnel is of type IPsec Tunnel is of type SSL.",
         "x-f5xc-minimum-configuration": {
           "description": "Minimum configuration for schemaSiteToSiteTunnelType",
           "required_fields": [],
@@ -31801,7 +31758,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.373037+00:00"
+                "validatedAt": "2026-07-20T14:40:11.337928+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31829,7 +31786,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.373077+00:00"
+                "validatedAt": "2026-07-20T14:40:11.337945+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31858,7 +31815,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.373119+00:00"
+                "validatedAt": "2026-07-20T14:40:11.337962+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31885,7 +31842,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.373157+00:00"
+                "validatedAt": "2026-07-20T14:40:11.337977+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31914,7 +31871,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.373198+00:00"
+                "validatedAt": "2026-07-20T14:40:11.337995+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31939,7 +31896,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.373239+00:00"
+                "validatedAt": "2026-07-20T14:40:11.338012+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32015,7 +31972,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.373304+00:00"
+                "validatedAt": "2026-07-20T14:40:11.338038+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32053,7 +32010,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:05.373351+00:00"
+                "validatedAt": "2026-07-20T14:40:11.338060+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32065,7 +32022,7 @@
             "maxLength": 6,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.889315+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.538938+00:00"
           },
           "object_index": {
             "type": "integer",
@@ -32125,7 +32082,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.373402+00:00"
+                "validatedAt": "2026-07-20T14:40:11.338081+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32169,7 +32126,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.373438+00:00"
+                "validatedAt": "2026-07-20T14:40:11.338097+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32182,7 +32139,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.889360+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.538966+00:00"
           },
           "trace_info": {
             "type": "string",
@@ -32201,7 +32158,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.373475+00:00"
+                "validatedAt": "2026-07-20T14:40:11.338113+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32228,7 +32185,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.373500+00:00"
+                "validatedAt": "2026-07-20T14:40:11.338124+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32242,7 +32199,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.889386+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.538982+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -32257,7 +32214,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.373535+00:00"
+                "validatedAt": "2026-07-20T14:40:11.338139+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32390,7 +32347,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:07:05.373705+00:00"
+                "validatedAt": "2026-07-20T14:40:11.338214+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32495,7 +32452,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:07:05.373752+00:00"
+                "validatedAt": "2026-07-20T14:40:11.338236+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32645,7 +32602,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:07:05.373833+00:00"
+                "validatedAt": "2026-07-20T14:40:11.338271+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32799,7 +32756,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.373890+00:00"
+                "validatedAt": "2026-07-20T14:40:11.338295+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32866,7 +32823,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:07:05.373921+00:00"
+                "validatedAt": "2026-07-20T14:40:11.338310+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32931,7 +32888,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:07:05.373968+00:00"
+                "validatedAt": "2026-07-20T14:40:11.338331+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32942,7 +32899,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.889620+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.539126+00:00"
           },
           "ref_value": {
             "allOf": [
@@ -32984,7 +32941,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.374008+00:00"
+                "validatedAt": "2026-07-20T14:40:11.338348+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33059,7 +33016,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T13:07:05.374206+00:00"
+                "validatedAt": "2026-07-20T14:40:11.338446+00:00"
               },
               "deterministic": true
             },
@@ -33086,7 +33043,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.374240+00:00"
+                "validatedAt": "2026-07-20T14:40:11.338460+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33112,7 +33069,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.374274+00:00"
+                "validatedAt": "2026-07-20T14:40:11.338474+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33123,7 +33080,7 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.889721+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.539184+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -33179,7 +33136,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.374313+00:00"
+                "validatedAt": "2026-07-20T14:40:11.338491+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33219,7 +33176,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:05.374338+00:00"
+                "validatedAt": "2026-07-20T14:40:11.338504+00:00"
               },
               "deterministic": true
             },
@@ -33231,9 +33188,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.889747+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.539201+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "serial": {
             "type": "string",
@@ -33251,7 +33207,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.374370+00:00"
+                "validatedAt": "2026-07-20T14:40:11.338517+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33277,7 +33233,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.374404+00:00"
+                "validatedAt": "2026-07-20T14:40:11.338532+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33303,7 +33259,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.374438+00:00"
+                "validatedAt": "2026-07-20T14:40:11.338545+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33314,7 +33270,7 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.889778+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.539221+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -33372,7 +33328,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.374476+00:00"
+                "validatedAt": "2026-07-20T14:40:11.338562+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33398,7 +33354,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.374509+00:00"
+                "validatedAt": "2026-07-20T14:40:11.338576+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33440,7 +33396,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.374552+00:00"
+                "validatedAt": "2026-07-20T14:40:11.338594+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33466,7 +33422,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.374587+00:00"
+                "validatedAt": "2026-07-20T14:40:11.338609+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33477,7 +33433,7 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.889824+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.539249+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -33579,7 +33535,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.374652+00:00"
+                "validatedAt": "2026-07-20T14:40:11.338635+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33634,7 +33590,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.374716+00:00"
+                "validatedAt": "2026-07-20T14:40:11.338658+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33701,7 +33657,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.374758+00:00"
+                "validatedAt": "2026-07-20T14:40:11.338675+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33726,7 +33682,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.374798+00:00"
+                "validatedAt": "2026-07-20T14:40:11.338692+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33805,7 +33761,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.374837+00:00"
+                "validatedAt": "2026-07-20T14:40:11.338708+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33830,7 +33786,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.374873+00:00"
+                "validatedAt": "2026-07-20T14:40:11.338723+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33855,7 +33811,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.374912+00:00"
+                "validatedAt": "2026-07-20T14:40:11.338740+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33918,7 +33874,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.374952+00:00"
+                "validatedAt": "2026-07-20T14:40:11.338756+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33943,7 +33899,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.374987+00:00"
+                "validatedAt": "2026-07-20T14:40:11.338775+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33968,7 +33924,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.375022+00:00"
+                "validatedAt": "2026-07-20T14:40:11.338789+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33979,7 +33935,7 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.889945+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.539322+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -34149,7 +34105,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.375075+00:00"
+                "validatedAt": "2026-07-20T14:40:11.338811+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34212,7 +34168,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.375110+00:00"
+                "validatedAt": "2026-07-20T14:40:11.338825+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34285,7 +34241,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T13:07:05.375165+00:00"
+                "validatedAt": "2026-07-20T14:40:11.338849+00:00"
               },
               "deterministic": true
             },
@@ -34325,7 +34281,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:05.375191+00:00"
+                "validatedAt": "2026-07-20T14:40:11.338862+00:00"
               },
               "deterministic": true
             },
@@ -34337,9 +34293,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.890021+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.539367+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "port": {
             "type": "string",
@@ -34358,7 +34313,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.375220+00:00"
+                "validatedAt": "2026-07-20T14:40:11.338875+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34441,7 +34396,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.375270+00:00"
+                "validatedAt": "2026-07-20T14:40:11.338900+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34480,7 +34435,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:05.375297+00:00"
+                "validatedAt": "2026-07-20T14:40:11.338913+00:00"
               },
               "deterministic": true
             },
@@ -34492,9 +34447,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.890060+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.539391+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "release": {
             "type": "string",
@@ -34511,7 +34465,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.375331+00:00"
+                "validatedAt": "2026-07-20T14:40:11.338928+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34536,7 +34490,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.375364+00:00"
+                "validatedAt": "2026-07-20T14:40:11.338942+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34561,7 +34515,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.375399+00:00"
+                "validatedAt": "2026-07-20T14:40:11.338957+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34572,7 +34526,7 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.890091+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.539411+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -34723,7 +34677,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:07:05.375452+00:00"
+                "validatedAt": "2026-07-20T14:40:11.338981+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34756,7 +34710,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:05.375496+00:00"
+                "validatedAt": "2026-07-20T14:40:11.339003+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34900,7 +34854,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:05.375554+00:00"
+                "validatedAt": "2026-07-20T14:40:11.339029+00:00"
               },
               "deterministic": true
             },
@@ -34912,9 +34866,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.890193+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.539473+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "serial": {
             "type": "string",
@@ -34933,7 +34886,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.375586+00:00"
+                "validatedAt": "2026-07-20T14:40:11.339043+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34958,7 +34911,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.375620+00:00"
+                "validatedAt": "2026-07-20T14:40:11.339057+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34984,7 +34937,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.375660+00:00"
+                "validatedAt": "2026-07-20T14:40:11.339072+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34995,7 +34948,7 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.890224+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.539493+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -35112,7 +35065,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.375697+00:00"
+                "validatedAt": "2026-07-20T14:40:11.339087+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35137,7 +35090,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.375730+00:00"
+                "validatedAt": "2026-07-20T14:40:11.339101+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35176,7 +35129,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:05.375756+00:00"
+                "validatedAt": "2026-07-20T14:40:11.339114+00:00"
               },
               "deterministic": true
             },
@@ -35188,9 +35141,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.890257+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.539514+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "serial": {
             "type": "string",
@@ -35207,7 +35159,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.375790+00:00"
+                "validatedAt": "2026-07-20T14:40:11.339128+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35247,7 +35199,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.375835+00:00"
+                "validatedAt": "2026-07-20T14:40:11.339147+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35329,7 +35281,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.375889+00:00"
+                "validatedAt": "2026-07-20T14:40:11.339169+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35355,7 +35307,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.375930+00:00"
+                "validatedAt": "2026-07-20T14:40:11.339186+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35381,7 +35333,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.375971+00:00"
+                "validatedAt": "2026-07-20T14:40:11.339203+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35421,7 +35373,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.376023+00:00"
+                "validatedAt": "2026-07-20T14:40:11.339224+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35446,7 +35398,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.376056+00:00"
+                "validatedAt": "2026-07-20T14:40:11.339238+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35491,7 +35443,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:07:05.376110+00:00"
+                "validatedAt": "2026-07-20T14:40:11.339262+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35502,7 +35454,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.890346+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.539569+00:00"
           },
           "i_manufacturer": {
             "type": "string",
@@ -35519,7 +35471,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.376149+00:00"
+                "validatedAt": "2026-07-20T14:40:11.339278+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35544,7 +35496,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.376186+00:00"
+                "validatedAt": "2026-07-20T14:40:11.339293+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35570,7 +35522,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.376222+00:00"
+                "validatedAt": "2026-07-20T14:40:11.339309+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35596,7 +35548,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.376259+00:00"
+                "validatedAt": "2026-07-20T14:40:11.339324+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35621,7 +35573,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.376295+00:00"
+                "validatedAt": "2026-07-20T14:40:11.339340+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35651,7 +35603,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:05.376323+00:00"
+                "validatedAt": "2026-07-20T14:40:11.339355+00:00"
               },
               "deterministic": true
             },
@@ -35678,7 +35630,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.376362+00:00"
+                "validatedAt": "2026-07-20T14:40:11.339372+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35704,7 +35656,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.376393+00:00"
+                "validatedAt": "2026-07-20T14:40:11.339385+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35743,7 +35695,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:05.376434+00:00"
+                "validatedAt": "2026-07-20T14:40:11.339402+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36022,7 +35974,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:17.555142+00:00"
+                "validatedAt": "2026-07-20T14:41:26.049886+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36114,7 +36066,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:17.555176+00:00"
+                "validatedAt": "2026-07-20T14:41:26.049902+00:00"
               },
               "deterministic": true
             },
@@ -36126,9 +36078,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.780599+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.446382+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -36160,7 +36111,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:17.555203+00:00"
+                "validatedAt": "2026-07-20T14:41:26.049915+00:00"
               },
               "deterministic": true
             },
@@ -36172,9 +36123,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.780618+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.446394+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -36337,7 +36287,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.780692+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.446473+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -36429,7 +36379,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:17.555321+00:00"
+                "validatedAt": "2026-07-20T14:41:26.049964+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36510,7 +36460,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:10:17.555367+00:00"
+                "validatedAt": "2026-07-20T14:41:26.049984+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36589,7 +36539,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:10:17.555418+00:00"
+                "validatedAt": "2026-07-20T14:41:26.050005+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36600,7 +36550,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.780750+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.446537+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -36687,7 +36637,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:17.555457+00:00"
+                "validatedAt": "2026-07-20T14:41:26.050022+00:00"
               },
               "deterministic": true
             },
@@ -36699,9 +36649,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.780796+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.446567+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -36732,7 +36681,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:17.555483+00:00"
+                "validatedAt": "2026-07-20T14:41:26.050035+00:00"
               },
               "deterministic": true
             },
@@ -36744,9 +36693,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.780814+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.446579+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -36815,7 +36763,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:17.555535+00:00"
+                "validatedAt": "2026-07-20T14:41:26.050055+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36827,7 +36775,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.780851+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.446603+00:00"
           },
           "uid": {
             "type": "string",
@@ -36844,7 +36792,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:17.555560+00:00"
+                "validatedAt": "2026-07-20T14:41:26.050066+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36857,7 +36805,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.780870+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.446615+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of usb_policy is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -37035,7 +36983,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:17.555616+00:00"
+                "validatedAt": "2026-07-20T14:41:26.050092+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37097,7 +37045,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:17.555681+00:00"
+                "validatedAt": "2026-07-20T14:41:26.050109+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37123,7 +37071,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:17.555724+00:00"
+                "validatedAt": "2026-07-20T14:41:26.050125+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37149,7 +37097,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:17.555765+00:00"
+                "validatedAt": "2026-07-20T14:41:26.050141+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37175,7 +37123,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:17.555801+00:00"
+                "validatedAt": "2026-07-20T14:41:26.050155+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37201,7 +37149,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:17.555839+00:00"
+                "validatedAt": "2026-07-20T14:41:26.050170+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37226,7 +37174,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:17.555876+00:00"
+                "validatedAt": "2026-07-20T14:41:26.050184+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37435,7 +37383,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:24.806206+00:00"
+                "validatedAt": "2026-07-20T14:41:28.649445+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37458,7 +37406,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:24.806269+00:00"
+                "validatedAt": "2026-07-20T14:41:28.649469+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37480,7 +37428,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:24.806310+00:00"
+                "validatedAt": "2026-07-20T14:41:28.649482+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37491,7 +37439,7 @@
             },
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.883613+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.585284+00:00"
           },
           "name": {
             "type": "string",
@@ -37520,7 +37468,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:24.806357+00:00"
+                "validatedAt": "2026-07-20T14:41:28.649498+00:00"
               },
               "deterministic": true
             },
@@ -37532,9 +37480,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.883636+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.585299+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ApplicationObj shows the upgrade status of each object in a application in either site/node level upgrades.",
@@ -37590,7 +37537,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:24.806404+00:00"
+                "validatedAt": "2026-07-20T14:41:28.649512+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37601,7 +37548,7 @@
             },
             "minLength": 15,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.883665+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.585312+00:00"
           },
           "reason": {
             "type": "string",
@@ -37618,7 +37565,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:24.806456+00:00"
+                "validatedAt": "2026-07-20T14:41:28.649526+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37629,7 +37576,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.883686+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.585324+00:00"
           },
           "status": {
             "allOf": [
@@ -37647,7 +37594,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.883705+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.585337+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -37738,7 +37685,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:24.806520+00:00"
+                "validatedAt": "2026-07-20T14:41:28.649541+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37759,7 +37706,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:24.806574+00:00"
+                "validatedAt": "2026-07-20T14:41:28.649554+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37781,7 +37728,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:24.806611+00:00"
+                "validatedAt": "2026-07-20T14:41:28.649566+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37959,7 +37906,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:24.806699+00:00"
+                "validatedAt": "2026-07-20T14:41:28.649595+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37985,7 +37932,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.883779+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.585378+00:00"
           }
         },
         "x-f5xc-description-short": "ImageDownload shows each the entire image download stage.",
@@ -38037,7 +37984,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:24.806738+00:00"
+                "validatedAt": "2026-07-20T14:41:28.649610+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38074,7 +38021,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:24.806769+00:00"
+                "validatedAt": "2026-07-20T14:41:28.649623+00:00"
               },
               "deterministic": true
             },
@@ -38086,9 +38033,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.883806+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.585395+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "status": {
             "allOf": [
@@ -38106,7 +38052,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.883825+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.585407+00:00"
           },
           "type": {
             "type": "string",
@@ -38120,7 +38066,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:24.806804+00:00"
+                "validatedAt": "2026-07-20T14:41:28.649636+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38197,7 +38143,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:24.806857+00:00"
+                "validatedAt": "2026-07-20T14:41:28.649657+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38223,7 +38169,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.883864+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.585431+00:00"
           }
         },
         "x-f5xc-description-short": "Node level upgrade shows the upgrades that are happening on a site level as opposed to site level.",
@@ -38287,7 +38233,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:24.806890+00:00"
+                "validatedAt": "2026-07-20T14:41:28.649671+00:00"
               },
               "deterministic": true
             },
@@ -38299,9 +38245,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.883884+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.585444+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "progress": {
             "allOf": [
@@ -38346,7 +38291,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.883917+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.585465+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -38413,7 +38358,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:24.806937+00:00"
+                "validatedAt": "2026-07-20T14:41:28.649690+00:00"
               },
               "deterministic": true
             },
@@ -38425,9 +38370,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.883937+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.585477+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "results": {
             "type": "array",
@@ -38458,7 +38402,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.883963+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.585493+00:00"
           }
         },
         "x-f5xc-description-short": "OSNodeResult shows the result of OS upgrade for each node.",
@@ -38525,7 +38469,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:24.807005+00:00"
+                "validatedAt": "2026-07-20T14:41:28.649716+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38551,7 +38495,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.883996+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.585513+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -38654,7 +38598,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:24.807065+00:00"
+                "validatedAt": "2026-07-20T14:41:28.649739+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38718,7 +38662,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:24.807111+00:00"
+                "validatedAt": "2026-07-20T14:41:28.649757+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38740,7 +38684,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:24.807142+00:00"
+                "validatedAt": "2026-07-20T14:41:28.649769+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38779,7 +38723,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.884069+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.585557+00:00"
           },
           "validation": {
             "allOf": [
@@ -38806,7 +38750,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:24.807185+00:00"
+                "validatedAt": "2026-07-20T14:41:28.649786+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38817,7 +38761,7 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.884093+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.585573+00:00"
           }
         },
         "x-f5xc-description-short": "SWStatus stores information about CE Site upgrade status.",
@@ -38905,7 +38849,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:24.807241+00:00"
+                "validatedAt": "2026-07-20T14:41:28.649807+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38931,7 +38875,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.884134+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.585597+00:00"
           }
         },
         "x-f5xc-description-short": "Site level upgrade shows the upgrades that are happening on a site level as opposed to node level.",
@@ -38999,7 +38943,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:24.807273+00:00"
+                "validatedAt": "2026-07-20T14:41:28.649821+00:00"
               },
               "deterministic": true
             },
@@ -39011,9 +38955,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.884154+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.585610+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "objects": {
             "type": "array",
@@ -39045,7 +38988,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.884180+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.585626+00:00"
           }
         },
         "x-f5xc-description-short": "StageApplication shows the upgrade status of each application in either site/node level upgrades.",
@@ -39127,7 +39070,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:24.807328+00:00"
+                "validatedAt": "2026-07-20T14:41:28.649844+00:00"
               },
               "deterministic": true
             },
@@ -39139,9 +39082,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.884207+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.585642+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "status": {
             "allOf": [
@@ -39159,7 +39101,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.884227+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.585655+00:00"
           }
         },
         "x-f5xc-description-short": "SiteLevelStageUpgradeResults shows the upgrade status of each stage and applications within the stage.",
@@ -39332,7 +39274,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:24.807409+00:00"
+                "validatedAt": "2026-07-20T14:41:28.649874+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39358,7 +39300,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.884276+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.585684+00:00"
           }
         },
         "x-f5xc-description-short": "Validation represents the last stage in the upgrade phase, checking if everything has been upgraded properly.",

--- a/docs/specifications/api/certificates.json
+++ b/docs/specifications/api/certificates.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Certificates",
     "description": "X.509 certificate chains with intermediate and root CA support. Trusted CA list bundles for client authentication and mTLS validation. CRL distribution points and OCSP stapling configuration. Certificate manifests link credentials to load balancers and gateways. Automatic expiration tracking and renewal notifications.",
-    "version": "2.1.182",
+    "version": "2.1.181",
     "contact": {
       "name": "F5 Distributed Cloud",
       "url": "https://docs.cloud.f5.com"
@@ -4927,7 +4927,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:51.809257+00:00"
+                "validatedAt": "2026-07-20T14:36:09.444462+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4983,7 +4983,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T12:56:51.809351+00:00"
+                "validatedAt": "2026-07-20T14:36:09.444490+00:00"
               },
               "deterministic": true
             },
@@ -5086,7 +5086,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:51.809398+00:00"
+                "validatedAt": "2026-07-20T14:36:09.444508+00:00"
               },
               "deterministic": true
             },
@@ -5098,9 +5098,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.793614+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.444415+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -5132,7 +5131,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:51.809427+00:00"
+                "validatedAt": "2026-07-20T14:36:09.444521+00:00"
               },
               "deterministic": true
             },
@@ -5144,9 +5143,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.793634+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.444428+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -5311,7 +5309,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.793712+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.444469+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -5437,7 +5435,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:51.809582+00:00"
+                "validatedAt": "2026-07-20T14:36:09.444588+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5493,7 +5491,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T12:56:51.809632+00:00"
+                "validatedAt": "2026-07-20T14:36:09.444609+00:00"
               },
               "deterministic": true
             },
@@ -5570,7 +5568,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:51.809711+00:00"
+                "validatedAt": "2026-07-20T14:36:09.444639+00:00"
               },
               "deterministic": true
             },
@@ -5654,7 +5652,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:56:51.809755+00:00"
+                "validatedAt": "2026-07-20T14:36:09.444658+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5734,7 +5732,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:56:51.809809+00:00"
+                "validatedAt": "2026-07-20T14:36:09.444681+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5745,7 +5743,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.793809+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.444526+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -5831,7 +5829,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:51.809851+00:00"
+                "validatedAt": "2026-07-20T14:36:09.444700+00:00"
               },
               "deterministic": true
             },
@@ -5843,9 +5841,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.793857+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.444554+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -5876,7 +5873,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:51.809880+00:00"
+                "validatedAt": "2026-07-20T14:36:09.444713+00:00"
               },
               "deterministic": true
             },
@@ -5888,9 +5885,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.793876+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.444566+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -5959,7 +5955,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:51.809933+00:00"
+                "validatedAt": "2026-07-20T14:36:09.444733+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5971,7 +5967,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.793914+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.444590+00:00"
           },
           "uid": {
             "type": "string",
@@ -5988,7 +5984,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:51.809959+00:00"
+                "validatedAt": "2026-07-20T14:36:09.444743+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6001,7 +5997,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.793934+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.444603+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of CRL is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -6217,7 +6213,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:51.810050+00:00"
+                "validatedAt": "2026-07-20T14:36:09.444781+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6273,7 +6269,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T12:56:51.810098+00:00"
+                "validatedAt": "2026-07-20T14:36:09.444802+00:00"
               },
               "deterministic": true
             },
@@ -6421,7 +6417,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:51.810163+00:00"
+                "validatedAt": "2026-07-20T14:36:09.444833+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6444,7 +6440,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:51.810196+00:00"
+                "validatedAt": "2026-07-20T14:36:09.444847+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6455,7 +6451,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.794033+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.444662+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -6519,7 +6515,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T12:56:51.810230+00:00"
+                "validatedAt": "2026-07-20T14:36:09.444865+00:00"
               },
               "deterministic": true
             },
@@ -6530,8 +6526,7 @@
               "read": false
             },
             "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "minLength": 1,
-            "format": "fqdn"
+            "minLength": 1
           },
           "last_update_time": {
             "type": "string",
@@ -6548,7 +6543,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:51.810272+00:00"
+                "validatedAt": "2026-07-20T14:36:09.444885+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6575,7 +6570,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:51.810305+00:00"
+                "validatedAt": "2026-07-20T14:36:09.444900+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6586,7 +6581,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.794068+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.444684+00:00"
           },
           "service_name": {
             "type": "string",
@@ -6603,7 +6598,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:51.810344+00:00"
+                "validatedAt": "2026-07-20T14:36:09.444916+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6636,7 +6631,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:51.810380+00:00"
+                "validatedAt": "2026-07-20T14:36:09.444932+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6647,7 +6642,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.794093+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.444700+00:00"
           },
           "type": {
             "type": "string",
@@ -6672,7 +6667,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:51.810414+00:00"
+                "validatedAt": "2026-07-20T14:36:09.444948+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6816,7 +6811,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:51.810454+00:00"
+                "validatedAt": "2026-07-20T14:36:09.444966+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6896,7 +6891,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:51.810484+00:00"
+                "validatedAt": "2026-07-20T14:36:09.444982+00:00"
               },
               "deterministic": true
             },
@@ -6908,9 +6903,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.794142+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.444731+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -7074,7 +7068,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:51.810577+00:00"
+                "validatedAt": "2026-07-20T14:36:09.445029+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -7089,7 +7083,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.794185+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.444757+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -7159,7 +7153,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:51.810614+00:00"
+                "validatedAt": "2026-07-20T14:36:09.445046+00:00"
               },
               "deterministic": true
             },
@@ -7171,9 +7165,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.794219+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.444778+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -7206,7 +7199,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:51.810641+00:00"
+                "validatedAt": "2026-07-20T14:36:09.445059+00:00"
               },
               "deterministic": true
             },
@@ -7218,9 +7211,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.794237+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.444790+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -7320,7 +7312,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:51.810723+00:00"
+                "validatedAt": "2026-07-20T14:36:09.445092+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -7335,7 +7327,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.794265+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.444808+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -7407,7 +7399,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:51.810760+00:00"
+                "validatedAt": "2026-07-20T14:36:09.445108+00:00"
               },
               "deterministic": true
             },
@@ -7419,9 +7411,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.794298+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.444829+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -7454,7 +7445,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:51.810786+00:00"
+                "validatedAt": "2026-07-20T14:36:09.445120+00:00"
               },
               "deterministic": true
             },
@@ -7466,9 +7457,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.794317+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.444841+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -7531,7 +7521,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:51.810817+00:00"
+                "validatedAt": "2026-07-20T14:36:09.445132+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7543,7 +7533,7 @@
             "readOnly": true,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.794337+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.444854+00:00"
           },
           "name": {
             "type": "string",
@@ -7576,7 +7566,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:51.810844+00:00"
+                "validatedAt": "2026-07-20T14:36:09.445169+00:00"
               },
               "deterministic": true
             },
@@ -7588,9 +7578,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.794355+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.444866+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -7623,7 +7612,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:51.810872+00:00"
+                "validatedAt": "2026-07-20T14:36:09.445192+00:00"
               },
               "deterministic": true
             },
@@ -7635,9 +7624,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.794374+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.444878+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -7656,7 +7644,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:51.810906+00:00"
+                "validatedAt": "2026-07-20T14:36:09.445207+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7669,7 +7657,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.794392+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.444890+00:00"
           },
           "uid": {
             "type": "string",
@@ -7688,7 +7676,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:51.810932+00:00"
+                "validatedAt": "2026-07-20T14:36:09.445218+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7702,7 +7690,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.794412+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.444903+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -7802,7 +7790,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:51.811007+00:00"
+                "validatedAt": "2026-07-20T14:36:09.445258+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -7817,7 +7805,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.794440+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.444920+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -7887,7 +7875,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:51.811043+00:00"
+                "validatedAt": "2026-07-20T14:36:09.445276+00:00"
               },
               "deterministic": true
             },
@@ -7899,9 +7887,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.794473+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.444941+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -7934,7 +7921,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:51.811069+00:00"
+                "validatedAt": "2026-07-20T14:36:09.445288+00:00"
               },
               "deterministic": true
             },
@@ -7946,9 +7933,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.794491+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.444953+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -8011,7 +7997,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:51.811111+00:00"
+                "validatedAt": "2026-07-20T14:36:09.445305+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8039,7 +8025,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:51.811151+00:00"
+                "validatedAt": "2026-07-20T14:36:09.445321+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8067,7 +8053,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:51.811188+00:00"
+                "validatedAt": "2026-07-20T14:36:09.445336+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8106,7 +8092,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:51.811228+00:00"
+                "validatedAt": "2026-07-20T14:36:09.445351+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8133,7 +8119,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:51.811253+00:00"
+                "validatedAt": "2026-07-20T14:36:09.445362+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8146,7 +8132,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.794545+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.444986+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -8162,7 +8148,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:51.811287+00:00"
+                "validatedAt": "2026-07-20T14:36:09.445375+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8307,7 +8293,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:51.811336+00:00"
+                "validatedAt": "2026-07-20T14:36:09.445397+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8318,7 +8304,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.794586+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.445011+00:00"
           },
           "status": {
             "type": "string",
@@ -8336,7 +8322,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:51.811369+00:00"
+                "validatedAt": "2026-07-20T14:36:09.445410+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8347,7 +8333,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.794605+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.445023+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -8407,7 +8393,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:51.811413+00:00"
+                "validatedAt": "2026-07-20T14:36:09.445427+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8434,7 +8420,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:51.811451+00:00"
+                "validatedAt": "2026-07-20T14:36:09.445442+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8461,7 +8447,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:51.811487+00:00"
+                "validatedAt": "2026-07-20T14:36:09.445456+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8489,7 +8475,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:51.811530+00:00"
+                "validatedAt": "2026-07-20T14:36:09.445472+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8565,7 +8551,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:51.811593+00:00"
+                "validatedAt": "2026-07-20T14:36:09.445496+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8633,7 +8619,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:51.811643+00:00"
+                "validatedAt": "2026-07-20T14:36:09.445514+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8645,7 +8631,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.794699+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.445077+00:00"
           },
           "uid": {
             "type": "string",
@@ -8664,7 +8650,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:51.811677+00:00"
+                "validatedAt": "2026-07-20T14:36:09.445526+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8677,7 +8663,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.794720+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.445089+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -8745,7 +8731,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:51.811710+00:00"
+                "validatedAt": "2026-07-20T14:36:09.445538+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8756,7 +8742,7 @@
             },
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.794740+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.445102+00:00"
           },
           "name": {
             "type": "string",
@@ -8789,7 +8775,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:51.811738+00:00"
+                "validatedAt": "2026-07-20T14:36:09.445550+00:00"
               },
               "deterministic": true
             },
@@ -8801,9 +8787,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.794759+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.445115+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -8836,7 +8821,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:51.811765+00:00"
+                "validatedAt": "2026-07-20T14:36:09.445563+00:00"
               },
               "deterministic": true
             },
@@ -8848,9 +8833,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.794777+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.445127+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "uid": {
             "type": "string",
@@ -8867,7 +8851,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:51.811791+00:00"
+                "validatedAt": "2026-07-20T14:36:09.445574+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8880,7 +8864,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.794797+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.445139+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -9141,7 +9125,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:08.733357+00:00"
+                "validatedAt": "2026-07-20T14:36:16.105658+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9321,7 +9305,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:08.733431+00:00"
+                "validatedAt": "2026-07-20T14:36:16.105708+00:00"
               },
               "deterministic": true
             },
@@ -9333,9 +9317,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.135947+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.667240+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -9367,7 +9350,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:08.733473+00:00"
+                "validatedAt": "2026-07-20T14:36:16.105736+00:00"
               },
               "deterministic": true
             },
@@ -9379,9 +9362,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.135967+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.667253+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -9546,7 +9528,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.136034+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.667301+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -9668,7 +9650,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:08.733705+00:00"
+                "validatedAt": "2026-07-20T14:36:16.105887+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9879,7 +9861,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:57:08.733801+00:00"
+                "validatedAt": "2026-07-20T14:36:16.105938+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9960,7 +9942,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:57:08.733859+00:00"
+                "validatedAt": "2026-07-20T14:36:16.105968+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9971,7 +9953,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.136152+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.667366+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -10058,7 +10040,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:08.733900+00:00"
+                "validatedAt": "2026-07-20T14:36:16.105990+00:00"
               },
               "deterministic": true
             },
@@ -10070,9 +10052,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.136200+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.667395+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -10103,7 +10084,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:08.733927+00:00"
+                "validatedAt": "2026-07-20T14:36:16.106006+00:00"
               },
               "deterministic": true
             },
@@ -10115,9 +10096,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.136219+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.667407+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -10186,7 +10166,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:08.733979+00:00"
+                "validatedAt": "2026-07-20T14:36:16.106028+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10198,7 +10178,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.136255+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.667431+00:00"
           },
           "uid": {
             "type": "string",
@@ -10215,7 +10195,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:08.734006+00:00"
+                "validatedAt": "2026-07-20T14:36:16.106041+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10228,7 +10208,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.136276+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.667444+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of certificate is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -10451,7 +10431,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:08.734083+00:00"
+                "validatedAt": "2026-07-20T14:36:16.106082+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10720,7 +10700,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:08.734157+00:00"
+                "validatedAt": "2026-07-20T14:36:16.106113+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10732,7 +10712,7 @@
             "readOnly": true,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.136374+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.667502+00:00"
           },
           "name": {
             "type": "string",
@@ -10765,7 +10745,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:08.734185+00:00"
+                "validatedAt": "2026-07-20T14:36:16.106127+00:00"
               },
               "deterministic": true
             },
@@ -10777,9 +10757,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.136392+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.667515+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -10812,7 +10791,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:08.734212+00:00"
+                "validatedAt": "2026-07-20T14:36:16.106141+00:00"
               },
               "deterministic": true
             },
@@ -10824,9 +10803,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.136410+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.667527+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -10845,7 +10823,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:08.734245+00:00"
+                "validatedAt": "2026-07-20T14:36:16.106156+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10858,7 +10836,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.136429+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.667539+00:00"
           },
           "uid": {
             "type": "string",
@@ -10877,7 +10855,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:08.734270+00:00"
+                "validatedAt": "2026-07-20T14:36:16.106167+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10891,7 +10869,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.136448+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.667552+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -10955,7 +10933,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:08.734383+00:00"
+                "validatedAt": "2026-07-20T14:36:16.106218+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10996,7 +10974,7 @@
                 "confidence": 1.0,
                 "category": "content",
                 "note": "Blindfold envelope encryption (AES-256-GCM + RSA-OAEP) of an RSA-2048 TLS private key produces ~3700 char string:/// URL. 128KB max secret size = ~175KB base64. Discovery reported 1024 which is incorrect.",
-                "validatedAt": "2026-07-20T12:57:08.734420+00:00"
+                "validatedAt": "2026-07-20T14:36:16.106241+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11007,7 +10985,7 @@
             },
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.136502+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.667793+00:00"
           },
           "store_provider": {
             "type": "string",
@@ -11026,7 +11004,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:08.734464+00:00"
+                "validatedAt": "2026-07-20T14:36:16.106261+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11089,7 +11067,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:08.734504+00:00"
+                "validatedAt": "2026-07-20T14:36:16.106278+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11114,7 +11092,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:08.734538+00:00"
+                "validatedAt": "2026-07-20T14:36:16.106292+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11137,7 +11115,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:08.734571+00:00"
+                "validatedAt": "2026-07-20T14:36:16.106307+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11160,7 +11138,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:08.734610+00:00"
+                "validatedAt": "2026-07-20T14:36:16.106324+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11184,7 +11162,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:08.734669+00:00"
+                "validatedAt": "2026-07-20T14:36:16.106344+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11272,7 +11250,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:08.734728+00:00"
+                "validatedAt": "2026-07-20T14:36:16.106365+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11283,7 +11261,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.137063+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.667835+00:00"
           },
           "url": {
             "type": "string",
@@ -11321,7 +11299,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:08.734786+00:00"
+                "validatedAt": "2026-07-20T14:36:16.106396+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -11451,7 +11429,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:08.735098+00:00"
+                "validatedAt": "2026-07-20T14:36:16.106538+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11651,7 +11629,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:08.736332+00:00"
+                "validatedAt": "2026-07-20T14:36:16.107117+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -11665,8 +11643,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -11705,7 +11682,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:08.736379+00:00"
+                "validatedAt": "2026-07-20T14:36:16.107145+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -11720,9 +11697,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.137798+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.668283+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -11751,7 +11727,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:08.736431+00:00"
+                "validatedAt": "2026-07-20T14:36:16.107172+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11764,7 +11740,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.137817+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.668295+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a direct reference from one object(the referrer) to another(the referred).",
@@ -12001,7 +11977,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:12.219133+00:00"
+                "validatedAt": "2026-07-20T14:36:17.442675+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12113,7 +12089,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:12.219189+00:00"
+                "validatedAt": "2026-07-20T14:36:17.442699+00:00"
               },
               "deterministic": true
             },
@@ -12125,9 +12101,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.175616+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.698922+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -12159,7 +12134,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:12.219232+00:00"
+                "validatedAt": "2026-07-20T14:36:17.442715+00:00"
               },
               "deterministic": true
             },
@@ -12171,9 +12146,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.175636+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.698936+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -12338,7 +12312,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.175712+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.698978+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -12436,7 +12410,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:12.219453+00:00"
+                "validatedAt": "2026-07-20T14:36:17.442838+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12549,7 +12523,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:57:12.219521+00:00"
+                "validatedAt": "2026-07-20T14:36:17.442867+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12630,7 +12604,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:57:12.219581+00:00"
+                "validatedAt": "2026-07-20T14:36:17.442893+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12641,7 +12615,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.175780+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.699018+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -12728,7 +12702,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:12.219623+00:00"
+                "validatedAt": "2026-07-20T14:36:17.442912+00:00"
               },
               "deterministic": true
             },
@@ -12740,9 +12714,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.175826+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.699046+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -12773,7 +12746,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:12.219651+00:00"
+                "validatedAt": "2026-07-20T14:36:17.442926+00:00"
               },
               "deterministic": true
             },
@@ -12785,9 +12758,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.175844+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.699058+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -12856,7 +12828,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:12.219716+00:00"
+                "validatedAt": "2026-07-20T14:36:17.442947+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12868,7 +12840,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.175881+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.699082+00:00"
           },
           "uid": {
             "type": "string",
@@ -12886,7 +12858,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:12.219744+00:00"
+                "validatedAt": "2026-07-20T14:36:17.442960+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12899,7 +12871,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.175901+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.699095+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of certificate_chain is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -13370,7 +13342,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:56.728166+00:00"
+                "validatedAt": "2026-07-20T14:40:08.026278+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13465,7 +13437,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:56.728198+00:00"
+                "validatedAt": "2026-07-20T14:40:08.026293+00:00"
               },
               "deterministic": true
             },
@@ -13477,9 +13449,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.742707+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.405339+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -13511,7 +13482,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:56.728225+00:00"
+                "validatedAt": "2026-07-20T14:40:08.026305+00:00"
               },
               "deterministic": true
             },
@@ -13523,9 +13494,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.742726+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.405351+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -13690,7 +13660,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.742792+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.405392+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -13791,7 +13761,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:56.728370+00:00"
+                "validatedAt": "2026-07-20T14:40:08.026361+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13876,7 +13846,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:06:56.728414+00:00"
+                "validatedAt": "2026-07-20T14:40:08.026379+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13957,7 +13927,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:06:56.728465+00:00"
+                "validatedAt": "2026-07-20T14:40:08.026400+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13968,7 +13938,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.742856+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.405431+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -14055,7 +14025,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:56.728505+00:00"
+                "validatedAt": "2026-07-20T14:40:08.026417+00:00"
               },
               "deterministic": true
             },
@@ -14067,9 +14037,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.742901+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.405460+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -14100,7 +14069,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:56.728534+00:00"
+                "validatedAt": "2026-07-20T14:40:08.026430+00:00"
               },
               "deterministic": true
             },
@@ -14112,9 +14081,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.742920+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.405472+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -14183,7 +14151,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:56.728585+00:00"
+                "validatedAt": "2026-07-20T14:40:08.026449+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14195,7 +14163,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.742957+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.405496+00:00"
           },
           "uid": {
             "type": "string",
@@ -14212,7 +14180,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:56.728611+00:00"
+                "validatedAt": "2026-07-20T14:40:08.026459+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14225,7 +14193,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.742976+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.405508+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of trusted_ca_list is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -14401,7 +14369,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:56.728701+00:00"
+                "validatedAt": "2026-07-20T14:40:08.026489+00:00"
               }
             },
             "x-f5xc-required-for": {

--- a/docs/specifications/api/cloud_infrastructure.json
+++ b/docs/specifications/api/cloud_infrastructure.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Cloud Infrastructure",
     "description": "Hyperscaler integration supporting Amazon Web Services, Microsoft Azure, and Google Cloud Platform environments. Virtual network attachment workflows enable elastic compute provisioning with automatic reattachment capabilities. Edge authentication secrets for provider access. Segment telemetry and cross-region link reapplication for distributed deployments. Autonomous path synchronization across peered networks with real-time topology updates.",
-    "version": "2.1.182",
+    "version": "2.1.181",
     "contact": {
       "name": "F5 Distributed Cloud",
       "url": "https://docs.cloud.f5.com"
@@ -8019,7 +8019,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:15.680062+00:00"
+                "validatedAt": "2026-07-20T14:36:18.845479+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8044,7 +8044,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:15.680118+00:00"
+                "validatedAt": "2026-07-20T14:36:18.845504+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8177,7 +8177,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:15.680163+00:00"
+                "validatedAt": "2026-07-20T14:36:18.845523+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8240,7 +8240,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:15.680227+00:00"
+                "validatedAt": "2026-07-20T14:36:18.845545+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8365,7 +8365,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:15.680342+00:00"
+                "validatedAt": "2026-07-20T14:36:18.845582+00:00"
               },
               "deterministic": true
             },
@@ -8377,9 +8377,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.209543+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.732002+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "type": {
             "allOf": [
@@ -8514,7 +8513,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:15.680425+00:00"
+                "validatedAt": "2026-07-20T14:36:18.845609+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8658,7 +8657,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.209629+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.732056+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -8870,7 +8869,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:15.680537+00:00"
+                "validatedAt": "2026-07-20T14:36:18.845651+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8894,7 +8893,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:15.680570+00:00"
+                "validatedAt": "2026-07-20T14:36:18.845666+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9025,7 +9024,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:15.680610+00:00"
+                "validatedAt": "2026-07-20T14:36:18.845685+00:00"
               },
               "deterministic": true
             },
@@ -9037,9 +9036,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.209702+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.732096+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "provider": {
             "type": "string",
@@ -9057,7 +9055,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:15.680645+00:00"
+                "validatedAt": "2026-07-20T14:36:18.845701+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9068,7 +9066,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.209722+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.732110+00:00"
           }
         },
         "x-f5xc-description-short": "Describes the image to be used for this certified hardware.",
@@ -9148,7 +9146,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:57:15.680702+00:00"
+                "validatedAt": "2026-07-20T14:36:18.845725+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9229,7 +9227,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:57:15.680757+00:00"
+                "validatedAt": "2026-07-20T14:36:18.845751+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9240,7 +9238,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.209767+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.732138+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -9327,7 +9325,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:15.680799+00:00"
+                "validatedAt": "2026-07-20T14:36:18.845775+00:00"
               },
               "deterministic": true
             },
@@ -9339,9 +9337,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.209813+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.732168+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -9372,7 +9369,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:15.680828+00:00"
+                "validatedAt": "2026-07-20T14:36:18.845793+00:00"
               },
               "deterministic": true
             },
@@ -9384,9 +9381,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.209832+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.732181+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -9455,7 +9451,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:15.680881+00:00"
+                "validatedAt": "2026-07-20T14:36:18.845814+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9467,7 +9463,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.209870+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.732206+00:00"
           },
           "uid": {
             "type": "string",
@@ -9485,7 +9481,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:15.680908+00:00"
+                "validatedAt": "2026-07-20T14:36:18.845827+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9498,7 +9494,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.209890+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.732220+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of certified_hardware is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -9580,7 +9576,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:15.680937+00:00"
+                "validatedAt": "2026-07-20T14:36:18.845843+00:00"
               },
               "deterministic": true
             },
@@ -9592,9 +9588,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.209911+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.732234+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "offer": {
             "type": "string",
@@ -9609,7 +9604,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:15.680969+00:00"
+                "validatedAt": "2026-07-20T14:36:18.845858+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9632,7 +9627,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:15.681006+00:00"
+                "validatedAt": "2026-07-20T14:36:18.845874+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9655,7 +9650,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:15.681033+00:00"
+                "validatedAt": "2026-07-20T14:36:18.845885+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9679,7 +9674,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:15.681068+00:00"
+                "validatedAt": "2026-07-20T14:36:18.845901+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9690,7 +9685,7 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.209950+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.732259+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -9909,7 +9904,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.210005+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.732295+00:00"
           }
         },
         "x-f5xc-description-short": "Most recently observed status of object.",
@@ -9970,7 +9965,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:15.681156+00:00"
+                "validatedAt": "2026-07-20T14:36:18.845936+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9982,7 +9977,7 @@
             "readOnly": true,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.210026+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.732309+00:00"
           },
           "name": {
             "type": "string",
@@ -10015,7 +10010,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:15.681182+00:00"
+                "validatedAt": "2026-07-20T14:36:18.845953+00:00"
               },
               "deterministic": true
             },
@@ -10027,9 +10022,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.210045+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.732322+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -10062,7 +10056,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:15.681210+00:00"
+                "validatedAt": "2026-07-20T14:36:18.845967+00:00"
               },
               "deterministic": true
             },
@@ -10074,9 +10068,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.210063+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.732335+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -10095,7 +10088,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:15.681243+00:00"
+                "validatedAt": "2026-07-20T14:36:18.845982+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10108,7 +10101,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.210081+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.732348+00:00"
           },
           "uid": {
             "type": "string",
@@ -10127,7 +10120,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:15.681269+00:00"
+                "validatedAt": "2026-07-20T14:36:18.845993+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10141,7 +10134,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.210101+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.732362+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -10197,7 +10190,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:15.681305+00:00"
+                "validatedAt": "2026-07-20T14:36:18.846009+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10220,7 +10213,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:15.681338+00:00"
+                "validatedAt": "2026-07-20T14:36:18.846024+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10231,7 +10224,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.210128+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.732380+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -10295,7 +10288,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T12:57:15.681371+00:00"
+                "validatedAt": "2026-07-20T14:36:18.846041+00:00"
               },
               "deterministic": true
             },
@@ -10306,8 +10299,7 @@
               "read": false
             },
             "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "minLength": 1,
-            "format": "fqdn"
+            "minLength": 1
           },
           "last_update_time": {
             "type": "string",
@@ -10324,7 +10316,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:15.681412+00:00"
+                "validatedAt": "2026-07-20T14:36:18.846058+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10351,7 +10343,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:15.681446+00:00"
+                "validatedAt": "2026-07-20T14:36:18.846072+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10362,7 +10354,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.210163+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.732403+00:00"
           },
           "service_name": {
             "type": "string",
@@ -10379,7 +10371,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:15.681485+00:00"
+                "validatedAt": "2026-07-20T14:36:18.846088+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10412,7 +10404,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:15.681528+00:00"
+                "validatedAt": "2026-07-20T14:36:18.846107+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10423,7 +10415,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.210188+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.732420+00:00"
           },
           "type": {
             "type": "string",
@@ -10448,7 +10440,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:15.681563+00:00"
+                "validatedAt": "2026-07-20T14:36:18.846122+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10592,7 +10584,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:15.681605+00:00"
+                "validatedAt": "2026-07-20T14:36:18.846139+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10672,7 +10664,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:15.681633+00:00"
+                "validatedAt": "2026-07-20T14:36:18.846154+00:00"
               },
               "deterministic": true
             },
@@ -10684,9 +10676,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.210238+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.732452+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -10851,7 +10842,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:15.681737+00:00"
+                "validatedAt": "2026-07-20T14:36:18.846205+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -10866,7 +10857,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.210281+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.732479+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -10938,7 +10929,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:15.681776+00:00"
+                "validatedAt": "2026-07-20T14:36:18.846224+00:00"
               },
               "deterministic": true
             },
@@ -10950,9 +10941,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.210316+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.732501+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -10985,7 +10975,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:15.681802+00:00"
+                "validatedAt": "2026-07-20T14:36:18.846239+00:00"
               },
               "deterministic": true
             },
@@ -10997,9 +10987,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.210334+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.732514+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -11062,7 +11051,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:15.681844+00:00"
+                "validatedAt": "2026-07-20T14:36:18.846257+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11090,7 +11079,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:15.681883+00:00"
+                "validatedAt": "2026-07-20T14:36:18.846299+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11118,7 +11107,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:15.681922+00:00"
+                "validatedAt": "2026-07-20T14:36:18.846320+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11157,7 +11146,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:15.681960+00:00"
+                "validatedAt": "2026-07-20T14:36:18.846340+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11184,7 +11173,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:15.681986+00:00"
+                "validatedAt": "2026-07-20T14:36:18.846356+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11197,7 +11186,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.210387+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.732549+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -11213,7 +11202,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:15.682019+00:00"
+                "validatedAt": "2026-07-20T14:36:18.846371+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11358,7 +11347,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:15.682066+00:00"
+                "validatedAt": "2026-07-20T14:36:18.846393+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11369,7 +11358,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.210428+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.732575+00:00"
           },
           "status": {
             "type": "string",
@@ -11387,7 +11376,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:15.682099+00:00"
+                "validatedAt": "2026-07-20T14:36:18.846408+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11398,7 +11387,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.210447+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.732588+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -11458,7 +11447,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:15.682142+00:00"
+                "validatedAt": "2026-07-20T14:36:18.846427+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11485,7 +11474,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:15.682183+00:00"
+                "validatedAt": "2026-07-20T14:36:18.846444+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11512,7 +11501,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:15.682219+00:00"
+                "validatedAt": "2026-07-20T14:36:18.846460+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11540,7 +11529,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:15.682261+00:00"
+                "validatedAt": "2026-07-20T14:36:18.846478+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11616,7 +11605,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:15.682323+00:00"
+                "validatedAt": "2026-07-20T14:36:18.846504+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11684,7 +11673,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:15.682373+00:00"
+                "validatedAt": "2026-07-20T14:36:18.846525+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11696,7 +11685,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.210534+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.732643+00:00"
           },
           "uid": {
             "type": "string",
@@ -11715,7 +11704,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:15.682399+00:00"
+                "validatedAt": "2026-07-20T14:36:18.846537+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11728,7 +11717,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.210553+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.732657+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -11796,7 +11785,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:15.682430+00:00"
+                "validatedAt": "2026-07-20T14:36:18.846551+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11807,7 +11796,7 @@
             },
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.210572+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.732680+00:00"
           },
           "name": {
             "type": "string",
@@ -11840,7 +11829,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:15.682457+00:00"
+                "validatedAt": "2026-07-20T14:36:18.846569+00:00"
               },
               "deterministic": true
             },
@@ -11852,9 +11841,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.210591+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.732693+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -11887,7 +11875,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:15.682484+00:00"
+                "validatedAt": "2026-07-20T14:36:18.846585+00:00"
               },
               "deterministic": true
             },
@@ -11899,9 +11887,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.210609+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.732706+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "uid": {
             "type": "string",
@@ -11918,7 +11905,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:15.682511+00:00"
+                "validatedAt": "2026-07-20T14:36:18.846596+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11931,7 +11918,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.210628+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.732719+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -12170,7 +12157,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:15.682650+00:00"
+                "validatedAt": "2026-07-20T14:36:18.846654+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12196,7 +12183,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:15.682699+00:00"
+                "validatedAt": "2026-07-20T14:36:18.846671+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12222,7 +12209,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:15.682741+00:00"
+                "validatedAt": "2026-07-20T14:36:18.846688+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12248,7 +12235,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:15.682775+00:00"
+                "validatedAt": "2026-07-20T14:36:18.846703+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12274,7 +12261,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:15.682811+00:00"
+                "validatedAt": "2026-07-20T14:36:18.846719+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12299,7 +12286,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:15.682848+00:00"
+                "validatedAt": "2026-07-20T14:36:18.846734+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12390,7 +12377,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:48.479331+00:00"
+                "validatedAt": "2026-07-20T14:36:32.473529+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12424,7 +12411,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:48.479380+00:00"
+                "validatedAt": "2026-07-20T14:36:32.473554+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12485,7 +12472,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.479448+00:00"
+                "validatedAt": "2026-07-20T14:36:32.473576+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12510,7 +12497,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.479505+00:00"
+                "validatedAt": "2026-07-20T14:36:32.473593+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12535,7 +12522,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.479566+00:00"
+                "validatedAt": "2026-07-20T14:36:32.473610+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12560,7 +12547,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.479633+00:00"
+                "validatedAt": "2026-07-20T14:36:32.473627+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12636,7 +12623,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.479744+00:00"
+                "validatedAt": "2026-07-20T14:36:32.473653+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12661,7 +12648,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.479804+00:00"
+                "validatedAt": "2026-07-20T14:36:32.473670+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12684,7 +12671,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.479840+00:00"
+                "validatedAt": "2026-07-20T14:36:32.473685+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12721,7 +12708,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.479879+00:00"
+                "validatedAt": "2026-07-20T14:36:32.473701+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12746,7 +12733,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.479915+00:00"
+                "validatedAt": "2026-07-20T14:36:32.473716+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12769,7 +12756,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.479953+00:00"
+                "validatedAt": "2026-07-20T14:36:32.473732+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12842,7 +12829,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.480001+00:00"
+                "validatedAt": "2026-07-20T14:36:32.473752+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12867,7 +12854,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.480042+00:00"
+                "validatedAt": "2026-07-20T14:36:32.473768+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12906,7 +12893,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.480086+00:00"
+                "validatedAt": "2026-07-20T14:36:32.473786+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12944,7 +12931,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.480132+00:00"
+                "validatedAt": "2026-07-20T14:36:32.473805+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12990,7 +12977,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.480180+00:00"
+                "validatedAt": "2026-07-20T14:36:32.473824+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13013,7 +13000,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.480227+00:00"
+                "validatedAt": "2026-07-20T14:36:32.473844+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13038,7 +13025,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.480274+00:00"
+                "validatedAt": "2026-07-20T14:36:32.473863+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13061,7 +13048,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.480315+00:00"
+                "validatedAt": "2026-07-20T14:36:32.473880+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13085,7 +13072,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.480359+00:00"
+                "validatedAt": "2026-07-20T14:36:32.473898+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13156,7 +13143,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.480403+00:00"
+                "validatedAt": "2026-07-20T14:36:32.473916+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13194,7 +13181,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.480446+00:00"
+                "validatedAt": "2026-07-20T14:36:32.473934+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13220,7 +13207,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.480487+00:00"
+                "validatedAt": "2026-07-20T14:36:32.473951+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13258,7 +13245,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:48.480523+00:00"
+                "validatedAt": "2026-07-20T14:36:32.473969+00:00"
               },
               "deterministic": true
             },
@@ -13270,9 +13257,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.840343+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.321013+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tags": {
             "type": "object",
@@ -13310,7 +13296,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:00.143525+00:00"
+                "validatedAt": "2026-07-20T14:36:36.911098+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13333,7 +13319,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:00.143577+00:00"
+                "validatedAt": "2026-07-20T14:36:36.911118+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13413,7 +13399,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:48.480575+00:00"
+                "validatedAt": "2026-07-20T14:36:32.473994+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13493,7 +13479,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:48.480624+00:00"
+                "validatedAt": "2026-07-20T14:36:32.474018+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13564,7 +13550,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:48.480724+00:00"
+                "validatedAt": "2026-07-20T14:36:32.474059+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13612,7 +13598,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:48.480770+00:00"
+                "validatedAt": "2026-07-20T14:36:32.474081+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13672,7 +13658,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.480811+00:00"
+                "validatedAt": "2026-07-20T14:36:32.474098+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13698,7 +13684,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.480853+00:00"
+                "validatedAt": "2026-07-20T14:36:32.474114+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13723,7 +13709,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:57:48.480895+00:00"
+                "validatedAt": "2026-07-20T14:36:32.474133+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13747,7 +13733,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.480935+00:00"
+                "validatedAt": "2026-07-20T14:36:32.474150+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13842,7 +13828,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.480994+00:00"
+                "validatedAt": "2026-07-20T14:36:32.474174+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13917,7 +13903,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.481057+00:00"
+                "validatedAt": "2026-07-20T14:36:32.474198+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13941,7 +13927,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.481104+00:00"
+                "validatedAt": "2026-07-20T14:36:32.474218+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13966,7 +13952,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.481153+00:00"
+                "validatedAt": "2026-07-20T14:36:32.474238+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14154,7 +14140,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:48.481219+00:00"
+                "validatedAt": "2026-07-20T14:36:32.474267+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14299,7 +14285,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:48.481299+00:00"
+                "validatedAt": "2026-07-20T14:36:32.474305+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14416,7 +14402,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.481357+00:00"
+                "validatedAt": "2026-07-20T14:36:32.474327+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14439,7 +14425,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.481401+00:00"
+                "validatedAt": "2026-07-20T14:36:32.474345+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14463,7 +14449,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.481442+00:00"
+                "validatedAt": "2026-07-20T14:36:32.474362+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14486,7 +14472,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.481485+00:00"
+                "validatedAt": "2026-07-20T14:36:32.474380+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14523,7 +14509,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.481528+00:00"
+                "validatedAt": "2026-07-20T14:36:32.474397+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14546,7 +14532,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.481569+00:00"
+                "validatedAt": "2026-07-20T14:36:32.474414+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14569,7 +14555,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.481611+00:00"
+                "validatedAt": "2026-07-20T14:36:32.474432+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14592,7 +14578,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.481661+00:00"
+                "validatedAt": "2026-07-20T14:36:32.474449+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14616,7 +14602,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.481702+00:00"
+                "validatedAt": "2026-07-20T14:36:32.474465+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14679,7 +14665,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.481762+00:00"
+                "validatedAt": "2026-07-20T14:36:32.474488+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14703,7 +14689,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.481800+00:00"
+                "validatedAt": "2026-07-20T14:36:32.474504+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14860,7 +14846,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:48.481885+00:00"
+                "validatedAt": "2026-07-20T14:36:32.474544+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14908,7 +14894,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:48.481933+00:00"
+                "validatedAt": "2026-07-20T14:36:32.474568+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14989,7 +14975,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:48.481978+00:00"
+                "validatedAt": "2026-07-20T14:36:32.474591+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15064,7 +15050,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:48.482020+00:00"
+                "validatedAt": "2026-07-20T14:36:32.474613+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15205,7 +15191,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:48.482098+00:00"
+                "validatedAt": "2026-07-20T14:36:32.474647+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15241,7 +15227,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:48.482151+00:00"
+                "validatedAt": "2026-07-20T14:36:32.474672+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15388,7 +15374,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:48.482202+00:00"
+                "validatedAt": "2026-07-20T14:36:32.474697+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15447,7 +15433,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.482244+00:00"
+                "validatedAt": "2026-07-20T14:36:32.474714+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15470,7 +15456,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.482284+00:00"
+                "validatedAt": "2026-07-20T14:36:32.474731+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15494,7 +15480,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.482321+00:00"
+                "validatedAt": "2026-07-20T14:36:32.474747+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15560,7 +15546,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T12:57:48.482357+00:00"
+                "validatedAt": "2026-07-20T14:36:32.474763+00:00"
               },
               "deterministic": true
             },
@@ -16189,7 +16175,7 @@
             "maxLength": 8,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.840911+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.321346+00:00"
           }
         },
         "x-f5xc-description-short": "Request to return all the credentials for the matching cloud site type.",
@@ -16309,7 +16295,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:48.482483+00:00"
+                "validatedAt": "2026-07-20T14:36:32.474811+00:00"
               },
               "deterministic": true
             },
@@ -16321,9 +16307,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.840941+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.321364+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Customer Edge uniquely identifies customer edge i.e. Site.",
@@ -16477,7 +16462,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:48.482520+00:00"
+                "validatedAt": "2026-07-20T14:36:32.474829+00:00"
               },
               "deterministic": true
             },
@@ -16489,9 +16474,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.840982+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.321390+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -16523,7 +16507,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:48.482546+00:00"
+                "validatedAt": "2026-07-20T14:36:32.474841+00:00"
               },
               "deterministic": true
             },
@@ -16535,9 +16519,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.841001+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.321402+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -16636,7 +16619,7 @@
             "maxLength": 8,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.841035+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.321423+00:00"
           },
           "region": {
             "type": "string",
@@ -16652,7 +16635,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.482589+00:00"
+                "validatedAt": "2026-07-20T14:36:32.474858+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16791,7 +16774,7 @@
             "maxLength": 8,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.841077+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.321448+00:00"
           },
           "region": {
             "type": "string",
@@ -16807,7 +16790,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.482645+00:00"
+                "validatedAt": "2026-07-20T14:36:32.474881+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16830,7 +16813,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.482687+00:00"
+                "validatedAt": "2026-07-20T14:36:32.474895+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16855,7 +16838,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.482723+00:00"
+                "validatedAt": "2026-07-20T14:36:32.474909+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17074,7 +17057,7 @@
             "maxLength": 8,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.841153+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.321494+00:00"
           },
           "region": {
             "type": "string",
@@ -17090,7 +17073,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.482795+00:00"
+                "validatedAt": "2026-07-20T14:36:32.474937+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17169,7 +17152,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.841188+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.321516+00:00"
           },
           "value": {
             "type": "array",
@@ -17188,7 +17171,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.841209+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.321529+00:00"
           }
         },
         "x-f5xc-description-short": "Field Data contains key/value pairs that uniquely identifies the group_by labels specified in the request.",
@@ -17294,7 +17277,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.482853+00:00"
+                "validatedAt": "2026-07-20T14:36:32.474960+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17330,7 +17313,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:48.482894+00:00"
+                "validatedAt": "2026-07-20T14:36:32.474980+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17391,7 +17374,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:48.482928+00:00"
+                "validatedAt": "2026-07-20T14:36:32.474996+00:00"
               },
               "deterministic": true
             },
@@ -17403,9 +17386,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.841250+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.321555+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "start_time": {
             "type": "string",
@@ -17430,7 +17412,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.482968+00:00"
+                "validatedAt": "2026-07-20T14:36:32.475012+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17463,7 +17445,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.483000+00:00"
+                "validatedAt": "2026-07-20T14:36:32.475026+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17554,7 +17536,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.483044+00:00"
+                "validatedAt": "2026-07-20T14:36:32.475044+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17724,7 +17706,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.841345+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.321612+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -17825,7 +17807,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.483151+00:00"
+                "validatedAt": "2026-07-20T14:36:32.475087+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17836,7 +17818,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.841384+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.321636+00:00"
           }
         },
         "x-f5xc-description-short": "Metrics used in the cloud connect are tagged with labels listed in the enum Label.",
@@ -17901,7 +17883,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.483189+00:00"
+                "validatedAt": "2026-07-20T14:36:32.475104+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17937,7 +17919,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:48.483230+00:00"
+                "validatedAt": "2026-07-20T14:36:32.475126+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17972,7 +17954,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:48.483272+00:00"
+                "validatedAt": "2026-07-20T14:36:32.475147+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18005,7 +17987,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.483311+00:00"
+                "validatedAt": "2026-07-20T14:36:32.475164+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18094,7 +18076,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.483357+00:00"
+                "validatedAt": "2026-07-20T14:36:32.475183+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18178,7 +18160,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:57:48.483400+00:00"
+                "validatedAt": "2026-07-20T14:36:32.475203+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18257,7 +18239,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:57:48.483450+00:00"
+                "validatedAt": "2026-07-20T14:36:32.475226+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18268,7 +18250,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.841469+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.321688+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -18355,7 +18337,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:48.483489+00:00"
+                "validatedAt": "2026-07-20T14:36:32.475244+00:00"
               },
               "deterministic": true
             },
@@ -18367,9 +18349,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.841514+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.321716+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -18400,7 +18381,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:48.483515+00:00"
+                "validatedAt": "2026-07-20T14:36:32.475257+00:00"
               },
               "deterministic": true
             },
@@ -18412,9 +18393,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.841532+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.321728+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -18483,7 +18463,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.483564+00:00"
+                "validatedAt": "2026-07-20T14:36:32.475278+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18495,7 +18475,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.841570+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.321752+00:00"
           },
           "uid": {
             "type": "string",
@@ -18512,7 +18492,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.483590+00:00"
+                "validatedAt": "2026-07-20T14:36:32.475289+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18525,7 +18505,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.841590+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.321764+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of cloud_connect is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -18600,7 +18580,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.483628+00:00"
+                "validatedAt": "2026-07-20T14:36:32.475305+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18636,7 +18616,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:48.483676+00:00"
+                "validatedAt": "2026-07-20T14:36:32.475326+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18686,7 +18666,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:48.483725+00:00"
+                "validatedAt": "2026-07-20T14:36:32.475348+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18719,7 +18699,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.483765+00:00"
+                "validatedAt": "2026-07-20T14:36:32.475364+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18752,7 +18732,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.483797+00:00"
+                "validatedAt": "2026-07-20T14:36:32.475377+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18856,7 +18836,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.483853+00:00"
+                "validatedAt": "2026-07-20T14:36:32.475400+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19001,7 +18981,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.483914+00:00"
+                "validatedAt": "2026-07-20T14:36:32.475424+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19039,7 +19019,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.483951+00:00"
+                "validatedAt": "2026-07-20T14:36:32.475439+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19062,7 +19042,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.483989+00:00"
+                "validatedAt": "2026-07-20T14:36:32.475454+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19150,7 +19130,7 @@
             "maxLength": 8,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.841735+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.321847+00:00"
           },
           "vpc_id": {
             "type": "string",
@@ -19165,7 +19145,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.484030+00:00"
+                "validatedAt": "2026-07-20T14:36:32.475472+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19662,7 +19642,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.484135+00:00"
+                "validatedAt": "2026-07-20T14:36:32.475513+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19685,7 +19665,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.484175+00:00"
+                "validatedAt": "2026-07-20T14:36:32.475529+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19708,7 +19688,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.484218+00:00"
+                "validatedAt": "2026-07-20T14:36:32.475547+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19732,7 +19712,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.484260+00:00"
+                "validatedAt": "2026-07-20T14:36:32.475565+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19756,7 +19736,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.484294+00:00"
+                "validatedAt": "2026-07-20T14:36:32.475578+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19767,7 +19747,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.841864+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.321923+00:00"
           },
           "subnet_id": {
             "type": "string",
@@ -19782,7 +19762,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.484330+00:00"
+                "validatedAt": "2026-07-20T14:36:32.475593+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19923,7 +19903,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.484383+00:00"
+                "validatedAt": "2026-07-20T14:36:32.475615+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19959,7 +19939,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:48.484423+00:00"
+                "validatedAt": "2026-07-20T14:36:32.475636+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19986,7 +19966,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.484455+00:00"
+                "validatedAt": "2026-07-20T14:36:32.475650+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20025,7 +20005,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T12:57:48.484497+00:00"
+                "validatedAt": "2026-07-20T14:36:32.475670+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20058,7 +20038,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.484537+00:00"
+                "validatedAt": "2026-07-20T14:36:32.475687+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20147,7 +20127,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.484580+00:00"
+                "validatedAt": "2026-07-20T14:36:32.475704+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20276,7 +20256,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:48.484613+00:00"
+                "validatedAt": "2026-07-20T14:36:32.475720+00:00"
               },
               "deterministic": true
             },
@@ -20288,9 +20268,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.841960+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.321982+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "site": {
             "allOf": [
@@ -20490,7 +20469,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:48.485245+00:00"
+                "validatedAt": "2026-07-20T14:36:32.476031+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20562,7 +20541,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:48.485294+00:00"
+                "validatedAt": "2026-07-20T14:36:32.476063+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20695,7 +20674,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.485343+00:00"
+                "validatedAt": "2026-07-20T14:36:32.476086+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20706,7 +20685,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.842276+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.322178+00:00"
           }
         },
         "x-f5xc-description-short": "Metric data contains timestamp and the value.",
@@ -20802,7 +20781,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:48.485417+00:00"
+                "validatedAt": "2026-07-20T14:36:32.476125+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -20817,7 +20796,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.842304+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.322195+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -20887,7 +20866,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:48.485457+00:00"
+                "validatedAt": "2026-07-20T14:36:32.476146+00:00"
               },
               "deterministic": true
             },
@@ -20899,9 +20878,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.842337+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.322216+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -20934,7 +20912,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:48.485483+00:00"
+                "validatedAt": "2026-07-20T14:36:32.476160+00:00"
               },
               "deterministic": true
             },
@@ -20946,9 +20924,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.842355+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.322228+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -21048,7 +21025,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:48.485705+00:00"
+                "validatedAt": "2026-07-20T14:36:32.476262+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -21063,7 +21040,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.842460+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.322295+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -21133,7 +21110,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:48.485743+00:00"
+                "validatedAt": "2026-07-20T14:36:32.476280+00:00"
               },
               "deterministic": true
             },
@@ -21145,9 +21122,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.842492+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.322316+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -21180,7 +21156,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:48.485771+00:00"
+                "validatedAt": "2026-07-20T14:36:32.476293+00:00"
               },
               "deterministic": true
             },
@@ -21192,9 +21168,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.842510+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.322328+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -21301,7 +21276,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:57:48.486466+00:00"
+                "validatedAt": "2026-07-20T14:36:32.476972+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21312,7 +21287,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.842757+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.322475+00:00"
           },
           "previous_value": {
             "type": "string",
@@ -21330,7 +21305,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.486507+00:00"
+                "validatedAt": "2026-07-20T14:36:32.477004+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21368,7 +21343,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:48.486544+00:00"
+                "validatedAt": "2026-07-20T14:36:32.477032+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21379,7 +21354,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.842788+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.322495+00:00"
           }
         },
         "x-f5xc-description-short": "Trend value contains trend value, trend sentiment and trend calculation description and window size.",
@@ -21893,7 +21868,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:48.486818+00:00"
+                "validatedAt": "2026-07-20T14:36:32.477262+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -21907,8 +21882,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -21947,7 +21921,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:48.486867+00:00"
+                "validatedAt": "2026-07-20T14:36:32.477312+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -21962,9 +21936,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.842952+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.322599+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -21993,7 +21966,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:48.486925+00:00"
+                "validatedAt": "2026-07-20T14:36:32.477362+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22006,7 +21979,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.842970+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.322611+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a direct reference from one object(the referrer) to another(the referred).",
@@ -22142,7 +22115,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:52.370593+00:00"
+                "validatedAt": "2026-07-20T14:36:34.018610+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22251,7 +22224,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:52.370742+00:00"
+                "validatedAt": "2026-07-20T14:36:34.018663+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22295,7 +22268,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:52.370859+00:00"
+                "validatedAt": "2026-07-20T14:36:34.018698+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22400,7 +22373,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:52.370964+00:00"
+                "validatedAt": "2026-07-20T14:36:34.018729+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22492,7 +22465,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:52.371034+00:00"
+                "validatedAt": "2026-07-20T14:36:34.018760+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22528,7 +22501,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:52.371097+00:00"
+                "validatedAt": "2026-07-20T14:36:34.018787+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22579,7 +22552,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:52.371161+00:00"
+                "validatedAt": "2026-07-20T14:36:34.018815+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22616,7 +22589,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:52.371218+00:00"
+                "validatedAt": "2026-07-20T14:36:34.018840+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22695,7 +22668,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:52.371276+00:00"
+                "validatedAt": "2026-07-20T14:36:34.018866+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22746,7 +22719,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:52.371341+00:00"
+                "validatedAt": "2026-07-20T14:36:34.018895+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22783,7 +22756,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:52.371397+00:00"
+                "validatedAt": "2026-07-20T14:36:34.018920+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23165,7 +23138,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:52.371475+00:00"
+                "validatedAt": "2026-07-20T14:36:34.018952+00:00"
               },
               "deterministic": true
             },
@@ -23177,9 +23150,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.927415+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.412723+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -23211,7 +23183,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:52.371506+00:00"
+                "validatedAt": "2026-07-20T14:36:34.018966+00:00"
               },
               "deterministic": true
             },
@@ -23223,9 +23195,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.927435+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.412737+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -23438,7 +23409,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.927511+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.412783+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -23673,7 +23644,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:57:52.371649+00:00"
+                "validatedAt": "2026-07-20T14:36:34.019020+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23752,7 +23723,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:57:52.371735+00:00"
+                "validatedAt": "2026-07-20T14:36:34.019042+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23763,7 +23734,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.927595+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.412833+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -23850,7 +23821,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:52.371777+00:00"
+                "validatedAt": "2026-07-20T14:36:34.019060+00:00"
               },
               "deterministic": true
             },
@@ -23862,9 +23833,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.927641+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.412861+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -23895,7 +23865,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:52.371805+00:00"
+                "validatedAt": "2026-07-20T14:36:34.019073+00:00"
               },
               "deterministic": true
             },
@@ -23907,9 +23877,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.927668+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.412873+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -23978,7 +23947,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:52.371860+00:00"
+                "validatedAt": "2026-07-20T14:36:34.019094+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23990,7 +23959,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.927706+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.412897+00:00"
           },
           "uid": {
             "type": "string",
@@ -24008,7 +23977,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:52.371887+00:00"
+                "validatedAt": "2026-07-20T14:36:34.019105+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24021,7 +23990,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.927725+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.412909+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of cloud_credentials is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -24409,7 +24378,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:52.372059+00:00"
+                "validatedAt": "2026-07-20T14:36:34.019171+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24450,7 +24419,7 @@
                 "confidence": 1.0,
                 "category": "content",
                 "note": "Blindfold envelope encryption (AES-256-GCM + RSA-OAEP) of an RSA-2048 TLS private key produces ~3700 char string:/// URL. 128KB max secret size = ~175KB base64. Discovery reported 1024 which is incorrect.",
-                "validatedAt": "2026-07-20T12:57:52.372096+00:00"
+                "validatedAt": "2026-07-20T14:36:34.019191+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24461,7 +24430,7 @@
             },
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.927851+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.412984+00:00"
           },
           "store_provider": {
             "type": "string",
@@ -24480,7 +24449,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:52.372142+00:00"
+                "validatedAt": "2026-07-20T14:36:34.019210+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24547,7 +24516,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:52.372179+00:00"
+                "validatedAt": "2026-07-20T14:36:34.019224+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24558,7 +24527,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.927878+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.413001+00:00"
           },
           "url": {
             "type": "string",
@@ -24596,7 +24565,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:52.372240+00:00"
+                "validatedAt": "2026-07-20T14:36:34.019258+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -24667,7 +24636,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:52.372862+00:00"
+                "validatedAt": "2026-07-20T14:36:34.019517+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24679,7 +24648,7 @@
             "readOnly": true,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.928184+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.413194+00:00"
           },
           "name": {
             "type": "string",
@@ -24712,7 +24681,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:52.372890+00:00"
+                "validatedAt": "2026-07-20T14:36:34.019530+00:00"
               },
               "deterministic": true
             },
@@ -24724,9 +24693,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.928203+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.413206+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -24759,7 +24727,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:52.372918+00:00"
+                "validatedAt": "2026-07-20T14:36:34.019543+00:00"
               },
               "deterministic": true
             },
@@ -24771,9 +24739,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.928221+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.413218+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -24792,7 +24759,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:52.372951+00:00"
+                "validatedAt": "2026-07-20T14:36:34.019555+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24805,7 +24772,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.928240+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.413230+00:00"
           },
           "uid": {
             "type": "string",
@@ -24824,7 +24791,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:52.372976+00:00"
+                "validatedAt": "2026-07-20T14:36:34.019565+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24838,7 +24805,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.928259+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.413242+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -25159,7 +25126,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:57:56.163973+00:00"
+                "validatedAt": "2026-07-20T14:36:35.404066+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25195,7 +25162,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:56.164055+00:00"
+                "validatedAt": "2026-07-20T14:36:35.404097+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25290,7 +25257,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:56.164118+00:00"
+                "validatedAt": "2026-07-20T14:36:35.404119+00:00"
               },
               "deterministic": true
             },
@@ -25302,9 +25269,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.985211+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.472762+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -25336,7 +25302,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:56.164165+00:00"
+                "validatedAt": "2026-07-20T14:36:35.404134+00:00"
               },
               "deterministic": true
             },
@@ -25348,9 +25314,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.985232+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.472776+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -25406,7 +25371,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:56.164199+00:00"
+                "validatedAt": "2026-07-20T14:36:35.404147+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25429,7 +25394,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:56.164246+00:00"
+                "validatedAt": "2026-07-20T14:36:35.404165+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25452,7 +25417,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:56.164284+00:00"
+                "validatedAt": "2026-07-20T14:36:35.404180+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25463,7 +25428,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.985268+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.472798+00:00"
           },
           "public_ip_address": {
             "type": "string",
@@ -25478,7 +25443,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:56.164327+00:00"
+                "validatedAt": "2026-07-20T14:36:35.404198+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25571,7 +25536,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:56.164374+00:00"
+                "validatedAt": "2026-07-20T14:36:35.404219+00:00"
               },
               "deterministic": true
             },
@@ -25583,9 +25548,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.985302+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.472819+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -25654,7 +25618,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:56.164405+00:00"
+                "validatedAt": "2026-07-20T14:36:35.404235+00:00"
               },
               "deterministic": true
             },
@@ -25666,9 +25630,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.985322+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.472833+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -25861,7 +25824,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.985390+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.472875+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -25946,7 +25909,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:57:56.164512+00:00"
+                "validatedAt": "2026-07-20T14:36:35.404288+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25982,7 +25945,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:56.164557+00:00"
+                "validatedAt": "2026-07-20T14:36:35.404310+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26065,7 +26028,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:57:56.164600+00:00"
+                "validatedAt": "2026-07-20T14:36:35.404330+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26144,7 +26107,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:57:56.164664+00:00"
+                "validatedAt": "2026-07-20T14:36:35.404354+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26155,7 +26118,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.985456+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.472914+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -26242,7 +26205,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:56.164709+00:00"
+                "validatedAt": "2026-07-20T14:36:35.404374+00:00"
               },
               "deterministic": true
             },
@@ -26254,9 +26217,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.985502+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.472943+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -26287,7 +26249,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:56.164736+00:00"
+                "validatedAt": "2026-07-20T14:36:35.404387+00:00"
               },
               "deterministic": true
             },
@@ -26299,9 +26261,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.985520+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.472956+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -26370,7 +26331,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:56.164790+00:00"
+                "validatedAt": "2026-07-20T14:36:35.404408+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26382,7 +26343,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.985559+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.472980+00:00"
           },
           "uid": {
             "type": "string",
@@ -26400,7 +26361,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:56.164817+00:00"
+                "validatedAt": "2026-07-20T14:36:35.404419+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26413,7 +26374,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.985580+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.472993+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of cloud_elastic_ip is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -26584,7 +26545,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:57:56.164863+00:00"
+                "validatedAt": "2026-07-20T14:36:35.404438+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26620,7 +26581,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:56.164905+00:00"
+                "validatedAt": "2026-07-20T14:36:35.404459+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27027,7 +26988,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.093804+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.599937+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -27208,7 +27169,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:58:02.061037+00:00"
+                "validatedAt": "2026-07-20T14:36:37.639721+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27289,7 +27250,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:58:02.061128+00:00"
+                "validatedAt": "2026-07-20T14:36:37.639750+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27300,7 +27261,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.093875+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.599979+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -27387,7 +27348,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:02.061192+00:00"
+                "validatedAt": "2026-07-20T14:36:37.639769+00:00"
               },
               "deterministic": true
             },
@@ -27399,9 +27360,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.093922+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.600009+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -27432,7 +27392,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:02.061236+00:00"
+                "validatedAt": "2026-07-20T14:36:37.639784+00:00"
               },
               "deterministic": true
             },
@@ -27444,9 +27404,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.093941+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.600021+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -27515,7 +27474,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:02.061323+00:00"
+                "validatedAt": "2026-07-20T14:36:37.639805+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27527,7 +27486,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.093978+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.600045+00:00"
           },
           "uid": {
             "type": "string",
@@ -27544,7 +27503,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:02.061361+00:00"
+                "validatedAt": "2026-07-20T14:36:37.639817+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27557,7 +27516,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.093997+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.600058+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of cloud_region is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -27912,7 +27871,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:06.229105+00:00"
+                "validatedAt": "2026-07-20T14:36:39.286456+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28030,7 +27989,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:06.229241+00:00"
+                "validatedAt": "2026-07-20T14:36:39.286509+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28095,7 +28054,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:06.229286+00:00"
+                "validatedAt": "2026-07-20T14:36:39.286527+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28174,7 +28133,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:06.229359+00:00"
+                "validatedAt": "2026-07-20T14:36:39.286560+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28334,7 +28293,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:06.229440+00:00"
+                "validatedAt": "2026-07-20T14:36:39.286590+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28359,7 +28318,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:06.229482+00:00"
+                "validatedAt": "2026-07-20T14:36:39.286607+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28560,7 +28519,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:06.229550+00:00"
+                "validatedAt": "2026-07-20T14:36:39.286632+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28597,7 +28556,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:06.229597+00:00"
+                "validatedAt": "2026-07-20T14:36:39.286650+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28627,7 +28586,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:06.229640+00:00"
+                "validatedAt": "2026-07-20T14:36:39.286668+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28656,7 +28615,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:06.229691+00:00"
+                "validatedAt": "2026-07-20T14:36:39.286684+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28680,7 +28639,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:06.229736+00:00"
+                "validatedAt": "2026-07-20T14:36:39.286701+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28704,7 +28663,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:06.229776+00:00"
+                "validatedAt": "2026-07-20T14:36:39.286717+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28984,7 +28943,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:06.229837+00:00"
+                "validatedAt": "2026-07-20T14:36:39.286742+00:00"
               },
               "deterministic": true
             },
@@ -28996,9 +28955,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.175988+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.704751+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -29030,7 +28988,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:06.229867+00:00"
+                "validatedAt": "2026-07-20T14:36:39.286756+00:00"
               },
               "deterministic": true
             },
@@ -29042,9 +29000,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.176007+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.704765+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -29098,7 +29055,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:06.229904+00:00"
+                "validatedAt": "2026-07-20T14:36:39.286771+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29121,7 +29078,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:06.229942+00:00"
+                "validatedAt": "2026-07-20T14:36:39.286785+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29145,7 +29102,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:06.229983+00:00"
+                "validatedAt": "2026-07-20T14:36:39.286802+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29170,7 +29127,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:06.230023+00:00"
+                "validatedAt": "2026-07-20T14:36:39.286817+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29200,7 +29157,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:06.230067+00:00"
+                "validatedAt": "2026-07-20T14:36:39.286834+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29243,7 +29200,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:06.230117+00:00"
+                "validatedAt": "2026-07-20T14:36:39.286853+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29280,7 +29237,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:06.230157+00:00"
+                "validatedAt": "2026-07-20T14:36:39.286869+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29291,7 +29248,7 @@
             },
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.176082+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.704813+00:00"
           },
           "owner_account": {
             "type": "string",
@@ -29307,7 +29264,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:06.230203+00:00"
+                "validatedAt": "2026-07-20T14:36:39.286885+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29332,7 +29289,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:06.230243+00:00"
+                "validatedAt": "2026-07-20T14:36:39.286900+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29357,7 +29314,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:06.230283+00:00"
+                "validatedAt": "2026-07-20T14:36:39.286915+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29381,7 +29338,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:06.230317+00:00"
+                "validatedAt": "2026-07-20T14:36:39.286928+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29504,7 +29461,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:06.230376+00:00"
+                "validatedAt": "2026-07-20T14:36:39.286952+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29528,7 +29485,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:06.230413+00:00"
+                "validatedAt": "2026-07-20T14:36:39.286966+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29551,7 +29508,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:06.230458+00:00"
+                "validatedAt": "2026-07-20T14:36:39.286983+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29576,7 +29533,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:06.230504+00:00"
+                "validatedAt": "2026-07-20T14:36:39.287001+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29606,7 +29563,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:06.230552+00:00"
+                "validatedAt": "2026-07-20T14:36:39.287020+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29630,7 +29587,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:06.230592+00:00"
+                "validatedAt": "2026-07-20T14:36:39.287036+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29654,7 +29611,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:06.230634+00:00"
+                "validatedAt": "2026-07-20T14:36:39.287052+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29740,7 +29697,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:06.230694+00:00"
+                "validatedAt": "2026-07-20T14:36:39.287076+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29816,7 +29773,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:06.230768+00:00"
+                "validatedAt": "2026-07-20T14:36:39.287108+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29865,7 +29822,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:06.230829+00:00"
+                "validatedAt": "2026-07-20T14:36:39.287136+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29902,7 +29859,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:06.230865+00:00"
+                "validatedAt": "2026-07-20T14:36:39.287151+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30003,7 +29960,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:06.230917+00:00"
+                "validatedAt": "2026-07-20T14:36:39.287172+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30027,7 +29984,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:06.230960+00:00"
+                "validatedAt": "2026-07-20T14:36:39.287188+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30051,7 +30008,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:06.230996+00:00"
+                "validatedAt": "2026-07-20T14:36:39.287202+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30091,7 +30048,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:06.231050+00:00"
+                "validatedAt": "2026-07-20T14:36:39.287222+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30115,7 +30072,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:06.231092+00:00"
+                "validatedAt": "2026-07-20T14:36:39.287238+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30160,7 +30117,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:06.231146+00:00"
+                "validatedAt": "2026-07-20T14:36:39.287264+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30184,7 +30141,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:06.231182+00:00"
+                "validatedAt": "2026-07-20T14:36:39.287278+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30208,7 +30165,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:06.231220+00:00"
+                "validatedAt": "2026-07-20T14:36:39.287293+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30282,7 +30239,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:06.231266+00:00"
+                "validatedAt": "2026-07-20T14:36:39.287313+00:00"
               },
               "deterministic": true
             },
@@ -30294,9 +30251,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.176453+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.705061+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "operational_status": {
             "type": "string",
@@ -30312,7 +30268,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:06.231307+00:00"
+                "validatedAt": "2026-07-20T14:36:39.287329+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30364,7 +30320,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:06.231359+00:00"
+                "validatedAt": "2026-07-20T14:36:39.287348+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30389,7 +30345,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:06.231393+00:00"
+                "validatedAt": "2026-07-20T14:36:39.287361+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30413,7 +30369,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:06.231427+00:00"
+                "validatedAt": "2026-07-20T14:36:39.287374+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30437,7 +30393,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:06.231466+00:00"
+                "validatedAt": "2026-07-20T14:36:39.287388+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30470,7 +30426,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:06.231498+00:00"
+                "validatedAt": "2026-07-20T14:36:39.287400+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30517,7 +30473,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:06.231551+00:00"
+                "validatedAt": "2026-07-20T14:36:39.287420+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30602,7 +30558,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:06.231590+00:00"
+                "validatedAt": "2026-07-20T14:36:39.287435+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30641,7 +30597,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:06.231618+00:00"
+                "validatedAt": "2026-07-20T14:36:39.287449+00:00"
               },
               "deterministic": true
             },
@@ -30653,9 +30609,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.176548+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.705118+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "portal_url": {
             "type": "string",
@@ -30672,7 +30627,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:06.231663+00:00"
+                "validatedAt": "2026-07-20T14:36:39.287463+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30985,7 +30940,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.176650+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.705180+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -31074,7 +31029,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:06.231812+00:00"
+                "validatedAt": "2026-07-20T14:36:39.287517+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31113,7 +31068,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:06.231858+00:00"
+                "validatedAt": "2026-07-20T14:36:39.287534+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31196,7 +31151,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:58:06.231902+00:00"
+                "validatedAt": "2026-07-20T14:36:39.287554+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31275,7 +31230,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:58:06.231956+00:00"
+                "validatedAt": "2026-07-20T14:36:39.287585+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31286,7 +31241,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.176725+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.705219+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -31373,7 +31328,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:06.231996+00:00"
+                "validatedAt": "2026-07-20T14:36:39.287603+00:00"
               },
               "deterministic": true
             },
@@ -31385,9 +31340,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.176771+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.705248+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -31418,7 +31372,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:06.232023+00:00"
+                "validatedAt": "2026-07-20T14:36:39.287616+00:00"
               },
               "deterministic": true
             },
@@ -31430,9 +31384,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.176789+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.705260+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -31501,7 +31454,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:06.232075+00:00"
+                "validatedAt": "2026-07-20T14:36:39.287635+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31513,7 +31466,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.176827+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.705284+00:00"
           },
           "uid": {
             "type": "string",
@@ -31530,7 +31483,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:06.232101+00:00"
+                "validatedAt": "2026-07-20T14:36:39.287646+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31543,7 +31496,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.176846+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.705297+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of cloud_link is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -31624,7 +31577,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:06.232129+00:00"
+                "validatedAt": "2026-07-20T14:36:39.287659+00:00"
               },
               "deterministic": true
             },
@@ -31636,9 +31589,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.176866+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.705310+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -31962,7 +31914,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:06.232218+00:00"
+                "validatedAt": "2026-07-20T14:36:39.287692+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31986,7 +31938,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:06.232260+00:00"
+                "validatedAt": "2026-07-20T14:36:39.287709+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32012,7 +31964,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:06.232298+00:00"
+                "validatedAt": "2026-07-20T14:36:39.287723+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32036,7 +31988,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:06.232346+00:00"
+                "validatedAt": "2026-07-20T14:36:39.287741+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32060,7 +32012,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:06.232381+00:00"
+                "validatedAt": "2026-07-20T14:36:39.287755+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32114,7 +32066,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:06.232446+00:00"
+                "validatedAt": "2026-07-20T14:36:39.287778+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32144,7 +32096,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:06.232496+00:00"
+                "validatedAt": "2026-07-20T14:36:39.287797+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32167,7 +32119,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:06.232541+00:00"
+                "validatedAt": "2026-07-20T14:36:39.287814+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32192,7 +32144,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:06.232587+00:00"
+                "validatedAt": "2026-07-20T14:36:39.287832+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32230,7 +32182,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:06.232626+00:00"
+                "validatedAt": "2026-07-20T14:36:39.287846+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32241,7 +32193,7 @@
             },
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.177021+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.705403+00:00"
           },
           "mtu": {
             "type": "integer",
@@ -32271,7 +32223,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:06.232681+00:00"
+                "validatedAt": "2026-07-20T14:36:39.287865+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32296,7 +32248,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:06.232716+00:00"
+                "validatedAt": "2026-07-20T14:36:39.287877+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32335,7 +32287,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:06.232763+00:00"
+                "validatedAt": "2026-07-20T14:36:39.287895+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32360,7 +32312,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:06.232809+00:00"
+                "validatedAt": "2026-07-20T14:36:39.287912+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32389,7 +32341,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:06.232854+00:00"
+                "validatedAt": "2026-07-20T14:36:39.287930+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32418,7 +32370,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:06.232899+00:00"
+                "validatedAt": "2026-07-20T14:36:39.287947+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32606,7 +32558,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:06.233729+00:00"
+                "validatedAt": "2026-07-20T14:36:39.288290+00:00"
               },
               "deterministic": true
             },
@@ -32618,7 +32570,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.177404+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.705670+00:00"
           },
           "name": {
             "type": "string",
@@ -32662,7 +32614,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:06.233780+00:00"
+                "validatedAt": "2026-07-20T14:36:39.288315+00:00"
               },
               "deterministic": true
             },
@@ -32672,8 +32624,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "MessageMetaType is metadata (common attributes) of a message that only certain messages have.",
@@ -32932,7 +32883,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:06.234972+00:00"
+                "validatedAt": "2026-07-20T14:36:39.288812+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32958,7 +32909,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.178049+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.706074+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -33139,7 +33090,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:06.235205+00:00"
+                "validatedAt": "2026-07-20T14:36:39.288923+00:00"
               }
             },
             "x-f5xc-required-for": {

--- a/docs/specifications/api/container_services.json
+++ b/docs/specifications/api/container_services.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Container Services",
     "description": "Namespaced isolation with configurable limits and autoscaling policies. vK8s abstracts operational overhead while providing scheduling, persistent storage, and service mesh integration. Compute profiles specify CPU, memory, and GPU allocations for reproducible environments. Telemetry tracks consumption patterns across geographically distributed infrastructure nodes.",
-    "version": "2.1.182",
+    "version": "2.1.181",
     "contact": {
       "name": "F5 Distributed Cloud",
       "url": "https://docs.cloud.f5.com"
@@ -3864,7 +3864,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:07.132106+00:00"
+                "validatedAt": "2026-07-20T14:41:44.410263+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3876,7 +3876,7 @@
             "readOnly": true,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.547266+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.441381+00:00"
           },
           "name": {
             "type": "string",
@@ -3909,7 +3909,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:07.132164+00:00"
+                "validatedAt": "2026-07-20T14:41:44.410290+00:00"
               },
               "deterministic": true
             },
@@ -3921,9 +3921,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.547287+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.441394+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -3956,7 +3955,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:07.132195+00:00"
+                "validatedAt": "2026-07-20T14:41:44.410306+00:00"
               },
               "deterministic": true
             },
@@ -3968,9 +3967,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.547307+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.441405+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -3989,7 +3987,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:07.132231+00:00"
+                "validatedAt": "2026-07-20T14:41:44.410320+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4002,7 +4000,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.547326+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.441416+00:00"
           },
           "uid": {
             "type": "string",
@@ -4021,7 +4019,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:07.132272+00:00"
+                "validatedAt": "2026-07-20T14:41:44.410331+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4035,7 +4033,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.547346+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.441429+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -4091,7 +4089,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:07.132326+00:00"
+                "validatedAt": "2026-07-20T14:41:44.410347+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4114,7 +4112,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:07.132376+00:00"
+                "validatedAt": "2026-07-20T14:41:44.410362+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4125,7 +4123,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.547376+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.441446+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -4189,7 +4187,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T13:11:07.132424+00:00"
+                "validatedAt": "2026-07-20T14:41:44.410378+00:00"
               },
               "deterministic": true
             },
@@ -4200,8 +4198,7 @@
               "read": false
             },
             "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "minLength": 1,
-            "format": "fqdn"
+            "minLength": 1
           },
           "last_update_time": {
             "type": "string",
@@ -4218,7 +4215,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:07.132490+00:00"
+                "validatedAt": "2026-07-20T14:41:44.410395+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4245,7 +4242,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:07.132546+00:00"
+                "validatedAt": "2026-07-20T14:41:44.410409+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4256,7 +4253,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.547411+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.441466+00:00"
           },
           "service_name": {
             "type": "string",
@@ -4273,7 +4270,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:07.132610+00:00"
+                "validatedAt": "2026-07-20T14:41:44.410425+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4306,7 +4303,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:07.132665+00:00"
+                "validatedAt": "2026-07-20T14:41:44.410442+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4317,7 +4314,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.547436+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.441480+00:00"
           },
           "type": {
             "type": "string",
@@ -4342,7 +4339,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:07.132701+00:00"
+                "validatedAt": "2026-07-20T14:41:44.410456+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4486,7 +4483,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:07.132744+00:00"
+                "validatedAt": "2026-07-20T14:41:44.410473+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4566,7 +4563,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:07.132775+00:00"
+                "validatedAt": "2026-07-20T14:41:44.410487+00:00"
               },
               "deterministic": true
             },
@@ -4578,9 +4575,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.547487+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.441509+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -4735,7 +4731,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:07.132849+00:00"
+                "validatedAt": "2026-07-20T14:41:44.410515+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4746,7 +4742,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.547535+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.441538+00:00"
           }
         },
         "x-f5xc-description-short": "Metric data contains timestamp and the value.",
@@ -4842,7 +4838,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:07.132935+00:00"
+                "validatedAt": "2026-07-20T14:41:44.410555+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -4857,7 +4853,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.547565+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.441554+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -4927,7 +4923,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:07.132977+00:00"
+                "validatedAt": "2026-07-20T14:41:44.410573+00:00"
               },
               "deterministic": true
             },
@@ -4939,9 +4935,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.547598+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.441575+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -4974,7 +4969,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:07.133005+00:00"
+                "validatedAt": "2026-07-20T14:41:44.410586+00:00"
               },
               "deterministic": true
             },
@@ -4986,9 +4981,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.547616+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.441586+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -5088,7 +5082,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:07.133080+00:00"
+                "validatedAt": "2026-07-20T14:41:44.410621+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -5103,7 +5097,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.547645+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.441602+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -5175,7 +5169,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:07.133119+00:00"
+                "validatedAt": "2026-07-20T14:41:44.410639+00:00"
               },
               "deterministic": true
             },
@@ -5187,9 +5181,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.547687+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.441620+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -5222,7 +5215,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:07.133146+00:00"
+                "validatedAt": "2026-07-20T14:41:44.410652+00:00"
               },
               "deterministic": true
             },
@@ -5234,9 +5227,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.547706+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.441631+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -5336,7 +5328,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:07.133220+00:00"
+                "validatedAt": "2026-07-20T14:41:44.410687+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -5351,7 +5343,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.547734+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.441648+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -5421,7 +5413,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:07.133258+00:00"
+                "validatedAt": "2026-07-20T14:41:44.410704+00:00"
               },
               "deterministic": true
             },
@@ -5433,9 +5425,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.547768+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.441668+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -5468,7 +5459,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:07.133286+00:00"
+                "validatedAt": "2026-07-20T14:41:44.410716+00:00"
               },
               "deterministic": true
             },
@@ -5480,9 +5471,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.547786+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.441680+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -5545,7 +5535,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:07.133330+00:00"
+                "validatedAt": "2026-07-20T14:41:44.410734+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5573,7 +5563,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:07.133370+00:00"
+                "validatedAt": "2026-07-20T14:41:44.410750+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5601,7 +5591,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:07.133407+00:00"
+                "validatedAt": "2026-07-20T14:41:44.410765+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5640,7 +5630,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:07.133448+00:00"
+                "validatedAt": "2026-07-20T14:41:44.410780+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5667,7 +5657,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:07.133474+00:00"
+                "validatedAt": "2026-07-20T14:41:44.410791+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5680,7 +5670,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.547840+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.441713+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -5696,7 +5686,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:07.133509+00:00"
+                "validatedAt": "2026-07-20T14:41:44.410805+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5841,7 +5831,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:07.133557+00:00"
+                "validatedAt": "2026-07-20T14:41:44.410824+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5852,7 +5842,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.547881+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.441736+00:00"
           },
           "status": {
             "type": "string",
@@ -5870,7 +5860,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:07.133592+00:00"
+                "validatedAt": "2026-07-20T14:41:44.410837+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5881,7 +5871,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.547899+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.441748+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -5941,7 +5931,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:07.133637+00:00"
+                "validatedAt": "2026-07-20T14:41:44.410855+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5968,7 +5958,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:07.133685+00:00"
+                "validatedAt": "2026-07-20T14:41:44.410871+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5995,7 +5985,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:07.133723+00:00"
+                "validatedAt": "2026-07-20T14:41:44.410885+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6023,7 +6013,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:07.133766+00:00"
+                "validatedAt": "2026-07-20T14:41:44.410902+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6099,7 +6089,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:07.133829+00:00"
+                "validatedAt": "2026-07-20T14:41:44.410926+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6167,7 +6157,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:07.133880+00:00"
+                "validatedAt": "2026-07-20T14:41:44.410946+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6179,7 +6169,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.547987+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.441802+00:00"
           },
           "uid": {
             "type": "string",
@@ -6198,7 +6188,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:07.133906+00:00"
+                "validatedAt": "2026-07-20T14:41:44.410956+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6211,7 +6201,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.548006+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.441813+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -6325,7 +6315,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:11:07.133953+00:00"
+                "validatedAt": "2026-07-20T14:41:44.410977+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6336,7 +6326,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.548027+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.441824+00:00"
           },
           "previous_value": {
             "type": "string",
@@ -6354,7 +6344,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:07.133993+00:00"
+                "validatedAt": "2026-07-20T14:41:44.410993+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6392,7 +6382,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:07.134028+00:00"
+                "validatedAt": "2026-07-20T14:41:44.411007+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6403,7 +6393,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.548058+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.441845+00:00"
           }
         },
         "x-f5xc-description-short": "Trend value contains trend value, trend sentiment and trend calculation description and window size.",
@@ -6528,7 +6518,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:07.134061+00:00"
+                "validatedAt": "2026-07-20T14:41:44.411020+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6539,7 +6529,7 @@
             },
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.548079+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.441856+00:00"
           },
           "name": {
             "type": "string",
@@ -6572,7 +6562,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:07.134089+00:00"
+                "validatedAt": "2026-07-20T14:41:44.411033+00:00"
               },
               "deterministic": true
             },
@@ -6584,9 +6574,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.548097+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.441867+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -6619,7 +6608,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:07.134117+00:00"
+                "validatedAt": "2026-07-20T14:41:44.411046+00:00"
               },
               "deterministic": true
             },
@@ -6631,9 +6620,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.548116+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.441878+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "uid": {
             "type": "string",
@@ -6650,7 +6638,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:07.134143+00:00"
+                "validatedAt": "2026-07-20T14:41:44.411057+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6663,7 +6651,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.548135+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.441889+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -6750,7 +6738,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:07.134198+00:00"
+                "validatedAt": "2026-07-20T14:41:44.411084+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -6764,8 +6752,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -6804,7 +6791,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:07.134248+00:00"
+                "validatedAt": "2026-07-20T14:41:44.411110+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -6819,9 +6806,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.548164+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.441904+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -6850,7 +6836,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:07.134302+00:00"
+                "validatedAt": "2026-07-20T14:41:44.411135+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6863,7 +6849,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.548183+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.441918+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a direct reference from one object(the referrer) to another(the referred).",
@@ -7134,7 +7120,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:07.134378+00:00"
+                "validatedAt": "2026-07-20T14:41:44.411168+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7235,7 +7221,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:07.134410+00:00"
+                "validatedAt": "2026-07-20T14:41:44.411183+00:00"
               },
               "deterministic": true
             },
@@ -7247,9 +7233,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.548272+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.441967+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -7281,7 +7266,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:07.134438+00:00"
+                "validatedAt": "2026-07-20T14:41:44.411195+00:00"
               },
               "deterministic": true
             },
@@ -7293,9 +7278,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.548291+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.441977+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -7460,7 +7444,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.548357+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.442013+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -7603,7 +7587,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:07.134561+00:00"
+                "validatedAt": "2026-07-20T14:41:44.411247+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7690,7 +7674,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:11:07.134604+00:00"
+                "validatedAt": "2026-07-20T14:41:44.411266+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7771,7 +7755,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:11:07.134661+00:00"
+                "validatedAt": "2026-07-20T14:41:44.411287+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7782,7 +7766,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.548434+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.442056+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -7869,7 +7853,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:07.134703+00:00"
+                "validatedAt": "2026-07-20T14:41:44.411305+00:00"
               },
               "deterministic": true
             },
@@ -7881,9 +7865,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.548479+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.442080+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -7914,7 +7897,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:07.134730+00:00"
+                "validatedAt": "2026-07-20T14:41:44.411318+00:00"
               },
               "deterministic": true
             },
@@ -7926,9 +7909,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.548497+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.442090+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -7997,7 +7979,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:07.134781+00:00"
+                "validatedAt": "2026-07-20T14:41:44.411339+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8009,7 +7991,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.548535+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.442111+00:00"
           },
           "uid": {
             "type": "string",
@@ -8026,7 +8008,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:07.134807+00:00"
+                "validatedAt": "2026-07-20T14:41:44.411350+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8039,7 +8021,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.548554+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.442122+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of virtual_k8s is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -8272,7 +8254,7 @@
             "maxLength": 16,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.548597+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.442145+00:00"
           },
           "value": {
             "type": "array",
@@ -8291,7 +8273,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.548619+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.442159+00:00"
           }
         },
         "x-f5xc-description-short": "PVC Metric Type Data contains key/value pair that uniquely identifies the group_by labels specified in the request.",
@@ -8357,7 +8339,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:07.134879+00:00"
+                "validatedAt": "2026-07-20T14:41:44.411377+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8402,7 +8384,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:07.134928+00:00"
+                "validatedAt": "2026-07-20T14:41:44.411401+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8429,7 +8411,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:07.134961+00:00"
+                "validatedAt": "2026-07-20T14:41:44.411414+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8484,7 +8466,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:07.135000+00:00"
+                "validatedAt": "2026-07-20T14:41:44.411432+00:00"
               },
               "deterministic": true
             },
@@ -8496,9 +8478,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.548679+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.442183+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "range": {
             "type": "string",
@@ -8523,7 +8504,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:07.135034+00:00"
+                "validatedAt": "2026-07-20T14:41:44.411445+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8556,7 +8537,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:07.135075+00:00"
+                "validatedAt": "2026-07-20T14:41:44.411462+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8589,7 +8570,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:07.135110+00:00"
+                "validatedAt": "2026-07-20T14:41:44.411475+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8684,7 +8665,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:07.135154+00:00"
+                "validatedAt": "2026-07-20T14:41:44.411494+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8912,7 +8893,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:07.135216+00:00"
+                "validatedAt": "2026-07-20T14:41:44.411523+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9093,7 +9074,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.173827+00:00"
+                "validatedAt": "2026-07-20T14:41:57.100662+00:00"
               },
               "deterministic": true
             },
@@ -9139,7 +9120,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.173958+00:00"
+                "validatedAt": "2026-07-20T14:41:57.100702+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9235,7 +9216,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.174033+00:00"
+                "validatedAt": "2026-07-20T14:41:57.100737+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9445,7 +9426,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.174118+00:00"
+                "validatedAt": "2026-07-20T14:41:57.100772+00:00"
               },
               "deterministic": true
             },
@@ -9491,7 +9472,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.174183+00:00"
+                "validatedAt": "2026-07-20T14:41:57.100803+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9527,7 +9508,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.174245+00:00"
+                "validatedAt": "2026-07-20T14:41:57.100832+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9674,7 +9655,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.174321+00:00"
+                "validatedAt": "2026-07-20T14:41:57.100866+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9899,7 +9880,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.174403+00:00"
+                "validatedAt": "2026-07-20T14:41:57.100900+00:00"
               },
               "deterministic": true
             },
@@ -9945,7 +9926,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.174464+00:00"
+                "validatedAt": "2026-07-20T14:41:57.100929+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9981,7 +9962,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.174525+00:00"
+                "validatedAt": "2026-07-20T14:41:57.100958+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10206,7 +10187,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.174604+00:00"
+                "validatedAt": "2026-07-20T14:41:57.100994+00:00"
               },
               "deterministic": true
             },
@@ -10344,7 +10325,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.174683+00:00"
+                "validatedAt": "2026-07-20T14:41:57.101027+00:00"
               },
               "deterministic": true
             },
@@ -10515,7 +10496,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.174764+00:00"
+                "validatedAt": "2026-07-20T14:41:57.101063+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10527,8 +10508,7 @@
             "x-f5xc-conflicts-with": [
               "auto_host_rewrite",
               "disable_host_rewrite"
-            ],
-            "format": "hostname"
+            ]
           },
           "http_method": {
             "allOf": [
@@ -10631,7 +10611,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.174828+00:00"
+                "validatedAt": "2026-07-20T14:41:57.101093+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10702,7 +10682,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.174890+00:00"
+                "validatedAt": "2026-07-20T14:41:57.101125+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -10716,8 +10696,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "presence": {
             "type": "boolean",
@@ -10762,7 +10741,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.174958+00:00"
+                "validatedAt": "2026-07-20T14:41:57.101158+00:00"
               },
               "byteLength": {
                 "max": 256
@@ -10852,7 +10831,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.175172+00:00"
+                "validatedAt": "2026-07-20T14:41:57.101256+00:00"
               },
               "deterministic": true
             },
@@ -10892,7 +10871,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.175226+00:00"
+                "validatedAt": "2026-07-20T14:41:57.101282+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10933,7 +10912,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.175292+00:00"
+                "validatedAt": "2026-07-20T14:41:57.101315+00:00"
               },
               "byteLength": {
                 "max": 256,
@@ -11038,7 +11017,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.175327+00:00"
+                "validatedAt": "2026-07-20T14:41:57.101331+00:00"
               },
               "deterministic": true
             },
@@ -11082,7 +11061,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.175389+00:00"
+                "validatedAt": "2026-07-20T14:41:57.101361+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11167,7 +11146,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.175531+00:00"
+                "validatedAt": "2026-07-20T14:41:57.101423+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11257,7 +11236,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:41.175591+00:00"
+                "validatedAt": "2026-07-20T14:41:57.101446+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11292,7 +11271,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.175651+00:00"
+                "validatedAt": "2026-07-20T14:41:57.101473+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11331,7 +11310,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.175723+00:00"
+                "validatedAt": "2026-07-20T14:41:57.101502+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11367,7 +11346,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:41.175765+00:00"
+                "validatedAt": "2026-07-20T14:41:57.101519+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11420,7 +11399,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.175831+00:00"
+                "validatedAt": "2026-07-20T14:41:57.101550+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11536,7 +11515,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:41.175896+00:00"
+                "validatedAt": "2026-07-20T14:41:57.101576+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11577,7 +11556,7 @@
                 "confidence": 1.0,
                 "category": "content",
                 "note": "Blindfold envelope encryption (AES-256-GCM + RSA-OAEP) of an RSA-2048 TLS private key produces ~3700 char string:/// URL. 128KB max secret size = ~175KB base64. Discovery reported 1024 which is incorrect.",
-                "validatedAt": "2026-07-20T13:11:41.175933+00:00"
+                "validatedAt": "2026-07-20T14:41:57.101596+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11588,7 +11567,7 @@
             },
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:26.128722+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:26.125366+00:00"
           },
           "store_provider": {
             "type": "string",
@@ -11607,7 +11586,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:41.175977+00:00"
+                "validatedAt": "2026-07-20T14:41:57.101615+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11674,7 +11653,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:41.176013+00:00"
+                "validatedAt": "2026-07-20T14:41:57.101630+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11685,7 +11664,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:26.128750+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:26.125383+00:00"
           },
           "url": {
             "type": "string",
@@ -11723,7 +11702,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.176071+00:00"
+                "validatedAt": "2026-07-20T14:41:57.101659+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -11853,7 +11832,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.176387+00:00"
+                "validatedAt": "2026-07-20T14:41:57.101791+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12082,7 +12061,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:41.176479+00:00"
+                "validatedAt": "2026-07-20T14:41:57.101829+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12093,7 +12072,7 @@
             },
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:26.128935+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:26.125492+00:00"
           },
           "name": {
             "type": "string",
@@ -12124,7 +12103,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.176506+00:00"
+                "validatedAt": "2026-07-20T14:41:57.101842+00:00"
               },
               "deterministic": true
             },
@@ -12136,9 +12115,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:26.128954+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:26.125504+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -12169,7 +12147,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.176532+00:00"
+                "validatedAt": "2026-07-20T14:41:57.101855+00:00"
               },
               "deterministic": true
             },
@@ -12181,9 +12159,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:26.128973+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:26.125516+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "KubeRefType represents a reference to a Kubernetes (K8s) object.",
@@ -12447,7 +12424,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.177710+00:00"
+                "validatedAt": "2026-07-20T14:41:57.102366+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12494,7 +12471,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:11:41.177762+00:00"
+                "validatedAt": "2026-07-20T14:41:57.102388+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12505,7 +12482,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:26.129526+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:26.125852+00:00"
           },
           "disable_ocsp_stapling": {
             "allOf": [
@@ -12739,7 +12716,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.178057+00:00"
+                "validatedAt": "2026-07-20T14:41:57.102522+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12900,7 +12877,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.178265+00:00"
+                "validatedAt": "2026-07-20T14:41:57.102632+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13008,7 +12985,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.178315+00:00"
+                "validatedAt": "2026-07-20T14:41:57.102657+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13224,7 +13201,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.178403+00:00"
+                "validatedAt": "2026-07-20T14:41:57.102697+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13500,7 +13477,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.178466+00:00"
+                "validatedAt": "2026-07-20T14:41:57.102726+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14250,7 +14227,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.178588+00:00"
+                "validatedAt": "2026-07-20T14:41:57.102783+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14355,7 +14332,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.178636+00:00"
+                "validatedAt": "2026-07-20T14:41:57.102808+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14406,7 +14383,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.178702+00:00"
+                "validatedAt": "2026-07-20T14:41:57.102840+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14459,7 +14436,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.178749+00:00"
+                "validatedAt": "2026-07-20T14:41:57.102865+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14644,7 +14621,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.178807+00:00"
+                "validatedAt": "2026-07-20T14:41:57.102894+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14680,7 +14657,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.178846+00:00"
+                "validatedAt": "2026-07-20T14:41:57.102914+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14830,7 +14807,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.178894+00:00"
+                "validatedAt": "2026-07-20T14:41:57.102943+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15205,7 +15182,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.178979+00:00"
+                "validatedAt": "2026-07-20T14:41:57.102982+00:00"
               },
               "deterministic": true
             },
@@ -15490,7 +15467,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.179071+00:00"
+                "validatedAt": "2026-07-20T14:41:57.103022+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15551,7 +15528,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.179123+00:00"
+                "validatedAt": "2026-07-20T14:41:57.103048+00:00"
               },
               "deterministic": true
             },
@@ -15563,9 +15540,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:26.130283+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:26.126292+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "volume_name": {
             "type": "string",
@@ -15592,7 +15568,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.179181+00:00"
+                "validatedAt": "2026-07-20T14:41:57.103076+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15742,7 +15718,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.179232+00:00"
+                "validatedAt": "2026-07-20T14:41:57.103103+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15860,7 +15836,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.179274+00:00"
+                "validatedAt": "2026-07-20T14:41:57.103124+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15896,7 +15872,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.179315+00:00"
+                "validatedAt": "2026-07-20T14:41:57.103145+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16049,7 +16025,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.179382+00:00"
+                "validatedAt": "2026-07-20T14:41:57.103178+00:00"
               },
               "deterministic": true
             },
@@ -16061,9 +16037,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:26.130385+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:26.126351+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "readiness_check": {
             "allOf": [
@@ -16316,7 +16291,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.179435+00:00"
+                "validatedAt": "2026-07-20T14:41:57.103201+00:00"
               },
               "deterministic": true
             },
@@ -16328,9 +16303,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:26.130451+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:26.126391+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -16362,7 +16336,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.179464+00:00"
+                "validatedAt": "2026-07-20T14:41:57.103215+00:00"
               },
               "deterministic": true
             },
@@ -16374,9 +16348,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:26.130470+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:26.126403+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -16452,7 +16425,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.179509+00:00"
+                "validatedAt": "2026-07-20T14:41:57.103238+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16535,7 +16508,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.179556+00:00"
+                "validatedAt": "2026-07-20T14:41:57.103261+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16783,7 +16756,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.179619+00:00"
+                "validatedAt": "2026-07-20T14:41:57.103290+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16866,7 +16839,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.179676+00:00"
+                "validatedAt": "2026-07-20T14:41:57.103312+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17027,7 +17000,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.179749+00:00"
+                "validatedAt": "2026-07-20T14:41:57.103347+00:00"
               },
               "deterministic": true
             },
@@ -17039,9 +17012,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:26.130575+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:26.126463+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "value": {
             "type": "string",
@@ -17065,7 +17037,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.179799+00:00"
+                "validatedAt": "2026-07-20T14:41:57.103373+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17076,7 +17048,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:26.130595+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:26.126475+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -17185,7 +17157,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.179855+00:00"
+                "validatedAt": "2026-07-20T14:41:57.103402+00:00"
               },
               "deterministic": true
             },
@@ -17197,9 +17169,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:26.130627+00:00",
-            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:26.126495+00:00",
+            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Ephemeral storage volume configuration for the workload.",
@@ -17281,7 +17252,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.179898+00:00"
+                "validatedAt": "2026-07-20T14:41:57.103431+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17454,7 +17425,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:26.130710+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:26.126539+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -17571,7 +17542,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.180038+00:00"
+                "validatedAt": "2026-07-20T14:41:57.103491+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17610,7 +17581,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.180102+00:00"
+                "validatedAt": "2026-07-20T14:41:57.103522+00:00"
               },
               "deterministic": true
             },
@@ -17740,7 +17711,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.180160+00:00"
+                "validatedAt": "2026-07-20T14:41:57.103551+00:00"
               },
               "deterministic": true
             },
@@ -17978,7 +17949,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T13:11:41.180249+00:00"
+                "validatedAt": "2026-07-20T14:41:57.103587+00:00"
               },
               "deterministic": true
             },
@@ -18037,7 +18008,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T13:11:41.180284+00:00"
+                "validatedAt": "2026-07-20T14:41:57.103604+00:00"
               },
               "deterministic": true
             },
@@ -18165,7 +18136,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.180383+00:00"
+                "validatedAt": "2026-07-20T14:41:57.103652+00:00"
               },
               "deterministic": true
             },
@@ -18328,7 +18299,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.180434+00:00"
+                "validatedAt": "2026-07-20T14:41:57.103679+00:00"
               },
               "deterministic": true
             },
@@ -18340,9 +18311,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:26.130881+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:26.126637+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "public": {
             "allOf": [
@@ -18458,7 +18428,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.180485+00:00"
+                "validatedAt": "2026-07-20T14:41:57.103704+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18505,7 +18475,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.180532+00:00"
+                "validatedAt": "2026-07-20T14:41:57.103727+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18538,7 +18508,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.180575+00:00"
+                "validatedAt": "2026-07-20T14:41:57.103750+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18627,7 +18597,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:11:41.180617+00:00"
+                "validatedAt": "2026-07-20T14:41:57.103768+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18707,7 +18677,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:11:41.180678+00:00"
+                "validatedAt": "2026-07-20T14:41:57.103791+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18718,7 +18688,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:26.130973+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:26.126689+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -18805,7 +18775,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.180721+00:00"
+                "validatedAt": "2026-07-20T14:41:57.103810+00:00"
               },
               "deterministic": true
             },
@@ -18817,9 +18787,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:26.131018+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:26.126716+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -18850,7 +18819,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.180748+00:00"
+                "validatedAt": "2026-07-20T14:41:57.103823+00:00"
               },
               "deterministic": true
             },
@@ -18862,9 +18831,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:26.131037+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:26.126728+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -18933,7 +18901,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:41.180802+00:00"
+                "validatedAt": "2026-07-20T14:41:57.103844+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18945,7 +18913,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:26.131074+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:26.126751+00:00"
           },
           "uid": {
             "type": "string",
@@ -18962,7 +18930,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:41.180827+00:00"
+                "validatedAt": "2026-07-20T14:41:57.103855+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18975,7 +18943,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:26.131093+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:26.126763+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of workload is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -19089,7 +19057,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.180896+00:00"
+                "validatedAt": "2026-07-20T14:41:57.103886+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19101,8 +19069,7 @@
             "x-f5xc-conflicts-with": [
               "auto_host_rewrite",
               "disable_host_rewrite"
-            ],
-            "format": "hostname"
+            ]
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -19170,7 +19137,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.180937+00:00"
+                "validatedAt": "2026-07-20T14:41:57.103907+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19298,7 +19265,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.180997+00:00"
+                "validatedAt": "2026-07-20T14:41:57.103936+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19501,7 +19468,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.181076+00:00"
+                "validatedAt": "2026-07-20T14:41:57.103973+00:00"
               },
               "deterministic": true
             },
@@ -19513,9 +19480,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:26.131186+00:00",
-            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:26.126815+00:00",
+            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
           },
           "persistent_volume": {
             "allOf": [
@@ -19606,7 +19572,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.181110+00:00"
+                "validatedAt": "2026-07-20T14:41:57.103990+00:00"
               },
               "deterministic": true
             },
@@ -19618,12 +19584,11 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:26.131214+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:26.126831+00:00",
             "x-f5xc-conflicts-with": [
               "num"
             ],
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "num": {
             "type": "integer",
@@ -19721,7 +19686,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.181152+00:00"
+                "validatedAt": "2026-07-20T14:41:57.104009+00:00"
               },
               "deterministic": true
             },
@@ -19879,7 +19844,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.181207+00:00"
+                "validatedAt": "2026-07-20T14:41:57.104032+00:00"
               },
               "deterministic": true
             },
@@ -19891,9 +19856,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:26.131275+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:26.126867+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -20415,7 +20379,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.181308+00:00"
+                "validatedAt": "2026-07-20T14:41:57.104075+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20466,7 +20430,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.181359+00:00"
+                "validatedAt": "2026-07-20T14:41:57.104102+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20506,7 +20470,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.181405+00:00"
+                "validatedAt": "2026-07-20T14:41:57.104125+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20556,7 +20520,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.181448+00:00"
+                "validatedAt": "2026-07-20T14:41:57.104147+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20784,7 +20748,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.181545+00:00"
+                "validatedAt": "2026-07-20T14:41:57.104192+00:00"
               },
               "deterministic": true
             },
@@ -20796,9 +20760,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:26.131482+00:00",
-            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:26.126985+00:00",
+            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
           },
           "persistent_volume": {
             "allOf": [
@@ -20945,7 +20908,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.181600+00:00"
+                "validatedAt": "2026-07-20T14:41:57.104221+00:00"
               },
               "deterministic": true
             },
@@ -21159,7 +21122,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:41.181670+00:00"
+                "validatedAt": "2026-07-20T14:41:57.104245+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21204,7 +21167,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.181717+00:00"
+                "validatedAt": "2026-07-20T14:41:57.104268+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21231,7 +21194,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:41.181752+00:00"
+                "validatedAt": "2026-07-20T14:41:57.104283+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21302,7 +21265,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.181796+00:00"
+                "validatedAt": "2026-07-20T14:41:57.104303+00:00"
               },
               "deterministic": true
             },
@@ -21314,9 +21277,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:26.131584+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:26.127045+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "range": {
             "type": "string",
@@ -21341,7 +21303,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:41.181830+00:00"
+                "validatedAt": "2026-07-20T14:41:57.104317+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21374,7 +21336,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:41.181871+00:00"
+                "validatedAt": "2026-07-20T14:41:57.104334+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21407,7 +21369,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:41.181904+00:00"
+                "validatedAt": "2026-07-20T14:41:57.104348+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21504,7 +21466,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:41.181948+00:00"
+                "validatedAt": "2026-07-20T14:41:57.104366+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21612,7 +21574,7 @@
             "maxLength": 16,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:26.131641+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:26.127078+00:00"
           },
           "value": {
             "type": "array",
@@ -21631,7 +21593,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:26.131671+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:26.127091+00:00"
           }
         },
         "x-f5xc-description-short": "Usage Type Data contains key/value pair that uniquely identifies a workload in the response and the corresponding metric data.",
@@ -21758,7 +21720,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.182040+00:00"
+                "validatedAt": "2026-07-20T14:41:57.104410+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21792,7 +21754,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:41.182094+00:00"
+                "validatedAt": "2026-07-20T14:41:57.104437+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21860,7 +21822,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:46.897119+00:00"
+                "validatedAt": "2026-07-20T14:41:59.300548+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21872,7 +21834,7 @@
             "readOnly": true,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:26.245366+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:26.248780+00:00"
           },
           "name": {
             "type": "string",
@@ -21905,7 +21867,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:46.897147+00:00"
+                "validatedAt": "2026-07-20T14:41:59.300562+00:00"
               },
               "deterministic": true
             },
@@ -21917,9 +21879,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:26.245384+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:26.248792+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -21952,7 +21913,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:46.897175+00:00"
+                "validatedAt": "2026-07-20T14:41:59.300576+00:00"
               },
               "deterministic": true
             },
@@ -21964,9 +21925,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:26.245402+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:26.248805+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -21985,7 +21945,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:46.897208+00:00"
+                "validatedAt": "2026-07-20T14:41:59.300590+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21998,7 +21958,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:26.245420+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:26.248817+00:00"
           },
           "uid": {
             "type": "string",
@@ -22017,7 +21977,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:46.897233+00:00"
+                "validatedAt": "2026-07-20T14:41:59.300601+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22031,7 +21991,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:26.245440+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:26.248829+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -22246,7 +22206,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:46.898166+00:00"
+                "validatedAt": "2026-07-20T14:41:59.300998+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22279,7 +22239,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:46.898206+00:00"
+                "validatedAt": "2026-07-20T14:41:59.301015+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22400,7 +22360,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:46.898257+00:00"
+                "validatedAt": "2026-07-20T14:41:59.301038+00:00"
               },
               "deterministic": true
             },
@@ -22412,9 +22372,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:26.245908+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:26.249112+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -22446,7 +22405,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:46.898283+00:00"
+                "validatedAt": "2026-07-20T14:41:59.301052+00:00"
               },
               "deterministic": true
             },
@@ -22458,9 +22417,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:26.245926+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:26.249124+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -22625,7 +22583,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:26.245993+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:26.249164+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -22710,7 +22668,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:46.898397+00:00"
+                "validatedAt": "2026-07-20T14:41:59.301100+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22743,7 +22701,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:46.898435+00:00"
+                "validatedAt": "2026-07-20T14:41:59.301118+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22851,7 +22809,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:11:46.898495+00:00"
+                "validatedAt": "2026-07-20T14:41:59.301146+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22932,7 +22890,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:11:46.898545+00:00"
+                "validatedAt": "2026-07-20T14:41:59.301169+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22943,7 +22901,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:26.246064+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:26.249205+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -23030,7 +22988,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:46.898584+00:00"
+                "validatedAt": "2026-07-20T14:41:59.301189+00:00"
               },
               "deterministic": true
             },
@@ -23042,9 +23000,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:26.246110+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:26.249233+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -23075,7 +23032,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:46.898612+00:00"
+                "validatedAt": "2026-07-20T14:41:59.301203+00:00"
               },
               "deterministic": true
             },
@@ -23087,9 +23044,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:26.246134+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:26.249245+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -23158,7 +23114,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:46.898673+00:00"
+                "validatedAt": "2026-07-20T14:41:59.301225+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23170,7 +23126,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:26.246173+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:26.249268+00:00"
           },
           "uid": {
             "type": "string",
@@ -23187,7 +23143,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:46.898699+00:00"
+                "validatedAt": "2026-07-20T14:41:59.301236+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23200,7 +23156,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:26.246191+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:26.249281+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of workload_flavor is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -23375,7 +23331,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:46.898751+00:00"
+                "validatedAt": "2026-07-20T14:41:59.301257+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23408,7 +23364,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:46.898788+00:00"
+                "validatedAt": "2026-07-20T14:41:59.301274+00:00"
               }
             },
             "x-f5xc-required-for": {

--- a/docs/specifications/api/data_and_privacy_security.json
+++ b/docs/specifications/api/data_and_privacy_security.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Data And Privacy Security",
     "description": "Pattern-based detection for personally identifiable information across request and response payloads. Custom data type definitions enable organization-specific classification beyond built-in PII categories. Regional log and metrics aggregation with Clickhouse, Elasticsearch, and Kafka export options. Geo-configuration policies enforce data residency requirements and jurisdiction-specific privacy regulations.",
-    "version": "2.1.182",
+    "version": "2.1.181",
     "contact": {
       "name": "F5 Distributed Cloud",
       "url": "https://docs.cloud.f5.com"
@@ -3366,7 +3366,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:34.525510+00:00"
+                "validatedAt": "2026-07-20T14:37:38.688356+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3439,7 +3439,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:34.525612+00:00"
+                "validatedAt": "2026-07-20T14:37:38.688392+00:00"
               },
               "deterministic": true
             },
@@ -3541,7 +3541,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:34.525688+00:00"
+                "validatedAt": "2026-07-20T14:37:38.688410+00:00"
               },
               "deterministic": true
             },
@@ -3553,9 +3553,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.714108+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.313906+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -3587,7 +3586,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:34.525737+00:00"
+                "validatedAt": "2026-07-20T14:37:38.688424+00:00"
               },
               "deterministic": true
             },
@@ -3599,9 +3598,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.714128+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.313920+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -3770,7 +3768,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:34.525799+00:00"
+                "validatedAt": "2026-07-20T14:37:38.688450+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3941,7 +3939,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.714224+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.313980+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -4034,7 +4032,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:34.525920+00:00"
+                "validatedAt": "2026-07-20T14:37:38.688498+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4107,7 +4105,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:34.525981+00:00"
+                "validatedAt": "2026-07-20T14:37:38.688527+00:00"
               },
               "deterministic": true
             },
@@ -4277,7 +4275,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:00:34.526032+00:00"
+                "validatedAt": "2026-07-20T14:37:38.688548+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4357,7 +4355,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:00:34.526089+00:00"
+                "validatedAt": "2026-07-20T14:37:38.688571+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4368,7 +4366,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.714323+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.314043+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -4455,7 +4453,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:34.526133+00:00"
+                "validatedAt": "2026-07-20T14:37:38.688591+00:00"
               },
               "deterministic": true
             },
@@ -4467,9 +4465,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.714368+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.314072+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -4500,7 +4497,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:34.526160+00:00"
+                "validatedAt": "2026-07-20T14:37:38.688603+00:00"
               },
               "deterministic": true
             },
@@ -4512,9 +4509,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.714387+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.314085+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -4583,7 +4579,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:34.526213+00:00"
+                "validatedAt": "2026-07-20T14:37:38.688623+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4595,7 +4591,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.714424+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.314109+00:00"
           },
           "uid": {
             "type": "string",
@@ -4612,7 +4608,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:34.526239+00:00"
+                "validatedAt": "2026-07-20T14:37:38.688634+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4625,7 +4621,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.714444+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.314123+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of data_type is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -4877,7 +4873,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:34.526303+00:00"
+                "validatedAt": "2026-07-20T14:37:38.688662+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4950,7 +4946,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:34.526365+00:00"
+                "validatedAt": "2026-07-20T14:37:38.688691+00:00"
               },
               "deterministic": true
             },
@@ -5050,7 +5046,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:34.526434+00:00"
+                "validatedAt": "2026-07-20T14:37:38.688721+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5090,7 +5086,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:34.526498+00:00"
+                "validatedAt": "2026-07-20T14:37:38.688751+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5272,7 +5268,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:34.526571+00:00"
+                "validatedAt": "2026-07-20T14:37:38.688777+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5295,7 +5291,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:34.526605+00:00"
+                "validatedAt": "2026-07-20T14:37:38.688791+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5306,7 +5302,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.714570+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.314201+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -5370,7 +5366,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T13:00:34.526639+00:00"
+                "validatedAt": "2026-07-20T14:37:38.688806+00:00"
               },
               "deterministic": true
             },
@@ -5381,8 +5377,7 @@
               "read": false
             },
             "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "minLength": 1,
-            "format": "fqdn"
+            "minLength": 1
           },
           "last_update_time": {
             "type": "string",
@@ -5399,7 +5394,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:34.526691+00:00"
+                "validatedAt": "2026-07-20T14:37:38.688823+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5426,7 +5421,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:34.526726+00:00"
+                "validatedAt": "2026-07-20T14:37:38.688836+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5437,7 +5432,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.714605+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.314224+00:00"
           },
           "service_name": {
             "type": "string",
@@ -5454,7 +5449,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:34.526766+00:00"
+                "validatedAt": "2026-07-20T14:37:38.688851+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5487,7 +5482,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:34.526804+00:00"
+                "validatedAt": "2026-07-20T14:37:38.688866+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5498,7 +5493,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.714630+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.314240+00:00"
           },
           "type": {
             "type": "string",
@@ -5523,7 +5518,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:34.526838+00:00"
+                "validatedAt": "2026-07-20T14:37:38.688879+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5667,7 +5662,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:34.526880+00:00"
+                "validatedAt": "2026-07-20T14:37:38.688895+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5747,7 +5742,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:34.526909+00:00"
+                "validatedAt": "2026-07-20T14:37:38.688927+00:00"
               },
               "deterministic": true
             },
@@ -5759,9 +5754,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.714686+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.314270+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -5925,7 +5919,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:34.527001+00:00"
+                "validatedAt": "2026-07-20T14:37:38.688980+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -5940,7 +5934,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.714729+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.314297+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -6010,7 +6004,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:34.527039+00:00"
+                "validatedAt": "2026-07-20T14:37:38.689000+00:00"
               },
               "deterministic": true
             },
@@ -6022,9 +6016,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.714761+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.314318+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -6057,7 +6050,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:34.527065+00:00"
+                "validatedAt": "2026-07-20T14:37:38.689014+00:00"
               },
               "deterministic": true
             },
@@ -6069,9 +6062,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.714779+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.314331+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -6171,7 +6163,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:34.527140+00:00"
+                "validatedAt": "2026-07-20T14:37:38.689051+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -6186,7 +6178,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.714807+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.314349+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -6258,7 +6250,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:34.527178+00:00"
+                "validatedAt": "2026-07-20T14:37:38.689068+00:00"
               },
               "deterministic": true
             },
@@ -6270,9 +6262,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.714839+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.314370+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -6305,7 +6296,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:34.527205+00:00"
+                "validatedAt": "2026-07-20T14:37:38.689080+00:00"
               },
               "deterministic": true
             },
@@ -6317,9 +6308,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.714857+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.314383+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -6382,7 +6372,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:34.527238+00:00"
+                "validatedAt": "2026-07-20T14:37:38.689094+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6394,7 +6384,7 @@
             "readOnly": true,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.714877+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.314396+00:00"
           },
           "name": {
             "type": "string",
@@ -6427,7 +6417,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:34.527265+00:00"
+                "validatedAt": "2026-07-20T14:37:38.689107+00:00"
               },
               "deterministic": true
             },
@@ -6439,9 +6429,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.714895+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.314409+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -6474,7 +6463,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:34.527292+00:00"
+                "validatedAt": "2026-07-20T14:37:38.689120+00:00"
               },
               "deterministic": true
             },
@@ -6486,9 +6475,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.714913+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.314421+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -6507,7 +6495,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:34.527325+00:00"
+                "validatedAt": "2026-07-20T14:37:38.689133+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6520,7 +6508,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.714931+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.314433+00:00"
           },
           "uid": {
             "type": "string",
@@ -6539,7 +6527,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:34.527351+00:00"
+                "validatedAt": "2026-07-20T14:37:38.689144+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6553,7 +6541,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.714951+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.314446+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -6653,7 +6641,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:34.527424+00:00"
+                "validatedAt": "2026-07-20T14:37:38.689178+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -6668,7 +6656,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.714978+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.314465+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -6738,7 +6726,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:34.527461+00:00"
+                "validatedAt": "2026-07-20T14:37:38.689194+00:00"
               },
               "deterministic": true
             },
@@ -6750,9 +6738,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.715011+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.314485+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -6785,7 +6772,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:34.527487+00:00"
+                "validatedAt": "2026-07-20T14:37:38.689207+00:00"
               },
               "deterministic": true
             },
@@ -6797,9 +6784,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.715029+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.314497+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -6862,7 +6848,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:34.527530+00:00"
+                "validatedAt": "2026-07-20T14:37:38.689226+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6890,7 +6876,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:34.527569+00:00"
+                "validatedAt": "2026-07-20T14:37:38.689242+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6918,7 +6904,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:34.527606+00:00"
+                "validatedAt": "2026-07-20T14:37:38.689257+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6957,7 +6943,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:34.527645+00:00"
+                "validatedAt": "2026-07-20T14:37:38.689272+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6984,7 +6970,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:34.527679+00:00"
+                "validatedAt": "2026-07-20T14:37:38.689283+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6997,7 +6983,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.715082+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.314531+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -7013,7 +6999,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:34.527714+00:00"
+                "validatedAt": "2026-07-20T14:37:38.689296+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7158,7 +7144,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:34.527765+00:00"
+                "validatedAt": "2026-07-20T14:37:38.689315+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7169,7 +7155,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.715122+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.314557+00:00"
           },
           "status": {
             "type": "string",
@@ -7187,7 +7173,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:34.527799+00:00"
+                "validatedAt": "2026-07-20T14:37:38.689329+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7198,7 +7184,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.715140+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.314569+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -7258,7 +7244,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:34.527840+00:00"
+                "validatedAt": "2026-07-20T14:37:38.689348+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7285,7 +7271,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:34.527879+00:00"
+                "validatedAt": "2026-07-20T14:37:38.689364+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7312,7 +7298,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:34.527917+00:00"
+                "validatedAt": "2026-07-20T14:37:38.689378+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7340,7 +7326,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:34.527959+00:00"
+                "validatedAt": "2026-07-20T14:37:38.689395+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7416,7 +7402,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:34.528025+00:00"
+                "validatedAt": "2026-07-20T14:37:38.689420+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7484,7 +7470,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:34.528074+00:00"
+                "validatedAt": "2026-07-20T14:37:38.689439+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7496,7 +7482,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.715225+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.314623+00:00"
           },
           "uid": {
             "type": "string",
@@ -7515,7 +7501,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:34.528100+00:00"
+                "validatedAt": "2026-07-20T14:37:38.689449+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7528,7 +7514,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.715244+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.314635+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -7596,7 +7582,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:34.528131+00:00"
+                "validatedAt": "2026-07-20T14:37:38.689462+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7607,7 +7593,7 @@
             },
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.715264+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.314648+00:00"
           },
           "name": {
             "type": "string",
@@ -7640,7 +7626,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:34.528158+00:00"
+                "validatedAt": "2026-07-20T14:37:38.689474+00:00"
               },
               "deterministic": true
             },
@@ -7652,9 +7638,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.715282+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.314663+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -7687,7 +7672,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:34.528185+00:00"
+                "validatedAt": "2026-07-20T14:37:38.689487+00:00"
               },
               "deterministic": true
             },
@@ -7699,9 +7684,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.715300+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.314676+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "uid": {
             "type": "string",
@@ -7718,7 +7702,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:34.528209+00:00"
+                "validatedAt": "2026-07-20T14:37:38.689497+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7731,7 +7715,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.715319+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.314689+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -7870,7 +7854,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.093260+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.193334+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -7958,7 +7942,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:01.094857+00:00"
+                "validatedAt": "2026-07-20T14:38:12.940999+00:00"
               },
               "minItems": 1
             },
@@ -8128,7 +8112,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:01.094942+00:00"
+                "validatedAt": "2026-07-20T14:38:12.941034+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8140,7 +8124,7 @@
             "readOnly": true,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.093320+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.193369+00:00"
           },
           "name": {
             "type": "string",
@@ -8173,7 +8157,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:01.094990+00:00"
+                "validatedAt": "2026-07-20T14:38:12.941052+00:00"
               },
               "deterministic": true
             },
@@ -8185,9 +8169,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.093339+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.193381+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -8220,7 +8203,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:01.095021+00:00"
+                "validatedAt": "2026-07-20T14:38:12.941067+00:00"
               },
               "deterministic": true
             },
@@ -8232,9 +8215,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.093357+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.193392+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -8253,7 +8235,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:01.095055+00:00"
+                "validatedAt": "2026-07-20T14:38:12.941081+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8266,7 +8248,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.093376+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.193404+00:00"
           },
           "uid": {
             "type": "string",
@@ -8285,7 +8267,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:01.095084+00:00"
+                "validatedAt": "2026-07-20T14:38:12.941092+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8299,7 +8281,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.093396+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.193416+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -8366,7 +8348,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:52.563694+00:00"
+                "validatedAt": "2026-07-20T14:38:57.214487+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8415,7 +8397,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:52.563739+00:00"
+                "validatedAt": "2026-07-20T14:38:57.214506+00:00"
               },
               "deterministic": true
             },
@@ -8452,7 +8434,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:52.563773+00:00"
+                "validatedAt": "2026-07-20T14:38:57.214521+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8657,7 +8639,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.842725+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.626999+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -8920,7 +8902,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:03:52.563935+00:00"
+                "validatedAt": "2026-07-20T14:38:57.214579+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8999,7 +8981,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:03:52.563992+00:00"
+                "validatedAt": "2026-07-20T14:38:57.214601+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9010,7 +8992,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.842813+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.627052+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -9097,7 +9079,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:52.564035+00:00"
+                "validatedAt": "2026-07-20T14:38:57.214618+00:00"
               },
               "deterministic": true
             },
@@ -9109,9 +9091,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.842860+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.627080+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -9142,7 +9123,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:52.564064+00:00"
+                "validatedAt": "2026-07-20T14:38:57.214631+00:00"
               },
               "deterministic": true
             },
@@ -9154,9 +9135,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.842878+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.627093+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -9225,7 +9205,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:52.564117+00:00"
+                "validatedAt": "2026-07-20T14:38:57.214650+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9237,7 +9217,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.842916+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.627117+00:00"
           },
           "uid": {
             "type": "string",
@@ -9254,7 +9234,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:52.564143+00:00"
+                "validatedAt": "2026-07-20T14:38:57.214660+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9267,7 +9247,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.842935+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.627129+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of lma_region is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -9421,7 +9401,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:52.564294+00:00"
+                "validatedAt": "2026-07-20T14:38:57.214715+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9462,7 +9442,7 @@
                 "confidence": 1.0,
                 "category": "content",
                 "note": "Blindfold envelope encryption (AES-256-GCM + RSA-OAEP) of an RSA-2048 TLS private key produces ~3700 char string:/// URL. 128KB max secret size = ~175KB base64. Discovery reported 1024 which is incorrect.",
-                "validatedAt": "2026-07-20T13:03:52.564336+00:00"
+                "validatedAt": "2026-07-20T14:38:57.214737+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9473,7 +9453,7 @@
             },
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.843012+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.627177+00:00"
           },
           "store_provider": {
             "type": "string",
@@ -9492,7 +9472,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:52.564382+00:00"
+                "validatedAt": "2026-07-20T14:38:57.214755+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9559,7 +9539,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:52.564419+00:00"
+                "validatedAt": "2026-07-20T14:38:57.214768+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9570,7 +9550,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.843040+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.627194+00:00"
           },
           "url": {
             "type": "string",
@@ -9608,7 +9588,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:52.564482+00:00"
+                "validatedAt": "2026-07-20T14:38:57.214801+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -9790,7 +9770,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:16.086780+00:00"
+                "validatedAt": "2026-07-20T14:39:06.125558+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9822,7 +9802,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:16.086816+00:00"
+                "validatedAt": "2026-07-20T14:39:06.125575+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9914,7 +9894,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:37.687745+00:00"
+                "validatedAt": "2026-07-20T14:40:23.948323+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9949,7 +9929,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:37.687788+00:00"
+                "validatedAt": "2026-07-20T14:40:23.948345+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9992,7 +9972,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:37.687836+00:00"
+                "validatedAt": "2026-07-20T14:40:23.948369+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10075,7 +10055,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:37.687882+00:00"
+                "validatedAt": "2026-07-20T14:40:23.948392+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10110,7 +10090,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:37.687924+00:00"
+                "validatedAt": "2026-07-20T14:40:23.948414+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10153,7 +10133,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:37.687971+00:00"
+                "validatedAt": "2026-07-20T14:40:23.948438+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10236,7 +10216,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:37.688017+00:00"
+                "validatedAt": "2026-07-20T14:40:23.948462+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10271,7 +10251,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:37.688058+00:00"
+                "validatedAt": "2026-07-20T14:40:23.948483+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10314,7 +10294,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:37.688104+00:00"
+                "validatedAt": "2026-07-20T14:40:23.948507+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10496,7 +10476,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:37.688192+00:00"
+                "validatedAt": "2026-07-20T14:40:23.948550+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -10510,8 +10490,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -10550,7 +10529,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:37.688241+00:00"
+                "validatedAt": "2026-07-20T14:40:23.948577+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -10565,9 +10544,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.490465+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.053790+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -10596,7 +10574,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:37.688293+00:00"
+                "validatedAt": "2026-07-20T14:40:23.948602+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10609,7 +10587,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.490484+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.053802+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a direct reference from one object(the referrer) to another(the referred).",
@@ -10903,7 +10881,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:37.688349+00:00"
+                "validatedAt": "2026-07-20T14:40:23.948626+00:00"
               },
               "deterministic": true
             },
@@ -10915,9 +10893,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.490553+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.053844+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -10949,7 +10926,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:37.688377+00:00"
+                "validatedAt": "2026-07-20T14:40:23.948639+00:00"
               },
               "deterministic": true
             },
@@ -10961,9 +10938,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.490572+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.053857+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -11128,7 +11104,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.490638+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.053897+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -11225,7 +11201,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:07:37.688489+00:00"
+                "validatedAt": "2026-07-20T14:40:23.948685+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11306,7 +11282,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:07:37.688539+00:00"
+                "validatedAt": "2026-07-20T14:40:23.948707+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11317,7 +11293,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.490696+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.053927+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -11404,7 +11380,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:37.688579+00:00"
+                "validatedAt": "2026-07-20T14:40:23.948726+00:00"
               },
               "deterministic": true
             },
@@ -11416,9 +11392,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.490742+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.053955+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -11449,7 +11424,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:37.688606+00:00"
+                "validatedAt": "2026-07-20T14:40:23.948740+00:00"
               },
               "deterministic": true
             },
@@ -11461,9 +11436,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.490760+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.053967+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -11532,7 +11506,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:37.688665+00:00"
+                "validatedAt": "2026-07-20T14:40:23.948763+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11544,7 +11518,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.490797+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.053991+00:00"
           },
           "uid": {
             "type": "string",
@@ -11562,7 +11536,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:37.688691+00:00"
+                "validatedAt": "2026-07-20T14:40:23.948774+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11575,7 +11549,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.490816+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.054003+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of sensitive_data_policy is returned in 'List'.",

--- a/docs/specifications/api/data_intelligence.json
+++ b/docs/specifications/api/data_intelligence.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Data Intelligence",
     "description": "APIs for configuring classification policies and resource management. Supports data classification, insight generation, and integration with security services across deployments.",
-    "version": "2.1.182",
+    "version": "2.1.181",
     "contact": {
       "name": "F5 Distributed Cloud",
       "url": "https://docs.cloud.f5.com"
@@ -3645,7 +3645,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:21.043285+00:00"
+                "validatedAt": "2026-07-20T14:37:33.514996+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3657,7 +3657,7 @@
             "readOnly": true,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.480647+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.023431+00:00"
           },
           "name": {
             "type": "string",
@@ -3690,7 +3690,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:21.043343+00:00"
+                "validatedAt": "2026-07-20T14:37:33.515040+00:00"
               },
               "deterministic": true
             },
@@ -3702,9 +3702,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.480677+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.023445+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -3737,7 +3736,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:21.043375+00:00"
+                "validatedAt": "2026-07-20T14:37:33.515067+00:00"
               },
               "deterministic": true
             },
@@ -3749,9 +3748,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.480696+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.023458+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -3770,7 +3768,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:21.043417+00:00"
+                "validatedAt": "2026-07-20T14:37:33.515094+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3783,7 +3781,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.480716+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.023471+00:00"
           },
           "uid": {
             "type": "string",
@@ -3802,7 +3800,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:21.043453+00:00"
+                "validatedAt": "2026-07-20T14:37:33.515115+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3816,7 +3814,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.480736+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.023484+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -3872,7 +3870,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:21.043508+00:00"
+                "validatedAt": "2026-07-20T14:37:33.515145+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3895,7 +3893,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:21.043557+00:00"
+                "validatedAt": "2026-07-20T14:37:33.515173+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3906,7 +3904,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.480765+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.023502+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -4075,7 +4073,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:21.043738+00:00"
+                "validatedAt": "2026-07-20T14:37:33.515263+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4259,7 +4257,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:21.043835+00:00"
+                "validatedAt": "2026-07-20T14:37:33.515333+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4602,7 +4600,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:21.043933+00:00"
+                "validatedAt": "2026-07-20T14:37:33.515411+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4809,7 +4807,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T13:00:21.043991+00:00"
+                "validatedAt": "2026-07-20T14:37:33.515456+00:00"
               },
               "deterministic": true
             },
@@ -4861,7 +4859,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:21.044027+00:00"
+                "validatedAt": "2026-07-20T14:37:33.515485+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4977,7 +4975,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:21.044067+00:00"
+                "validatedAt": "2026-07-20T14:37:33.515517+00:00"
               },
               "deterministic": true
             },
@@ -4989,9 +4987,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.481016+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.023647+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -5023,7 +5020,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:21.044096+00:00"
+                "validatedAt": "2026-07-20T14:37:33.515543+00:00"
               },
               "deterministic": true
             },
@@ -5035,9 +5032,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.481035+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.023660+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -5124,7 +5120,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:21.044172+00:00"
+                "validatedAt": "2026-07-20T14:37:33.515609+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5335,7 +5331,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.481129+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.023717+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -5464,7 +5460,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:21.044317+00:00"
+                "validatedAt": "2026-07-20T14:37:33.515721+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5498,7 +5494,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:21.044359+00:00"
+                "validatedAt": "2026-07-20T14:37:33.515754+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5525,7 +5521,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:21.044404+00:00"
+                "validatedAt": "2026-07-20T14:37:33.515788+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5594,7 +5590,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:21.044448+00:00"
+                "validatedAt": "2026-07-20T14:37:33.515821+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5628,7 +5624,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:21.044491+00:00"
+                "validatedAt": "2026-07-20T14:37:33.515854+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5851,7 +5847,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:21.044562+00:00"
+                "validatedAt": "2026-07-20T14:37:33.515916+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5958,7 +5954,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:21.044626+00:00"
+                "validatedAt": "2026-07-20T14:37:33.515971+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6043,7 +6039,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:00:21.044688+00:00"
+                "validatedAt": "2026-07-20T14:37:33.516011+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6123,7 +6119,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:00:21.044745+00:00"
+                "validatedAt": "2026-07-20T14:37:33.516056+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6134,7 +6130,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.481319+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.023835+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -6221,7 +6217,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:21.044787+00:00"
+                "validatedAt": "2026-07-20T14:37:33.516095+00:00"
               },
               "deterministic": true
             },
@@ -6233,9 +6229,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.481365+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.023864+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -6266,7 +6261,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:21.044816+00:00"
+                "validatedAt": "2026-07-20T14:37:33.516124+00:00"
               },
               "deterministic": true
             },
@@ -6278,9 +6273,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.481383+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.023876+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -6349,7 +6343,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:21.044868+00:00"
+                "validatedAt": "2026-07-20T14:37:33.516164+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6361,7 +6355,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.481421+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.023900+00:00"
           },
           "uid": {
             "type": "string",
@@ -6378,7 +6372,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:21.044894+00:00"
+                "validatedAt": "2026-07-20T14:37:33.516186+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6391,7 +6385,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.481441+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.023913+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of receiver is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -6610,7 +6604,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:21.044968+00:00"
+                "validatedAt": "2026-07-20T14:37:33.516301+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6795,7 +6789,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:21.045022+00:00"
+                "validatedAt": "2026-07-20T14:37:33.516360+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6850,7 +6844,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:21.045094+00:00"
+                "validatedAt": "2026-07-20T14:37:33.516404+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6970,7 +6964,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T13:00:21.045139+00:00"
+                "validatedAt": "2026-07-20T14:37:33.516428+00:00"
               },
               "deterministic": true
             },
@@ -7189,7 +7183,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:21.045251+00:00"
+                "validatedAt": "2026-07-20T14:37:33.516493+00:00"
               },
               "deterministic": true
             },
@@ -7402,7 +7396,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:21.045339+00:00"
+                "validatedAt": "2026-07-20T14:37:33.516536+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7479,7 +7473,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:21.045381+00:00"
+                "validatedAt": "2026-07-20T14:37:33.516555+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7520,7 +7514,7 @@
                 "confidence": 1.0,
                 "category": "content",
                 "note": "Blindfold envelope encryption (AES-256-GCM + RSA-OAEP) of an RSA-2048 TLS private key produces ~3700 char string:/// URL. 128KB max secret size = ~175KB base64. Discovery reported 1024 which is incorrect.",
-                "validatedAt": "2026-07-20T13:00:21.045416+00:00"
+                "validatedAt": "2026-07-20T14:37:33.516577+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7531,7 +7525,7 @@
             },
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.481698+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.024060+00:00"
           },
           "store_provider": {
             "type": "string",
@@ -7550,7 +7544,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:21.045460+00:00"
+                "validatedAt": "2026-07-20T14:37:33.516611+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7617,7 +7611,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:21.045496+00:00"
+                "validatedAt": "2026-07-20T14:37:33.516633+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7628,7 +7622,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.481725+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.024077+00:00"
           },
           "url": {
             "type": "string",
@@ -7666,7 +7660,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:21.045550+00:00"
+                "validatedAt": "2026-07-20T14:37:33.516672+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -7741,7 +7735,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T13:00:21.045581+00:00"
+                "validatedAt": "2026-07-20T14:37:33.516688+00:00"
               },
               "deterministic": true
             },
@@ -7752,8 +7746,7 @@
               "read": false
             },
             "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "minLength": 1,
-            "format": "fqdn"
+            "minLength": 1
           },
           "last_update_time": {
             "type": "string",
@@ -7770,7 +7763,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:21.045621+00:00"
+                "validatedAt": "2026-07-20T14:37:33.516705+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7797,7 +7790,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:21.045664+00:00"
+                "validatedAt": "2026-07-20T14:37:33.516721+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7808,7 +7801,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.481765+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.024101+00:00"
           },
           "service_name": {
             "type": "string",
@@ -7825,7 +7818,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:21.045704+00:00"
+                "validatedAt": "2026-07-20T14:37:33.516737+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7858,7 +7851,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:21.045740+00:00"
+                "validatedAt": "2026-07-20T14:37:33.516752+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7869,7 +7862,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.481790+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.024118+00:00"
           },
           "type": {
             "type": "string",
@@ -7894,7 +7887,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:21.045774+00:00"
+                "validatedAt": "2026-07-20T14:37:33.516766+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8038,7 +8031,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:21.045815+00:00"
+                "validatedAt": "2026-07-20T14:37:33.516782+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8118,7 +8111,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:21.045843+00:00"
+                "validatedAt": "2026-07-20T14:37:33.516798+00:00"
               },
               "deterministic": true
             },
@@ -8130,9 +8123,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.481839+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.024147+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -8296,7 +8288,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:21.045934+00:00"
+                "validatedAt": "2026-07-20T14:37:33.516845+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -8311,7 +8303,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.481881+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.024174+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -8381,7 +8373,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:21.045972+00:00"
+                "validatedAt": "2026-07-20T14:37:33.516864+00:00"
               },
               "deterministic": true
             },
@@ -8393,9 +8385,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.481915+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.024194+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -8428,7 +8419,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:21.045998+00:00"
+                "validatedAt": "2026-07-20T14:37:33.516878+00:00"
               },
               "deterministic": true
             },
@@ -8440,9 +8431,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.481933+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.024206+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -8542,7 +8532,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:21.046072+00:00"
+                "validatedAt": "2026-07-20T14:37:33.516920+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -8557,7 +8547,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.481961+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.024224+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -8629,7 +8619,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:21.046109+00:00"
+                "validatedAt": "2026-07-20T14:37:33.516938+00:00"
               },
               "deterministic": true
             },
@@ -8641,9 +8631,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.481994+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.024245+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -8676,7 +8665,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:21.046135+00:00"
+                "validatedAt": "2026-07-20T14:37:33.516951+00:00"
               },
               "deterministic": true
             },
@@ -8688,9 +8677,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.482012+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.024257+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -8790,7 +8778,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:21.046207+00:00"
+                "validatedAt": "2026-07-20T14:37:33.516987+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -8805,7 +8793,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.482040+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.024275+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -8875,7 +8863,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:21.046244+00:00"
+                "validatedAt": "2026-07-20T14:37:33.517004+00:00"
               },
               "deterministic": true
             },
@@ -8887,9 +8875,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.482073+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.024296+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -8922,7 +8909,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:21.046268+00:00"
+                "validatedAt": "2026-07-20T14:37:33.517021+00:00"
               },
               "deterministic": true
             },
@@ -8934,9 +8921,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.482091+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.024308+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -9107,7 +9093,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:21.046319+00:00"
+                "validatedAt": "2026-07-20T14:37:33.517041+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9135,7 +9121,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:21.046357+00:00"
+                "validatedAt": "2026-07-20T14:37:33.517057+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9163,7 +9149,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:21.046394+00:00"
+                "validatedAt": "2026-07-20T14:37:33.517072+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9202,7 +9188,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:21.046433+00:00"
+                "validatedAt": "2026-07-20T14:37:33.517087+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9229,7 +9215,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:21.046458+00:00"
+                "validatedAt": "2026-07-20T14:37:33.517098+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9242,7 +9228,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.482160+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.024349+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -9258,7 +9244,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:21.046492+00:00"
+                "validatedAt": "2026-07-20T14:37:33.517112+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9403,7 +9389,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:21.046539+00:00"
+                "validatedAt": "2026-07-20T14:37:33.517132+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9414,7 +9400,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.482200+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.024374+00:00"
           },
           "status": {
             "type": "string",
@@ -9432,7 +9418,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:21.046571+00:00"
+                "validatedAt": "2026-07-20T14:37:33.517146+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9443,7 +9429,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.482219+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.024386+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -9503,7 +9489,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:21.046613+00:00"
+                "validatedAt": "2026-07-20T14:37:33.517163+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9530,7 +9516,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:21.046659+00:00"
+                "validatedAt": "2026-07-20T14:37:33.517179+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9557,7 +9543,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:21.046698+00:00"
+                "validatedAt": "2026-07-20T14:37:33.517195+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9585,7 +9571,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:21.046739+00:00"
+                "validatedAt": "2026-07-20T14:37:33.517211+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9661,7 +9647,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:21.046804+00:00"
+                "validatedAt": "2026-07-20T14:37:33.517236+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9729,7 +9715,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:21.046854+00:00"
+                "validatedAt": "2026-07-20T14:37:33.517255+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9741,7 +9727,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.482306+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.024439+00:00"
           },
           "uid": {
             "type": "string",
@@ -9760,7 +9746,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:21.046879+00:00"
+                "validatedAt": "2026-07-20T14:37:33.517268+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9773,7 +9759,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.482325+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.024451+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -9841,7 +9827,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:21.046909+00:00"
+                "validatedAt": "2026-07-20T14:37:33.517280+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9852,7 +9838,7 @@
             },
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.482345+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.024464+00:00"
           },
           "name": {
             "type": "string",
@@ -9885,7 +9871,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:21.046935+00:00"
+                "validatedAt": "2026-07-20T14:37:33.517294+00:00"
               },
               "deterministic": true
             },
@@ -9897,9 +9883,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.482363+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.024476+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -9932,7 +9917,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:21.046962+00:00"
+                "validatedAt": "2026-07-20T14:37:33.517311+00:00"
               },
               "deterministic": true
             },
@@ -9944,9 +9929,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.482382+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.024489+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "uid": {
             "type": "string",
@@ -9963,7 +9947,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:21.046987+00:00"
+                "validatedAt": "2026-07-20T14:37:33.517321+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9976,7 +9960,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.482401+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.024501+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -10063,7 +10047,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:21.047039+00:00"
+                "validatedAt": "2026-07-20T14:37:33.517350+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -10077,8 +10061,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -10117,7 +10100,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:21.047085+00:00"
+                "validatedAt": "2026-07-20T14:37:33.517377+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -10132,9 +10115,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.482429+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.024519+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -10163,7 +10145,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:21.047138+00:00"
+                "validatedAt": "2026-07-20T14:37:33.517403+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10176,7 +10158,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.482448+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.024531+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a direct reference from one object(the referrer) to another(the referred).",
@@ -10242,7 +10224,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T13:00:25.093812+00:00"
+                "validatedAt": "2026-07-20T14:37:35.104672+00:00"
               },
               "deterministic": true
             },
@@ -10268,7 +10250,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.586770+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.140680+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -10326,7 +10308,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:00:25.093918+00:00"
+                "validatedAt": "2026-07-20T14:37:35.104703+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10337,7 +10319,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.586795+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.140695+00:00"
           },
           "id": {
             "type": "string",
@@ -10356,7 +10338,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:25.093963+00:00"
+                "validatedAt": "2026-07-20T14:37:35.104714+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10395,7 +10377,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:25.094003+00:00"
+                "validatedAt": "2026-07-20T14:37:35.104729+00:00"
               },
               "deterministic": true
             },
@@ -10407,9 +10389,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.586823+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.140712+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "status": {
             "type": "string",
@@ -10427,7 +10408,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:25.094037+00:00"
+                "validatedAt": "2026-07-20T14:37:35.104743+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10438,7 +10419,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.586842+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.140725+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -10496,7 +10477,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:25.094076+00:00"
+                "validatedAt": "2026-07-20T14:37:35.104758+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10549,7 +10530,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:25.094139+00:00"
+                "validatedAt": "2026-07-20T14:37:35.104782+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10560,7 +10541,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.586883+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.140749+00:00"
           }
         },
         "x-f5xc-description-short": "Message object representing events reason.",
@@ -10619,7 +10600,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:25.094180+00:00"
+                "validatedAt": "2026-07-20T14:37:35.104798+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10646,7 +10627,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:00:25.094227+00:00"
+                "validatedAt": "2026-07-20T14:37:35.104818+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10657,7 +10638,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.586911+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.140767+00:00"
           },
           "feature_name": {
             "type": "string",
@@ -10673,7 +10654,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:25.094269+00:00"
+                "validatedAt": "2026-07-20T14:37:35.104835+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10711,7 +10692,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:25.094305+00:00"
+                "validatedAt": "2026-07-20T14:37:35.104849+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10794,7 +10775,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:25.094346+00:00"
+                "validatedAt": "2026-07-20T14:37:35.104865+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10817,7 +10798,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:25.094381+00:00"
+                "validatedAt": "2026-07-20T14:37:35.104879+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10992,7 +10973,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:25.094453+00:00"
+                "validatedAt": "2026-07-20T14:37:35.104907+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11208,7 +11189,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:25.094558+00:00"
+                "validatedAt": "2026-07-20T14:37:35.104948+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11248,7 +11229,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:25.094589+00:00"
+                "validatedAt": "2026-07-20T14:37:35.104962+00:00"
               },
               "deterministic": true
             },
@@ -11260,9 +11241,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.587038+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.140855+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "platform": {
             "type": "string",
@@ -11280,7 +11260,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:25.094625+00:00"
+                "validatedAt": "2026-07-20T14:37:35.104976+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11305,7 +11285,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:25.094672+00:00"
+                "validatedAt": "2026-07-20T14:37:35.104991+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11337,7 +11317,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T13:00:25.094716+00:00"
+                "validatedAt": "2026-07-20T14:37:35.105009+00:00"
               },
               "deterministic": true
             },
@@ -11524,7 +11504,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:25.094777+00:00"
+                "validatedAt": "2026-07-20T14:37:35.105034+00:00"
               },
               "deterministic": true
             },
@@ -11536,9 +11516,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.587105+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.140895+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -11786,7 +11765,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:25.094952+00:00"
+                "validatedAt": "2026-07-20T14:37:35.105100+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11833,7 +11812,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:25.094985+00:00"
+                "validatedAt": "2026-07-20T14:37:35.105117+00:00"
               },
               "deterministic": true
             },
@@ -11845,9 +11824,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.587198+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.140951+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Request to test receiver & destination sink.",
@@ -11905,7 +11883,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:25.095021+00:00"
+                "validatedAt": "2026-07-20T14:37:35.105132+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11931,7 +11909,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.587226+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.140969+00:00"
           }
         },
         "x-f5xc-description-short": "Response for the Receiver test request; empty because the only returned information is error message.",
@@ -12038,7 +12016,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:25.095053+00:00"
+                "validatedAt": "2026-07-20T14:37:35.105145+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12078,7 +12056,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:25.095082+00:00"
+                "validatedAt": "2026-07-20T14:37:35.105159+00:00"
               },
               "deterministic": true
             },
@@ -12090,9 +12068,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.587255+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.140986+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "type": {
             "allOf": [
@@ -12164,7 +12141,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:25.095111+00:00"
+                "validatedAt": "2026-07-20T14:37:35.105172+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12190,7 +12167,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:25.095151+00:00"
+                "validatedAt": "2026-07-20T14:37:35.105188+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12216,7 +12193,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:25.095184+00:00"
+                "validatedAt": "2026-07-20T14:37:35.105201+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12227,7 +12204,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.587295+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.141010+00:00"
           }
         },
         "x-f5xc-description-short": "Payload about status of receiver status result.",
@@ -12293,7 +12270,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:25.095250+00:00"
+                "validatedAt": "2026-07-20T14:37:35.105232+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12327,7 +12304,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:25.095311+00:00"
+                "validatedAt": "2026-07-20T14:37:35.105260+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12367,7 +12344,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:25.095341+00:00"
+                "validatedAt": "2026-07-20T14:37:35.105273+00:00"
               },
               "deterministic": true
             },
@@ -12379,9 +12356,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.587328+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.141032+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "request_body": {
             "allOf": [
@@ -12453,7 +12429,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:00:25.095378+00:00"
+                "validatedAt": "2026-07-20T14:37:35.105290+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12518,7 +12494,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:00:25.095423+00:00"
+                "validatedAt": "2026-07-20T14:37:35.105309+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12529,7 +12505,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.587364+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.141054+00:00"
           },
           "ref_value": {
             "allOf": [
@@ -12571,7 +12547,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:25.095463+00:00"
+                "validatedAt": "2026-07-20T14:37:35.105325+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12600,7 +12576,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:25.095497+00:00"
+                "validatedAt": "2026-07-20T14:37:35.105339+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12611,7 +12587,7 @@
             },
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.587396+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.141074+00:00"
           },
           "value": {
             "type": "string",
@@ -12627,7 +12603,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:25.095530+00:00"
+                "validatedAt": "2026-07-20T14:37:35.105351+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12638,7 +12614,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.587416+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.141086+00:00"
           }
         },
         "x-f5xc-description-short": "Tuple with a suggested value and it's description.",

--- a/docs/specifications/api/ddos.json
+++ b/docs/specifications/api/ddos.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Ddos",
     "description": "Network perimeter hardening through deny list configurations, rule group hierarchies, and encrypted tunnel endpoints. Attack signature detection identifies flood patterns while throttling mechanisms block anomalous traffic bursts. Tunnel health checks verify coverage across distributed segments. Priority ordering governs policy application for multi-layered screening approaches.",
-    "version": "2.1.182",
+    "version": "2.1.181",
     "contact": {
       "name": "F5 Distributed Cloud",
       "url": "https://docs.cloud.f5.com"
@@ -15763,7 +15763,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.046893+00:00"
+                "validatedAt": "2026-07-20T14:38:32.639582+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15858,7 +15858,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.046970+00:00"
+                "validatedAt": "2026-07-20T14:38:32.639609+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15884,7 +15884,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.047007+00:00"
+                "validatedAt": "2026-07-20T14:38:32.639624+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15925,7 +15925,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:50.047044+00:00"
+                "validatedAt": "2026-07-20T14:38:32.639642+00:00"
               },
               "deterministic": true
             },
@@ -15937,9 +15937,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.858954+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.772243+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Request to add an alert to event (link them together).",
@@ -16050,7 +16049,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:02:50.047113+00:00"
+                "validatedAt": "2026-07-20T14:38:32.639670+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16061,7 +16060,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.858984+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.772261+00:00"
           },
           "event_id": {
             "type": "string",
@@ -16079,7 +16078,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.047150+00:00"
+                "validatedAt": "2026-07-20T14:38:32.639685+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16120,7 +16119,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:50.047180+00:00"
+                "validatedAt": "2026-07-20T14:38:32.639699+00:00"
               },
               "deterministic": true
             },
@@ -16132,9 +16131,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.859010+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.772277+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "time": {
             "type": "string",
@@ -16157,7 +16155,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T13:02:50.047218+00:00"
+                "validatedAt": "2026-07-20T14:38:32.639716+00:00"
               },
               "deterministic": true
             },
@@ -16183,7 +16181,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.047251+00:00"
+                "validatedAt": "2026-07-20T14:38:32.639730+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16194,7 +16192,7 @@
             },
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.859036+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.772293+00:00"
           }
         },
         "x-f5xc-description-short": "Request to add a single event detail to an event.",
@@ -16306,7 +16304,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.047294+00:00"
+                "validatedAt": "2026-07-20T14:38:32.639747+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16335,7 +16333,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.047332+00:00"
+                "validatedAt": "2026-07-20T14:38:32.639762+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16359,7 +16357,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.047367+00:00"
+                "validatedAt": "2026-07-20T14:38:32.639776+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16388,7 +16386,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.047402+00:00"
+                "validatedAt": "2026-07-20T14:38:32.639790+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16433,7 +16431,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.047440+00:00"
+                "validatedAt": "2026-07-20T14:38:32.639804+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16459,7 +16457,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.047467+00:00"
+                "validatedAt": "2026-07-20T14:38:32.639816+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16482,7 +16480,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.047505+00:00"
+                "validatedAt": "2026-07-20T14:38:32.639831+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16524,7 +16522,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.047547+00:00"
+                "validatedAt": "2026-07-20T14:38:32.639848+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16549,7 +16547,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.047579+00:00"
+                "validatedAt": "2026-07-20T14:38:32.639861+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16624,7 +16622,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.047613+00:00"
+                "validatedAt": "2026-07-20T14:38:32.639874+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16677,7 +16675,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:50.047647+00:00"
+                "validatedAt": "2026-07-20T14:38:32.639889+00:00"
               },
               "deterministic": true
             },
@@ -16689,9 +16687,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.859152+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.772360+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "number": {
             "type": "integer",
@@ -16725,7 +16722,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.047706+00:00"
+                "validatedAt": "2026-07-20T14:38:32.639909+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16750,7 +16747,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.047742+00:00"
+                "validatedAt": "2026-07-20T14:38:32.639924+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16823,7 +16820,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T13:02:50.047778+00:00"
+                "validatedAt": "2026-07-20T14:38:32.639941+00:00"
               },
               "deterministic": true
             },
@@ -16865,7 +16862,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.047819+00:00"
+                "validatedAt": "2026-07-20T14:38:32.639958+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16892,7 +16889,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.047858+00:00"
+                "validatedAt": "2026-07-20T14:38:32.639973+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17001,7 +16998,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.047901+00:00"
+                "validatedAt": "2026-07-20T14:38:32.639990+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17042,7 +17039,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.047940+00:00"
+                "validatedAt": "2026-07-20T14:38:32.640005+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17068,7 +17065,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.047976+00:00"
+                "validatedAt": "2026-07-20T14:38:32.640019+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17094,7 +17091,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.048015+00:00"
+                "validatedAt": "2026-07-20T14:38:32.640034+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17133,7 +17130,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:50.048042+00:00"
+                "validatedAt": "2026-07-20T14:38:32.640048+00:00"
               },
               "deterministic": true
             },
@@ -17145,9 +17142,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.859253+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.772418+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "size_bytes": {
             "type": "string",
@@ -17166,7 +17162,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.048079+00:00"
+                "validatedAt": "2026-07-20T14:38:32.640062+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17193,7 +17189,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.048117+00:00"
+                "validatedAt": "2026-07-20T14:38:32.640077+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17353,7 +17349,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.048184+00:00"
+                "validatedAt": "2026-07-20T14:38:32.640103+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17449,7 +17445,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:50.048219+00:00"
+                "validatedAt": "2026-07-20T14:38:32.640120+00:00"
               },
               "deterministic": true
             },
@@ -17461,9 +17457,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.859322+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.772459+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "time": {
             "type": "string",
@@ -17490,7 +17485,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T13:02:50.048264+00:00"
+                "validatedAt": "2026-07-20T14:38:32.640139+00:00"
               },
               "deterministic": true
             },
@@ -17560,7 +17555,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:02:50.048297+00:00"
+                "validatedAt": "2026-07-20T14:38:32.640154+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17779,7 +17774,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:50.048359+00:00"
+                "validatedAt": "2026-07-20T14:38:32.640185+00:00"
               },
               "deterministic": true
             },
@@ -17791,9 +17786,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.859368+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.772485+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "zone1": {
             "allOf": [
@@ -17903,7 +17897,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:02:50.048433+00:00"
+                "validatedAt": "2026-07-20T14:38:32.640213+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17914,7 +17908,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.859407+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.772509+00:00"
           },
           "event_detail_id": {
             "type": "string",
@@ -17931,7 +17925,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.048473+00:00"
+                "validatedAt": "2026-07-20T14:38:32.640228+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17958,7 +17952,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.048508+00:00"
+                "validatedAt": "2026-07-20T14:38:32.640242+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17999,7 +17993,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:50.048536+00:00"
+                "validatedAt": "2026-07-20T14:38:32.640256+00:00"
               },
               "deterministic": true
             },
@@ -18011,9 +18005,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.859439+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.772528+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "time": {
             "type": "string",
@@ -18036,7 +18029,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T13:02:50.048573+00:00"
+                "validatedAt": "2026-07-20T14:38:32.640273+00:00"
               },
               "deterministic": true
             },
@@ -18062,7 +18055,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.048604+00:00"
+                "validatedAt": "2026-07-20T14:38:32.640286+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18073,7 +18066,7 @@
             },
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.859464+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.772543+00:00"
           }
         },
         "x-f5xc-description-short": "Request to update a single event detail.",
@@ -18190,7 +18183,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:02:50.048660+00:00"
+                "validatedAt": "2026-07-20T14:38:32.640307+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18201,7 +18194,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.859492+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.772560+00:00"
           },
           "end_time": {
             "type": "string",
@@ -18221,7 +18214,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.048698+00:00"
+                "validatedAt": "2026-07-20T14:38:32.640320+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18262,7 +18255,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.048748+00:00"
+                "validatedAt": "2026-07-20T14:38:32.640339+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18302,7 +18295,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:50.048774+00:00"
+                "validatedAt": "2026-07-20T14:38:32.640352+00:00"
               },
               "deterministic": true
             },
@@ -18314,9 +18307,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.859530+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.772584+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -18348,7 +18340,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:50.048800+00:00"
+                "validatedAt": "2026-07-20T14:38:32.640365+00:00"
               },
               "deterministic": true
             },
@@ -18360,9 +18352,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.859548+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.772595+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -18490,7 +18481,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.048850+00:00"
+                "validatedAt": "2026-07-20T14:38:32.640385+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18521,7 +18512,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:02:50.048895+00:00"
+                "validatedAt": "2026-07-20T14:38:32.640404+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18532,7 +18523,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.859590+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.772620+00:00"
           },
           "end_time": {
             "type": "string",
@@ -18551,7 +18542,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.048929+00:00"
+                "validatedAt": "2026-07-20T14:38:32.640418+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18607,7 +18598,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.048960+00:00"
+                "validatedAt": "2026-07-20T14:38:32.640430+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18632,7 +18623,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.048985+00:00"
+                "validatedAt": "2026-07-20T14:38:32.640441+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18657,7 +18648,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.049025+00:00"
+                "validatedAt": "2026-07-20T14:38:32.640457+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18697,7 +18688,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:50.049052+00:00"
+                "validatedAt": "2026-07-20T14:38:32.640469+00:00"
               },
               "deterministic": true
             },
@@ -18709,9 +18700,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.859647+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.772655+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "network_id": {
             "type": "string",
@@ -18728,7 +18718,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.049089+00:00"
+                "validatedAt": "2026-07-20T14:38:32.640483+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18756,7 +18746,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.049126+00:00"
+                "validatedAt": "2026-07-20T14:38:32.640499+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18846,7 +18836,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.049174+00:00"
+                "validatedAt": "2026-07-20T14:38:32.640519+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18877,7 +18867,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:02:50.049218+00:00"
+                "validatedAt": "2026-07-20T14:38:32.640538+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18888,7 +18878,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.859702+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.772683+00:00"
           },
           "id": {
             "type": "string",
@@ -18908,7 +18898,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.049241+00:00"
+                "validatedAt": "2026-07-20T14:38:32.640548+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18940,7 +18930,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T13:02:50.049279+00:00"
+                "validatedAt": "2026-07-20T14:38:32.640566+00:00"
               },
               "deterministic": true
             },
@@ -18966,7 +18956,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.049312+00:00"
+                "validatedAt": "2026-07-20T14:38:32.640579+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18977,7 +18967,7 @@
             },
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.859734+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.772702+00:00"
           }
         },
         "x-f5xc-description-short": "Event detail represents a single occurrence of event detail, that tracks customer, SOC notes on a given event.",
@@ -19041,7 +19031,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.049337+00:00"
+                "validatedAt": "2026-07-20T14:38:32.640590+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19081,7 +19071,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:50.049364+00:00"
+                "validatedAt": "2026-07-20T14:38:32.640604+00:00"
               },
               "deterministic": true
             },
@@ -19093,9 +19083,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.859760+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.772718+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -19306,7 +19295,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.049427+00:00"
+                "validatedAt": "2026-07-20T14:38:32.640629+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19442,7 +19431,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.049481+00:00"
+                "validatedAt": "2026-07-20T14:38:32.640650+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19469,7 +19458,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.049517+00:00"
+                "validatedAt": "2026-07-20T14:38:32.640665+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19510,7 +19499,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:50.049545+00:00"
+                "validatedAt": "2026-07-20T14:38:32.640679+00:00"
               },
               "deterministic": true
             },
@@ -19522,9 +19511,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.859838+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.772764+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "network_id": {
             "type": "string",
@@ -19543,7 +19531,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.049582+00:00"
+                "validatedAt": "2026-07-20T14:38:32.640693+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19573,7 +19561,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.049619+00:00"
+                "validatedAt": "2026-07-20T14:38:32.640708+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19952,7 +19940,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.049732+00:00"
+                "validatedAt": "2026-07-20T14:38:32.640749+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19979,7 +19967,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.049773+00:00"
+                "validatedAt": "2026-07-20T14:38:32.640765+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20020,7 +20008,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:50.049802+00:00"
+                "validatedAt": "2026-07-20T14:38:32.640778+00:00"
               },
               "deterministic": true
             },
@@ -20032,9 +20020,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.859924+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.772813+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "network_id": {
             "type": "string",
@@ -20052,7 +20039,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.049839+00:00"
+                "validatedAt": "2026-07-20T14:38:32.640792+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20082,7 +20069,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.049878+00:00"
+                "validatedAt": "2026-07-20T14:38:32.640807+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20318,7 +20305,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.049951+00:00"
+                "validatedAt": "2026-07-20T14:38:32.640836+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20385,7 +20372,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.049987+00:00"
+                "validatedAt": "2026-07-20T14:38:32.640850+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20412,7 +20399,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.050026+00:00"
+                "validatedAt": "2026-07-20T14:38:32.640866+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20453,7 +20440,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:50.050055+00:00"
+                "validatedAt": "2026-07-20T14:38:32.640880+00:00"
               },
               "deterministic": true
             },
@@ -20465,9 +20452,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.860001+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.772859+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "network_id": {
             "type": "string",
@@ -20486,7 +20472,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.050092+00:00"
+                "validatedAt": "2026-07-20T14:38:32.640894+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20516,7 +20502,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.050129+00:00"
+                "validatedAt": "2026-07-20T14:38:32.640909+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20639,7 +20625,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:02:50.050180+00:00"
+                "validatedAt": "2026-07-20T14:38:32.640933+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20707,7 +20693,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.050218+00:00"
+                "validatedAt": "2026-07-20T14:38:32.640949+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20747,7 +20733,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:50.050247+00:00"
+                "validatedAt": "2026-07-20T14:38:32.640964+00:00"
               },
               "deterministic": true
             },
@@ -20759,9 +20745,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.860056+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.772892+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "start_time": {
             "type": "string",
@@ -20782,7 +20767,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.050285+00:00"
+                "validatedAt": "2026-07-20T14:38:32.640979+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20902,7 +20887,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.050336+00:00"
+                "validatedAt": "2026-07-20T14:38:32.640999+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20927,7 +20912,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.050371+00:00"
+                "validatedAt": "2026-07-20T14:38:32.641013+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20956,7 +20941,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.050407+00:00"
+                "validatedAt": "2026-07-20T14:38:32.641027+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20983,7 +20968,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.050431+00:00"
+                "validatedAt": "2026-07-20T14:38:32.641037+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21036,7 +21021,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:50.050461+00:00"
+                "validatedAt": "2026-07-20T14:38:32.641051+00:00"
               },
               "deterministic": true
             },
@@ -21048,9 +21033,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.860123+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.772931+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "network_id": {
             "type": "string",
@@ -21066,7 +21050,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.050498+00:00"
+                "validatedAt": "2026-07-20T14:38:32.641066+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21093,7 +21077,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.050537+00:00"
+                "validatedAt": "2026-07-20T14:38:32.641081+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21118,7 +21102,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.050571+00:00"
+                "validatedAt": "2026-07-20T14:38:32.641095+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21146,7 +21130,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.050610+00:00"
+                "validatedAt": "2026-07-20T14:38:32.641111+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21218,7 +21202,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.050649+00:00"
+                "validatedAt": "2026-07-20T14:38:32.641127+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21243,7 +21227,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.050692+00:00"
+                "validatedAt": "2026-07-20T14:38:32.641142+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21271,7 +21255,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.050716+00:00"
+                "validatedAt": "2026-07-20T14:38:32.641152+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21302,7 +21286,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T13:02:50.050752+00:00"
+                "validatedAt": "2026-07-20T14:38:32.641169+00:00"
               },
               "deterministic": true
             },
@@ -21369,7 +21353,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.050777+00:00"
+                "validatedAt": "2026-07-20T14:38:32.641179+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21397,7 +21381,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.050813+00:00"
+                "validatedAt": "2026-07-20T14:38:32.641194+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21464,7 +21448,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.050838+00:00"
+                "validatedAt": "2026-07-20T14:38:32.641205+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21503,7 +21487,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:50.050865+00:00"
+                "validatedAt": "2026-07-20T14:38:32.641218+00:00"
               },
               "deterministic": true
             },
@@ -21515,9 +21499,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.860215+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.772986+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "prefixes": {
             "allOf": [
@@ -21611,7 +21594,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T13:02:50.050914+00:00"
+                "validatedAt": "2026-07-20T14:38:32.641238+00:00"
               },
               "deterministic": true
             },
@@ -21638,7 +21621,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.050948+00:00"
+                "validatedAt": "2026-07-20T14:38:32.641252+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21665,7 +21648,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.050972+00:00"
+                "validatedAt": "2026-07-20T14:38:32.641262+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21704,7 +21687,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:50.050997+00:00"
+                "validatedAt": "2026-07-20T14:38:32.641276+00:00"
               },
               "deterministic": true
             },
@@ -21716,9 +21699,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.860267+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.773017+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "scheduled": {
             "type": "boolean",
@@ -21749,7 +21731,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.051039+00:00"
+                "validatedAt": "2026-07-20T14:38:32.641293+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21774,7 +21756,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.051068+00:00"
+                "validatedAt": "2026-07-20T14:38:32.641305+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21800,7 +21782,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.051103+00:00"
+                "validatedAt": "2026-07-20T14:38:32.641319+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21811,7 +21793,7 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.860305+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.773040+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -21881,7 +21863,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:50.051166+00:00"
+                "validatedAt": "2026-07-20T14:38:32.641349+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21915,7 +21897,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:50.051226+00:00"
+                "validatedAt": "2026-07-20T14:38:32.641377+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21955,7 +21937,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:50.051254+00:00"
+                "validatedAt": "2026-07-20T14:38:32.641390+00:00"
               },
               "deterministic": true
             },
@@ -21967,9 +21949,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.860338+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.773060+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "request_body": {
             "allOf": [
@@ -22172,7 +22153,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.051313+00:00"
+                "validatedAt": "2026-07-20T14:38:32.641414+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22217,7 +22198,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:50.051363+00:00"
+                "validatedAt": "2026-07-20T14:38:32.641439+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22244,7 +22225,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.051396+00:00"
+                "validatedAt": "2026-07-20T14:38:32.641453+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22299,7 +22280,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:50.051436+00:00"
+                "validatedAt": "2026-07-20T14:38:32.641471+00:00"
               },
               "deterministic": true
             },
@@ -22311,9 +22292,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.860411+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.773103+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "range": {
             "type": "string",
@@ -22338,7 +22318,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.051470+00:00"
+                "validatedAt": "2026-07-20T14:38:32.641484+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22371,7 +22351,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.051509+00:00"
+                "validatedAt": "2026-07-20T14:38:32.641500+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22404,7 +22384,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.051541+00:00"
+                "validatedAt": "2026-07-20T14:38:32.641513+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22499,7 +22479,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.051584+00:00"
+                "validatedAt": "2026-07-20T14:38:32.641531+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22606,7 +22586,7 @@
             "maxLength": 16,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.860468+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.773136+00:00"
           },
           "value": {
             "type": "array",
@@ -22625,7 +22605,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.860490+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.773150+00:00"
           }
         },
         "x-f5xc-description-short": "Transit Usage Type Data contains key/value pair that uniquely identifies the group_by labels specified in the request.",
@@ -22678,7 +22658,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.051636+00:00"
+                "validatedAt": "2026-07-20T14:38:32.641553+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22701,7 +22681,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.051676+00:00"
+                "validatedAt": "2026-07-20T14:38:32.641567+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22712,7 +22692,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.860517+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.773167+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -22891,7 +22871,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:50.051738+00:00"
+                "validatedAt": "2026-07-20T14:38:32.641597+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22963,7 +22943,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:50.051789+00:00"
+                "validatedAt": "2026-07-20T14:38:32.641623+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23056,7 +23036,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.051838+00:00"
+                "validatedAt": "2026-07-20T14:38:32.641644+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23067,7 +23047,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.860582+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.773205+00:00"
           }
         },
         "x-f5xc-description-short": "Metric data contains timestamp and the value.",
@@ -23138,7 +23118,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:50.051881+00:00"
+                "validatedAt": "2026-07-20T14:38:32.641665+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23249,7 +23229,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:02:50.051927+00:00"
+                "validatedAt": "2026-07-20T14:38:32.641687+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23260,7 +23240,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.860612+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.773223+00:00"
           },
           "previous_value": {
             "type": "string",
@@ -23278,7 +23258,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.051966+00:00"
+                "validatedAt": "2026-07-20T14:38:32.641704+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23316,7 +23296,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.051999+00:00"
+                "validatedAt": "2026-07-20T14:38:32.641717+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23327,7 +23307,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.860643+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.773242+00:00"
           }
         },
         "x-f5xc-description-short": "Trend value contains trend value, trend sentiment and trend calculation description and window size.",
@@ -23455,7 +23435,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:02:50.052030+00:00"
+                "validatedAt": "2026-07-20T14:38:32.641733+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23522,7 +23502,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:02:50.052074+00:00"
+                "validatedAt": "2026-07-20T14:38:32.641753+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23533,7 +23513,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.860681+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.773259+00:00"
           },
           "ref_value": {
             "allOf": [
@@ -23575,7 +23555,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.052113+00:00"
+                "validatedAt": "2026-07-20T14:38:32.641769+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23602,7 +23582,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:50.052145+00:00"
+                "validatedAt": "2026-07-20T14:38:32.641783+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23613,7 +23593,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.860715+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.773279+00:00"
           }
         },
         "x-f5xc-description-short": "Tuple with a suggested value and it's description.",
@@ -23700,7 +23680,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:50.052201+00:00"
+                "validatedAt": "2026-07-20T14:38:32.641814+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -23714,8 +23694,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -23754,7 +23733,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:50.052250+00:00"
+                "validatedAt": "2026-07-20T14:38:32.641838+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -23769,9 +23748,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.860743+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.773296+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -23800,7 +23778,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:50.052302+00:00"
+                "validatedAt": "2026-07-20T14:38:32.641864+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23813,7 +23791,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.860761+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.773308+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a direct reference from one object(the referrer) to another(the referred).",
@@ -24144,7 +24122,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:52.024426+00:00"
+                "validatedAt": "2026-07-20T14:38:33.409404+00:00"
               },
               "deterministic": true
             },
@@ -24156,9 +24134,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.917871+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.815993+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -24190,7 +24167,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:52.024461+00:00"
+                "validatedAt": "2026-07-20T14:38:33.409423+00:00"
               },
               "deterministic": true
             },
@@ -24202,9 +24179,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.917891+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.816006+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -24367,7 +24343,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.917959+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.816047+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -24617,7 +24593,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:02:52.024674+00:00"
+                "validatedAt": "2026-07-20T14:38:33.409485+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24696,7 +24672,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:02:52.024765+00:00"
+                "validatedAt": "2026-07-20T14:38:33.409516+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24707,7 +24683,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.918050+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.816102+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -24794,7 +24770,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:52.024834+00:00"
+                "validatedAt": "2026-07-20T14:38:33.409536+00:00"
               },
               "deterministic": true
             },
@@ -24806,9 +24782,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.918096+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.816130+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -24839,7 +24814,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:52.024865+00:00"
+                "validatedAt": "2026-07-20T14:38:33.409552+00:00"
               },
               "deterministic": true
             },
@@ -24851,9 +24826,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.918114+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.816142+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -24922,7 +24896,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:52.024918+00:00"
+                "validatedAt": "2026-07-20T14:38:33.409574+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24934,7 +24908,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.918151+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.816165+00:00"
           },
           "uid": {
             "type": "string",
@@ -24952,7 +24926,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:52.024945+00:00"
+                "validatedAt": "2026-07-20T14:38:33.409585+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24965,7 +24939,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.918171+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.816178+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of infraprotect_asn is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -25256,7 +25230,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:52.025014+00:00"
+                "validatedAt": "2026-07-20T14:38:33.409617+00:00"
               },
               "deterministic": true
             },
@@ -25268,9 +25242,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.918227+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.816211+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -25309,7 +25282,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:52.025050+00:00"
+                "validatedAt": "2026-07-20T14:38:33.409636+00:00"
               },
               "deterministic": true
             },
@@ -25321,9 +25294,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.918246+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.816223+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "review_type_approved": {
             "allOf": [
@@ -25508,7 +25480,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T13:02:52.025165+00:00"
+                "validatedAt": "2026-07-20T14:38:33.409688+00:00"
               },
               "deterministic": true
             },
@@ -25519,8 +25491,7 @@
               "read": false
             },
             "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "minLength": 1,
-            "format": "fqdn"
+            "minLength": 1
           },
           "last_update_time": {
             "type": "string",
@@ -25537,7 +25508,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:52.025206+00:00"
+                "validatedAt": "2026-07-20T14:38:33.409704+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25564,7 +25535,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:52.025240+00:00"
+                "validatedAt": "2026-07-20T14:38:33.409719+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25575,7 +25546,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.918329+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.816272+00:00"
           },
           "service_name": {
             "type": "string",
@@ -25592,7 +25563,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:52.025278+00:00"
+                "validatedAt": "2026-07-20T14:38:33.409735+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25625,7 +25596,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:52.025315+00:00"
+                "validatedAt": "2026-07-20T14:38:33.409750+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25636,7 +25607,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.918354+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.816288+00:00"
           },
           "type": {
             "type": "string",
@@ -25661,7 +25632,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:52.025349+00:00"
+                "validatedAt": "2026-07-20T14:38:33.409765+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25805,7 +25776,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:52.025391+00:00"
+                "validatedAt": "2026-07-20T14:38:33.409781+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25885,7 +25856,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:52.025420+00:00"
+                "validatedAt": "2026-07-20T14:38:33.409795+00:00"
               },
               "deterministic": true
             },
@@ -25897,9 +25868,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.918402+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.816316+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -26063,7 +26033,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:52.025515+00:00"
+                "validatedAt": "2026-07-20T14:38:33.409843+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -26078,7 +26048,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.918444+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.816342+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -26148,7 +26118,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:52.025554+00:00"
+                "validatedAt": "2026-07-20T14:38:33.409861+00:00"
               },
               "deterministic": true
             },
@@ -26160,9 +26130,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.918477+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.816362+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -26195,7 +26164,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:52.025582+00:00"
+                "validatedAt": "2026-07-20T14:38:33.409875+00:00"
               },
               "deterministic": true
             },
@@ -26207,9 +26176,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.918495+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.816373+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -26309,7 +26277,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:52.025668+00:00"
+                "validatedAt": "2026-07-20T14:38:33.409915+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -26324,7 +26292,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.918524+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.816390+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -26396,7 +26364,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:52.025708+00:00"
+                "validatedAt": "2026-07-20T14:38:33.409933+00:00"
               },
               "deterministic": true
             },
@@ -26408,9 +26376,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.918556+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.816411+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -26443,7 +26410,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:52.025736+00:00"
+                "validatedAt": "2026-07-20T14:38:33.409948+00:00"
               },
               "deterministic": true
             },
@@ -26455,9 +26422,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.918574+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.816422+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -26520,7 +26486,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:52.025768+00:00"
+                "validatedAt": "2026-07-20T14:38:33.409960+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26532,7 +26498,7 @@
             "readOnly": true,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.918594+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.816435+00:00"
           },
           "name": {
             "type": "string",
@@ -26565,7 +26531,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:52.025794+00:00"
+                "validatedAt": "2026-07-20T14:38:33.409974+00:00"
               },
               "deterministic": true
             },
@@ -26577,9 +26543,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.918612+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.816446+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -26612,7 +26577,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:52.025821+00:00"
+                "validatedAt": "2026-07-20T14:38:33.409988+00:00"
               },
               "deterministic": true
             },
@@ -26624,9 +26589,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.918631+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.816458+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -26645,7 +26609,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:52.025854+00:00"
+                "validatedAt": "2026-07-20T14:38:33.410001+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26658,7 +26622,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.918649+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.816470+00:00"
           },
           "uid": {
             "type": "string",
@@ -26677,7 +26641,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:52.025879+00:00"
+                "validatedAt": "2026-07-20T14:38:33.410012+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26691,7 +26655,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.918677+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.816482+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -26791,7 +26755,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:52.025953+00:00"
+                "validatedAt": "2026-07-20T14:38:33.410049+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -26806,7 +26770,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.918705+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.816499+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -26876,7 +26840,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:52.025991+00:00"
+                "validatedAt": "2026-07-20T14:38:33.410067+00:00"
               },
               "deterministic": true
             },
@@ -26888,9 +26852,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.918737+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.816519+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -26923,7 +26886,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:52.026018+00:00"
+                "validatedAt": "2026-07-20T14:38:33.410082+00:00"
               },
               "deterministic": true
             },
@@ -26935,9 +26898,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.918755+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.816531+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -27000,7 +26962,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:52.026061+00:00"
+                "validatedAt": "2026-07-20T14:38:33.410100+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27028,7 +26990,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:52.026101+00:00"
+                "validatedAt": "2026-07-20T14:38:33.410157+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27056,7 +27018,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:52.026138+00:00"
+                "validatedAt": "2026-07-20T14:38:33.410174+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27095,7 +27057,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:52.026178+00:00"
+                "validatedAt": "2026-07-20T14:38:33.410191+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27122,7 +27084,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:52.026203+00:00"
+                "validatedAt": "2026-07-20T14:38:33.410202+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27135,7 +27097,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.918809+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.816564+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -27151,7 +27113,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:52.026237+00:00"
+                "validatedAt": "2026-07-20T14:38:33.410216+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27296,7 +27258,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:52.026285+00:00"
+                "validatedAt": "2026-07-20T14:38:33.410236+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27307,7 +27269,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.918849+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.816588+00:00"
           },
           "status": {
             "type": "string",
@@ -27325,7 +27287,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:52.026319+00:00"
+                "validatedAt": "2026-07-20T14:38:33.410252+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27336,7 +27298,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.918867+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.816600+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -27396,7 +27358,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:52.026362+00:00"
+                "validatedAt": "2026-07-20T14:38:33.410269+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27423,7 +27385,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:52.026401+00:00"
+                "validatedAt": "2026-07-20T14:38:33.410285+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27450,7 +27412,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:52.026438+00:00"
+                "validatedAt": "2026-07-20T14:38:33.410300+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27478,7 +27440,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:52.026480+00:00"
+                "validatedAt": "2026-07-20T14:38:33.410317+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27554,7 +27516,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:52.026545+00:00"
+                "validatedAt": "2026-07-20T14:38:33.410341+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27622,7 +27584,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:52.026594+00:00"
+                "validatedAt": "2026-07-20T14:38:33.410361+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27634,7 +27596,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.918953+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.816650+00:00"
           },
           "uid": {
             "type": "string",
@@ -27653,7 +27615,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:52.026619+00:00"
+                "validatedAt": "2026-07-20T14:38:33.410371+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27666,7 +27628,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.918971+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.816662+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -27734,7 +27696,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:52.026650+00:00"
+                "validatedAt": "2026-07-20T14:38:33.410384+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27745,7 +27707,7 @@
             },
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.918991+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.816674+00:00"
           },
           "name": {
             "type": "string",
@@ -27778,7 +27740,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:52.026686+00:00"
+                "validatedAt": "2026-07-20T14:38:33.410398+00:00"
               },
               "deterministic": true
             },
@@ -27790,9 +27752,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.919009+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.816686+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -27825,7 +27786,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:52.026712+00:00"
+                "validatedAt": "2026-07-20T14:38:33.410412+00:00"
               },
               "deterministic": true
             },
@@ -27837,9 +27798,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.919027+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.816698+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "uid": {
             "type": "string",
@@ -27856,7 +27816,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:52.026737+00:00"
+                "validatedAt": "2026-07-20T14:38:33.410422+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27869,7 +27829,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.919046+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.816710+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -28100,7 +28060,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:57.888045+00:00"
+                "validatedAt": "2026-07-20T14:38:35.774261+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28194,7 +28154,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:57.888116+00:00"
+                "validatedAt": "2026-07-20T14:38:35.774291+00:00"
               },
               "deterministic": true
             },
@@ -28206,9 +28166,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.030049+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.892431+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -28240,7 +28199,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:57.888147+00:00"
+                "validatedAt": "2026-07-20T14:38:35.774307+00:00"
               },
               "deterministic": true
             },
@@ -28252,9 +28211,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.030070+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.892444+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -28417,7 +28375,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.030137+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.892484+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -28589,7 +28547,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:57.888291+00:00"
+                "validatedAt": "2026-07-20T14:38:35.774364+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28761,7 +28719,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:57.888360+00:00"
+                "validatedAt": "2026-07-20T14:38:35.774392+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28856,7 +28814,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:02:57.888409+00:00"
+                "validatedAt": "2026-07-20T14:38:35.774459+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28935,7 +28893,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:02:57.888465+00:00"
+                "validatedAt": "2026-07-20T14:38:35.774488+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28946,7 +28904,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.030288+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.892574+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -29034,7 +28992,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:57.888506+00:00"
+                "validatedAt": "2026-07-20T14:38:35.774510+00:00"
               },
               "deterministic": true
             },
@@ -29046,9 +29004,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.030334+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.892602+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -29079,7 +29036,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:57.888533+00:00"
+                "validatedAt": "2026-07-20T14:38:35.774525+00:00"
               },
               "deterministic": true
             },
@@ -29091,9 +29048,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.030353+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.892614+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -29162,7 +29118,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:57.888587+00:00"
+                "validatedAt": "2026-07-20T14:38:35.774549+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29174,7 +29130,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.030390+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.892637+00:00"
           },
           "uid": {
             "type": "string",
@@ -29192,7 +29148,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:57.888613+00:00"
+                "validatedAt": "2026-07-20T14:38:35.774561+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29205,7 +29161,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.030411+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.892650+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of infraprotect_asn_prefix is returned in 'List'.",
@@ -29496,7 +29452,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:57.888692+00:00"
+                "validatedAt": "2026-07-20T14:38:35.774591+00:00"
               },
               "deterministic": true
             },
@@ -29508,9 +29464,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.030467+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.892683+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -29549,7 +29504,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:57.888724+00:00"
+                "validatedAt": "2026-07-20T14:38:35.774608+00:00"
               },
               "deterministic": true
             },
@@ -29561,9 +29516,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.030487+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.892695+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Request to update infraprotect ASN irr override status.",
@@ -29667,7 +29621,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:57.888752+00:00"
+                "validatedAt": "2026-07-20T14:38:35.774622+00:00"
               },
               "deterministic": true
             },
@@ -29679,9 +29633,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.030507+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.892709+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -29720,7 +29673,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:57.888782+00:00"
+                "validatedAt": "2026-07-20T14:38:35.774637+00:00"
               },
               "deterministic": true
             },
@@ -29732,9 +29685,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.030525+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.892720+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "review_type_approved": {
             "allOf": [
@@ -29881,7 +29833,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:57.888828+00:00"
+                "validatedAt": "2026-07-20T14:38:35.774654+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29893,7 +29845,7 @@
             "readOnly": true,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.030567+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.892746+00:00"
           },
           "name": {
             "type": "string",
@@ -29926,7 +29878,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:57.888857+00:00"
+                "validatedAt": "2026-07-20T14:38:35.774668+00:00"
               },
               "deterministic": true
             },
@@ -29938,9 +29890,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.030585+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.892758+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -29973,7 +29924,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:57.888885+00:00"
+                "validatedAt": "2026-07-20T14:38:35.774682+00:00"
               },
               "deterministic": true
             },
@@ -29985,9 +29936,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.030603+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.892770+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -30006,7 +29956,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:57.888919+00:00"
+                "validatedAt": "2026-07-20T14:38:35.774696+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30019,7 +29969,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.030621+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.892781+00:00"
           },
           "uid": {
             "type": "string",
@@ -30038,7 +29988,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:57.888945+00:00"
+                "validatedAt": "2026-07-20T14:38:35.774706+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30052,7 +30002,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.030640+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.892793+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -30278,7 +30228,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:59.809297+00:00"
+                "validatedAt": "2026-07-20T14:38:36.526011+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30398,7 +30348,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:59.809376+00:00"
+                "validatedAt": "2026-07-20T14:38:36.526045+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30500,7 +30450,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:59.809434+00:00"
+                "validatedAt": "2026-07-20T14:38:36.526068+00:00"
               },
               "deterministic": true
             },
@@ -30512,9 +30462,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.062237+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.912884+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -30546,7 +30495,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:59.809477+00:00"
+                "validatedAt": "2026-07-20T14:38:36.526082+00:00"
               },
               "deterministic": true
             },
@@ -30558,9 +30507,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.062258+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.912898+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -30723,7 +30671,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.062325+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.912939+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -30817,7 +30765,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:59.809669+00:00"
+                "validatedAt": "2026-07-20T14:38:36.526129+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30853,7 +30801,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:59.809731+00:00"
+                "validatedAt": "2026-07-20T14:38:36.526146+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30936,7 +30884,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:02:59.809780+00:00"
+                "validatedAt": "2026-07-20T14:38:36.526167+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31015,7 +30963,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:02:59.809838+00:00"
+                "validatedAt": "2026-07-20T14:38:36.526192+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31026,7 +30974,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.062398+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.912981+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -31114,7 +31062,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:59.809880+00:00"
+                "validatedAt": "2026-07-20T14:38:36.526211+00:00"
               },
               "deterministic": true
             },
@@ -31126,9 +31074,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.062443+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.913009+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -31159,7 +31106,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:59.809911+00:00"
+                "validatedAt": "2026-07-20T14:38:36.526225+00:00"
               },
               "deterministic": true
             },
@@ -31171,9 +31118,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.062462+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.913021+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -31242,7 +31188,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:59.809966+00:00"
+                "validatedAt": "2026-07-20T14:38:36.526247+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31254,7 +31200,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.062499+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.913044+00:00"
           },
           "uid": {
             "type": "string",
@@ -31272,7 +31218,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:59.809993+00:00"
+                "validatedAt": "2026-07-20T14:38:36.526258+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31285,7 +31231,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.062519+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.913056+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of infraprotect_deny_list_rule is returned in 'List'.",
@@ -31469,7 +31415,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:59.810050+00:00"
+                "validatedAt": "2026-07-20T14:38:36.526281+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31589,7 +31535,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:59.810100+00:00"
+                "validatedAt": "2026-07-20T14:38:36.526301+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31940,7 +31886,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:03.724159+00:00"
+                "validatedAt": "2026-07-20T14:38:38.035290+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32238,7 +32184,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:03.724289+00:00"
+                "validatedAt": "2026-07-20T14:38:38.035334+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32421,7 +32367,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:03.724369+00:00"
+                "validatedAt": "2026-07-20T14:38:38.035361+00:00"
               },
               "deterministic": true
             },
@@ -32433,9 +32379,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.122055+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.950117+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -32467,7 +32412,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:03.724418+00:00"
+                "validatedAt": "2026-07-20T14:38:38.035377+00:00"
               },
               "deterministic": true
             },
@@ -32479,9 +32424,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.122076+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.950131+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -32644,7 +32588,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.122144+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.950172+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -32779,7 +32723,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:03.724594+00:00"
+                "validatedAt": "2026-07-20T14:38:38.035430+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33077,7 +33021,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:03.724691+00:00"
+                "validatedAt": "2026-07-20T14:38:38.035464+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33569,7 +33513,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:03:03.724820+00:00"
+                "validatedAt": "2026-07-20T14:38:38.035516+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33648,7 +33592,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:03:03.724876+00:00"
+                "validatedAt": "2026-07-20T14:38:38.035542+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33659,7 +33603,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.122636+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.950479+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -33747,7 +33691,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:03.724918+00:00"
+                "validatedAt": "2026-07-20T14:38:38.035560+00:00"
               },
               "deterministic": true
             },
@@ -33759,9 +33703,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.122692+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.950508+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -33792,7 +33735,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:03.724946+00:00"
+                "validatedAt": "2026-07-20T14:38:38.035575+00:00"
               },
               "deterministic": true
             },
@@ -33804,9 +33747,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.122712+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.950520+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -33875,7 +33817,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:03.724999+00:00"
+                "validatedAt": "2026-07-20T14:38:38.035597+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33887,7 +33829,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.122749+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.950544+00:00"
           },
           "uid": {
             "type": "string",
@@ -33905,7 +33847,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:03.725025+00:00"
+                "validatedAt": "2026-07-20T14:38:38.035608+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33918,7 +33860,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.122769+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.950557+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of infraprotect_firewall_rule is returned in 'List'.",
@@ -34139,7 +34081,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:03.725091+00:00"
+                "validatedAt": "2026-07-20T14:38:38.035635+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34437,7 +34379,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:03.725173+00:00"
+                "validatedAt": "2026-07-20T14:38:38.035667+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34671,7 +34613,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:03:03.725262+00:00"
+                "validatedAt": "2026-07-20T14:38:38.035705+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34682,7 +34624,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.122961+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.950671+00:00"
           },
           "destination_port_all": {
             "allOf": [
@@ -34721,7 +34663,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:03.725311+00:00"
+                "validatedAt": "2026-07-20T14:38:38.035726+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34771,7 +34713,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:03.725357+00:00"
+                "validatedAt": "2026-07-20T14:38:38.035745+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34844,7 +34786,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:03:03.725404+00:00"
+                "validatedAt": "2026-07-20T14:38:38.035767+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34855,7 +34797,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.123008+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.950701+00:00"
           },
           "destination_port_all": {
             "allOf": [
@@ -34894,7 +34836,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:03.725454+00:00"
+                "validatedAt": "2026-07-20T14:38:38.035788+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34944,7 +34886,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:03.725501+00:00"
+                "validatedAt": "2026-07-20T14:38:38.035808+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35161,7 +35103,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:09.111746+00:00"
+                "validatedAt": "2026-07-20T14:38:40.411787+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35254,7 +35196,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:09.111810+00:00"
+                "validatedAt": "2026-07-20T14:38:40.411817+00:00"
               },
               "deterministic": true
             },
@@ -35266,9 +35208,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.189750+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.993897+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -35300,7 +35241,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:09.111857+00:00"
+                "validatedAt": "2026-07-20T14:38:40.411837+00:00"
               },
               "deterministic": true
             },
@@ -35312,9 +35253,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.189771+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.993910+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -35477,7 +35417,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.189838+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.993951+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -35558,7 +35498,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:09.112037+00:00"
+                "validatedAt": "2026-07-20T14:38:40.411887+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35593,7 +35533,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:09.112108+00:00"
+                "validatedAt": "2026-07-20T14:38:40.411915+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35675,7 +35615,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:03:09.112157+00:00"
+                "validatedAt": "2026-07-20T14:38:40.411938+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35754,7 +35694,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:03:09.112212+00:00"
+                "validatedAt": "2026-07-20T14:38:40.411962+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35765,7 +35705,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.189906+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.993992+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -35853,7 +35793,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:09.112253+00:00"
+                "validatedAt": "2026-07-20T14:38:40.411982+00:00"
               },
               "deterministic": true
             },
@@ -35865,9 +35805,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.189952+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.994021+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -35898,7 +35837,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:09.112280+00:00"
+                "validatedAt": "2026-07-20T14:38:40.411996+00:00"
               },
               "deterministic": true
             },
@@ -35910,9 +35849,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.189970+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.994034+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -35981,7 +35919,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:09.112336+00:00"
+                "validatedAt": "2026-07-20T14:38:40.412018+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35993,7 +35931,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.190008+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.994058+00:00"
           },
           "uid": {
             "type": "string",
@@ -36011,7 +35949,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:09.112362+00:00"
+                "validatedAt": "2026-07-20T14:38:40.412029+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36024,7 +35962,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.190027+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.994071+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of infraprotect_firewall_rule_group is returned in 'List'.",
@@ -36191,7 +36129,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:09.112420+00:00"
+                "validatedAt": "2026-07-20T14:38:40.412052+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36337,7 +36275,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:11.586953+00:00"
+                "validatedAt": "2026-07-20T14:38:41.546807+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36365,7 +36303,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:11.586987+00:00"
+                "validatedAt": "2026-07-20T14:38:41.546822+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36390,7 +36328,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:11.587018+00:00"
+                "validatedAt": "2026-07-20T14:38:41.546835+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36459,7 +36397,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:11.587321+00:00"
+                "validatedAt": "2026-07-20T14:38:41.546971+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36503,7 +36441,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:11.587365+00:00"
+                "validatedAt": "2026-07-20T14:38:41.546990+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36616,7 +36554,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:11.587847+00:00"
+                "validatedAt": "2026-07-20T14:38:41.547270+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36681,7 +36619,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:11.587882+00:00"
+                "validatedAt": "2026-07-20T14:38:41.547297+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36746,7 +36684,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:11.587917+00:00"
+                "validatedAt": "2026-07-20T14:38:41.547313+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36811,7 +36749,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:11.587952+00:00"
+                "validatedAt": "2026-07-20T14:38:41.547329+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36876,7 +36814,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:11.587988+00:00"
+                "validatedAt": "2026-07-20T14:38:41.547345+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36941,7 +36879,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:11.588023+00:00"
+                "validatedAt": "2026-07-20T14:38:41.547360+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37006,7 +36944,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:11.588058+00:00"
+                "validatedAt": "2026-07-20T14:38:41.547376+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37071,7 +37009,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:11.588093+00:00"
+                "validatedAt": "2026-07-20T14:38:41.547391+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37135,7 +37073,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:11.588128+00:00"
+                "validatedAt": "2026-07-20T14:38:41.547408+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37200,7 +37138,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:11.588163+00:00"
+                "validatedAt": "2026-07-20T14:38:41.547422+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37265,7 +37203,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:11.588198+00:00"
+                "validatedAt": "2026-07-20T14:38:41.547437+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37329,7 +37267,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:11.588234+00:00"
+                "validatedAt": "2026-07-20T14:38:41.547452+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37394,7 +37332,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:11.588270+00:00"
+                "validatedAt": "2026-07-20T14:38:41.547470+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37459,7 +37397,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:11.588306+00:00"
+                "validatedAt": "2026-07-20T14:38:41.547485+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37524,7 +37462,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:11.588342+00:00"
+                "validatedAt": "2026-07-20T14:38:41.547500+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37589,7 +37527,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:11.588378+00:00"
+                "validatedAt": "2026-07-20T14:38:41.547515+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37654,7 +37592,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:11.588413+00:00"
+                "validatedAt": "2026-07-20T14:38:41.547529+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37719,7 +37657,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:11.588450+00:00"
+                "validatedAt": "2026-07-20T14:38:41.547544+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37784,7 +37722,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:11.588486+00:00"
+                "validatedAt": "2026-07-20T14:38:41.547559+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37849,7 +37787,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:11.588521+00:00"
+                "validatedAt": "2026-07-20T14:38:41.547574+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37914,7 +37852,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:11.588557+00:00"
+                "validatedAt": "2026-07-20T14:38:41.547588+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37979,7 +37917,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:11.588592+00:00"
+                "validatedAt": "2026-07-20T14:38:41.547603+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38044,7 +37982,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:11.588627+00:00"
+                "validatedAt": "2026-07-20T14:38:41.547620+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38108,7 +38046,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:11.588670+00:00"
+                "validatedAt": "2026-07-20T14:38:41.547657+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38173,7 +38111,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:11.588708+00:00"
+                "validatedAt": "2026-07-20T14:38:41.547675+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38238,7 +38176,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:11.588743+00:00"
+                "validatedAt": "2026-07-20T14:38:41.547691+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38303,7 +38241,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:11.588778+00:00"
+                "validatedAt": "2026-07-20T14:38:41.547707+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38368,7 +38306,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:11.588814+00:00"
+                "validatedAt": "2026-07-20T14:38:41.547723+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38433,7 +38371,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:11.588850+00:00"
+                "validatedAt": "2026-07-20T14:38:41.547739+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38498,7 +38436,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:11.588885+00:00"
+                "validatedAt": "2026-07-20T14:38:41.547755+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39136,7 +39074,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.296744+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.098570+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -39221,7 +39159,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:13.501275+00:00"
+                "validatedAt": "2026-07-20T14:38:42.339872+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39336,7 +39274,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:03:13.501359+00:00"
+                "validatedAt": "2026-07-20T14:38:42.339901+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39415,7 +39353,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:03:13.501449+00:00"
+                "validatedAt": "2026-07-20T14:38:42.339930+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39426,7 +39364,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.296823+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.098615+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -39514,7 +39452,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:13.501516+00:00"
+                "validatedAt": "2026-07-20T14:38:42.339952+00:00"
               },
               "deterministic": true
             },
@@ -39526,9 +39464,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.296869+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.098644+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -39559,7 +39496,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:13.501562+00:00"
+                "validatedAt": "2026-07-20T14:38:42.339967+00:00"
               },
               "deterministic": true
             },
@@ -39571,9 +39508,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.296888+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.098656+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -39642,7 +39578,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:13.501631+00:00"
+                "validatedAt": "2026-07-20T14:38:42.339991+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39654,7 +39590,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.296926+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.098680+00:00"
           },
           "uid": {
             "type": "string",
@@ -39672,7 +39608,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:13.501671+00:00"
+                "validatedAt": "2026-07-20T14:38:42.340003+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39685,7 +39621,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.296946+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.098693+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of infraprotect_firewall_ruleset is returned in 'List'.",
@@ -39856,7 +39792,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:13.501727+00:00"
+                "validatedAt": "2026-07-20T14:38:42.340031+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40079,7 +40015,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.347362+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.142260+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -40157,7 +40093,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:17.210795+00:00"
+                "validatedAt": "2026-07-20T14:38:43.841917+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40308,7 +40244,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:17.210942+00:00"
+                "validatedAt": "2026-07-20T14:38:43.841961+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40425,7 +40361,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:17.211001+00:00"
+                "validatedAt": "2026-07-20T14:38:43.841989+00:00"
               },
               "deterministic": true
             },
@@ -40650,7 +40586,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:17.211100+00:00"
+                "validatedAt": "2026-07-20T14:38:43.842031+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40691,7 +40627,7 @@
                 "confidence": 1.0,
                 "category": "content",
                 "note": "Blindfold envelope encryption (AES-256-GCM + RSA-OAEP) of an RSA-2048 TLS private key produces ~3700 char string:/// URL. 128KB max secret size = ~175KB base64. Discovery reported 1024 which is incorrect.",
-                "validatedAt": "2026-07-20T13:03:17.211144+00:00"
+                "validatedAt": "2026-07-20T14:38:43.842058+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40702,7 +40638,7 @@
             },
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.347537+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.142365+00:00"
           },
           "store_provider": {
             "type": "string",
@@ -40721,7 +40657,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:17.211189+00:00"
+                "validatedAt": "2026-07-20T14:38:43.842096+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40788,7 +40724,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:17.211226+00:00"
+                "validatedAt": "2026-07-20T14:38:43.842122+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40799,7 +40735,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.347564+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.142382+00:00"
           },
           "url": {
             "type": "string",
@@ -40837,7 +40773,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:17.211287+00:00"
+                "validatedAt": "2026-07-20T14:38:43.842163+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -41210,7 +41146,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:21.086846+00:00"
+                "validatedAt": "2026-07-20T14:38:45.340831+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41247,7 +41183,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:21.086912+00:00"
+                "validatedAt": "2026-07-20T14:38:45.340856+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41347,7 +41283,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:21.086975+00:00"
+                "validatedAt": "2026-07-20T14:38:45.340878+00:00"
               },
               "deterministic": true
             },
@@ -41359,9 +41295,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.401072+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.187732+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -41393,7 +41328,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:21.087017+00:00"
+                "validatedAt": "2026-07-20T14:38:45.340892+00:00"
               },
               "deterministic": true
             },
@@ -41405,9 +41340,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.401092+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.187746+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -41570,7 +41504,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.401159+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.187788+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -41699,7 +41633,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:21.087216+00:00"
+                "validatedAt": "2026-07-20T14:38:45.340940+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41736,7 +41670,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:21.087280+00:00"
+                "validatedAt": "2026-07-20T14:38:45.340956+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41821,7 +41755,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:03:21.087329+00:00"
+                "validatedAt": "2026-07-20T14:38:45.340976+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41900,7 +41834,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:03:21.087386+00:00"
+                "validatedAt": "2026-07-20T14:38:45.340999+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41911,7 +41845,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.401244+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.187840+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -41999,7 +41933,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:21.087428+00:00"
+                "validatedAt": "2026-07-20T14:38:45.341018+00:00"
               },
               "deterministic": true
             },
@@ -42011,9 +41945,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.401290+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.187868+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -42044,7 +41977,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:21.087457+00:00"
+                "validatedAt": "2026-07-20T14:38:45.341032+00:00"
               },
               "deterministic": true
             },
@@ -42056,9 +41989,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.401308+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.187881+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -42127,7 +42059,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:21.087509+00:00"
+                "validatedAt": "2026-07-20T14:38:45.341052+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42139,7 +42071,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.401345+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.187905+00:00"
           },
           "uid": {
             "type": "string",
@@ -42157,7 +42089,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:21.087536+00:00"
+                "validatedAt": "2026-07-20T14:38:45.341063+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42170,7 +42102,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.401365+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.187918+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of infraprotect_internet_prefix_advertisement is returned in 'List'.",
@@ -42385,7 +42317,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:21.087597+00:00"
+                "validatedAt": "2026-07-20T14:38:45.341086+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42591,7 +42523,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:21.087679+00:00"
+                "validatedAt": "2026-07-20T14:38:45.341115+00:00"
               },
               "deterministic": true
             },
@@ -42603,9 +42535,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.401461+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.187976+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -42644,7 +42575,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:21.087711+00:00"
+                "validatedAt": "2026-07-20T14:38:45.341129+00:00"
               },
               "deterministic": true
             },
@@ -42656,9 +42587,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.401480+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.187988+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Request to toggle Internet prefix advertisement announcement/withdrawal.",
@@ -43297,7 +43227,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:07.838996+00:00"
+                "validatedAt": "2026-07-20T14:41:22.477532+00:00"
               },
               "deterministic": true
             },
@@ -43309,9 +43239,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.595504+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.239161+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -43343,7 +43272,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:07.839045+00:00"
+                "validatedAt": "2026-07-20T14:41:22.477549+00:00"
               },
               "deterministic": true
             },
@@ -43355,9 +43284,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.595544+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.239175+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -43520,7 +43448,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.595629+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.239214+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -43637,7 +43565,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:07.839268+00:00"
+                "validatedAt": "2026-07-20T14:41:22.477605+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43665,7 +43593,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:07.839317+00:00"
+                "validatedAt": "2026-07-20T14:41:22.477624+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43689,7 +43617,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:07.839357+00:00"
+                "validatedAt": "2026-07-20T14:41:22.477640+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43717,7 +43645,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:07.839407+00:00"
+                "validatedAt": "2026-07-20T14:41:22.477659+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43745,7 +43673,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:07.839453+00:00"
+                "validatedAt": "2026-07-20T14:41:22.477676+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43852,7 +43780,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:07.839503+00:00"
+                "validatedAt": "2026-07-20T14:41:22.477695+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44107,7 +44035,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:07.839577+00:00"
+                "validatedAt": "2026-07-20T14:41:22.477723+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44281,7 +44209,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:07.839644+00:00"
+                "validatedAt": "2026-07-20T14:41:22.477749+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44386,7 +44314,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:07.839708+00:00"
+                "validatedAt": "2026-07-20T14:41:22.477769+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44457,7 +44385,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:07.839756+00:00"
+                "validatedAt": "2026-07-20T14:41:22.477788+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44666,7 +44594,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:10:07.839805+00:00"
+                "validatedAt": "2026-07-20T14:41:22.477808+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44745,7 +44673,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:10:07.839861+00:00"
+                "validatedAt": "2026-07-20T14:41:22.477831+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44756,7 +44684,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.595917+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.239370+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -44843,7 +44771,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:07.839904+00:00"
+                "validatedAt": "2026-07-20T14:41:22.477848+00:00"
               },
               "deterministic": true
             },
@@ -44855,9 +44783,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.595970+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.239397+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -44888,7 +44815,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:07.839932+00:00"
+                "validatedAt": "2026-07-20T14:41:22.477861+00:00"
               },
               "deterministic": true
             },
@@ -44900,9 +44827,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.595989+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.239409+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -44971,7 +44897,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:07.839985+00:00"
+                "validatedAt": "2026-07-20T14:41:22.477881+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44983,7 +44909,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.596027+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.239432+00:00"
           },
           "uid": {
             "type": "string",
@@ -45001,7 +44927,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:07.840013+00:00"
+                "validatedAt": "2026-07-20T14:41:22.477893+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45014,7 +44940,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.596048+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.239444+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of infraprotect_tunnel is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -45432,7 +45358,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:07.840129+00:00"
+                "validatedAt": "2026-07-20T14:41:22.477942+00:00"
               },
               "deterministic": true
             },
@@ -45444,9 +45370,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.596145+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.239499+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "zone1": {
             "allOf": [
@@ -45597,7 +45522,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:07.840167+00:00"
+                "validatedAt": "2026-07-20T14:41:22.477959+00:00"
               },
               "deterministic": true
             },
@@ -45609,9 +45534,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.596180+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.239519+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tunnel_id": {
             "type": "string",
@@ -45636,7 +45560,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:07.840206+00:00"
+                "validatedAt": "2026-07-20T14:41:22.477974+00:00"
               }
             },
             "x-f5xc-required-for": {

--- a/docs/specifications/api/dns.json
+++ b/docs/specifications/api/dns.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Dns",
     "description": "Name infrastructure with authoritative zones, A/AAAA/CNAME record types, and zone management. Supports zone transfers, security extensions, health-based routing, and delegation. Enables reliable name resolution, geographic load balancing, and name-based traffic steering across distributed environments.",
-    "version": "2.1.182",
+    "version": "2.1.181",
     "contact": {
       "name": "F5 Distributed Cloud",
       "url": "https://docs.cloud.f5.com"
@@ -2141,7 +2141,7 @@
           },
           {
             "name": "response_format",
-            "description": "The format in which the configuration object is to be fetched. This could be for example\n - in GetSpec form for the contents of object\n - in CreateRequest form to create a new similar object\n - to ReplaceRequest form to replace changeable values\n\nDefault format of returned resource\nResponse should be in CreateRequest format\nResponse should be in ReplaceRequest format\nResponse should be in StatusObject(s) format\nResponse should be in format of GetSpecType\nResponse should have other objects referring to this object\nResponse should have deleted and disabled objects referred by this object.",
+            "description": "The format in which the configuration object is to be fetched. This could be for example\n - in GetSpec form for the contents of object\n - in CreateRequest form to create a new similar object\n - to ReplaceRequest form to replace changeable values\n\nDefault format of returned resource\nResponse should be in CreateRequest format\nResponse should be in ReplaceRequest format\nResponse should be in StatusObject(s) format\nResponse should be in format of GetSpecType\nResponse should have other objects referring to this object\nResponse should have deleted and disabled objects referrred by this object.",
             "in": "query",
             "required": false,
             "x-displayname": "Broken Referred Objects.",
@@ -13307,7 +13307,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:35.234073+00:00"
+                "validatedAt": "2026-07-20T14:36:51.142983+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13342,7 +13342,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:35.234129+00:00"
+                "validatedAt": "2026-07-20T14:36:51.143011+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13385,7 +13385,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:35.234197+00:00"
+                "validatedAt": "2026-07-20T14:36:51.143035+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13580,7 +13580,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:35.234266+00:00"
+                "validatedAt": "2026-07-20T14:36:51.143058+00:00"
               },
               "deterministic": true
             },
@@ -13592,9 +13592,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.851843+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.424672+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -13626,7 +13625,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:35.234309+00:00"
+                "validatedAt": "2026-07-20T14:36:51.143074+00:00"
               },
               "deterministic": true
             },
@@ -13638,9 +13637,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.851864+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.424686+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -13971,7 +13969,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.851934+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.424728+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -14058,7 +14056,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:35.234484+00:00"
+                "validatedAt": "2026-07-20T14:36:51.143127+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14093,7 +14091,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:35.234532+00:00"
+                "validatedAt": "2026-07-20T14:36:51.143150+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14136,7 +14134,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:35.234577+00:00"
+                "validatedAt": "2026-07-20T14:36:51.143172+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14237,7 +14235,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:58:35.234637+00:00"
+                "validatedAt": "2026-07-20T14:36:51.143197+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14318,7 +14316,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:58:35.234710+00:00"
+                "validatedAt": "2026-07-20T14:36:51.143223+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14329,7 +14327,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.852014+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.424775+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -14416,7 +14414,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:35.234753+00:00"
+                "validatedAt": "2026-07-20T14:36:51.143242+00:00"
               },
               "deterministic": true
             },
@@ -14428,9 +14426,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.852060+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.424804+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -14461,7 +14458,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:35.234780+00:00"
+                "validatedAt": "2026-07-20T14:36:51.143256+00:00"
               },
               "deterministic": true
             },
@@ -14473,9 +14470,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.852078+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.424816+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -14544,7 +14540,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:35.234834+00:00"
+                "validatedAt": "2026-07-20T14:36:51.143277+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14556,7 +14552,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.852116+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.424842+00:00"
           },
           "uid": {
             "type": "string",
@@ -14574,7 +14570,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:35.234861+00:00"
+                "validatedAt": "2026-07-20T14:36:51.143289+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14587,7 +14583,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.852136+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.424856+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of dns_compliance_checks is returned in 'List'.",
@@ -14764,7 +14760,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:35.234920+00:00"
+                "validatedAt": "2026-07-20T14:36:51.143316+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14799,7 +14795,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:35.234968+00:00"
+                "validatedAt": "2026-07-20T14:36:51.143340+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14842,7 +14838,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:35.235012+00:00"
+                "validatedAt": "2026-07-20T14:36:51.143362+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15010,7 +15006,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:35.235081+00:00"
+                "validatedAt": "2026-07-20T14:36:51.143389+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15022,7 +15018,7 @@
             "readOnly": true,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.852219+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.424907+00:00"
           },
           "name": {
             "type": "string",
@@ -15055,7 +15051,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:35.235111+00:00"
+                "validatedAt": "2026-07-20T14:36:51.143402+00:00"
               },
               "deterministic": true
             },
@@ -15067,9 +15063,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.852239+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.424920+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -15102,7 +15097,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:35.235137+00:00"
+                "validatedAt": "2026-07-20T14:36:51.143416+00:00"
               },
               "deterministic": true
             },
@@ -15114,9 +15109,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.852257+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.424932+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -15135,7 +15129,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:35.235171+00:00"
+                "validatedAt": "2026-07-20T14:36:51.143429+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15148,7 +15142,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.852276+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.424945+00:00"
           },
           "uid": {
             "type": "string",
@@ -15167,7 +15161,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:35.235196+00:00"
+                "validatedAt": "2026-07-20T14:36:51.143440+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15181,7 +15175,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.852295+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.424957+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -15237,7 +15231,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:35.235233+00:00"
+                "validatedAt": "2026-07-20T14:36:51.143455+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15260,7 +15254,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:35.235267+00:00"
+                "validatedAt": "2026-07-20T14:36:51.143469+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15271,7 +15265,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.852323+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.424975+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -15335,7 +15329,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T12:58:35.235301+00:00"
+                "validatedAt": "2026-07-20T14:36:51.143485+00:00"
               },
               "deterministic": true
             },
@@ -15346,8 +15340,7 @@
               "read": false
             },
             "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "minLength": 1,
-            "format": "fqdn"
+            "minLength": 1
           },
           "last_update_time": {
             "type": "string",
@@ -15364,7 +15357,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:35.235344+00:00"
+                "validatedAt": "2026-07-20T14:36:51.143502+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15391,7 +15384,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:35.235378+00:00"
+                "validatedAt": "2026-07-20T14:36:51.143517+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15402,7 +15395,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.852358+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.424997+00:00"
           },
           "service_name": {
             "type": "string",
@@ -15419,7 +15412,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:35.235417+00:00"
+                "validatedAt": "2026-07-20T14:36:51.143533+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15452,7 +15445,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:35.235458+00:00"
+                "validatedAt": "2026-07-20T14:36:51.143549+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15463,7 +15456,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.852383+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.425014+00:00"
           },
           "type": {
             "type": "string",
@@ -15488,7 +15481,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:35.235492+00:00"
+                "validatedAt": "2026-07-20T14:36:51.143563+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15632,7 +15625,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:35.235533+00:00"
+                "validatedAt": "2026-07-20T14:36:51.143579+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15712,7 +15705,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:35.235563+00:00"
+                "validatedAt": "2026-07-20T14:36:51.143593+00:00"
               },
               "deterministic": true
             },
@@ -15724,9 +15717,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.852433+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.425044+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -15890,7 +15882,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:35.235664+00:00"
+                "validatedAt": "2026-07-20T14:36:51.143636+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -15905,7 +15897,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.852475+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.425071+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -15975,7 +15967,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:35.235705+00:00"
+                "validatedAt": "2026-07-20T14:36:51.143654+00:00"
               },
               "deterministic": true
             },
@@ -15987,9 +15979,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.852509+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.425092+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -16022,7 +16013,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:35.235732+00:00"
+                "validatedAt": "2026-07-20T14:36:51.143667+00:00"
               },
               "deterministic": true
             },
@@ -16034,9 +16025,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.852527+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.425104+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -16136,7 +16126,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:35.235806+00:00"
+                "validatedAt": "2026-07-20T14:36:51.143702+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -16151,7 +16141,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.852555+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.425122+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -16223,7 +16213,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:35.235843+00:00"
+                "validatedAt": "2026-07-20T14:36:51.143720+00:00"
               },
               "deterministic": true
             },
@@ -16235,9 +16225,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.852588+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.425142+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -16270,7 +16259,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:35.235869+00:00"
+                "validatedAt": "2026-07-20T14:36:51.143733+00:00"
               },
               "deterministic": true
             },
@@ -16282,9 +16271,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.852607+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.425155+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -16384,7 +16372,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:35.235941+00:00"
+                "validatedAt": "2026-07-20T14:36:51.143769+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -16399,7 +16387,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.852635+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.425173+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -16469,7 +16457,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:35.235977+00:00"
+                "validatedAt": "2026-07-20T14:36:51.143787+00:00"
               },
               "deterministic": true
             },
@@ -16481,9 +16469,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.852677+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.425194+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -16516,7 +16503,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:35.236003+00:00"
+                "validatedAt": "2026-07-20T14:36:51.143800+00:00"
               },
               "deterministic": true
             },
@@ -16528,9 +16515,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.852696+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.425206+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -16593,7 +16579,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:35.236047+00:00"
+                "validatedAt": "2026-07-20T14:36:51.143818+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16621,7 +16607,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:35.236086+00:00"
+                "validatedAt": "2026-07-20T14:36:51.143835+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16649,7 +16635,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:35.236124+00:00"
+                "validatedAt": "2026-07-20T14:36:51.143850+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16688,7 +16674,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:35.236164+00:00"
+                "validatedAt": "2026-07-20T14:36:51.143866+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16715,7 +16701,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:35.236190+00:00"
+                "validatedAt": "2026-07-20T14:36:51.143877+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16728,7 +16714,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.852751+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.425240+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -16744,7 +16730,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:35.236224+00:00"
+                "validatedAt": "2026-07-20T14:36:51.143891+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16889,7 +16875,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:35.236274+00:00"
+                "validatedAt": "2026-07-20T14:36:51.143911+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16900,7 +16886,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.852793+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.425265+00:00"
           },
           "status": {
             "type": "string",
@@ -16918,7 +16904,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:35.236308+00:00"
+                "validatedAt": "2026-07-20T14:36:51.143924+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16929,7 +16915,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.852811+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.425277+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -16989,7 +16975,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:35.236350+00:00"
+                "validatedAt": "2026-07-20T14:36:51.143941+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17016,7 +17002,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:35.236390+00:00"
+                "validatedAt": "2026-07-20T14:36:51.143957+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17043,7 +17029,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:35.236426+00:00"
+                "validatedAt": "2026-07-20T14:36:51.143972+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17071,7 +17057,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:35.236468+00:00"
+                "validatedAt": "2026-07-20T14:36:51.143989+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17147,7 +17133,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:35.236531+00:00"
+                "validatedAt": "2026-07-20T14:36:51.144015+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17215,7 +17201,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:35.236582+00:00"
+                "validatedAt": "2026-07-20T14:36:51.144036+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17227,7 +17213,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.852899+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.425330+00:00"
           },
           "uid": {
             "type": "string",
@@ -17246,7 +17232,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:35.236607+00:00"
+                "validatedAt": "2026-07-20T14:36:51.144047+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17259,7 +17245,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.852918+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.425343+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -17327,7 +17313,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:35.236639+00:00"
+                "validatedAt": "2026-07-20T14:36:51.144059+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17338,7 +17324,7 @@
             },
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.852939+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.425356+00:00"
           },
           "name": {
             "type": "string",
@@ -17371,7 +17357,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:35.236674+00:00"
+                "validatedAt": "2026-07-20T14:36:51.144073+00:00"
               },
               "deterministic": true
             },
@@ -17383,9 +17369,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.852957+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.425368+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -17418,7 +17403,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:35.236702+00:00"
+                "validatedAt": "2026-07-20T14:36:51.144086+00:00"
               },
               "deterministic": true
             },
@@ -17430,9 +17415,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.852975+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.425380+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "uid": {
             "type": "string",
@@ -17449,7 +17433,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:35.236728+00:00"
+                "validatedAt": "2026-07-20T14:36:51.144097+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17462,7 +17446,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.852994+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.425392+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -17549,7 +17533,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:35.236783+00:00"
+                "validatedAt": "2026-07-20T14:36:51.144125+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -17564,9 +17548,8 @@
               "read": false
             },
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.001238+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.518451+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -17605,7 +17588,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:35.236829+00:00"
+                "validatedAt": "2026-07-20T14:36:51.144150+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -17620,9 +17603,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.853022+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.425410+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -17651,7 +17633,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:35.236881+00:00"
+                "validatedAt": "2026-07-20T14:36:51.144176+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17664,7 +17646,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.853041+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.425423+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a direct reference from one object(the referrer) to another(the referred).",
@@ -17984,7 +17966,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:08.258623+00:00"
+                "validatedAt": "2026-07-20T14:37:04.710706+00:00"
               },
               "deterministic": true
             },
@@ -17996,9 +17978,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.818056+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:13.320831+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -18030,7 +18011,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:08.258685+00:00"
+                "validatedAt": "2026-07-20T14:37:04.710724+00:00"
               },
               "deterministic": true
             },
@@ -18042,9 +18023,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.818076+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:13.320843+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -18207,7 +18187,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.818143+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:13.320880+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -18393,7 +18373,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:08.258898+00:00"
+                "validatedAt": "2026-07-20T14:37:04.710783+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18460,7 +18440,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T12:59:08.258962+00:00"
+                "validatedAt": "2026-07-20T14:37:04.710809+00:00"
               },
               "deterministic": true
             },
@@ -18501,7 +18481,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T12:59:08.258994+00:00"
+                "validatedAt": "2026-07-20T14:37:04.710824+00:00"
               },
               "deterministic": true
             },
@@ -18666,7 +18646,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:59:08.259061+00:00"
+                "validatedAt": "2026-07-20T14:37:04.710851+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18744,7 +18724,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:59:08.259120+00:00"
+                "validatedAt": "2026-07-20T14:37:04.710874+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18755,7 +18735,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.818257+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:13.320986+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -18842,7 +18822,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:08.259162+00:00"
+                "validatedAt": "2026-07-20T14:37:04.710894+00:00"
               },
               "deterministic": true
             },
@@ -18854,9 +18834,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.818303+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:13.321094+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -18887,7 +18866,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:08.259190+00:00"
+                "validatedAt": "2026-07-20T14:37:04.710907+00:00"
               },
               "deterministic": true
             },
@@ -18899,9 +18878,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.818321+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:13.321149+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -18970,7 +18948,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:08.259246+00:00"
+                "validatedAt": "2026-07-20T14:37:04.710928+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18982,7 +18960,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.818359+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:13.321226+00:00"
           },
           "uid": {
             "type": "string",
@@ -18999,7 +18977,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:08.259272+00:00"
+                "validatedAt": "2026-07-20T14:37:04.710938+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19012,7 +18990,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.818379+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:13.321249+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of dns_proxy is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -19112,7 +19090,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:08.259327+00:00"
+                "validatedAt": "2026-07-20T14:37:04.710972+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19682,7 +19660,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:08.259456+00:00"
+                "validatedAt": "2026-07-20T14:37:04.711027+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19722,7 +19700,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:08.259517+00:00"
+                "validatedAt": "2026-07-20T14:37:04.711056+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19833,7 +19811,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:08.259587+00:00"
+                "validatedAt": "2026-07-20T14:37:04.711087+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19868,7 +19846,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:08.259646+00:00"
+                "validatedAt": "2026-07-20T14:37:04.711113+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20028,7 +20006,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:08.259868+00:00"
+                "validatedAt": "2026-07-20T14:37:04.711199+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20152,7 +20130,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:08.259925+00:00"
+                "validatedAt": "2026-07-20T14:37:04.711226+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20242,7 +20220,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:08.259986+00:00"
+                "validatedAt": "2026-07-20T14:37:04.711255+00:00"
               },
               "deterministic": true
             },
@@ -20252,8 +20230,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "format": "hostname"
+            "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$"
           },
           "refresh_interval": {
             "type": "integer",
@@ -20413,7 +20390,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:08.261564+00:00"
+                "validatedAt": "2026-07-20T14:37:04.711899+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20606,7 +20583,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:08.261628+00:00"
+                "validatedAt": "2026-07-20T14:37:04.711928+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20919,7 +20896,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:08.261716+00:00"
+                "validatedAt": "2026-07-20T14:37:04.711961+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21072,7 +21049,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:08.261926+00:00"
+                "validatedAt": "2026-07-20T14:37:04.712065+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21155,7 +21132,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:08.261971+00:00"
+                "validatedAt": "2026-07-20T14:37:04.712088+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21297,7 +21274,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:08.262017+00:00"
+                "validatedAt": "2026-07-20T14:37:04.712111+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21621,7 +21598,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:08.262076+00:00"
+                "validatedAt": "2026-07-20T14:37:04.712137+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21764,7 +21741,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:08.262119+00:00"
+                "validatedAt": "2026-07-20T14:37:04.712158+00:00"
               },
               "deterministic": true
             },
@@ -21811,7 +21788,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:08.262182+00:00"
+                "validatedAt": "2026-07-20T14:37:04.712187+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22165,7 +22142,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:08.262271+00:00"
+                "validatedAt": "2026-07-20T14:37:04.712224+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22200,7 +22177,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:08.262327+00:00"
+                "validatedAt": "2026-07-20T14:37:04.712250+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22381,7 +22358,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:08.262382+00:00"
+                "validatedAt": "2026-07-20T14:37:04.712275+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23011,7 +22988,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:56.035153+00:00"
+                "validatedAt": "2026-07-20T14:37:23.509182+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23034,7 +23011,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:56.035212+00:00"
+                "validatedAt": "2026-07-20T14:37:23.509205+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23057,7 +23034,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:56.035273+00:00"
+                "validatedAt": "2026-07-20T14:37:23.509223+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23080,7 +23057,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:56.035320+00:00"
+                "validatedAt": "2026-07-20T14:37:23.509237+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23103,7 +23080,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:56.035374+00:00"
+                "validatedAt": "2026-07-20T14:37:23.509251+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23149,7 +23126,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T12:59:56.035460+00:00"
+                "validatedAt": "2026-07-20T14:37:23.509278+00:00"
               },
               "deterministic": true
             },
@@ -23260,7 +23237,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:56.035544+00:00"
+                "validatedAt": "2026-07-20T14:37:23.509301+00:00"
               },
               "deterministic": true
             },
@@ -23272,9 +23249,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.000029+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.517685+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -23306,7 +23282,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:56.035574+00:00"
+                "validatedAt": "2026-07-20T14:37:23.509315+00:00"
               },
               "deterministic": true
             },
@@ -23318,9 +23294,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.000049+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.517698+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -23483,7 +23458,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.000117+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.517739+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -23571,7 +23546,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:56.035696+00:00"
+                "validatedAt": "2026-07-20T14:37:23.509358+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23583,7 +23558,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.000152+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.517761+00:00"
           },
           "txt_record": {
             "type": "string",
@@ -23598,7 +23573,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:56.035736+00:00"
+                "validatedAt": "2026-07-20T14:37:23.509375+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23697,7 +23672,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:59:56.035787+00:00"
+                "validatedAt": "2026-07-20T14:37:23.509398+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23776,7 +23751,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:59:56.035843+00:00"
+                "validatedAt": "2026-07-20T14:37:23.509422+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23787,7 +23762,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.000210+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.517796+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -23874,7 +23849,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:56.035884+00:00"
+                "validatedAt": "2026-07-20T14:37:23.509440+00:00"
               },
               "deterministic": true
             },
@@ -23886,9 +23861,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.000256+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.517824+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -23919,7 +23893,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:56.035913+00:00"
+                "validatedAt": "2026-07-20T14:37:23.509454+00:00"
               },
               "deterministic": true
             },
@@ -23931,9 +23905,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.000274+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.517837+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -24002,7 +23975,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:56.035966+00:00"
+                "validatedAt": "2026-07-20T14:37:23.509474+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24014,7 +23987,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.000312+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.517860+00:00"
           },
           "uid": {
             "type": "string",
@@ -24031,7 +24004,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:56.035992+00:00"
+                "validatedAt": "2026-07-20T14:37:23.509485+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24044,7 +24017,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.000332+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.517873+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of dns_domain is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -24385,7 +24358,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:56.036070+00:00"
+                "validatedAt": "2026-07-20T14:37:23.509517+00:00"
               },
               "deterministic": true
             },
@@ -24397,9 +24370,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.000409+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.517919+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -24431,7 +24403,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:56.036098+00:00"
+                "validatedAt": "2026-07-20T14:37:23.509531+00:00"
               },
               "deterministic": true
             },
@@ -24443,9 +24415,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.000427+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.517932+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -24711,7 +24682,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:59:58.201389+00:00"
+                "validatedAt": "2026-07-20T14:37:24.361564+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24805,7 +24776,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:58.201452+00:00"
+                "validatedAt": "2026-07-20T14:37:24.361593+00:00"
               },
               "deterministic": true
             },
@@ -24817,9 +24788,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.036981+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.563134+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "status": {
             "type": "array",
@@ -24839,7 +24809,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.037003+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.563149+00:00"
           }
         },
         "x-f5xc-description-short": "Individual item in a collection of DNS Load Balancer.",
@@ -24913,7 +24883,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.037032+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.563167+00:00"
           }
         },
         "x-f5xc-description-short": "Response for DNS Load Balancer Health Status Request.",
@@ -24985,7 +24955,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:58.201557+00:00"
+                "validatedAt": "2026-07-20T14:37:24.361634+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25024,7 +24994,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:58.201587+00:00"
+                "validatedAt": "2026-07-20T14:37:24.361649+00:00"
               },
               "deterministic": true
             },
@@ -25036,9 +25006,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.037066+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.563188+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "status": {
             "type": "array",
@@ -25059,7 +25028,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.037086+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.563202+00:00"
           }
         },
         "x-f5xc-description-short": "Individual item in a collection of DNS Load Balancer Pool.",
@@ -25136,7 +25105,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.037113+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.563219+00:00"
           }
         },
         "x-f5xc-description-short": "Response for DNS Load Balancer Pool Health Status Request.",
@@ -25205,7 +25174,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:58.201702+00:00"
+                "validatedAt": "2026-07-20T14:37:24.361683+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25230,7 +25199,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:58.201748+00:00"
+                "validatedAt": "2026-07-20T14:37:24.361702+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25258,7 +25227,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.037155+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.563245+00:00"
           }
         },
         "x-f5xc-description-short": "Pool member health status change event data.",
@@ -25319,7 +25288,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:59:58.201791+00:00"
+                "validatedAt": "2026-07-20T14:37:24.361721+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25382,7 +25351,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:58.201836+00:00"
+                "validatedAt": "2026-07-20T14:37:24.361738+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25407,7 +25376,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:58.201881+00:00"
+                "validatedAt": "2026-07-20T14:37:24.361755+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25446,7 +25415,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:58.201927+00:00"
+                "validatedAt": "2026-07-20T14:37:24.361774+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25472,7 +25441,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:58.201969+00:00"
+                "validatedAt": "2026-07-20T14:37:24.361792+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25525,7 +25494,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:58.202000+00:00"
+                "validatedAt": "2026-07-20T14:37:24.361807+00:00"
               },
               "deterministic": true
             },
@@ -25537,9 +25506,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.037222+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.563286+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "ports": {
             "type": "array",
@@ -25568,7 +25536,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:58.202052+00:00"
+                "validatedAt": "2026-07-20T14:37:24.361833+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25597,7 +25565,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.037249+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.563303+00:00"
           },
           "unhealthy_ports": {
             "type": "array",
@@ -25625,7 +25593,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:58.202108+00:00"
+                "validatedAt": "2026-07-20T14:37:24.361861+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25778,7 +25746,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:58.202164+00:00"
+                "validatedAt": "2026-07-20T14:37:24.361884+00:00"
               },
               "deterministic": true
             },
@@ -25790,9 +25758,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.037290+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.563329+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -25824,7 +25791,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:58.202193+00:00"
+                "validatedAt": "2026-07-20T14:37:24.361899+00:00"
               },
               "deterministic": true
             },
@@ -25836,9 +25803,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.037309+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.563342+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -26001,7 +25967,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.037376+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.563382+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -26134,7 +26100,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.037411+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.563404+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -26208,7 +26174,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:59:58.202320+00:00"
+                "validatedAt": "2026-07-20T14:37:24.361950+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26287,7 +26253,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:59:58.202375+00:00"
+                "validatedAt": "2026-07-20T14:37:24.361975+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26298,7 +26264,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.037456+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.563431+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -26385,7 +26351,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:58.202416+00:00"
+                "validatedAt": "2026-07-20T14:37:24.361994+00:00"
               },
               "deterministic": true
             },
@@ -26397,9 +26363,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.037502+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.563462+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -26430,7 +26395,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:58.202443+00:00"
+                "validatedAt": "2026-07-20T14:37:24.362008+00:00"
               },
               "deterministic": true
             },
@@ -26442,9 +26407,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.037520+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.563474+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -26513,7 +26477,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:58.202496+00:00"
+                "validatedAt": "2026-07-20T14:37:24.362029+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26525,7 +26489,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.037558+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.563498+00:00"
           },
           "uid": {
             "type": "string",
@@ -26543,7 +26507,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:58.202522+00:00"
+                "validatedAt": "2026-07-20T14:37:24.362041+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26556,7 +26520,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.037577+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.563511+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of dns_load_balancer is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -26867,7 +26831,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:58.202620+00:00"
+                "validatedAt": "2026-07-20T14:37:24.362087+00:00"
               },
               "deterministic": true
             },
@@ -27272,7 +27236,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:58.202765+00:00"
+                "validatedAt": "2026-07-20T14:37:24.362144+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27306,7 +27270,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:58.202826+00:00"
+                "validatedAt": "2026-07-20T14:37:24.362173+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27346,7 +27310,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:58.202858+00:00"
+                "validatedAt": "2026-07-20T14:37:24.362188+00:00"
               },
               "deterministic": true
             },
@@ -27358,9 +27322,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.037739+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.563602+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "request_body": {
             "allOf": [
@@ -27500,7 +27463,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:58.203052+00:00"
+                "validatedAt": "2026-07-20T14:37:24.362279+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27577,7 +27540,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:58.203095+00:00"
+                "validatedAt": "2026-07-20T14:37:24.362313+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27666,7 +27629,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:58.203145+00:00"
+                "validatedAt": "2026-07-20T14:37:24.362338+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27762,7 +27725,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:58.203196+00:00"
+                "validatedAt": "2026-07-20T14:37:24.362364+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27945,7 +27908,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:58.203620+00:00"
+                "validatedAt": "2026-07-20T14:37:24.362563+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28037,7 +28000,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:58.203676+00:00"
+                "validatedAt": "2026-07-20T14:37:24.362583+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28048,7 +28011,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.038077+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.563814+00:00"
           }
         },
         "x-f5xc-description-short": "Metric data contains timestamp and the value.",
@@ -28152,7 +28115,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:59:58.204744+00:00"
+                "validatedAt": "2026-07-20T14:37:24.363056+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28163,7 +28126,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.038548+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.564116+00:00"
           },
           "previous_value": {
             "type": "string",
@@ -28181,7 +28144,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:58.204783+00:00"
+                "validatedAt": "2026-07-20T14:37:24.363073+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28219,7 +28182,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:58.204817+00:00"
+                "validatedAt": "2026-07-20T14:37:24.363086+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28230,7 +28193,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.038579+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.564136+00:00"
           }
         },
         "x-f5xc-description-short": "Trend value contains trend value, trend sentiment and trend calculation description and window size.",
@@ -28798,7 +28761,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:59:58.205043+00:00"
+                "validatedAt": "2026-07-20T14:37:24.363183+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28863,7 +28826,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:59:58.205088+00:00"
+                "validatedAt": "2026-07-20T14:37:24.363204+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28874,7 +28837,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.038802+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.564267+00:00"
           },
           "ref_value": {
             "allOf": [
@@ -28916,7 +28879,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:58.205127+00:00"
+                "validatedAt": "2026-07-20T14:37:24.363220+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29330,7 +29293,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:04.004891+00:00"
+                "validatedAt": "2026-07-20T14:37:26.591708+00:00"
               },
               "deterministic": true
             },
@@ -29342,9 +29305,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.135380+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.692135+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -29376,7 +29338,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:04.004927+00:00"
+                "validatedAt": "2026-07-20T14:37:26.591726+00:00"
               },
               "deterministic": true
             },
@@ -29388,9 +29350,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.135401+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.692148+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -29553,7 +29514,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.135468+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.692190+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -29876,7 +29837,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:04.005244+00:00"
+                "validatedAt": "2026-07-20T14:37:26.591819+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29908,7 +29869,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:04.005298+00:00"
+                "validatedAt": "2026-07-20T14:37:26.591845+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29957,7 +29918,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:28.937306+00:00"
+                "validatedAt": "2026-07-20T14:37:36.546511+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30045,7 +30006,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:00:04.005345+00:00"
+                "validatedAt": "2026-07-20T14:37:26.591867+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30124,7 +30085,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:00:04.005405+00:00"
+                "validatedAt": "2026-07-20T14:37:26.591893+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30135,7 +30096,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.135594+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.692265+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -30222,7 +30183,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:04.005449+00:00"
+                "validatedAt": "2026-07-20T14:37:26.591912+00:00"
               },
               "deterministic": true
             },
@@ -30234,9 +30195,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.135641+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.692293+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -30267,7 +30227,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:04.005477+00:00"
+                "validatedAt": "2026-07-20T14:37:26.591926+00:00"
               },
               "deterministic": true
             },
@@ -30279,9 +30239,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.135667+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.692306+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -30350,7 +30309,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:04.005529+00:00"
+                "validatedAt": "2026-07-20T14:37:26.591947+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30362,7 +30321,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.135706+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.692329+00:00"
           },
           "uid": {
             "type": "string",
@@ -30380,7 +30339,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:04.005556+00:00"
+                "validatedAt": "2026-07-20T14:37:26.591959+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30393,7 +30352,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.135726+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.692342+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of dns_lb_health_check is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -30868,7 +30827,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:04.005721+00:00"
+                "validatedAt": "2026-07-20T14:37:26.592021+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30901,7 +30860,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:04.005772+00:00"
+                "validatedAt": "2026-07-20T14:37:26.592051+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31028,7 +30987,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:04.005866+00:00"
+                "validatedAt": "2026-07-20T14:37:26.592093+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31064,7 +31023,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:04.005918+00:00"
+                "validatedAt": "2026-07-20T14:37:26.592120+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31196,7 +31155,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:04.006013+00:00"
+                "validatedAt": "2026-07-20T14:37:26.592164+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31234,7 +31193,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:04.006066+00:00"
+                "validatedAt": "2026-07-20T14:37:26.592189+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31341,7 +31300,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:07.994217+00:00"
+                "validatedAt": "2026-07-20T14:37:28.138087+00:00"
               },
               "deterministic": true
             },
@@ -31494,7 +31453,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:07.994349+00:00"
+                "validatedAt": "2026-07-20T14:37:28.138129+00:00"
               },
               "deterministic": true
             },
@@ -31587,7 +31546,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:07.994450+00:00"
+                "validatedAt": "2026-07-20T14:37:28.138162+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31632,7 +31591,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:07.994510+00:00"
+                "validatedAt": "2026-07-20T14:37:28.138192+00:00"
               },
               "deterministic": true
             },
@@ -31644,9 +31603,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.198548+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.755982+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "priority": {
             "type": "integer",
@@ -31674,7 +31632,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:00:07.994549+00:00"
+                "validatedAt": "2026-07-20T14:37:28.138210+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31776,7 +31734,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:07.994624+00:00"
+                "validatedAt": "2026-07-20T14:37:28.138243+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31788,7 +31746,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.198585+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.756005+00:00"
           },
           "final_translation": {
             "type": "boolean",
@@ -31839,7 +31797,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:07.994694+00:00"
+                "validatedAt": "2026-07-20T14:37:28.138270+00:00"
               },
               "deterministic": true
             },
@@ -31851,9 +31809,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.198612+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.756022+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "ratio": {
             "type": "integer",
@@ -31949,7 +31906,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:07.994766+00:00"
+                "validatedAt": "2026-07-20T14:37:28.138303+00:00"
               },
               "deterministic": true
             },
@@ -32434,7 +32391,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:07.994853+00:00"
+                "validatedAt": "2026-07-20T14:37:28.138337+00:00"
               },
               "deterministic": true
             },
@@ -32446,9 +32403,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.198752+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.756100+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -32480,7 +32436,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:07.994882+00:00"
+                "validatedAt": "2026-07-20T14:37:28.138351+00:00"
               },
               "deterministic": true
             },
@@ -32492,9 +32448,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.198771+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.756113+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -32657,7 +32612,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.198838+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.756154+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -32966,7 +32921,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:00:07.995040+00:00"
+                "validatedAt": "2026-07-20T14:37:28.138412+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33045,7 +33000,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:00:07.995094+00:00"
+                "validatedAt": "2026-07-20T14:37:28.138434+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33056,7 +33011,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.198950+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.756221+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -33143,7 +33098,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:07.995134+00:00"
+                "validatedAt": "2026-07-20T14:37:28.138452+00:00"
               },
               "deterministic": true
             },
@@ -33155,9 +33110,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.198996+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.756250+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -33188,7 +33142,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:07.995161+00:00"
+                "validatedAt": "2026-07-20T14:37:28.138464+00:00"
               },
               "deterministic": true
             },
@@ -33200,9 +33154,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.199014+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.756262+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -33271,7 +33224,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:07.995215+00:00"
+                "validatedAt": "2026-07-20T14:37:28.138484+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33283,7 +33236,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.199052+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.756286+00:00"
           },
           "uid": {
             "type": "string",
@@ -33300,7 +33253,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:07.995242+00:00"
+                "validatedAt": "2026-07-20T14:37:28.138494+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33313,7 +33266,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.199072+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.756299+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of dns_lb_pool is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -33433,7 +33386,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:07.995298+00:00"
+                "validatedAt": "2026-07-20T14:37:28.138521+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33445,7 +33398,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.199094+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.756313+00:00"
           },
           "name": {
             "type": "string",
@@ -33482,7 +33435,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:07.995351+00:00"
+                "validatedAt": "2026-07-20T14:37:28.138547+00:00"
               },
               "deterministic": true
             },
@@ -33494,9 +33447,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.199112+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.756325+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "priority": {
             "type": "integer",
@@ -33523,7 +33475,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:00:07.995384+00:00"
+                "validatedAt": "2026-07-20T14:37:28.138561+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33654,7 +33606,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:07.995468+00:00"
+                "validatedAt": "2026-07-20T14:37:28.138600+00:00"
               },
               "deterministic": true
             },
@@ -34045,7 +33997,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:07.995562+00:00"
+                "validatedAt": "2026-07-20T14:37:28.138641+00:00"
               },
               "deterministic": true
             },
@@ -34057,9 +34009,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.199235+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.756399+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "port": {
             "type": "integer",
@@ -34092,7 +34043,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:07.995590+00:00"
+                "validatedAt": "2026-07-20T14:37:28.138654+00:00"
               },
               "deterministic": true
             },
@@ -34132,7 +34083,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:00:07.995622+00:00"
+                "validatedAt": "2026-07-20T14:37:28.138670+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34192,7 +34143,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:07.995712+00:00"
+                "validatedAt": "2026-07-20T14:37:28.138708+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34231,7 +34182,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:00:07.995747+00:00"
+                "validatedAt": "2026-07-20T14:37:28.138723+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34342,7 +34293,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:07.995823+00:00"
+                "validatedAt": "2026-07-20T14:37:28.138757+00:00"
               },
               "deterministic": true
             },
@@ -34543,7 +34494,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.980162+00:00"
+                "validatedAt": "2026-07-20T14:37:31.920637+00:00"
               },
               "deterministic": true
             },
@@ -34554,8 +34505,7 @@
               "read": false
             },
             "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "minLength": 1,
-            "format": "hostname"
+            "minLength": 1
           },
           "subtype": {
             "allOf": [
@@ -34743,7 +34693,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.980305+00:00"
+                "validatedAt": "2026-07-20T14:37:31.920693+00:00"
               },
               "deterministic": true
             },
@@ -34830,7 +34780,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.980396+00:00"
+                "validatedAt": "2026-07-20T14:37:31.920729+00:00"
               },
               "deterministic": true
             },
@@ -34842,9 +34792,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.373889+00:00",
-            "pattern": "^([a-zA-Z0-9*?]|([a-zA-Z0-9?*]+-[a-zA-Z0-9*?]+)){0,253}",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.931355+00:00",
+            "pattern": "^([a-zA-Z0-9*?]|([a-zA-Z0-9?*]+-[a-zA-Z0-9*?]+)){0,253}"
           },
           "values": {
             "type": "array",
@@ -34878,7 +34827,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.980473+00:00"
+                "validatedAt": "2026-07-20T14:37:31.920753+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35017,7 +34966,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:16.980541+00:00"
+                "validatedAt": "2026-07-20T14:37:31.920772+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35053,7 +35002,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.980600+00:00"
+                "validatedAt": "2026-07-20T14:37:31.920800+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35115,7 +35064,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:16.980637+00:00"
+                "validatedAt": "2026-07-20T14:37:31.920817+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35127,7 +35076,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.373945+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.931387+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -35505,7 +35454,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.980768+00:00"
+                "validatedAt": "2026-07-20T14:37:31.920869+00:00"
               },
               "deterministic": true
             },
@@ -35517,9 +35466,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.374035+00:00",
-            "pattern": "^$|^([*]|[a-zA-Z0-9-/_]{1,63})([.][a-zA-Z0-9-/_]{1,63})*$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.931437+00:00",
+            "pattern": "^$|^([*]|[a-zA-Z0-9-/_]{1,63})([.][a-zA-Z0-9-/_]{1,63})*$"
           },
           "values": {
             "type": "array",
@@ -35558,7 +35506,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.980812+00:00"
+                "validatedAt": "2026-07-20T14:37:31.920895+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35642,7 +35590,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.980871+00:00"
+                "validatedAt": "2026-07-20T14:37:31.920927+00:00"
               },
               "deterministic": true
             },
@@ -35654,9 +35602,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.374063+00:00",
-            "pattern": "^([a-zA-Z0-9*?]|([a-zA-Z0-9?*]+-[a-zA-Z0-9*?]+)){0,253}",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.931454+00:00",
+            "pattern": "^([a-zA-Z0-9*?]|([a-zA-Z0-9?*]+-[a-zA-Z0-9*?]+)){0,253}"
           },
           "values": {
             "type": "array",
@@ -35690,7 +35637,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.980912+00:00"
+                "validatedAt": "2026-07-20T14:37:31.920948+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35773,7 +35720,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.980970+00:00"
+                "validatedAt": "2026-07-20T14:37:31.920980+00:00"
               },
               "deterministic": true
             },
@@ -35785,9 +35732,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.374090+00:00",
-            "pattern": "^$|^([*]|[a-zA-Z0-9-/_]{1,63})([.][a-zA-Z0-9-/_]{1,63})*$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.931471+00:00",
+            "pattern": "^$|^([*]|[a-zA-Z0-9-/_]{1,63})([.][a-zA-Z0-9-/_]{1,63})*$"
           },
           "values": {
             "type": "array",
@@ -35826,7 +35772,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.981013+00:00"
+                "validatedAt": "2026-07-20T14:37:31.921001+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35897,7 +35843,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.981067+00:00"
+                "validatedAt": "2026-07-20T14:37:31.921027+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35908,8 +35854,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.374118+00:00",
-            "format": "hostname"
+            "x-reconciled-at": "2026-07-20T14:42:14.931488+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -35982,7 +35927,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.981124+00:00"
+                "validatedAt": "2026-07-20T14:37:31.921059+00:00"
               },
               "deterministic": true
             },
@@ -35994,9 +35939,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.374138+00:00",
-            "pattern": "^$|^([*]|[a-zA-Z0-9-/_]{1,63})([.][a-zA-Z0-9-/_]{1,63})*$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.931500+00:00",
+            "pattern": "^$|^([*]|[a-zA-Z0-9-/_]{1,63})([.][a-zA-Z0-9-/_]{1,63})*$"
           },
           "values": {
             "type": "array",
@@ -36021,7 +35965,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.981165+00:00"
+                "validatedAt": "2026-07-20T14:37:31.921080+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36104,7 +36048,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.981220+00:00"
+                "validatedAt": "2026-07-20T14:37:31.921111+00:00"
               },
               "deterministic": true
             },
@@ -36116,9 +36060,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.374166+00:00",
-            "pattern": "^([a-zA-Z0-9*?]|([a-zA-Z0-9?*]+-[a-zA-Z0-9*?]+)){0,253}",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.931517+00:00",
+            "pattern": "^([a-zA-Z0-9*?]|([a-zA-Z0-9?*]+-[a-zA-Z0-9*?]+)){0,253}"
           },
           "values": {
             "type": "array",
@@ -36150,7 +36093,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.981262+00:00"
+                "validatedAt": "2026-07-20T14:37:31.921133+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36236,7 +36179,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.981320+00:00"
+                "validatedAt": "2026-07-20T14:37:31.921165+00:00"
               },
               "deterministic": true
             },
@@ -36248,9 +36191,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.374194+00:00",
-            "pattern": "^([*]|[a-zA-Z0-9-/_]{1,63})([.][a-zA-Z0-9-/_]{1,63})*$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.931534+00:00",
+            "pattern": "^([*]|[a-zA-Z0-9-/_]{1,63})([.][a-zA-Z0-9-/_]{1,63})*$"
           },
           "value": {
             "type": "string",
@@ -36277,7 +36219,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.981371+00:00"
+                "validatedAt": "2026-07-20T14:37:31.921189+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36288,8 +36230,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.374213+00:00",
-            "format": "hostname"
+            "x-reconciled-at": "2026-07-20T14:42:14.931547+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -36364,7 +36305,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.981428+00:00"
+                "validatedAt": "2026-07-20T14:37:31.921219+00:00"
               },
               "deterministic": true
             },
@@ -36376,9 +36317,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.374234+00:00",
-            "pattern": "^([a-zA-Z0-9*?]|([a-zA-Z0-9?*]+-[a-zA-Z0-9*?]+)){0,253}",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.931560+00:00",
+            "pattern": "^([a-zA-Z0-9*?]|([a-zA-Z0-9?*]+-[a-zA-Z0-9*?]+)){0,253}"
           },
           "values": {
             "type": "array",
@@ -36410,7 +36350,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.981469+00:00"
+                "validatedAt": "2026-07-20T14:37:31.921240+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36535,7 +36475,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.981526+00:00"
+                "validatedAt": "2026-07-20T14:37:31.921272+00:00"
               },
               "deterministic": true
             },
@@ -36547,9 +36487,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.374262+00:00",
-            "pattern": "^([a-zA-Z0-9*?]|([a-zA-Z0-9?*]+-[a-zA-Z0-9*?]+)){0,253}",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.931577+00:00",
+            "pattern": "^([a-zA-Z0-9*?]|([a-zA-Z0-9?*]+-[a-zA-Z0-9*?]+)){0,253}"
           },
           "value": {
             "type": "string",
@@ -36583,7 +36522,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.981589+00:00"
+                "validatedAt": "2026-07-20T14:37:31.921303+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36667,7 +36606,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.981645+00:00"
+                "validatedAt": "2026-07-20T14:37:31.921333+00:00"
               },
               "deterministic": true
             },
@@ -36679,9 +36618,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.374291+00:00",
-            "pattern": "^([a-zA-Z0-9*?]|([a-zA-Z0-9?*]+-[a-zA-Z0-9*?]+)){0,253}",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.931594+00:00",
+            "pattern": "^([a-zA-Z0-9*?]|([a-zA-Z0-9?*]+-[a-zA-Z0-9*?]+)){0,253}"
           },
           "value": {
             "type": "string",
@@ -36715,7 +36653,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.981718+00:00"
+                "validatedAt": "2026-07-20T14:37:31.921364+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36799,7 +36737,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.981767+00:00"
+                "validatedAt": "2026-07-20T14:37:31.921389+00:00"
               },
               "deterministic": true
             },
@@ -36811,9 +36749,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.374319+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.931611+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "value": {
             "allOf": [
@@ -36830,7 +36767,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.374340+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:14.931624+00:00",
             "x-f5xc-references": [
               {
                 "resource_kind": null,
@@ -36914,7 +36851,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.981825+00:00"
+                "validatedAt": "2026-07-20T14:37:31.921420+00:00"
               },
               "deterministic": true
             },
@@ -36926,9 +36863,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.374360+00:00",
-            "pattern": "^([a-zA-Z0-9*?]|([a-zA-Z0-9?*]+-[a-zA-Z0-9*?]+)){0,253}",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.931637+00:00",
+            "pattern": "^([a-zA-Z0-9*?]|([a-zA-Z0-9?*]+-[a-zA-Z0-9*?]+)){0,253}"
           },
           "values": {
             "type": "array",
@@ -36962,7 +36898,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.981867+00:00"
+                "validatedAt": "2026-07-20T14:37:31.921441+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37044,7 +36980,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.981923+00:00"
+                "validatedAt": "2026-07-20T14:37:31.921472+00:00"
               },
               "deterministic": true
             },
@@ -37056,9 +36992,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.374387+00:00",
-            "pattern": "^$|^([*]|[a-zA-Z0-9-/_]{1,63})([.][a-zA-Z0-9-/_]{1,63})*$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.931654+00:00",
+            "pattern": "^$|^([*]|[a-zA-Z0-9-/_]{1,63})([.][a-zA-Z0-9-/_]{1,63})*$"
           },
           "values": {
             "type": "array",
@@ -37086,7 +37021,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.981963+00:00"
+                "validatedAt": "2026-07-20T14:37:31.921492+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37170,7 +37105,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.982019+00:00"
+                "validatedAt": "2026-07-20T14:37:31.921522+00:00"
               },
               "deterministic": true
             },
@@ -37182,9 +37117,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.374414+00:00",
-            "pattern": "^([a-zA-Z0-9*?]|([a-zA-Z0-9?*]+-[a-zA-Z0-9*?]+)){0,253}",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.931671+00:00",
+            "pattern": "^([a-zA-Z0-9*?]|([a-zA-Z0-9?*]+-[a-zA-Z0-9*?]+)){0,253}"
           },
           "values": {
             "type": "array",
@@ -37218,7 +37152,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.982059+00:00"
+                "validatedAt": "2026-07-20T14:37:31.921543+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37300,7 +37234,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.982115+00:00"
+                "validatedAt": "2026-07-20T14:37:31.921575+00:00"
               },
               "deterministic": true
             },
@@ -37312,9 +37246,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.374441+00:00",
-            "pattern": "^$|^([*]|[a-zA-Z0-9-/_]{1,63})([.][a-zA-Z0-9-/_]{1,63})*$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.931688+00:00",
+            "pattern": "^$|^([*]|[a-zA-Z0-9-/_]{1,63})([.][a-zA-Z0-9-/_]{1,63})*$"
           },
           "values": {
             "type": "array",
@@ -37353,7 +37286,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.982158+00:00"
+                "validatedAt": "2026-07-20T14:37:31.921597+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37435,7 +37368,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.982212+00:00"
+                "validatedAt": "2026-07-20T14:37:31.921630+00:00"
               },
               "deterministic": true
             },
@@ -37447,9 +37380,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.374469+00:00",
-            "pattern": "^$|^([*]|[a-zA-Z0-9-/_]{1,63})([.][a-zA-Z0-9-/_]{1,63})*$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.931704+00:00",
+            "pattern": "^$|^([*]|[a-zA-Z0-9-/_]{1,63})([.][a-zA-Z0-9-/_]{1,63})*$"
           },
           "values": {
             "type": "array",
@@ -37488,7 +37420,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.982254+00:00"
+                "validatedAt": "2026-07-20T14:37:31.921651+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37740,7 +37672,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.982335+00:00"
+                "validatedAt": "2026-07-20T14:37:31.921690+00:00"
               },
               "deterministic": true
             },
@@ -37752,9 +37684,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.374527+00:00",
-            "pattern": "^([*]|[a-zA-Z0-9-_]{1,63})([.][a-zA-Z0-9-_]{1,63})*$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.931738+00:00",
+            "pattern": "^([*]|[a-zA-Z0-9-_]{1,63})([.][a-zA-Z0-9-_]{1,63})*$"
           },
           "values": {
             "type": "array",
@@ -37788,7 +37719,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.982375+00:00"
+                "validatedAt": "2026-07-20T14:37:31.921710+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37870,7 +37801,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.982429+00:00"
+                "validatedAt": "2026-07-20T14:37:31.921740+00:00"
               },
               "deterministic": true
             },
@@ -37882,9 +37813,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.374554+00:00",
-            "pattern": "^$|^([*]|[a-zA-Z0-9-/_]{1,63})([.][a-zA-Z0-9-/_]{1,63})*$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.931755+00:00",
+            "pattern": "^$|^([*]|[a-zA-Z0-9-/_]{1,63})([.][a-zA-Z0-9-/_]{1,63})*$"
           },
           "values": {
             "type": "array",
@@ -37924,7 +37854,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.982471+00:00"
+                "validatedAt": "2026-07-20T14:37:31.921762+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38120,7 +38050,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:16.982533+00:00"
+                "validatedAt": "2026-07-20T14:37:31.921787+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38151,7 +38081,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:16.982570+00:00"
+                "validatedAt": "2026-07-20T14:37:31.921801+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38182,7 +38112,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:16.982611+00:00"
+                "validatedAt": "2026-07-20T14:37:31.921817+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38258,7 +38188,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T13:00:16.982693+00:00"
+                "validatedAt": "2026-07-20T14:37:31.921846+00:00"
               },
               "deterministic": true
             },
@@ -38513,7 +38443,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.982768+00:00"
+                "validatedAt": "2026-07-20T14:37:31.921876+00:00"
               },
               "deterministic": true
             },
@@ -38525,9 +38455,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.374703+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.931835+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -38559,7 +38488,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.982795+00:00"
+                "validatedAt": "2026-07-20T14:37:31.921889+00:00"
               },
               "deterministic": true
             },
@@ -38571,9 +38500,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.374722+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.931847+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -38635,7 +38563,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:16.982834+00:00"
+                "validatedAt": "2026-07-20T14:37:31.921905+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38662,7 +38590,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:16.982867+00:00"
+                "validatedAt": "2026-07-20T14:37:31.921919+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38714,7 +38642,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:00:16.982917+00:00"
+                "validatedAt": "2026-07-20T14:37:31.921941+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38754,7 +38682,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.982947+00:00"
+                "validatedAt": "2026-07-20T14:37:31.921956+00:00"
               },
               "deterministic": true
             },
@@ -38766,9 +38694,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.374769+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.931879+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "sort": {
             "allOf": [
@@ -38807,7 +38734,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:16.982988+00:00"
+                "validatedAt": "2026-07-20T14:37:31.921972+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38840,7 +38767,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:16.983020+00:00"
+                "validatedAt": "2026-07-20T14:37:31.921986+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38932,7 +38859,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:16.983066+00:00"
+                "validatedAt": "2026-07-20T14:37:31.922004+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38960,7 +38887,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:16.983103+00:00"
+                "validatedAt": "2026-07-20T14:37:31.922019+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39031,7 +38958,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:16.983143+00:00"
+                "validatedAt": "2026-07-20T14:37:31.922034+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39058,7 +38985,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:16.983177+00:00"
+                "validatedAt": "2026-07-20T14:37:31.922048+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39095,7 +39022,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:00:16.983211+00:00"
+                "validatedAt": "2026-07-20T14:37:31.922063+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39135,7 +39062,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.983238+00:00"
+                "validatedAt": "2026-07-20T14:37:31.922077+00:00"
               },
               "deterministic": true
             },
@@ -39147,9 +39074,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.374848+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.931929+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "sort": {
             "allOf": [
@@ -39188,7 +39114,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:16.983281+00:00"
+                "validatedAt": "2026-07-20T14:37:31.922093+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39276,7 +39202,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:16.983330+00:00"
+                "validatedAt": "2026-07-20T14:37:31.922112+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39338,7 +39264,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:16.983371+00:00"
+                "validatedAt": "2026-07-20T14:37:31.922128+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39363,7 +39289,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:16.983410+00:00"
+                "validatedAt": "2026-07-20T14:37:31.922143+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39388,7 +39314,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:16.983450+00:00"
+                "validatedAt": "2026-07-20T14:37:31.922159+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39413,7 +39339,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:16.983484+00:00"
+                "validatedAt": "2026-07-20T14:37:31.922172+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39425,7 +39351,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.374916+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.931970+00:00"
           },
           "query_type": {
             "type": "string",
@@ -39442,7 +39368,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:16.983523+00:00"
+                "validatedAt": "2026-07-20T14:37:31.922187+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39467,7 +39393,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:16.983562+00:00"
+                "validatedAt": "2026-07-20T14:37:31.922202+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39508,7 +39434,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T13:00:16.983606+00:00"
+                "validatedAt": "2026-07-20T14:37:31.922220+00:00"
               },
               "deterministic": true
             },
@@ -39591,7 +39517,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:16.983644+00:00"
+                "validatedAt": "2026-07-20T14:37:31.922235+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39724,7 +39650,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:16.983708+00:00"
+                "validatedAt": "2026-07-20T14:37:31.922257+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39747,7 +39673,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:16.983746+00:00"
+                "validatedAt": "2026-07-20T14:37:31.922271+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39807,7 +39733,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:16.983784+00:00"
+                "validatedAt": "2026-07-20T14:37:31.922287+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39976,7 +39902,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.375050+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.932051+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -40050,7 +39976,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:16.983891+00:00"
+                "validatedAt": "2026-07-20T14:37:31.922327+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40062,7 +39988,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.375079+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.932069+00:00"
           },
           "num_of_dns_records": {
             "type": "integer",
@@ -40198,7 +40124,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.983975+00:00"
+                "validatedAt": "2026-07-20T14:37:31.922365+00:00"
               },
               "deterministic": true
             },
@@ -40208,8 +40134,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "format": "hostname"
+            "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$"
           },
           "primary_server": {
             "type": "string",
@@ -40237,7 +40162,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.984033+00:00"
+                "validatedAt": "2026-07-20T14:37:31.922391+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40367,7 +40292,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:00:16.984088+00:00"
+                "validatedAt": "2026-07-20T14:37:31.922415+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40378,7 +40303,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.375148+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.932111+00:00"
           },
           "file": {
             "type": "string",
@@ -40405,7 +40330,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:16.984119+00:00"
+                "validatedAt": "2026-07-20T14:37:31.922428+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40564,7 +40489,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:00:16.984211+00:00"
+                "validatedAt": "2026-07-20T14:37:31.922465+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40575,7 +40500,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.375197+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.932141+00:00"
           },
           "file": {
             "type": "string",
@@ -40602,7 +40527,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:16.984243+00:00"
+                "validatedAt": "2026-07-20T14:37:31.922478+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40793,7 +40718,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:16.984300+00:00"
+                "validatedAt": "2026-07-20T14:37:31.922501+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40817,7 +40742,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:16.984336+00:00"
+                "validatedAt": "2026-07-20T14:37:31.922515+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40941,7 +40866,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.984415+00:00"
+                "validatedAt": "2026-07-20T14:37:31.922550+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40991,7 +40916,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.984463+00:00"
+                "validatedAt": "2026-07-20T14:37:31.922573+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41078,7 +41003,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.984541+00:00"
+                "validatedAt": "2026-07-20T14:37:31.922608+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41128,7 +41053,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.984589+00:00"
+                "validatedAt": "2026-07-20T14:37:31.922631+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41305,7 +41230,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:00:16.984673+00:00"
+                "validatedAt": "2026-07-20T14:37:31.922663+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41383,7 +41308,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:00:16.984724+00:00"
+                "validatedAt": "2026-07-20T14:37:31.922684+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41394,7 +41319,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.375370+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.932243+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -41481,7 +41406,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.984766+00:00"
+                "validatedAt": "2026-07-20T14:37:31.922703+00:00"
               },
               "deterministic": true
             },
@@ -41493,9 +41418,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.375415+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.932271+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -41526,7 +41450,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.984794+00:00"
+                "validatedAt": "2026-07-20T14:37:31.922716+00:00"
               },
               "deterministic": true
             },
@@ -41538,9 +41462,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.375433+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.932283+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -41609,7 +41532,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:16.984846+00:00"
+                "validatedAt": "2026-07-20T14:37:31.922736+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41621,7 +41544,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.375470+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.932307+00:00"
           },
           "uid": {
             "type": "string",
@@ -41638,7 +41561,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:16.984871+00:00"
+                "validatedAt": "2026-07-20T14:37:31.922747+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41651,7 +41574,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.375489+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.932320+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of dns_zone is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -41764,7 +41687,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.984926+00:00"
+                "validatedAt": "2026-07-20T14:37:31.922773+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41776,7 +41699,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.375510+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.932333+00:00"
           },
           "priority": {
             "type": "integer",
@@ -41803,7 +41726,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:00:16.984963+00:00"
+                "validatedAt": "2026-07-20T14:37:31.922790+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41881,7 +41804,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.375545+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.932356+00:00"
           }
         },
         "x-f5xc-description-short": "Metrics Data contains key/value pairs that uniquely identifies the group_by labels specified in the request.",
@@ -41950,7 +41873,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.985045+00:00"
+                "validatedAt": "2026-07-20T14:37:31.922828+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42038,7 +41961,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.985127+00:00"
+                "validatedAt": "2026-07-20T14:37:31.922864+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42064,7 +41987,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:16.985165+00:00"
+                "validatedAt": "2026-07-20T14:37:31.922879+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42099,7 +42022,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.985228+00:00"
+                "validatedAt": "2026-07-20T14:37:31.922911+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42185,7 +42108,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.985276+00:00"
+                "validatedAt": "2026-07-20T14:37:31.922935+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42251,7 +42174,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.985324+00:00"
+                "validatedAt": "2026-07-20T14:37:31.922958+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42340,7 +42263,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:16.985359+00:00"
+                "validatedAt": "2026-07-20T14:37:31.922972+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42385,7 +42308,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.985405+00:00"
+                "validatedAt": "2026-07-20T14:37:31.922995+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42451,7 +42374,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.985453+00:00"
+                "validatedAt": "2026-07-20T14:37:31.923018+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42841,7 +42764,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:00:16.985534+00:00"
+                "validatedAt": "2026-07-20T14:37:31.923050+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42852,7 +42775,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.375757+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.932479+00:00"
           },
           "ds_record": {
             "allOf": [
@@ -43431,7 +43354,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.985625+00:00"
+                "validatedAt": "2026-07-20T14:37:31.923088+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43691,7 +43614,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.985702+00:00"
+                "validatedAt": "2026-07-20T14:37:31.923120+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43771,7 +43694,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.985771+00:00"
+                "validatedAt": "2026-07-20T14:37:31.923152+00:00"
               },
               "deterministic": true
             },
@@ -43847,7 +43770,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.985824+00:00"
+                "validatedAt": "2026-07-20T14:37:31.923178+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43927,7 +43850,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.985888+00:00"
+                "validatedAt": "2026-07-20T14:37:31.923210+00:00"
               },
               "deterministic": true
             },
@@ -44003,7 +43926,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.985942+00:00"
+                "validatedAt": "2026-07-20T14:37:31.923235+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44236,7 +44159,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.986043+00:00"
+                "validatedAt": "2026-07-20T14:37:31.923277+00:00"
               },
               "deterministic": true
             },
@@ -44273,7 +44196,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:00:16.986076+00:00"
+                "validatedAt": "2026-07-20T14:37:31.923292+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44307,7 +44230,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.986142+00:00"
+                "validatedAt": "2026-07-20T14:37:31.923323+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44343,7 +44266,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:00:16.986175+00:00"
+                "validatedAt": "2026-07-20T14:37:31.923339+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44557,7 +44480,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.986243+00:00"
+                "validatedAt": "2026-07-20T14:37:31.923375+00:00"
               },
               "deterministic": true
             },
@@ -44569,9 +44492,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.376030+00:00",
-            "pattern": "^([a-zA-Z0-9*?]|([a-zA-Z0-9?*]+-[a-zA-Z0-9*?]+)){0,253}",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.932642+00:00",
+            "pattern": "^([a-zA-Z0-9*?]|([a-zA-Z0-9?*]+-[a-zA-Z0-9*?]+)){0,253}"
           },
           "values": {
             "type": "array",
@@ -44605,7 +44527,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.986283+00:00"
+                "validatedAt": "2026-07-20T14:37:31.923395+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44689,7 +44611,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.986329+00:00"
+                "validatedAt": "2026-07-20T14:37:31.923418+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44737,7 +44659,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.986389+00:00"
+                "validatedAt": "2026-07-20T14:37:31.923446+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44745,8 +44667,7 @@
               "create": false,
               "update": false,
               "read": false
-            },
-            "format": "hostname"
+            }
           },
           "tsig_key_value": {
             "allOf": [
@@ -44826,7 +44747,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:16.986437+00:00"
+                "validatedAt": "2026-07-20T14:37:31.923465+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44869,7 +44790,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.986482+00:00"
+                "validatedAt": "2026-07-20T14:37:31.923488+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44914,7 +44835,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.986540+00:00"
+                "validatedAt": "2026-07-20T14:37:31.923517+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44922,8 +44843,7 @@
               "create": false,
               "update": false,
               "read": false
-            },
-            "format": "hostname"
+            }
           },
           "tsig_key_value": {
             "allOf": [
@@ -45234,7 +45154,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.986647+00:00"
+                "validatedAt": "2026-07-20T14:37:31.923562+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45360,7 +45280,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.986722+00:00"
+                "validatedAt": "2026-07-20T14:37:31.923596+00:00"
               },
               "deterministic": true
             },
@@ -45372,9 +45292,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.376179+00:00",
-            "pattern": "^([a-zA-Z0-9*?]|([a-zA-Z0-9?*]+-[a-zA-Z0-9*?]+)){0,253}",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.932728+00:00",
+            "pattern": "^([a-zA-Z0-9*?]|([a-zA-Z0-9?*]+-[a-zA-Z0-9*?]+)){0,253}"
           },
           "values": {
             "type": "array",
@@ -45408,7 +45327,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.986763+00:00"
+                "validatedAt": "2026-07-20T14:37:31.923622+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45494,7 +45413,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.986828+00:00"
+                "validatedAt": "2026-07-20T14:37:31.923652+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45502,8 +45421,7 @@
               "create": false,
               "update": false,
               "read": false
-            },
-            "format": "hostname"
+            }
           },
           "tsig_key_value": {
             "allOf": [
@@ -45627,7 +45545,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:16.986884+00:00"
+                "validatedAt": "2026-07-20T14:37:31.923675+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45692,7 +45610,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:16.987159+00:00"
+                "validatedAt": "2026-07-20T14:37:31.923785+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45733,7 +45651,7 @@
                 "confidence": 1.0,
                 "category": "content",
                 "note": "Blindfold envelope encryption (AES-256-GCM + RSA-OAEP) of an RSA-2048 TLS private key produces ~3700 char string:/// URL. 128KB max secret size = ~175KB base64. Discovery reported 1024 which is incorrect.",
-                "validatedAt": "2026-07-20T13:00:16.987196+00:00"
+                "validatedAt": "2026-07-20T14:37:31.923806+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45744,7 +45662,7 @@
             },
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.376371+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.932849+00:00"
           },
           "store_provider": {
             "type": "string",
@@ -45763,7 +45681,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:16.987245+00:00"
+                "validatedAt": "2026-07-20T14:37:31.923826+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45830,7 +45748,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:16.987283+00:00"
+                "validatedAt": "2026-07-20T14:37:31.923848+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45841,7 +45759,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.376398+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.932865+00:00"
           },
           "url": {
             "type": "string",
@@ -45879,7 +45797,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.987340+00:00"
+                "validatedAt": "2026-07-20T14:37:31.923881+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -45958,7 +45876,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.987741+00:00"
+                "validatedAt": "2026-07-20T14:37:31.924034+00:00"
               },
               "deterministic": true
             },
@@ -45970,7 +45888,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.376544+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.932955+00:00"
           },
           "name": {
             "type": "string",
@@ -46014,7 +45932,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:16.987792+00:00"
+                "validatedAt": "2026-07-20T14:37:31.924058+00:00"
               },
               "deterministic": true
             },
@@ -46024,8 +45942,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "MessageMetaType is metadata (common attributes) of a message that only certain messages have.",
@@ -46284,7 +46201,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:08.827169+00:00"
+                "validatedAt": "2026-07-20T14:37:53.021317+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46323,7 +46240,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:08.827235+00:00"
+                "validatedAt": "2026-07-20T14:37:53.021349+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46410,7 +46327,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:08.827307+00:00"
+                "validatedAt": "2026-07-20T14:37:53.021383+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46449,7 +46366,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:08.827373+00:00"
+                "validatedAt": "2026-07-20T14:37:53.021415+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46480,7 +46397,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:08.827415+00:00"
+                "validatedAt": "2026-07-20T14:37:53.021433+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46525,7 +46442,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:08.827449+00:00"
+                "validatedAt": "2026-07-20T14:37:53.021447+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46590,7 +46507,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:08.827490+00:00"
+                "validatedAt": "2026-07-20T14:37:53.021463+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46614,7 +46531,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:08.827527+00:00"
+                "validatedAt": "2026-07-20T14:37:53.021478+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46652,7 +46569,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:08.827556+00:00"
+                "validatedAt": "2026-07-20T14:37:53.021492+00:00"
               },
               "deterministic": true
             },
@@ -46664,9 +46581,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.352885+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.733081+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "record_name": {
             "type": "string",
@@ -46682,7 +46598,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:08.827594+00:00"
+                "validatedAt": "2026-07-20T14:37:53.021507+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46718,7 +46634,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:08.827626+00:00"
+                "validatedAt": "2026-07-20T14:37:53.021521+00:00"
               }
             },
             "x-f5xc-required-for": {

--- a/docs/specifications/api/index.json
+++ b/docs/specifications/api/index.json
@@ -1,6 +1,6 @@
 {
-  "version": "2.1.182",
-  "timestamp": "2026-07-20T13:12:51.290377+00:00",
+  "version": "2.1.181",
+  "timestamp": "2026-07-20T14:42:40.179680+00:00",
   "specifications": [
     {
       "domain": "admin_console_and_ui",

--- a/docs/specifications/api/managed_kubernetes.json
+++ b/docs/specifications/api/managed_kubernetes.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Managed Kubernetes",
     "description": "Role-based access controls with cluster-scoped permissions and namespace bindings. Pod security admission levels enforce baseline, restricted, or privileged profiles. Container registry credentials support private image pulls across hybrid deployments. Policy rules define resource verbs, groups, and non-resource URL access patterns.",
-    "version": "2.1.182",
+    "version": "2.1.181",
     "contact": {
       "name": "F5 Distributed Cloud",
       "url": "https://docs.cloud.f5.com"
@@ -6045,7 +6045,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:41.268809+00:00"
+                "validatedAt": "2026-07-20T14:37:17.731783+00:00"
               },
               "deterministic": true
             },
@@ -6096,7 +6096,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:41.268882+00:00"
+                "validatedAt": "2026-07-20T14:37:17.731815+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6104,8 +6104,7 @@
               "create": true,
               "update": false,
               "read": false
-            },
-            "format": "hostname"
+            }
           },
           "user_name": {
             "type": "string",
@@ -6132,7 +6131,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:41.268945+00:00"
+                "validatedAt": "2026-07-20T14:37:17.731844+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6232,7 +6231,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:41.268987+00:00"
+                "validatedAt": "2026-07-20T14:37:17.731863+00:00"
               },
               "deterministic": true
             },
@@ -6244,9 +6243,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.690057+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.179964+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -6278,7 +6276,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:41.269017+00:00"
+                "validatedAt": "2026-07-20T14:37:17.731877+00:00"
               },
               "deterministic": true
             },
@@ -6290,9 +6288,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.690078+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.179977+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -6457,7 +6454,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.690146+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.180020+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -6548,7 +6545,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:41.269150+00:00"
+                "validatedAt": "2026-07-20T14:37:17.731932+00:00"
               },
               "deterministic": true
             },
@@ -6599,7 +6596,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:41.269207+00:00"
+                "validatedAt": "2026-07-20T14:37:17.731959+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6607,8 +6604,7 @@
               "create": true,
               "update": false,
               "read": false
-            },
-            "format": "hostname"
+            }
           },
           "user_name": {
             "type": "string",
@@ -6635,7 +6631,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:41.269266+00:00"
+                "validatedAt": "2026-07-20T14:37:17.731986+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6721,7 +6717,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:59:41.269314+00:00"
+                "validatedAt": "2026-07-20T14:37:17.732012+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6802,7 +6798,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:59:41.269370+00:00"
+                "validatedAt": "2026-07-20T14:37:17.732036+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6813,7 +6809,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.690226+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.180068+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -6900,7 +6896,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:41.269411+00:00"
+                "validatedAt": "2026-07-20T14:37:17.732054+00:00"
               },
               "deterministic": true
             },
@@ -6912,9 +6908,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.690272+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.180097+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -6945,7 +6940,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:41.269439+00:00"
+                "validatedAt": "2026-07-20T14:37:17.732067+00:00"
               },
               "deterministic": true
             },
@@ -6957,9 +6952,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.690291+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.180109+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -7028,7 +7022,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:41.269493+00:00"
+                "validatedAt": "2026-07-20T14:37:17.732087+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7040,7 +7034,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.690328+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.180134+00:00"
           },
           "uid": {
             "type": "string",
@@ -7058,7 +7052,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:41.269518+00:00"
+                "validatedAt": "2026-07-20T14:37:17.732098+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7071,7 +7065,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.690349+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.180147+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of container_registry is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -7252,7 +7246,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:41.269583+00:00"
+                "validatedAt": "2026-07-20T14:37:17.732128+00:00"
               },
               "deterministic": true
             },
@@ -7303,7 +7297,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:41.269640+00:00"
+                "validatedAt": "2026-07-20T14:37:17.732155+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7311,8 +7305,7 @@
               "create": true,
               "update": false,
               "read": false
-            },
-            "format": "hostname"
+            }
           },
           "user_name": {
             "type": "string",
@@ -7339,7 +7332,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:41.269710+00:00"
+                "validatedAt": "2026-07-20T14:37:17.732182+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7485,7 +7478,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:41.269779+00:00"
+                "validatedAt": "2026-07-20T14:37:17.732209+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7508,7 +7501,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:41.269815+00:00"
+                "validatedAt": "2026-07-20T14:37:17.732223+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7519,7 +7512,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.690441+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.180202+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -7580,7 +7573,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:41.269859+00:00"
+                "validatedAt": "2026-07-20T14:37:17.732240+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7621,7 +7614,7 @@
                 "confidence": 1.0,
                 "category": "content",
                 "note": "Blindfold envelope encryption (AES-256-GCM + RSA-OAEP) of an RSA-2048 TLS private key produces ~3700 char string:/// URL. 128KB max secret size = ~175KB base64. Discovery reported 1024 which is incorrect.",
-                "validatedAt": "2026-07-20T12:59:41.269897+00:00"
+                "validatedAt": "2026-07-20T14:37:17.732260+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7632,7 +7625,7 @@
             },
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.690470+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.180221+00:00"
           },
           "store_provider": {
             "type": "string",
@@ -7651,7 +7644,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:41.269942+00:00"
+                "validatedAt": "2026-07-20T14:37:17.732279+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7718,7 +7711,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:41.269978+00:00"
+                "validatedAt": "2026-07-20T14:37:17.732293+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7729,7 +7722,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.690497+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.180238+00:00"
           },
           "url": {
             "type": "string",
@@ -7767,7 +7760,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:41.270036+00:00"
+                "validatedAt": "2026-07-20T14:37:17.732321+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -7842,7 +7835,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T12:59:41.270069+00:00"
+                "validatedAt": "2026-07-20T14:37:17.732335+00:00"
               },
               "deterministic": true
             },
@@ -7853,8 +7846,7 @@
               "read": false
             },
             "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "minLength": 1,
-            "format": "fqdn"
+            "minLength": 1
           },
           "last_update_time": {
             "type": "string",
@@ -7871,7 +7863,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:41.270111+00:00"
+                "validatedAt": "2026-07-20T14:37:17.732359+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7898,7 +7890,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:41.270146+00:00"
+                "validatedAt": "2026-07-20T14:37:17.732372+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7909,7 +7901,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.690537+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.180264+00:00"
           },
           "service_name": {
             "type": "string",
@@ -7926,7 +7918,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:41.270186+00:00"
+                "validatedAt": "2026-07-20T14:37:17.732387+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7959,7 +7951,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:41.270223+00:00"
+                "validatedAt": "2026-07-20T14:37:17.732402+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7970,7 +7962,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.690562+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.180281+00:00"
           },
           "type": {
             "type": "string",
@@ -7995,7 +7987,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:41.270256+00:00"
+                "validatedAt": "2026-07-20T14:37:17.732417+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8139,7 +8131,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:41.270298+00:00"
+                "validatedAt": "2026-07-20T14:37:17.732434+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8219,7 +8211,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:41.270326+00:00"
+                "validatedAt": "2026-07-20T14:37:17.732447+00:00"
               },
               "deterministic": true
             },
@@ -8231,9 +8223,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.690612+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.180311+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -8397,7 +8388,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:41.270416+00:00"
+                "validatedAt": "2026-07-20T14:37:17.732487+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -8412,7 +8403,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.690662+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.180337+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -8482,7 +8473,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:41.270455+00:00"
+                "validatedAt": "2026-07-20T14:37:17.732505+00:00"
               },
               "deterministic": true
             },
@@ -8494,9 +8485,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.690698+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.180358+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -8529,7 +8519,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:41.270481+00:00"
+                "validatedAt": "2026-07-20T14:37:17.732518+00:00"
               },
               "deterministic": true
             },
@@ -8541,9 +8531,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.690716+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.180371+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -8643,7 +8632,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:41.270554+00:00"
+                "validatedAt": "2026-07-20T14:37:17.732551+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -8658,7 +8647,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.690745+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.180388+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -8730,7 +8719,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:41.270589+00:00"
+                "validatedAt": "2026-07-20T14:37:17.732568+00:00"
               },
               "deterministic": true
             },
@@ -8742,9 +8731,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.690779+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.180409+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -8777,7 +8765,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:41.270616+00:00"
+                "validatedAt": "2026-07-20T14:37:17.732580+00:00"
               },
               "deterministic": true
             },
@@ -8789,9 +8777,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.690797+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.180422+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -8854,7 +8841,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:41.270647+00:00"
+                "validatedAt": "2026-07-20T14:37:17.732592+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8866,7 +8853,7 @@
             "readOnly": true,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.690818+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.180435+00:00"
           },
           "name": {
             "type": "string",
@@ -8899,7 +8886,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:41.270688+00:00"
+                "validatedAt": "2026-07-20T14:37:17.732605+00:00"
               },
               "deterministic": true
             },
@@ -8911,9 +8898,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.690837+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.180447+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -8946,7 +8932,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:41.270716+00:00"
+                "validatedAt": "2026-07-20T14:37:17.732618+00:00"
               },
               "deterministic": true
             },
@@ -8958,9 +8944,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.690856+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.180460+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -8979,7 +8964,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:41.270751+00:00"
+                "validatedAt": "2026-07-20T14:37:17.732631+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8992,7 +8977,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.690875+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.180472+00:00"
           },
           "uid": {
             "type": "string",
@@ -9011,7 +8996,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:41.270776+00:00"
+                "validatedAt": "2026-07-20T14:37:17.732642+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9025,7 +9010,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.690894+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.180485+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -9125,7 +9110,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:41.270850+00:00"
+                "validatedAt": "2026-07-20T14:37:17.732676+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -9140,7 +9125,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.690923+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.180502+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -9210,7 +9195,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:41.270888+00:00"
+                "validatedAt": "2026-07-20T14:37:17.732693+00:00"
               },
               "deterministic": true
             },
@@ -9222,9 +9207,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.690956+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.180523+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -9257,7 +9241,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:41.270915+00:00"
+                "validatedAt": "2026-07-20T14:37:17.732705+00:00"
               },
               "deterministic": true
             },
@@ -9269,9 +9253,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.690974+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.180536+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -9442,7 +9425,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:41.270967+00:00"
+                "validatedAt": "2026-07-20T14:37:17.732725+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9470,7 +9453,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:41.271006+00:00"
+                "validatedAt": "2026-07-20T14:37:17.732740+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9498,7 +9481,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:41.271044+00:00"
+                "validatedAt": "2026-07-20T14:37:17.732756+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9537,7 +9520,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:41.271084+00:00"
+                "validatedAt": "2026-07-20T14:37:17.732772+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9564,7 +9547,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:41.271110+00:00"
+                "validatedAt": "2026-07-20T14:37:17.732782+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9577,7 +9560,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.691045+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.180578+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -9593,7 +9576,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:41.271143+00:00"
+                "validatedAt": "2026-07-20T14:37:17.732795+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9738,7 +9721,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:41.271193+00:00"
+                "validatedAt": "2026-07-20T14:37:17.732815+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9749,7 +9732,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.691086+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.180603+00:00"
           },
           "status": {
             "type": "string",
@@ -9767,7 +9750,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:41.271227+00:00"
+                "validatedAt": "2026-07-20T14:37:17.732829+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9778,7 +9761,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.691105+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.180615+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -9838,7 +9821,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:41.271271+00:00"
+                "validatedAt": "2026-07-20T14:37:17.732846+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9865,7 +9848,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:41.271311+00:00"
+                "validatedAt": "2026-07-20T14:37:17.732861+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9892,7 +9875,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:41.271347+00:00"
+                "validatedAt": "2026-07-20T14:37:17.732876+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9920,7 +9903,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:41.271389+00:00"
+                "validatedAt": "2026-07-20T14:37:17.732891+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9996,7 +9979,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:41.271451+00:00"
+                "validatedAt": "2026-07-20T14:37:17.732915+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10064,7 +10047,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:41.271502+00:00"
+                "validatedAt": "2026-07-20T14:37:17.732934+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10076,7 +10059,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.691192+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.180668+00:00"
           },
           "uid": {
             "type": "string",
@@ -10095,7 +10078,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:41.271528+00:00"
+                "validatedAt": "2026-07-20T14:37:17.732944+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10108,7 +10091,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.691211+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.180681+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -10176,7 +10159,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:41.271560+00:00"
+                "validatedAt": "2026-07-20T14:37:17.732957+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10187,7 +10170,7 @@
             },
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.691231+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.180694+00:00"
           },
           "name": {
             "type": "string",
@@ -10220,7 +10203,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:41.271587+00:00"
+                "validatedAt": "2026-07-20T14:37:17.732969+00:00"
               },
               "deterministic": true
             },
@@ -10232,9 +10215,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.691249+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.180706+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -10267,7 +10249,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:41.271614+00:00"
+                "validatedAt": "2026-07-20T14:37:17.732986+00:00"
               },
               "deterministic": true
             },
@@ -10279,9 +10261,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.691268+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.180719+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "uid": {
             "type": "string",
@@ -10298,7 +10279,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:41.271639+00:00"
+                "validatedAt": "2026-07-20T14:37:17.732996+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10311,7 +10292,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.691287+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.180731+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -10560,7 +10541,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:32.469049+00:00"
+                "validatedAt": "2026-07-20T14:38:49.628540+00:00"
               },
               "deterministic": true,
               "format": "uri"
@@ -10658,7 +10639,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:32.469110+00:00"
+                "validatedAt": "2026-07-20T14:38:49.628559+00:00"
               },
               "deterministic": true
             },
@@ -10670,9 +10651,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.566682+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.355261+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -10704,7 +10684,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:32.469152+00:00"
+                "validatedAt": "2026-07-20T14:38:49.628573+00:00"
               },
               "deterministic": true
             },
@@ -10716,9 +10696,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.566704+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.355274+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -10881,7 +10860,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.566772+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.355316+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -11004,7 +10983,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:32.469364+00:00"
+                "validatedAt": "2026-07-20T14:38:49.628634+00:00"
               },
               "deterministic": true,
               "format": "uri"
@@ -11093,7 +11072,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:03:32.469408+00:00"
+                "validatedAt": "2026-07-20T14:38:49.628653+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11172,7 +11151,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:03:32.469467+00:00"
+                "validatedAt": "2026-07-20T14:38:49.628677+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11183,7 +11162,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.566844+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.355360+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -11270,7 +11249,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:32.469508+00:00"
+                "validatedAt": "2026-07-20T14:38:49.628694+00:00"
               },
               "deterministic": true
             },
@@ -11282,9 +11261,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.566889+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.355388+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -11315,7 +11293,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:32.469537+00:00"
+                "validatedAt": "2026-07-20T14:38:49.628707+00:00"
               },
               "deterministic": true
             },
@@ -11327,9 +11305,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.566907+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.355401+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -11398,7 +11375,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:32.469592+00:00"
+                "validatedAt": "2026-07-20T14:38:49.628727+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11410,7 +11387,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.566945+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.355425+00:00"
           },
           "uid": {
             "type": "string",
@@ -11428,7 +11405,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:32.469620+00:00"
+                "validatedAt": "2026-07-20T14:38:49.628738+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11441,7 +11418,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.566965+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.355438+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of k8s_cluster_role is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -11532,7 +11509,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:32.469685+00:00"
+                "validatedAt": "2026-07-20T14:38:49.628763+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11581,7 +11558,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:32.469731+00:00"
+                "validatedAt": "2026-07-20T14:38:49.628784+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11664,7 +11641,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:32.469778+00:00"
+                "validatedAt": "2026-07-20T14:38:49.628806+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11937,7 +11914,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:32.469867+00:00"
+                "validatedAt": "2026-07-20T14:38:49.628845+00:00"
               },
               "deterministic": true,
               "format": "uri"
@@ -12032,7 +12009,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:32.469914+00:00"
+                "validatedAt": "2026-07-20T14:38:49.628867+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12074,7 +12051,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:32.469958+00:00"
+                "validatedAt": "2026-07-20T14:38:49.628888+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12123,7 +12100,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:32.470006+00:00"
+                "validatedAt": "2026-07-20T14:38:49.628910+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12172,7 +12149,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:32.470047+00:00"
+                "validatedAt": "2026-07-20T14:38:49.628932+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12342,7 +12319,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:32.470511+00:00"
+                "validatedAt": "2026-07-20T14:38:49.629114+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12407,7 +12384,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:36.256611+00:00"
+                "validatedAt": "2026-07-20T14:38:51.069545+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12419,7 +12396,7 @@
             "readOnly": true,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.641211+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.417899+00:00"
           },
           "name": {
             "type": "string",
@@ -12452,7 +12429,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:36.256686+00:00"
+                "validatedAt": "2026-07-20T14:38:51.069573+00:00"
               },
               "deterministic": true
             },
@@ -12464,9 +12441,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.641233+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.417913+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -12499,7 +12475,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:36.256718+00:00"
+                "validatedAt": "2026-07-20T14:38:51.069589+00:00"
               },
               "deterministic": true
             },
@@ -12511,9 +12487,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.641251+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.417925+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -12532,7 +12507,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:36.256754+00:00"
+                "validatedAt": "2026-07-20T14:38:51.069603+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12545,7 +12520,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.641270+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.417937+00:00"
           },
           "uid": {
             "type": "string",
@@ -12564,7 +12539,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:36.256780+00:00"
+                "validatedAt": "2026-07-20T14:38:51.069613+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12578,7 +12553,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.641290+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.417951+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -12822,7 +12797,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:36.256866+00:00"
+                "validatedAt": "2026-07-20T14:38:51.069653+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12914,7 +12889,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:36.256904+00:00"
+                "validatedAt": "2026-07-20T14:38:51.069671+00:00"
               },
               "deterministic": true
             },
@@ -12926,9 +12901,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.641368+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.417998+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -12960,7 +12934,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:36.256930+00:00"
+                "validatedAt": "2026-07-20T14:38:51.069685+00:00"
               },
               "deterministic": true
             },
@@ -12972,9 +12946,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.641387+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.418011+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -13137,7 +13110,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.641453+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.418052+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -13253,7 +13226,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:36.257055+00:00"
+                "validatedAt": "2026-07-20T14:38:51.069736+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13337,7 +13310,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:03:36.257101+00:00"
+                "validatedAt": "2026-07-20T14:38:51.069757+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13416,7 +13389,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:03:36.257154+00:00"
+                "validatedAt": "2026-07-20T14:38:51.069781+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13427,7 +13400,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.641518+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.418092+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -13515,7 +13488,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:36.257194+00:00"
+                "validatedAt": "2026-07-20T14:38:51.069799+00:00"
               },
               "deterministic": true
             },
@@ -13527,9 +13500,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.641564+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.418120+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -13560,7 +13532,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:36.257221+00:00"
+                "validatedAt": "2026-07-20T14:38:51.069812+00:00"
               },
               "deterministic": true
             },
@@ -13572,9 +13544,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.641583+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.418133+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -13643,7 +13614,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:36.257276+00:00"
+                "validatedAt": "2026-07-20T14:38:51.069833+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13655,7 +13626,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.641620+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.418158+00:00"
           },
           "uid": {
             "type": "string",
@@ -13673,7 +13644,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:36.257301+00:00"
+                "validatedAt": "2026-07-20T14:38:51.069844+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13686,7 +13657,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.641640+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.418171+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of k8s_cluster_role_binding is returned in 'List'.",
@@ -13888,7 +13859,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:36.257359+00:00"
+                "validatedAt": "2026-07-20T14:38:51.069871+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13978,7 +13949,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:36.257421+00:00"
+                "validatedAt": "2026-07-20T14:38:51.069902+00:00"
               },
               "deterministic": true
             },
@@ -13988,8 +13959,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -14033,7 +14003,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:36.257469+00:00"
+                "validatedAt": "2026-07-20T14:38:51.069928+00:00"
               },
               "deterministic": true
             },
@@ -14043,8 +14013,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -14194,7 +14163,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:36.257556+00:00"
+                "validatedAt": "2026-07-20T14:38:51.069964+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14256,7 +14225,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:36.257607+00:00"
+                "validatedAt": "2026-07-20T14:38:51.069992+00:00"
               },
               "deterministic": true
             },
@@ -14352,7 +14321,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:36.259177+00:00"
+                "validatedAt": "2026-07-20T14:38:51.070652+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -14366,8 +14335,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -14406,7 +14374,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:36.259223+00:00"
+                "validatedAt": "2026-07-20T14:38:51.070676+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -14421,9 +14389,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.642447+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.418683+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -14452,7 +14419,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:36.259276+00:00"
+                "validatedAt": "2026-07-20T14:38:51.070700+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14465,7 +14432,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.642466+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.418695+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a direct reference from one object(the referrer) to another(the referred).",
@@ -14721,7 +14688,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:39.933545+00:00"
+                "validatedAt": "2026-07-20T14:38:52.597388+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14816,7 +14783,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:39.933581+00:00"
+                "validatedAt": "2026-07-20T14:38:52.597405+00:00"
               },
               "deterministic": true
             },
@@ -14828,9 +14795,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.688057+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.464841+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -14862,7 +14828,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:39.933609+00:00"
+                "validatedAt": "2026-07-20T14:38:52.597418+00:00"
               },
               "deterministic": true
             },
@@ -14874,9 +14840,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.688075+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.464854+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -15041,7 +15006,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.688141+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.464896+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -15135,7 +15100,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:39.933745+00:00"
+                "validatedAt": "2026-07-20T14:38:52.597469+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15219,7 +15184,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:03:39.933791+00:00"
+                "validatedAt": "2026-07-20T14:38:52.597489+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15300,7 +15265,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:03:39.933846+00:00"
+                "validatedAt": "2026-07-20T14:38:52.597513+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15311,7 +15276,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.688201+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.464933+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -15399,7 +15364,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:39.933888+00:00"
+                "validatedAt": "2026-07-20T14:38:52.597532+00:00"
               },
               "deterministic": true
             },
@@ -15411,9 +15376,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.688246+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.464962+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -15444,7 +15408,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:39.933916+00:00"
+                "validatedAt": "2026-07-20T14:38:52.597544+00:00"
               },
               "deterministic": true
             },
@@ -15456,9 +15420,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.688265+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.464975+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -15527,7 +15490,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:39.933968+00:00"
+                "validatedAt": "2026-07-20T14:38:52.597565+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15539,7 +15502,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.688302+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.465000+00:00"
           },
           "uid": {
             "type": "string",
@@ -15557,7 +15520,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:39.933994+00:00"
+                "validatedAt": "2026-07-20T14:38:52.597575+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15570,7 +15533,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.688321+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.465013+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of k8s_pod_security_admission is returned in 'List'.",
@@ -15902,7 +15865,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:39.934073+00:00"
+                "validatedAt": "2026-07-20T14:38:52.597609+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16073,7 +16036,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:43.860186+00:00"
+                "validatedAt": "2026-07-20T14:38:54.068943+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16311,7 +16274,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:43.860318+00:00"
+                "validatedAt": "2026-07-20T14:38:54.068994+00:00"
               },
               "deterministic": true,
               "format": "uri"
@@ -16414,7 +16377,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:43.860369+00:00"
+                "validatedAt": "2026-07-20T14:38:54.069012+00:00"
               },
               "deterministic": true
             },
@@ -16426,9 +16389,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.747205+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.525408+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -16460,7 +16422,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:43.860412+00:00"
+                "validatedAt": "2026-07-20T14:38:54.069025+00:00"
               },
               "deterministic": true
             },
@@ -16472,9 +16434,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.747226+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.525422+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -16639,7 +16600,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.747294+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.525463+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -16744,7 +16705,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:43.860619+00:00"
+                "validatedAt": "2026-07-20T14:38:54.069083+00:00"
               },
               "deterministic": true,
               "format": "uri"
@@ -16831,7 +16792,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:43.860699+00:00"
+                "validatedAt": "2026-07-20T14:38:54.069112+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17012,7 +16973,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:43.860788+00:00"
+                "validatedAt": "2026-07-20T14:38:54.069147+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17053,7 +17014,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:43.860843+00:00"
+                "validatedAt": "2026-07-20T14:38:54.069174+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17137,7 +17098,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:03:43.860889+00:00"
+                "validatedAt": "2026-07-20T14:38:54.069195+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17218,7 +17179,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:03:43.860946+00:00"
+                "validatedAt": "2026-07-20T14:38:54.069218+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17229,7 +17190,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.747405+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.525529+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -17317,7 +17278,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:43.860989+00:00"
+                "validatedAt": "2026-07-20T14:38:54.069236+00:00"
               },
               "deterministic": true
             },
@@ -17329,9 +17290,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.747451+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.525558+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -17362,7 +17322,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:43.861017+00:00"
+                "validatedAt": "2026-07-20T14:38:54.069249+00:00"
               },
               "deterministic": true
             },
@@ -17374,9 +17334,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.747469+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.525570+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -17445,7 +17404,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:43.861071+00:00"
+                "validatedAt": "2026-07-20T14:38:54.069269+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17457,7 +17416,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.747507+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.525595+00:00"
           },
           "uid": {
             "type": "string",
@@ -17475,7 +17434,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:43.861096+00:00"
+                "validatedAt": "2026-07-20T14:38:54.069279+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17488,7 +17447,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.747526+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.525608+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of k8s_pod_security_policy is returned in 'List'.",
@@ -17617,7 +17576,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:43.861153+00:00"
+                "validatedAt": "2026-07-20T14:38:54.069305+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17662,7 +17621,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:43.861198+00:00"
+                "validatedAt": "2026-07-20T14:38:54.069329+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17699,7 +17658,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:43.861243+00:00"
+                "validatedAt": "2026-07-20T14:38:54.069351+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17738,7 +17697,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:43.861288+00:00"
+                "validatedAt": "2026-07-20T14:38:54.069372+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17777,7 +17736,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:43.861333+00:00"
+                "validatedAt": "2026-07-20T14:38:54.069393+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17864,7 +17823,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:43.861394+00:00"
+                "validatedAt": "2026-07-20T14:38:54.069418+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17955,7 +17914,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:43.861453+00:00"
+                "validatedAt": "2026-07-20T14:38:54.069439+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18226,7 +18185,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:43.861544+00:00"
+                "validatedAt": "2026-07-20T14:38:54.069477+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18445,7 +18404,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:43.861622+00:00"
+                "validatedAt": "2026-07-20T14:38:54.069511+00:00"
               },
               "deterministic": true,
               "format": "uri"

--- a/docs/specifications/api/marketplace.json
+++ b/docs/specifications/api/marketplace.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Marketplace",
     "description": "External connector infrastructure supporting direct, GRE, and encrypted tunnel modes with IKE parameter configuration and dead peer detection intervals. Cloud provider instances for Terraform automation and vendor partnerships. Service catalog entries with per-namespace activation flags, resource quotas, and administrative dashboard tile arrangement for operational workflows.",
-    "version": "2.1.182",
+    "version": "2.1.181",
     "contact": {
       "name": "F5 Distributed Cloud",
       "url": "https://docs.cloud.f5.com"
@@ -1100,7 +1100,7 @@
           },
           {
             "name": "response_format",
-            "description": "The format in which the configuration object is to be fetched. This could be for example\n - in GetSpec form for the contents of object\n - in CreateRequest form to create a new similar object\n - to ReplaceRequest form to replace changeable values\n\nDefault format of returned resource\nResponse should be in StatusObject(s) format\nResponse should be in format of GetSpecType\nResponse should have other objects referring to this object\nResponse should have deleted and disabled objects referred by this object.",
+            "description": "The format in which the configuration object is to be fetched. This could be for example\n - in GetSpec form for the contents of object\n - in CreateRequest form to create a new similar object\n - to ReplaceRequest form to replace changeable values\n\nDefault format of returned resource\nResponse should be in StatusObject(s) format\nResponse should be in format of GetSpecType\nResponse should have other objects referring to this object\nResponse should have deleted and disabled objects referrred by this object.",
             "in": "query",
             "required": false,
             "x-displayname": "Broken Referred Objects.",
@@ -1882,8 +1882,8 @@
     },
     "/api/web/namespaces/{namespace}/addon_subscriptions/{name}": {
       "get": {
-        "summary": "GET Addon Subscription.",
-        "description": "GET Addon Subscription reads a given object from storage backend for metadata.namespace.",
+        "summary": "GET Addon Subsciption.",
+        "description": "GET Addon Subsciption reads a given object from storage backend for metadata.namespace.",
         "operationId": "ves.io.schema.pbac.addon_subscription.API.Get",
         "responses": {
           "200": {
@@ -2010,7 +2010,7 @@
           },
           {
             "name": "response_format",
-            "description": "The format in which the configuration object is to be fetched. This could be for example\n - in GetSpec form for the contents of object\n - in CreateRequest form to create a new similar object\n - to ReplaceRequest form to replace changeable values\n\nDefault format of returned resource\nResponse should be in CreateRequest format\nResponse should be in ReplaceRequest format\nResponse should be in format of GetSpecType\nResponse should have other objects referring to this object\nResponse should have deleted and disabled objects referred by this object.",
+            "description": "The format in which the configuration object is to be fetched. This could be for example\n - in GetSpec form for the contents of object\n - in CreateRequest form to create a new similar object\n - to ReplaceRequest form to replace changeable values\n\nDefault format of returned resource\nResponse should be in CreateRequest format\nResponse should be in ReplaceRequest format\nResponse should be in format of GetSpecType\nResponse should have other objects referring to this object\nResponse should have deleted and disabled objects referrred by this object.",
             "in": "query",
             "required": false,
             "x-displayname": "Broken Referred Objects.",
@@ -8860,7 +8860,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:55:03.152514+00:00"
+                "validatedAt": "2026-07-20T14:35:25.858390+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8871,7 +8871,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.753321+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.439348+00:00"
           },
           "subject": {
             "type": "string",
@@ -8886,7 +8886,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:03.152561+00:00"
+                "validatedAt": "2026-07-20T14:35:25.858412+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9156,7 +9156,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:03.152639+00:00"
+                "validatedAt": "2026-07-20T14:35:25.858446+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9181,7 +9181,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:03.152707+00:00"
+                "validatedAt": "2026-07-20T14:35:25.858467+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9210,7 +9210,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:55:03.152740+00:00"
+                "validatedAt": "2026-07-20T14:35:25.858485+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9479,7 +9479,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.753488+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.439451+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -9574,7 +9574,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:55:03.152880+00:00"
+                "validatedAt": "2026-07-20T14:35:25.858544+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9655,7 +9655,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:55:03.152932+00:00"
+                "validatedAt": "2026-07-20T14:35:25.858570+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9666,7 +9666,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.753539+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.439483+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -9753,7 +9753,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:03.152976+00:00"
+                "validatedAt": "2026-07-20T14:35:25.858593+00:00"
               },
               "deterministic": true
             },
@@ -9765,9 +9765,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.753586+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.439513+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -9798,7 +9797,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:03.153005+00:00"
+                "validatedAt": "2026-07-20T14:35:25.858609+00:00"
               },
               "deterministic": true
             },
@@ -9810,9 +9809,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.753605+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.439527+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -9881,7 +9879,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:03.153061+00:00"
+                "validatedAt": "2026-07-20T14:35:25.858633+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9893,7 +9891,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.753642+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.439551+00:00"
           },
           "uid": {
             "type": "string",
@@ -9910,7 +9908,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:03.153087+00:00"
+                "validatedAt": "2026-07-20T14:35:25.858645+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9923,7 +9921,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.753671+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.439564+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of addon_service is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -10111,7 +10109,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:03.153173+00:00"
+                "validatedAt": "2026-07-20T14:35:25.858688+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10509,7 +10507,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:03.153260+00:00"
+                "validatedAt": "2026-07-20T14:35:25.858731+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10585,7 +10583,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:03.153307+00:00"
+                "validatedAt": "2026-07-20T14:35:25.858757+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10623,7 +10621,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:03.153352+00:00"
+                "validatedAt": "2026-07-20T14:35:25.858782+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10660,7 +10658,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:03.153405+00:00"
+                "validatedAt": "2026-07-20T14:35:25.858813+00:00"
               },
               "deterministic": true
             },
@@ -10697,7 +10695,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:03.153449+00:00"
+                "validatedAt": "2026-07-20T14:35:25.858837+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10779,7 +10777,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T12:55:03.153487+00:00"
+                "validatedAt": "2026-07-20T14:35:25.858856+00:00"
               },
               "deterministic": true
             },
@@ -10860,7 +10858,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:03.153528+00:00"
+                "validatedAt": "2026-07-20T14:35:25.858874+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10883,7 +10881,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:03.153563+00:00"
+                "validatedAt": "2026-07-20T14:35:25.858889+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10894,7 +10892,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.753837+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.439668+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -11045,7 +11043,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T12:55:03.153597+00:00"
+                "validatedAt": "2026-07-20T14:35:25.858908+00:00"
               },
               "deterministic": true
             },
@@ -11056,8 +11054,7 @@
               "read": false
             },
             "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "minLength": 1,
-            "format": "fqdn"
+            "minLength": 1
           },
           "last_update_time": {
             "type": "string",
@@ -11074,7 +11071,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:03.153639+00:00"
+                "validatedAt": "2026-07-20T14:35:25.858925+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11100,7 +11097,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:03.153682+00:00"
+                "validatedAt": "2026-07-20T14:35:25.858941+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11111,7 +11108,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.753873+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.439693+00:00"
           },
           "service_name": {
             "type": "string",
@@ -11128,7 +11125,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:03.153725+00:00"
+                "validatedAt": "2026-07-20T14:35:25.858958+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11140,7 +11137,7 @@
           },
           "status": {
             "type": "string",
-            "description": "Status of the condition\n\"Success\" Validation has succeeded. Requested operation was successful.\n\"Failed\" Validation has failed.\n\"Incomplete\" Validation of configuration has failed due to missing configuration.\n\"Installed\" Validation has passed and configuration has been installed in data path or K8s\n\"Down\" Configuration is operationally down. E.g. Down interface\n\"Disabled\" Configuration is administratively disabled i.e. objectmetatype.disable = true.\n\"NotApplicable\" Configuration is not applicable e.g. Tenant service_policy_set(s) in system namespace are not applicable on REs.",
+            "description": "Status of the condition\n\"Success\" Validtion has succeded. Requested operation was successful.\n\"Failed\" Validation has failed.\n\"Incomplete\" Validation of configuration has failed due to missing configuration.\n\"Installed\" Validation has passed and configuration has been installed in data path or K8s\n\"Down\" Configuration is operationally down. E.g. Down interface\n\"Disabled\" Configuration is administratively disabled i.e. objectmetatype.disable = true.\n\"NotApplicable\" Configuration is not applicable e.g. Tenant service_policy_set(s) in system namespace are not applicable on REs.",
             "title": "status",
             "x-displayname": "Status",
             "x-ves-example": "Failed",
@@ -11151,8 +11148,8 @@
             "x-validation-rules": {
               "ves.io.schema.rules.string.in": "[\\\"Success\\\",\\\"Failed\\\",\\\"Incomplete\\\",\\\"Installed\\\",\\\"Down\\\",\\\"Disabled\\\",\\\"NotApplicable\\\"]"
             },
-            "x-f5xc-description-short": "Status of the condition \"Success\" Validation has succeeded.",
-            "x-f5xc-description-medium": "Status of the condition \"Success\" Validation has succeeded. Requested operation was successful. \"Failed\" Validation has failed. \"Incomplete\" Validation of configuration has failed due to missing configuration. \"Installed\" Validation has passed and configuration has been installed in data path or...",
+            "x-f5xc-description-short": "Status of the condition \"Success\" Validtion has succeded.",
+            "x-f5xc-description-medium": "Status of the condition \"Success\" Validtion has succeded. Requested operation was successful. \"Failed\" Validation has failed. \"Incomplete\" Validation of configuration has failed due to missing configuration. \"Installed\" Validation has passed and configuration has been installed in data path or...",
             "maxLength": 1024,
             "x-f5xc-constraints": {
               "constraintType": "string",
@@ -11161,7 +11158,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:03.153764+00:00"
+                "validatedAt": "2026-07-20T14:35:25.858975+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11172,7 +11169,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.753898+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.439711+00:00"
           },
           "type": {
             "type": "string",
@@ -11197,7 +11194,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:03.153799+00:00"
+                "validatedAt": "2026-07-20T14:35:25.858990+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11341,7 +11338,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:03.153843+00:00"
+                "validatedAt": "2026-07-20T14:35:25.859008+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11464,7 +11461,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:03.153874+00:00"
+                "validatedAt": "2026-07-20T14:35:25.859025+00:00"
               },
               "deterministic": true
             },
@@ -11476,9 +11473,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.753947+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.439743+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -11643,7 +11639,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:03.153969+00:00"
+                "validatedAt": "2026-07-20T14:35:25.859073+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -11658,7 +11654,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.753990+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.439773+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -11730,7 +11726,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:03.154007+00:00"
+                "validatedAt": "2026-07-20T14:35:25.859093+00:00"
               },
               "deterministic": true
             },
@@ -11742,9 +11738,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.754022+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.439795+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -11777,7 +11772,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:03.154033+00:00"
+                "validatedAt": "2026-07-20T14:35:25.859108+00:00"
               },
               "deterministic": true
             },
@@ -11789,9 +11784,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.754040+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.439808+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -11854,7 +11848,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:03.154065+00:00"
+                "validatedAt": "2026-07-20T14:35:25.859122+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11866,7 +11860,7 @@
             "readOnly": true,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.754060+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.439822+00:00"
           },
           "name": {
             "type": "string",
@@ -11899,7 +11893,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:03.154091+00:00"
+                "validatedAt": "2026-07-20T14:35:25.859137+00:00"
               },
               "deterministic": true
             },
@@ -11911,9 +11905,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.754079+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.439835+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -11946,7 +11939,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:03.154119+00:00"
+                "validatedAt": "2026-07-20T14:35:25.859152+00:00"
               },
               "deterministic": true
             },
@@ -11958,9 +11951,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.754097+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.439848+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -11979,7 +11971,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:03.154152+00:00"
+                "validatedAt": "2026-07-20T14:35:25.859167+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11992,7 +11984,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.754116+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.439862+00:00"
           },
           "uid": {
             "type": "string",
@@ -12011,7 +12003,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:03.154176+00:00"
+                "validatedAt": "2026-07-20T14:35:25.859179+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12025,7 +12017,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.754135+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.439876+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -12088,7 +12080,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:03.154220+00:00"
+                "validatedAt": "2026-07-20T14:35:25.859199+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12116,7 +12108,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:03.154260+00:00"
+                "validatedAt": "2026-07-20T14:35:25.859217+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12144,7 +12136,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:03.154298+00:00"
+                "validatedAt": "2026-07-20T14:35:25.859233+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12183,7 +12175,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:03.154338+00:00"
+                "validatedAt": "2026-07-20T14:35:25.859250+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12210,7 +12202,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:03.154363+00:00"
+                "validatedAt": "2026-07-20T14:35:25.859261+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12223,7 +12215,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.754189+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.439911+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -12239,7 +12231,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:03.154399+00:00"
+                "validatedAt": "2026-07-20T14:35:25.859277+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12384,7 +12376,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:03.154450+00:00"
+                "validatedAt": "2026-07-20T14:35:25.859300+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12395,7 +12387,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.754229+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.439939+00:00"
           },
           "status": {
             "type": "string",
@@ -12413,7 +12405,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:03.154484+00:00"
+                "validatedAt": "2026-07-20T14:35:25.859314+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12424,7 +12416,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.754247+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.439952+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -12484,7 +12476,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:03.154527+00:00"
+                "validatedAt": "2026-07-20T14:35:25.859333+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12511,7 +12503,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:03.154568+00:00"
+                "validatedAt": "2026-07-20T14:35:25.859350+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12538,7 +12530,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:03.154605+00:00"
+                "validatedAt": "2026-07-20T14:35:25.859366+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12566,7 +12558,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:03.154648+00:00"
+                "validatedAt": "2026-07-20T14:35:25.859384+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12642,7 +12634,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:03.154721+00:00"
+                "validatedAt": "2026-07-20T14:35:25.859411+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12710,7 +12702,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:03.154773+00:00"
+                "validatedAt": "2026-07-20T14:35:25.859432+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12722,7 +12714,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.754333+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.440009+00:00"
           },
           "uid": {
             "type": "string",
@@ -12741,7 +12733,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:03.154798+00:00"
+                "validatedAt": "2026-07-20T14:35:25.859443+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12754,7 +12746,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.754352+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.440022+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -12822,7 +12814,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:03.154830+00:00"
+                "validatedAt": "2026-07-20T14:35:25.859457+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12833,7 +12825,7 @@
             },
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.754372+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.440036+00:00"
           },
           "name": {
             "type": "string",
@@ -12866,7 +12858,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:03.154857+00:00"
+                "validatedAt": "2026-07-20T14:35:25.859471+00:00"
               },
               "deterministic": true
             },
@@ -12878,9 +12870,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.754390+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.440049+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -12913,7 +12904,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:03.154884+00:00"
+                "validatedAt": "2026-07-20T14:35:25.859487+00:00"
               },
               "deterministic": true
             },
@@ -12925,9 +12916,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.754407+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.440062+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "uid": {
             "type": "string",
@@ -12944,7 +12934,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:03.154909+00:00"
+                "validatedAt": "2026-07-20T14:35:25.859498+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12957,7 +12947,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.754426+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.440076+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -13244,7 +13234,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.781323+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.471978+00:00"
           }
         },
         "x-f5xc-description-short": "Create a new Addon Subscription with Addon Subscription State.",
@@ -13335,7 +13325,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:05.002609+00:00"
+                "validatedAt": "2026-07-20T14:35:26.676288+00:00"
               },
               "deterministic": true
             },
@@ -13347,9 +13337,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.781353+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.471997+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -13381,7 +13370,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:05.002650+00:00"
+                "validatedAt": "2026-07-20T14:35:26.676308+00:00"
               },
               "deterministic": true
             },
@@ -13393,9 +13382,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.781372+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.472010+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -13595,8 +13583,8 @@
       },
       "addon_subscriptionGetSpecType": {
         "type": "object",
-        "description": "GET Addon Subscription reads a given object from storage backend for metadata.namespace.",
-        "title": "Get Addon Subscription",
+        "description": "GET Addon Subsciption reads a given object from storage backend for metadata.namespace.",
+        "title": "Get Addon Subsciption",
         "x-displayname": "GET Addon Subsciption.",
         "x-ves-displayorder": "1,2,3",
         "x-ves-proto-message": "ves.io.schema.pbac.addon_subscription.GetSpecType",
@@ -13654,10 +13642,10 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.781461+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.472065+00:00"
           }
         },
-        "x-f5xc-description-short": "GET Addon Subscription reads a given object from storage backend for metadata.namespace.",
+        "x-f5xc-description-short": "GET Addon Subsciption reads a given object from storage backend for metadata.namespace.",
         "x-f5xc-minimum-configuration": {
           "description": "Minimum configuration for addon_subscriptionGetSpecType",
           "required_fields": [
@@ -13732,7 +13720,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:55:05.002785+00:00"
+                "validatedAt": "2026-07-20T14:35:26.676362+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13813,7 +13801,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:55:05.002843+00:00"
+                "validatedAt": "2026-07-20T14:35:26.676390+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13824,7 +13812,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.781505+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.472093+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -13911,7 +13899,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:05.002886+00:00"
+                "validatedAt": "2026-07-20T14:35:26.676412+00:00"
               },
               "deterministic": true
             },
@@ -13923,9 +13911,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.781552+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.472122+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -13956,7 +13943,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:05.002915+00:00"
+                "validatedAt": "2026-07-20T14:35:26.676428+00:00"
               },
               "deterministic": true
             },
@@ -13968,9 +13955,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.781570+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.472136+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -14023,7 +14009,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:05.002957+00:00"
+                "validatedAt": "2026-07-20T14:35:26.676448+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14035,7 +14021,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.781601+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.472156+00:00"
           },
           "uid": {
             "type": "string",
@@ -14053,7 +14039,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:05.002983+00:00"
+                "validatedAt": "2026-07-20T14:35:26.676461+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14066,7 +14052,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.781621+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.472170+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of addon_subscription is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -14345,7 +14331,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.781694+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.472209+00:00"
           }
         },
         "x-f5xc-description-short": "Replace a given Addon Subscription with with Addon Subscription State.",
@@ -14403,7 +14389,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:05.003054+00:00"
+                "validatedAt": "2026-07-20T14:35:26.676493+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14428,7 +14414,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:05.003100+00:00"
+                "validatedAt": "2026-07-20T14:35:26.676515+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14496,7 +14482,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:05.003132+00:00"
+                "validatedAt": "2026-07-20T14:35:26.676531+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14508,7 +14494,7 @@
             "readOnly": true,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.781731+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.472232+00:00"
           },
           "name": {
             "type": "string",
@@ -14541,7 +14527,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:05.003159+00:00"
+                "validatedAt": "2026-07-20T14:35:26.676547+00:00"
               },
               "deterministic": true
             },
@@ -14553,9 +14539,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.781751+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.472245+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -14588,7 +14573,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:05.003186+00:00"
+                "validatedAt": "2026-07-20T14:35:26.676563+00:00"
               },
               "deterministic": true
             },
@@ -14600,9 +14585,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.781769+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.472258+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -14621,7 +14605,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:05.003218+00:00"
+                "validatedAt": "2026-07-20T14:35:26.676579+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14634,7 +14618,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.781788+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.472271+00:00"
           },
           "uid": {
             "type": "string",
@@ -14653,7 +14637,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:05.003243+00:00"
+                "validatedAt": "2026-07-20T14:35:26.676591+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14667,7 +14651,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.781807+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.472284+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -14766,7 +14750,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:05.003534+00:00"
+                "validatedAt": "2026-07-20T14:35:26.676743+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -14781,7 +14765,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.781930+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.472362+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -14851,7 +14835,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:05.003573+00:00"
+                "validatedAt": "2026-07-20T14:35:26.676764+00:00"
               },
               "deterministic": true
             },
@@ -14863,9 +14847,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.781963+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.472384+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -14898,7 +14881,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:05.003600+00:00"
+                "validatedAt": "2026-07-20T14:35:26.676778+00:00"
               },
               "deterministic": true
             },
@@ -14910,9 +14893,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.781982+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.472397+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -15012,7 +14994,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:05.003819+00:00"
+                "validatedAt": "2026-07-20T14:35:26.676894+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -15027,7 +15009,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.782090+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.472468+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -15097,7 +15079,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:05.003855+00:00"
+                "validatedAt": "2026-07-20T14:35:26.676914+00:00"
               },
               "deterministic": true
             },
@@ -15109,9 +15091,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.782123+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.472489+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -15144,7 +15125,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:05.003881+00:00"
+                "validatedAt": "2026-07-20T14:35:26.676929+00:00"
               },
               "deterministic": true
             },
@@ -15156,9 +15137,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.782141+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.472502+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -15247,7 +15227,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:05.004423+00:00"
+                "validatedAt": "2026-07-20T14:35:26.677197+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -15261,8 +15241,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -15301,7 +15280,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:05.004470+00:00"
+                "validatedAt": "2026-07-20T14:35:26.677229+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -15316,9 +15295,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.782397+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.472673+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -15347,7 +15325,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:05.004522+00:00"
+                "validatedAt": "2026-07-20T14:35:26.677259+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15360,7 +15338,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.782415+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.472686+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a direct reference from one object(the referrer) to another(the referred).",
@@ -15622,7 +15600,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:04.832501+00:00"
+                "validatedAt": "2026-07-20T14:36:14.537246+00:00"
               },
               "deterministic": true
             },
@@ -15666,7 +15644,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:04.832591+00:00"
+                "validatedAt": "2026-07-20T14:36:14.537286+00:00"
               },
               "deterministic": true
             },
@@ -15770,7 +15748,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:04.832641+00:00"
+                "validatedAt": "2026-07-20T14:36:14.537304+00:00"
               },
               "deterministic": true
             },
@@ -15782,9 +15760,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.075252+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.621383+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -15816,7 +15793,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:04.832699+00:00"
+                "validatedAt": "2026-07-20T14:36:14.537319+00:00"
               },
               "deterministic": true
             },
@@ -15828,9 +15805,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.075273+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.621396+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -15995,7 +15971,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.075342+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.621438+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -16129,7 +16105,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:04.832885+00:00"
+                "validatedAt": "2026-07-20T14:36:14.537366+00:00"
               },
               "deterministic": true
             },
@@ -16173,7 +16149,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:04.832943+00:00"
+                "validatedAt": "2026-07-20T14:36:14.537396+00:00"
               },
               "deterministic": true
             },
@@ -16262,7 +16238,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:57:04.832988+00:00"
+                "validatedAt": "2026-07-20T14:36:14.537419+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16343,7 +16319,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:57:04.833047+00:00"
+                "validatedAt": "2026-07-20T14:36:14.537443+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16354,7 +16330,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.075430+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.621489+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -16441,7 +16417,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:04.833089+00:00"
+                "validatedAt": "2026-07-20T14:36:14.537462+00:00"
               },
               "deterministic": true
             },
@@ -16453,9 +16429,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.075476+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.621518+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -16486,7 +16461,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:04.833119+00:00"
+                "validatedAt": "2026-07-20T14:36:14.537477+00:00"
               },
               "deterministic": true
             },
@@ -16498,9 +16473,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.075494+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.621531+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -16569,7 +16543,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:04.833173+00:00"
+                "validatedAt": "2026-07-20T14:36:14.537498+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16581,7 +16555,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.075532+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.621555+00:00"
           },
           "uid": {
             "type": "string",
@@ -16598,7 +16572,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:04.833200+00:00"
+                "validatedAt": "2026-07-20T14:36:14.537510+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16611,7 +16585,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.075552+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.621568+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of cminstance is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -16835,7 +16809,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:04.833250+00:00"
+                "validatedAt": "2026-07-20T14:36:14.537532+00:00"
               },
               "deterministic": true
             },
@@ -16879,7 +16853,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:04.833304+00:00"
+                "validatedAt": "2026-07-20T14:36:14.537559+00:00"
               },
               "deterministic": true
             },
@@ -17037,7 +17011,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:04.833448+00:00"
+                "validatedAt": "2026-07-20T14:36:14.537619+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17078,7 +17052,7 @@
                 "confidence": 1.0,
                 "category": "content",
                 "note": "Blindfold envelope encryption (AES-256-GCM + RSA-OAEP) of an RSA-2048 TLS private key produces ~3700 char string:/// URL. 128KB max secret size = ~175KB base64. Discovery reported 1024 which is incorrect.",
-                "validatedAt": "2026-07-20T12:57:04.833486+00:00"
+                "validatedAt": "2026-07-20T14:36:14.537642+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17089,7 +17063,7 @@
             },
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.075690+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.621646+00:00"
           },
           "store_provider": {
             "type": "string",
@@ -17108,7 +17082,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:04.833531+00:00"
+                "validatedAt": "2026-07-20T14:36:14.537661+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17175,7 +17149,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:04.833568+00:00"
+                "validatedAt": "2026-07-20T14:36:14.537677+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17186,7 +17160,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.075716+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.621663+00:00"
           },
           "url": {
             "type": "string",
@@ -17224,7 +17198,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:04.833625+00:00"
+                "validatedAt": "2026-07-20T14:36:14.537707+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -17302,7 +17276,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:04.834002+00:00"
+                "validatedAt": "2026-07-20T14:36:14.537863+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17808,7 +17782,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:06.810635+00:00"
+                "validatedAt": "2026-07-20T14:37:52.224739+00:00"
               },
               "deterministic": true
             },
@@ -17820,9 +17794,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.316158+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.707808+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -17854,7 +17827,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:06.810700+00:00"
+                "validatedAt": "2026-07-20T14:37:52.224758+00:00"
               },
               "deterministic": true
             },
@@ -17866,9 +17839,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.316178+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.707820+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -17933,7 +17905,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T13:01:06.810764+00:00"
+                "validatedAt": "2026-07-20T14:37:52.224780+00:00"
               },
               "deterministic": true
             },
@@ -18093,7 +18065,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:29.187855+00:00"
+                "validatedAt": "2026-07-20T14:38:00.674874+00:00"
               }
             }
           },
@@ -18290,7 +18262,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.316299+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.707886+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -18572,7 +18544,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:06.810973+00:00"
+                "validatedAt": "2026-07-20T14:37:52.224890+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18718,7 +18690,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:01:06.811029+00:00"
+                "validatedAt": "2026-07-20T14:37:52.224917+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18799,7 +18771,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:01:06.811086+00:00"
+                "validatedAt": "2026-07-20T14:37:52.224942+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18810,7 +18782,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.316429+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.707961+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -18897,7 +18869,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:06.811127+00:00"
+                "validatedAt": "2026-07-20T14:37:52.224961+00:00"
               },
               "deterministic": true
             },
@@ -18909,9 +18881,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.316475+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.707988+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -18942,7 +18913,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:06.811154+00:00"
+                "validatedAt": "2026-07-20T14:37:52.224975+00:00"
               },
               "deterministic": true
             },
@@ -18954,9 +18925,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.316493+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.707999+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -19025,7 +18995,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:06.811206+00:00"
+                "validatedAt": "2026-07-20T14:37:52.225005+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19037,7 +19007,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.316530+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.708022+00:00"
           },
           "uid": {
             "type": "string",
@@ -19055,7 +19025,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:06.811233+00:00"
+                "validatedAt": "2026-07-20T14:37:52.225025+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19068,7 +19038,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.316550+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.708035+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of external_connector is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -19418,7 +19388,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:06.811324+00:00"
+                "validatedAt": "2026-07-20T14:37:52.225062+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19454,7 +19424,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:06.811368+00:00"
+                "validatedAt": "2026-07-20T14:37:52.225080+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19486,7 +19456,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:06.811402+00:00"
+                "validatedAt": "2026-07-20T14:37:52.225094+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19522,7 +19492,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:06.811448+00:00"
+                "validatedAt": "2026-07-20T14:37:52.225113+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19610,7 +19580,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:06.811480+00:00"
+                "validatedAt": "2026-07-20T14:37:52.225127+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19713,7 +19683,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:06.811542+00:00"
+                "validatedAt": "2026-07-20T14:37:52.225159+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19897,7 +19867,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:06.812202+00:00"
+                "validatedAt": "2026-07-20T14:37:52.225440+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19973,7 +19943,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:06.812665+00:00"
+                "validatedAt": "2026-07-20T14:37:52.225658+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20168,7 +20138,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.028365+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.759513+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -20255,7 +20225,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:10.172434+00:00"
+                "validatedAt": "2026-07-20T14:39:27.329388+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20286,7 +20256,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:10.172556+00:00"
+                "validatedAt": "2026-07-20T14:39:27.329423+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20323,7 +20293,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:10.172614+00:00"
+                "validatedAt": "2026-07-20T14:39:27.329451+00:00"
               },
               "deterministic": true
             },
@@ -20373,7 +20343,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:10.172678+00:00"
+                "validatedAt": "2026-07-20T14:39:27.329474+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20409,7 +20379,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:10.172722+00:00"
+                "validatedAt": "2026-07-20T14:39:27.329494+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20437,7 +20407,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T13:05:10.172756+00:00"
+                "validatedAt": "2026-07-20T14:39:27.329509+00:00"
               },
               "deterministic": true
             },
@@ -20528,7 +20498,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:05:10.172800+00:00"
+                "validatedAt": "2026-07-20T14:39:27.329527+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20609,7 +20579,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:05:10.172855+00:00"
+                "validatedAt": "2026-07-20T14:39:27.329549+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20620,7 +20590,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.028468+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.759576+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -20707,7 +20677,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:10.172899+00:00"
+                "validatedAt": "2026-07-20T14:39:27.329567+00:00"
               },
               "deterministic": true
             },
@@ -20719,9 +20689,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.028515+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.759625+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -20752,7 +20721,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:10.172928+00:00"
+                "validatedAt": "2026-07-20T14:39:27.329581+00:00"
               },
               "deterministic": true
             },
@@ -20764,9 +20733,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.028533+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.759640+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -20835,7 +20803,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:10.172980+00:00"
+                "validatedAt": "2026-07-20T14:39:27.329601+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20847,7 +20815,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.028571+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.759665+00:00"
           },
           "uid": {
             "type": "string",
@@ -20864,7 +20832,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:10.173007+00:00"
+                "validatedAt": "2026-07-20T14:39:27.329611+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20877,7 +20845,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.028590+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.759679+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of navigation_tile is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -21042,7 +21010,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:39.137018+00:00"
+                "validatedAt": "2026-07-20T14:39:38.052967+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21185,7 +21153,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:39.137100+00:00"
+                "validatedAt": "2026-07-20T14:39:38.052999+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21250,7 +21218,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:39.137155+00:00"
+                "validatedAt": "2026-07-20T14:39:38.053016+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21360,7 +21328,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:39.137255+00:00"
+                "validatedAt": "2026-07-20T14:39:38.053048+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21370,9 +21338,9 @@
               "read": false
             },
             "minLength": 26,
-            "format": "dns-label",
+            "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.506425+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:19.208653+00:00",
             "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "locale": {
@@ -21397,7 +21365,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:39.137342+00:00"
+                "validatedAt": "2026-07-20T14:39:38.053074+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21424,7 +21392,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:39.137411+00:00"
+                "validatedAt": "2026-07-20T14:39:38.053091+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21456,7 +21424,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:39.137480+00:00"
+                "validatedAt": "2026-07-20T14:39:38.053117+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21554,7 +21522,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:39.137541+00:00"
+                "validatedAt": "2026-07-20T14:39:38.053146+00:00"
               },
               "deterministic": true
             },
@@ -21566,9 +21534,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.506476+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.208684+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -21624,7 +21591,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:39.137577+00:00"
+                "validatedAt": "2026-07-20T14:39:38.053161+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21649,7 +21616,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:39.137612+00:00"
+                "validatedAt": "2026-07-20T14:39:38.053175+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21674,7 +21641,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:39.137642+00:00"
+                "validatedAt": "2026-07-20T14:39:38.053188+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21699,7 +21666,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:39.137687+00:00"
+                "validatedAt": "2026-07-20T14:39:38.053201+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21725,7 +21692,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:39.137722+00:00"
+                "validatedAt": "2026-07-20T14:39:38.053214+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21750,7 +21717,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:39.137762+00:00"
+                "validatedAt": "2026-07-20T14:39:38.053229+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21776,7 +21743,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:39.137794+00:00"
+                "validatedAt": "2026-07-20T14:39:38.053242+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21802,7 +21769,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:39.137832+00:00"
+                "validatedAt": "2026-07-20T14:39:38.053256+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21827,7 +21794,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:39.137867+00:00"
+                "validatedAt": "2026-07-20T14:39:38.053270+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21906,7 +21873,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:39.137931+00:00"
+                "validatedAt": "2026-07-20T14:39:38.053300+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21946,7 +21913,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:39.137990+00:00"
+                "validatedAt": "2026-07-20T14:39:38.053327+00:00"
               },
               "deterministic": true
             },
@@ -21979,7 +21946,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:39.138047+00:00"
+                "validatedAt": "2026-07-20T14:39:38.053353+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22011,7 +21978,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:39.138102+00:00"
+                "validatedAt": "2026-07-20T14:39:38.053379+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22157,7 +22124,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.756977+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.492871+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -22244,7 +22211,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:56.401220+00:00"
+                "validatedAt": "2026-07-20T14:39:44.863168+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22281,7 +22248,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:56.401324+00:00"
+                "validatedAt": "2026-07-20T14:39:44.863207+00:00"
               },
               "deterministic": true
             },
@@ -22319,7 +22286,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:56.401384+00:00"
+                "validatedAt": "2026-07-20T14:39:44.863233+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22405,7 +22372,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:05:56.401431+00:00"
+                "validatedAt": "2026-07-20T14:39:44.863256+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22485,7 +22452,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:05:56.401490+00:00"
+                "validatedAt": "2026-07-20T14:39:44.863283+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22496,7 +22463,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.757055+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.492916+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -22582,7 +22549,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:56.401537+00:00"
+                "validatedAt": "2026-07-20T14:39:44.863305+00:00"
               },
               "deterministic": true
             },
@@ -22594,9 +22561,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.757101+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.492944+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -22627,7 +22593,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:56.401566+00:00"
+                "validatedAt": "2026-07-20T14:39:44.863321+00:00"
               },
               "deterministic": true
             },
@@ -22639,9 +22605,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.757121+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.492957+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -22710,7 +22675,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:56.401619+00:00"
+                "validatedAt": "2026-07-20T14:39:44.863343+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22722,7 +22687,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.757159+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.492980+00:00"
           },
           "uid": {
             "type": "string",
@@ -22739,7 +22704,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:56.401645+00:00"
+                "validatedAt": "2026-07-20T14:39:44.863355+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22752,7 +22717,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.757178+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.492993+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of plan is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -22904,7 +22869,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:46.675278+00:00"
+                "validatedAt": "2026-07-20T14:41:14.368051+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22995,7 +22960,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:46.675381+00:00"
+                "validatedAt": "2026-07-20T14:41:14.368084+00:00"
               },
               "deterministic": true
             },
@@ -23007,9 +22972,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.257292+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:23.828697+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-example": "[EMAIL, CC]",
@@ -23141,7 +23105,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:46.675477+00:00"
+                "validatedAt": "2026-07-20T14:41:14.368108+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23166,7 +23130,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:46.675525+00:00"
+                "validatedAt": "2026-07-20T14:41:14.368123+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23231,7 +23195,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:46.675575+00:00"
+                "validatedAt": "2026-07-20T14:41:14.368142+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23447,7 +23411,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:46.675641+00:00"
+                "validatedAt": "2026-07-20T14:41:14.368167+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23568,7 +23532,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:46.675724+00:00"
+                "validatedAt": "2026-07-20T14:41:14.368194+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23592,7 +23556,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:46.675764+00:00"
+                "validatedAt": "2026-07-20T14:41:14.368210+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23717,7 +23681,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:46.675811+00:00"
+                "validatedAt": "2026-07-20T14:41:14.368227+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23741,7 +23705,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:46.675850+00:00"
+                "validatedAt": "2026-07-20T14:41:14.368243+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24269,7 +24233,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:46.676035+00:00"
+                "validatedAt": "2026-07-20T14:41:14.368319+00:00"
               },
               "deterministic": true
             },
@@ -24407,7 +24371,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:46.676087+00:00"
+                "validatedAt": "2026-07-20T14:41:14.368345+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24639,7 +24603,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:46.676152+00:00"
+                "validatedAt": "2026-07-20T14:41:14.368375+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24677,7 +24641,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:46.676221+00:00"
+                "validatedAt": "2026-07-20T14:41:14.368408+00:00"
               },
               "deterministic": true
             },
@@ -24852,7 +24816,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:46.676281+00:00"
+                "validatedAt": "2026-07-20T14:41:14.368435+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24928,7 +24892,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:46.676339+00:00"
+                "validatedAt": "2026-07-20T14:41:14.368463+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24938,9 +24902,9 @@
               "read": false
             },
             "minLength": 26,
-            "format": "fqdn",
+            "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.257713+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.828941+00:00"
           },
           "simple_login": {
             "allOf": [
@@ -25090,7 +25054,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:46.676414+00:00"
+                "validatedAt": "2026-07-20T14:41:14.368495+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25129,7 +25093,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:46.676473+00:00"
+                "validatedAt": "2026-07-20T14:41:14.368522+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25652,7 +25616,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:46.676579+00:00"
+                "validatedAt": "2026-07-20T14:41:14.368566+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25771,7 +25735,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:46.676632+00:00"
+                "validatedAt": "2026-07-20T14:41:14.368591+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25880,7 +25844,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:46.676707+00:00"
+                "validatedAt": "2026-07-20T14:41:14.368619+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25919,7 +25883,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:46.676765+00:00"
+                "validatedAt": "2026-07-20T14:41:14.368645+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25971,7 +25935,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:46.676832+00:00"
+                "validatedAt": "2026-07-20T14:41:14.368675+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25982,8 +25946,7 @@
             },
             "x-f5xc-conflicts-with": [
               "any_domain"
-            ],
-            "format": "fqdn"
+            ]
           },
           "validation_mode": {
             "allOf": [
@@ -26083,7 +26046,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:46.676890+00:00"
+                "validatedAt": "2026-07-20T14:41:14.368702+00:00"
               },
               "deterministic": true
             },
@@ -26177,7 +26140,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:46.676938+00:00"
+                "validatedAt": "2026-07-20T14:41:14.368725+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26486,7 +26449,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:46.677774+00:00"
+                "validatedAt": "2026-07-20T14:41:14.369086+00:00"
               },
               "deterministic": true
             },
@@ -26498,7 +26461,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.258329+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.829321+00:00"
           },
           "name": {
             "type": "string",
@@ -26542,7 +26505,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:46.677823+00:00"
+                "validatedAt": "2026-07-20T14:41:14.369112+00:00"
               },
               "deterministic": true
             },
@@ -26552,8 +26515,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "MessageMetaType is metadata (common attributes) of a message that only certain messages have.",
@@ -26660,7 +26622,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:09:46.679016+00:00"
+                "validatedAt": "2026-07-20T14:41:14.369616+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26819,7 +26781,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.258932+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.829691+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -26935,7 +26897,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:46.679120+00:00"
+                "validatedAt": "2026-07-20T14:41:14.369656+00:00"
               },
               "deterministic": true
             },
@@ -26947,9 +26909,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.258965+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:23.829711+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "third_party_applications_list": {
             "allOf": [
@@ -27043,7 +27004,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:09:46.679165+00:00"
+                "validatedAt": "2026-07-20T14:41:14.369676+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27124,7 +27085,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:09:46.679216+00:00"
+                "validatedAt": "2026-07-20T14:41:14.369698+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27135,7 +27096,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.259015+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.829741+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -27223,7 +27184,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:46.679255+00:00"
+                "validatedAt": "2026-07-20T14:41:14.369720+00:00"
               },
               "deterministic": true
             },
@@ -27235,9 +27196,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.259060+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:23.829769+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -27268,7 +27228,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:46.679283+00:00"
+                "validatedAt": "2026-07-20T14:41:14.369733+00:00"
               },
               "deterministic": true
             },
@@ -27280,9 +27240,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.259078+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:23.829781+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -27351,7 +27310,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:46.679337+00:00"
+                "validatedAt": "2026-07-20T14:41:14.369753+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27363,7 +27322,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.259116+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.829804+00:00"
           },
           "uid": {
             "type": "string",
@@ -27381,7 +27340,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:46.679363+00:00"
+                "validatedAt": "2026-07-20T14:41:14.369764+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27394,7 +27353,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.259134+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.829816+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of third_party_application is returned in 'List'.",
@@ -27670,7 +27629,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:46.679453+00:00"
+                "validatedAt": "2026-07-20T14:41:14.369802+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28275,7 +28234,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:57.322064+00:00"
+                "validatedAt": "2026-07-20T14:41:40.393182+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28318,7 +28277,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:57.322107+00:00"
+                "validatedAt": "2026-07-20T14:41:40.393200+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28363,7 +28322,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:57.322153+00:00"
+                "validatedAt": "2026-07-20T14:41:40.393219+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28389,7 +28348,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:57.322193+00:00"
+                "validatedAt": "2026-07-20T14:41:40.393235+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28415,7 +28374,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:57.322230+00:00"
+                "validatedAt": "2026-07-20T14:41:40.393250+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28438,7 +28397,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:57.322267+00:00"
+                "validatedAt": "2026-07-20T14:41:40.393267+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28564,7 +28523,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:57.322301+00:00"
+                "validatedAt": "2026-07-20T14:41:40.393285+00:00"
               },
               "deterministic": true
             },
@@ -28576,9 +28535,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.304247+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.226203+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "view_kind": {
             "type": "string",
@@ -28596,7 +28554,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:57.322337+00:00"
+                "validatedAt": "2026-07-20T14:41:40.393300+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28622,7 +28580,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:57.322373+00:00"
+                "validatedAt": "2026-07-20T14:41:40.393316+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28774,7 +28732,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.304291+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.226228+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -28911,7 +28869,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:57.322428+00:00"
+                "validatedAt": "2026-07-20T14:41:40.393336+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28955,7 +28913,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:57.322475+00:00"
+                "validatedAt": "2026-07-20T14:41:40.393355+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28997,7 +28955,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:57.322519+00:00"
+                "validatedAt": "2026-07-20T14:41:40.393372+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29023,7 +28981,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:57.322559+00:00"
+                "validatedAt": "2026-07-20T14:41:40.393388+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29161,7 +29119,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:57.322592+00:00"
+                "validatedAt": "2026-07-20T14:41:40.393403+00:00"
               },
               "deterministic": true
             },
@@ -29173,9 +29131,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.304363+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.226269+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "view_kind": {
             "type": "string",
@@ -29193,7 +29150,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:57.322629+00:00"
+                "validatedAt": "2026-07-20T14:41:40.393419+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29219,7 +29176,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:57.322674+00:00"
+                "validatedAt": "2026-07-20T14:41:40.393434+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29434,7 +29391,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:57.322757+00:00"
+                "validatedAt": "2026-07-20T14:41:40.393466+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29532,7 +29489,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:48.549036+00:00"
+                "validatedAt": "2026-07-20T14:41:59.922476+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29557,7 +29514,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:48.549109+00:00"
+                "validatedAt": "2026-07-20T14:41:59.922500+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29569,7 +29526,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:26.269448+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:26.283024+00:00"
           },
           "email": {
             "type": "string",
@@ -29595,7 +29552,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T13:11:48.549168+00:00"
+                "validatedAt": "2026-07-20T14:41:59.922522+00:00"
               },
               "deterministic": true
             },
@@ -29622,7 +29579,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:48.549234+00:00"
+                "validatedAt": "2026-07-20T14:41:59.922541+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29688,7 +29645,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:48.549291+00:00"
+                "validatedAt": "2026-07-20T14:41:59.922557+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29769,7 +29726,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:11:48.549357+00:00"
+                "validatedAt": "2026-07-20T14:41:59.922580+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29849,7 +29806,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:48.549431+00:00"
+                "validatedAt": "2026-07-20T14:41:59.922617+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29858,9 +29815,9 @@
               "update": false,
               "read": false
             },
-            "format": "dns-label",
+            "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:26.269509+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:26.283061+00:00",
             "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "token": {
@@ -29879,7 +29836,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:11:48.549472+00:00"
+                "validatedAt": "2026-07-20T14:41:59.922637+00:00"
               }
             },
             "x-f5xc-required-for": {

--- a/docs/specifications/api/minimal-export-defaults.json
+++ b/docs/specifications/api/minimal-export-defaults.json
@@ -5120,8 +5120,5 @@
       "serverDefaultFields": []
     }
   },
-  "version": "2.1.181",
-  "info": {
-    "version": "2.1.182"
-  }
+  "version": "2.1.181"
 }

--- a/docs/specifications/api/namespace_profiles.json
+++ b/docs/specifications/api/namespace_profiles.json
@@ -1,6 +1,6 @@
 {
   "version": "2.1.181",
-  "generated_at": "2026-07-20T13:12:53.785001+00:00",
+  "generated_at": "2026-07-20T14:42:41.083122+00:00",
   "source": "api-specs-enriched/config/namespace_profile.yaml",
   "default": {
     "constraint": {
@@ -5495,8 +5495,5 @@
       "tpm_category",
       "usb_policy"
     ]
-  },
-  "info": {
-    "version": "2.1.182"
   }
 }

--- a/docs/specifications/api/network.json
+++ b/docs/specifications/api/network.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Network",
     "description": "Routing table manipulation via peer state machines and path selection algorithms. Secure conduits between locations using IKE handshakes, cipher suites, and key exchanges. Segment attachments bridge hybrid topologies spanning cloud providers and on-premises infrastructure. SRv6 addressing, CIDR block matching, and advertisement controls direct traffic flows across distributed deployments with granular policy enforcement.",
-    "version": "2.1.182",
+    "version": "2.1.181",
     "contact": {
       "name": "F5 Distributed Cloud",
       "url": "https://docs.cloud.f5.com"
@@ -699,7 +699,7 @@
           },
           {
             "name": "response_format",
-            "description": "The format in which the configuration object is to be fetched. This could be for example\n - in GetSpec form for the contents of object\n - in CreateRequest form to create a new similar object\n - to ReplaceRequest form to replace changeable values\n\nDefault format of returned resource\nResponse should be in CreateRequest format\nResponse should be in StatusObject(s) format\nResponse should be in format of GetSpecType\nResponse should have other objects referring to this object\nResponse should have deleted and disabled objects referred by this object.",
+            "description": "The format in which the configuration object is to be fetched. This could be for example\n - in GetSpec form for the contents of object\n - in CreateRequest form to create a new similar object\n - to ReplaceRequest form to replace changeable values\n\nDefault format of returned resource\nResponse should be in CreateRequest format\nResponse should be in StatusObject(s) format\nResponse should be in format of GetSpecType\nResponse should have other objects referring to this object\nResponse should have deleted and disabled objects referrred by this object.",
             "in": "query",
             "required": false,
             "x-displayname": "Broken Referred Objects.",
@@ -1831,7 +1831,7 @@
           },
           {
             "name": "response_format",
-            "description": "The format in which the configuration object is to be fetched. This could be for example\n - in GetSpec form for the contents of object\n - in CreateRequest form to create a new similar object\n - to ReplaceRequest form to replace changeable values\n\nDefault format of returned resource\nResponse should be in CreateRequest format\nResponse should be in ReplaceRequest format\nResponse should be in StatusObject(s) format\nResponse should be in format of GetSpecType\nResponse should have other objects referring to this object\nResponse should have deleted and disabled objects referred by this object.",
+            "description": "The format in which the configuration object is to be fetched. This could be for example\n - in GetSpec form for the contents of object\n - in CreateRequest form to create a new similar object\n - to ReplaceRequest form to replace changeable values\n\nDefault format of returned resource\nResponse should be in CreateRequest format\nResponse should be in ReplaceRequest format\nResponse should be in StatusObject(s) format\nResponse should be in format of GetSpecType\nResponse should have other objects referring to this object\nResponse should have deleted and disabled objects referrred by this object.",
             "in": "query",
             "required": false,
             "x-displayname": "Broken Referred Objects.",
@@ -22959,7 +22959,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:06.853428+00:00"
+                "validatedAt": "2026-07-20T14:35:27.495145+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23069,7 +23069,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:06.853500+00:00"
+                "validatedAt": "2026-07-20T14:35:27.495173+00:00"
               },
               "deterministic": true
             },
@@ -23081,9 +23081,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.808088+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.506788+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -23115,7 +23114,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:06.853541+00:00"
+                "validatedAt": "2026-07-20T14:35:27.495189+00:00"
               },
               "deterministic": true
             },
@@ -23127,9 +23126,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.808109+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.506802+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -23278,7 +23276,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.808170+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.506842+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -23385,7 +23383,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:06.853745+00:00"
+                "validatedAt": "2026-07-20T14:35:27.495248+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23482,7 +23480,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:55:06.853795+00:00"
+                "validatedAt": "2026-07-20T14:35:27.495271+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23561,7 +23559,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:55:06.853857+00:00"
+                "validatedAt": "2026-07-20T14:35:27.495299+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23572,7 +23570,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.808243+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.506888+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -23659,7 +23657,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:06.853900+00:00"
+                "validatedAt": "2026-07-20T14:35:27.495321+00:00"
               },
               "deterministic": true
             },
@@ -23671,9 +23669,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.808291+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.506919+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -23704,7 +23701,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:06.853928+00:00"
+                "validatedAt": "2026-07-20T14:35:27.495336+00:00"
               },
               "deterministic": true
             },
@@ -23716,9 +23713,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.808309+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.506931+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -23787,7 +23783,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:06.853981+00:00"
+                "validatedAt": "2026-07-20T14:35:27.495361+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23799,7 +23795,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.808347+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.506956+00:00"
           },
           "uid": {
             "type": "string",
@@ -23817,7 +23813,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:06.854010+00:00"
+                "validatedAt": "2026-07-20T14:35:27.495375+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23830,7 +23826,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.808368+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.506970+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of address_allocator is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -24016,7 +24012,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:06.854077+00:00"
+                "validatedAt": "2026-07-20T14:35:27.495405+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24039,7 +24035,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:06.854111+00:00"
+                "validatedAt": "2026-07-20T14:35:27.495421+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24050,7 +24046,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.808419+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.507002+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -24112,7 +24108,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T12:55:06.854147+00:00"
+                "validatedAt": "2026-07-20T14:35:27.495438+00:00"
               },
               "deterministic": true
             },
@@ -24123,8 +24119,7 @@
               "read": false
             },
             "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "minLength": 1,
-            "format": "fqdn"
+            "minLength": 1
           },
           "last_update_time": {
             "type": "string",
@@ -24141,7 +24136,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:06.854188+00:00"
+                "validatedAt": "2026-07-20T14:35:27.495457+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24167,7 +24162,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:06.854223+00:00"
+                "validatedAt": "2026-07-20T14:35:27.495472+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24178,7 +24173,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.808454+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.507025+00:00"
           },
           "service_name": {
             "type": "string",
@@ -24195,7 +24190,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:06.854262+00:00"
+                "validatedAt": "2026-07-20T14:35:27.495490+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24207,7 +24202,7 @@
           },
           "status": {
             "type": "string",
-            "description": "Status of the condition\n\"Success\" Validation has succeeded. Requested operation was successful.\n\"Failed\" Validation has failed.\n\"Incomplete\" Validation of configuration has failed due to missing configuration.\n\"Installed\" Validation has passed and configuration has been installed in data path or K8s\n\"Down\" Configuration is operationally down. E.g. Down interface\n\"Disabled\" Configuration is administratively disabled i.e. objectmetatype.disable = true.\n\"NotApplicable\" Configuration is not applicable e.g. Tenant service_policy_set(s) in system namespace are not applicable on REs.",
+            "description": "Status of the condition\n\"Success\" Validtion has succeded. Requested operation was successful.\n\"Failed\" Validation has failed.\n\"Incomplete\" Validation of configuration has failed due to missing configuration.\n\"Installed\" Validation has passed and configuration has been installed in data path or K8s\n\"Down\" Configuration is operationally down. E.g. Down interface\n\"Disabled\" Configuration is administratively disabled i.e. objectmetatype.disable = true.\n\"NotApplicable\" Configuration is not applicable e.g. Tenant service_policy_set(s) in system namespace are not applicable on REs.",
             "title": "status",
             "x-displayname": "Status",
             "x-ves-example": "Failed",
@@ -24218,8 +24213,8 @@
             "x-validation-rules": {
               "ves.io.schema.rules.string.in": "[\\\"Success\\\",\\\"Failed\\\",\\\"Incomplete\\\",\\\"Installed\\\",\\\"Down\\\",\\\"Disabled\\\",\\\"NotApplicable\\\"]"
             },
-            "x-f5xc-description-short": "Status of the condition \"Success\" Validation has succeeded.",
-            "x-f5xc-description-medium": "Status of the condition \"Success\" Validation has succeeded. Requested operation was successful. \"Failed\" Validation has failed. \"Incomplete\" Validation of configuration has failed due to missing configuration. \"Installed\" Validation has passed and configuration has been installed in data path or...",
+            "x-f5xc-description-short": "Status of the condition \"Success\" Validtion has succeded.",
+            "x-f5xc-description-medium": "Status of the condition \"Success\" Validtion has succeded. Requested operation was successful. \"Failed\" Validation has failed. \"Incomplete\" Validation of configuration has failed due to missing configuration. \"Installed\" Validation has passed and configuration has been installed in data path or...",
             "maxLength": 1024,
             "x-f5xc-constraints": {
               "constraintType": "string",
@@ -24228,7 +24223,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:06.854304+00:00"
+                "validatedAt": "2026-07-20T14:35:27.495508+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24239,7 +24234,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.808480+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.507043+00:00"
           },
           "type": {
             "type": "string",
@@ -24264,7 +24259,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:06.854338+00:00"
+                "validatedAt": "2026-07-20T14:35:27.495525+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24404,7 +24399,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:06.854381+00:00"
+                "validatedAt": "2026-07-20T14:35:27.495543+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24482,7 +24477,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:06.854411+00:00"
+                "validatedAt": "2026-07-20T14:35:27.495559+00:00"
               },
               "deterministic": true
             },
@@ -24494,9 +24489,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.808529+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.507075+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -24656,7 +24650,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:06.854513+00:00"
+                "validatedAt": "2026-07-20T14:35:27.495609+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -24671,7 +24665,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.808571+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.507104+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -24741,7 +24735,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:06.854552+00:00"
+                "validatedAt": "2026-07-20T14:35:27.495630+00:00"
               },
               "deterministic": true
             },
@@ -24753,9 +24747,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.808605+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.507126+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -24788,7 +24781,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:06.854582+00:00"
+                "validatedAt": "2026-07-20T14:35:27.495644+00:00"
               },
               "deterministic": true
             },
@@ -24800,9 +24793,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.808624+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.507139+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -24900,7 +24892,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:06.854679+00:00"
+                "validatedAt": "2026-07-20T14:35:27.495684+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -24915,7 +24907,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.808652+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.507158+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -24987,7 +24979,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:06.854720+00:00"
+                "validatedAt": "2026-07-20T14:35:27.495704+00:00"
               },
               "deterministic": true
             },
@@ -24999,9 +24991,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.808699+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.507180+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -25034,7 +25025,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:06.854747+00:00"
+                "validatedAt": "2026-07-20T14:35:27.495720+00:00"
               },
               "deterministic": true
             },
@@ -25046,9 +25037,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.808718+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.507193+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -25109,7 +25099,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:06.854779+00:00"
+                "validatedAt": "2026-07-20T14:35:27.495734+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25121,7 +25111,7 @@
             "readOnly": true,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.808738+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.507207+00:00"
           },
           "name": {
             "type": "string",
@@ -25154,7 +25144,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:06.854808+00:00"
+                "validatedAt": "2026-07-20T14:35:27.495749+00:00"
               },
               "deterministic": true
             },
@@ -25166,9 +25156,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.808758+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.507220+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -25201,7 +25190,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:06.854835+00:00"
+                "validatedAt": "2026-07-20T14:35:27.495763+00:00"
               },
               "deterministic": true
             },
@@ -25213,9 +25202,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.808776+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.507233+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -25234,7 +25222,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:06.854870+00:00"
+                "validatedAt": "2026-07-20T14:35:27.495778+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25247,7 +25235,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.808795+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.507246+00:00"
           },
           "uid": {
             "type": "string",
@@ -25266,7 +25254,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:06.854896+00:00"
+                "validatedAt": "2026-07-20T14:35:27.495790+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25280,7 +25268,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.808814+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.507259+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -25341,7 +25329,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:06.854940+00:00"
+                "validatedAt": "2026-07-20T14:35:27.495810+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25369,7 +25357,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:06.854979+00:00"
+                "validatedAt": "2026-07-20T14:35:27.495831+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25397,7 +25385,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:06.855020+00:00"
+                "validatedAt": "2026-07-20T14:35:27.495850+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25436,7 +25424,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:06.855059+00:00"
+                "validatedAt": "2026-07-20T14:35:27.495871+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25463,7 +25451,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:06.855086+00:00"
+                "validatedAt": "2026-07-20T14:35:27.495883+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25476,7 +25464,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.808869+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.507294+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -25492,7 +25480,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:06.855121+00:00"
+                "validatedAt": "2026-07-20T14:35:27.495899+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25633,7 +25621,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:06.855170+00:00"
+                "validatedAt": "2026-07-20T14:35:27.495921+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25644,7 +25632,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.808910+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.507321+00:00"
           },
           "status": {
             "type": "string",
@@ -25662,7 +25650,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:06.855204+00:00"
+                "validatedAt": "2026-07-20T14:35:27.495936+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25673,7 +25661,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.808928+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.507334+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -25731,7 +25719,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:06.855248+00:00"
+                "validatedAt": "2026-07-20T14:35:27.495956+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25758,7 +25746,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:06.855288+00:00"
+                "validatedAt": "2026-07-20T14:35:27.495974+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25785,7 +25773,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:06.855326+00:00"
+                "validatedAt": "2026-07-20T14:35:27.495991+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25813,7 +25801,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:06.855368+00:00"
+                "validatedAt": "2026-07-20T14:35:27.496010+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25889,7 +25877,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:06.855431+00:00"
+                "validatedAt": "2026-07-20T14:35:27.496039+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25957,7 +25945,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:06.855482+00:00"
+                "validatedAt": "2026-07-20T14:35:27.496062+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25969,7 +25957,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.809015+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.507390+00:00"
           },
           "uid": {
             "type": "string",
@@ -25988,7 +25976,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:06.855508+00:00"
+                "validatedAt": "2026-07-20T14:35:27.496074+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26001,7 +25989,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.809034+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.507404+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -26067,7 +26055,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:06.855540+00:00"
+                "validatedAt": "2026-07-20T14:35:27.496088+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26078,7 +26066,7 @@
             },
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.809055+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.507418+00:00"
           },
           "name": {
             "type": "string",
@@ -26111,7 +26099,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:06.855569+00:00"
+                "validatedAt": "2026-07-20T14:35:27.496103+00:00"
               },
               "deterministic": true
             },
@@ -26123,9 +26111,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.809073+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.507431+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -26158,7 +26145,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:06.855596+00:00"
+                "validatedAt": "2026-07-20T14:35:27.496118+00:00"
               },
               "deterministic": true
             },
@@ -26170,9 +26157,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.809091+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.507444+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "uid": {
             "type": "string",
@@ -26189,7 +26175,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:06.855621+00:00"
+                "validatedAt": "2026-07-20T14:35:27.496129+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26202,7 +26188,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.809110+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.507457+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -26410,7 +26396,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:08.881620+00:00"
+                "validatedAt": "2026-07-20T14:35:28.342882+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26445,7 +26431,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:08.881692+00:00"
+                "validatedAt": "2026-07-20T14:35:28.342910+00:00"
               },
               "deterministic": true
             },
@@ -26490,7 +26476,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:08.881763+00:00"
+                "validatedAt": "2026-07-20T14:35:28.342946+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26523,7 +26509,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:08.881802+00:00"
+                "validatedAt": "2026-07-20T14:35:28.342965+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26694,7 +26680,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:08.881869+00:00"
+                "validatedAt": "2026-07-20T14:35:28.342997+00:00"
               },
               "deterministic": true
             },
@@ -26706,9 +26692,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.836586+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.543542+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -26740,7 +26725,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:08.881901+00:00"
+                "validatedAt": "2026-07-20T14:35:28.343014+00:00"
               },
               "deterministic": true
             },
@@ -26752,9 +26737,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.836608+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.543556+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -26917,7 +26901,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.836689+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.543598+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -27001,7 +26985,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:08.882031+00:00"
+                "validatedAt": "2026-07-20T14:35:28.343073+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27036,7 +27020,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:08.882067+00:00"
+                "validatedAt": "2026-07-20T14:35:28.343093+00:00"
               },
               "deterministic": true
             },
@@ -27081,7 +27065,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:08.882130+00:00"
+                "validatedAt": "2026-07-20T14:35:28.343126+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27114,7 +27098,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:08.882170+00:00"
+                "validatedAt": "2026-07-20T14:35:28.343144+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27269,7 +27253,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:55:08.882236+00:00"
+                "validatedAt": "2026-07-20T14:35:28.343176+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27348,7 +27332,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:55:08.882290+00:00"
+                "validatedAt": "2026-07-20T14:35:28.343202+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27359,7 +27343,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.836797+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.543666+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -27446,7 +27430,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:08.882333+00:00"
+                "validatedAt": "2026-07-20T14:35:28.343223+00:00"
               },
               "deterministic": true
             },
@@ -27458,9 +27442,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.836849+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.543696+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -27491,7 +27474,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:08.882361+00:00"
+                "validatedAt": "2026-07-20T14:35:28.343238+00:00"
               },
               "deterministic": true
             },
@@ -27503,9 +27486,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.836869+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.543709+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -27574,7 +27556,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:08.882412+00:00"
+                "validatedAt": "2026-07-20T14:35:28.343261+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27586,7 +27568,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.836906+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.543734+00:00"
           },
           "uid": {
             "type": "string",
@@ -27604,7 +27586,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:08.882440+00:00"
+                "validatedAt": "2026-07-20T14:35:28.343273+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27617,7 +27599,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.836926+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.543748+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of advertise_policy is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -27694,7 +27676,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:08.882469+00:00"
+                "validatedAt": "2026-07-20T14:35:28.343289+00:00"
               },
               "deterministic": true
             },
@@ -27706,9 +27688,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.836948+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.543763+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "port": {
             "type": "integer",
@@ -27728,7 +27709,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:08.882497+00:00"
+                "validatedAt": "2026-07-20T14:35:28.343305+00:00"
               },
               "deterministic": true
             },
@@ -27753,7 +27734,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:08.882530+00:00"
+                "validatedAt": "2026-07-20T14:35:28.343320+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27764,7 +27745,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.836975+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.543780+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -27922,7 +27903,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:08.882593+00:00"
+                "validatedAt": "2026-07-20T14:35:28.343352+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27957,7 +27938,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:08.882624+00:00"
+                "validatedAt": "2026-07-20T14:35:28.343368+00:00"
               },
               "deterministic": true
             },
@@ -28002,7 +27983,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:08.882695+00:00"
+                "validatedAt": "2026-07-20T14:35:28.343399+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28035,7 +28016,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:08.882734+00:00"
+                "validatedAt": "2026-07-20T14:35:28.343416+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28306,7 +28287,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:08.882914+00:00"
+                "validatedAt": "2026-07-20T14:35:28.343495+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28347,7 +28328,7 @@
                 "confidence": 1.0,
                 "category": "content",
                 "note": "Blindfold envelope encryption (AES-256-GCM + RSA-OAEP) of an RSA-2048 TLS private key produces ~3700 char string:/// URL. 128KB max secret size = ~175KB base64. Discovery reported 1024 which is incorrect.",
-                "validatedAt": "2026-07-20T12:55:08.882952+00:00"
+                "validatedAt": "2026-07-20T14:35:28.343518+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28358,7 +28339,7 @@
             },
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.837131+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.543877+00:00"
           },
           "store_provider": {
             "type": "string",
@@ -28377,7 +28358,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:08.882996+00:00"
+                "validatedAt": "2026-07-20T14:35:28.343539+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28444,7 +28425,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:08.883032+00:00"
+                "validatedAt": "2026-07-20T14:35:28.343555+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28455,7 +28436,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.837158+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.543895+00:00"
           },
           "url": {
             "type": "string",
@@ -28493,7 +28474,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:08.883089+00:00"
+                "validatedAt": "2026-07-20T14:35:28.343588+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -28642,7 +28623,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:08.883364+00:00"
+                "validatedAt": "2026-07-20T14:35:28.343717+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28767,7 +28748,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:08.883454+00:00"
+                "validatedAt": "2026-07-20T14:35:28.343762+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28841,7 +28822,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:08.883540+00:00"
+                "validatedAt": "2026-07-20T14:35:28.343807+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28883,7 +28864,7 @@
       },
       "schemaNetworkSiteRefSelector": {
         "type": "object",
-        "description": "NetworkSiteRefSelector defines a union of reference to site or reference to virtual_network or reference to virtual_site\nIt is used to determine virtual network using following rules\n* Direct reference to virtual_network object\n* Site local network when referring to site object\n* All site local networks for sites selected by referring to virtual_site object.",
+        "description": "NetworkSiteRefSelector defines a union of reference to site or reference to virtual_network or reference to virtual_site\nIt is used to determine virtual network using following rules\n* Direct reference to virtual_network object\n* Site local network when refering to site object\n* All site local networks for sites selected by refering to virtual_site object.",
         "title": "NetworkSiteRefSelector",
         "x-displayname": "Network or Site Reference.",
         "x-ves-oneof-field-ref_or_selector": "[\"site\",\"virtual_network\",\"virtual_site\"]",
@@ -28976,7 +28957,7 @@
           }
         },
         "x-f5xc-description-short": "NetworkSiteRefSelector defines a union of reference to site or reference to virtual_network or reference to virtual_site It is used to determine...",
-        "x-f5xc-description-medium": "NetworkSiteRefSelector defines a union of reference to site or reference to virtual_network or reference to virtual_site It is used to determine virtual network using following rules * Direct reference to virtual_network object * Site local network when referring to site object * All site local...",
+        "x-f5xc-description-medium": "NetworkSiteRefSelector defines a union of reference to site or reference to virtual_network or reference to virtual_site It is used to determine virtual network using following rules * Direct reference to virtual_network object * Site local network when refering to site object * All site local...",
         "x-f5xc-minimum-configuration": {
           "description": "Minimum configuration for schemaNetworkSiteRefSelector",
           "required_fields": [
@@ -29068,7 +29049,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:08.884068+00:00"
+                "validatedAt": "2026-07-20T14:35:28.344068+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -29083,7 +29064,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.837641+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.544210+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -29153,7 +29134,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:08.884108+00:00"
+                "validatedAt": "2026-07-20T14:35:28.344088+00:00"
               },
               "deterministic": true
             },
@@ -29165,9 +29146,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.837683+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.544231+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -29200,7 +29180,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:08.884136+00:00"
+                "validatedAt": "2026-07-20T14:35:28.344101+00:00"
               },
               "deterministic": true
             },
@@ -29212,9 +29192,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.837702+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.544244+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -29401,7 +29380,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:08.884194+00:00"
+                "validatedAt": "2026-07-20T14:35:28.344130+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29489,7 +29468,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:08.884884+00:00"
+                "validatedAt": "2026-07-20T14:35:28.344425+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29536,7 +29515,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:55:08.884933+00:00"
+                "validatedAt": "2026-07-20T14:35:28.344447+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29547,7 +29526,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.837993+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.544431+00:00"
           },
           "disable_ocsp_stapling": {
             "allOf": [
@@ -29670,7 +29649,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:08.884984+00:00"
+                "validatedAt": "2026-07-20T14:35:28.344474+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29878,7 +29857,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:08.885078+00:00"
+                "validatedAt": "2026-07-20T14:35:28.344518+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29974,7 +29953,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:08.885138+00:00"
+                "validatedAt": "2026-07-20T14:35:28.344547+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30095,7 +30074,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:08.885185+00:00"
+                "validatedAt": "2026-07-20T14:35:28.344572+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30139,7 +30118,7 @@
       },
       "schemaVirtualNetworkType": {
         "type": "string",
-        "description": "Different types of virtual networks understood by the system\n\nVirtual-network of type VIRTUAL_NETWORK_SITE_LOCAL provides connectivity to public (outside) network.\nThis is an insecure network and is connected to public internet via NAT Gateways/firwalls\nVirtual-network of this type is local to every site. Two virtual networks of this type on different\nsites are neither related nor connected.\n\nConstraints:\nThere can be atmost one virtual network of this type in a given site.\nThis network type is supported on CE sites. This network is created automatically and present on all sites\nVirtual-network of type VIRTUAL_NETWORK_SITE_LOCAL_INSIDE is a private network inside site.\nIt is a secure network and is not connected to public network.\nVirtual-network of this type is local to every site. Two virtual networks of this type on different\nsites are neither related nor connected.\n\nConstraints:\nThere can be atmost one virtual network of this type in a given site.\nThis network type is supported on CE sites. This network is created during provisioning of site\nUser defined per-site virtual network. Scope of this virtual network is limited to the site.\nThis is not yet supported\nVirtual-network of type VIRTUAL_NETWORK_PUBLIC directly connects to the public internet.\nVirtual-network of this type is local to every site. Two virtual networks of this type on different sites are neither related nor connected.\n\nConstraints:\nThere can be atmost one virtual network of this type in a given site.\nThis network type is supported on RE sites only\nIt is an internally created by the system. They must not be created by user\nVirtual Networks with global scope across different sites in F5XC domain.\nAn example global virtual-network called \"AIN Network\" is created for every tenant.\nFor F5 Distributed Cloud fabric\n\nConstraints:\nIt is currently only supported as internally created by the system.\nVK8s service network for a given tenant. Used to advertise a virtual host only to vk8s pods for that tenant\nConstraints:\nIt is an internally created by the system. Must not be created by user\nVER internal network for the site. It can only be used for virtual hosts with SMA_PROXY type proxy\nConstraints:\nIt is an internally created by the system. Must not be created by user\nVirtual-network of type VIRTUAL_NETWORK_SITE_LOCAL_INSIDE_OUTSIDE represents both\nVIRTUAL_NETWORK_SITE_LOCAL and VIRTUAL_NETWORK_SITE_LOCAL_INSIDE\n\nConstraints:\nThis network type is only meaningful in an advertise policy\nWhen virtual-network of type VIRTUAL_NETWORK_IP_AUTO is selected for\nan endpoint, VER will try to determine the network based on the provided\nIP address\n\nConstraints:\nThis network type is only meaningful in an endpoint\n\nVoltADN Private Network is used on F5 Distributed Cloud RE(s) to connect to customer private networks\nThis network is created by opening a support ticket\n\nThis network is per site srv6 network\nVER IP Fabric network for the site.\nThis Virtual network type is used for exposing virtual host on IP Fabric network on the VER site or\nfor endpoint in IP Fabric network\nConstraints:\nIt is an internally created by the system. Must not be created by user\nNetwork internally created for a segment\nConstraints:\nIt is an internally created by the system. Must not be created by user\nVirtual-network of type VIRTUAL_NETWORK_MANAGEMENT is used for management purposes.",
+        "description": "Different types of virtual networks understood by the system\n\nVirtual-network of type VIRTUAL_NETWORK_SITE_LOCAL provides connectivity to public (outside) network.\nThis is an insecure network and is connected to public internet via NAT Gateways/firwalls\nVirtual-network of this type is local to every site. Two virtual networks of this type on different\nsites are neither related nor connected.\n\nConstraints:\nThere can be atmost one virtual network of this type in a given site.\nThis network type is supported on CE sites. This network is created automatically and present on all sites\nVirtual-network of type VIRTUAL_NETWORK_SITE_LOCAL_INSIDE is a private network inside site.\nIt is a secure network and is not connected to public network.\nVirtual-network of this type is local to every site. Two virtual networks of this type on different\nsites are neither related nor connected.\n\nConstraints:\nThere can be atmost one virtual network of this type in a given site.\nThis network type is supported on CE sites. This network is created during provisioning of site\nUser defined per-site virtual network. Scope of this virtual network is limited to the site.\nThis is not yet supported\nVirtual-network of type VIRTUAL_NETWORK_PUBLIC directly conects to the public internet.\nVirtual-network of this type is local to every site. Two virtual networks of this type on different sites are neither related nor connected.\n\nConstraints:\nThere can be atmost one virtual network of this type in a given site.\nThis network type is supported on RE sites only\nIt is an internally created by the system. They must not be created by user\nVirtual Neworks with global scope across different sites in F5XC domain.\nAn example global virtual-network called \"AIN Network\" is created for every tenant.\nFor F5 Distributed Cloud fabric\n\nConstraints:\nIt is currently only supported as internally created by the system.\nVK8s service network for a given tenant. Used to advertise a virtual host only to vk8s pods for that tenant\nConstraints:\nIt is an internally created by the system. Must not be created by user\nVER internal network for the site. It can only be used for virtual hosts with SMA_PROXY type proxy\nConstraints:\nIt is an internally created by the system. Must not be created by user\nVirtual-network of type VIRTUAL_NETWORK_SITE_LOCAL_INSIDE_OUTSIDE represents both\nVIRTUAL_NETWORK_SITE_LOCAL and VIRTUAL_NETWORK_SITE_LOCAL_INSIDE\n\nConstraints:\nThis network type is only meaningful in an advertise policy\nWhen virtual-network of type VIRTUAL_NETWORK_IP_AUTO is selected for\nan endpoint, VER will try to determine the network based on the provided\nIP address\n\nConstraints:\nThis network type is only meaningful in an endpoint\n\nVoltADN Private Network is used on F5 Distributed Cloud RE(s) to connect to customer private networks\nThis network is created by opening a support ticket\n\nThis network is per site srv6 network\nVER IP Fabric network for the site.\nThis Virtual network type is used for exposing virtual host on IP Fabric network on the VER site or\nfor endpoint in IP Fabric network\nConstraints:\nIt is an internally created by the system. Must not be created by user\nNetwork internally created for a segment\nConstraints:\nIt is an internally created by the system. Must not be created by user\nVirtual-network of type VIRTUAL_NETWORK_MANAGEMENT is used for management purposes.",
         "title": "VirtualNetworkType",
         "enum": [
           "VIRTUAL_NETWORK_SITE_LOCAL",
@@ -30425,7 +30404,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:49.578376+00:00"
+                "validatedAt": "2026-07-20T14:35:44.408877+00:00"
               },
               "deterministic": true
             },
@@ -30585,7 +30564,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:49.578458+00:00"
+                "validatedAt": "2026-07-20T14:35:44.408911+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30609,7 +30588,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:49.578499+00:00"
+                "validatedAt": "2026-07-20T14:35:44.408927+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30672,7 +30651,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:49.578569+00:00"
+                "validatedAt": "2026-07-20T14:35:44.408955+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30739,7 +30718,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:49.578634+00:00"
+                "validatedAt": "2026-07-20T14:35:44.408982+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30873,7 +30852,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:49.578701+00:00"
+                "validatedAt": "2026-07-20T14:35:44.409010+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31003,7 +30982,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:49.578760+00:00"
+                "validatedAt": "2026-07-20T14:35:44.409041+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31097,7 +31076,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:49.578819+00:00"
+                "validatedAt": "2026-07-20T14:35:44.409065+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31147,7 +31126,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:49.578876+00:00"
+                "validatedAt": "2026-07-20T14:35:44.409093+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31379,7 +31358,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:49.578937+00:00"
+                "validatedAt": "2026-07-20T14:35:44.409122+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31499,7 +31478,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:49.578977+00:00"
+                "validatedAt": "2026-07-20T14:35:44.409141+00:00"
               },
               "deterministic": true
             },
@@ -31511,9 +31490,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.628557+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.364075+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -31545,7 +31523,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:49.579008+00:00"
+                "validatedAt": "2026-07-20T14:35:44.409156+00:00"
               },
               "deterministic": true
             },
@@ -31557,9 +31535,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.628578+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.364089+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -32102,7 +32079,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.628740+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.364180+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -32203,7 +32180,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:49.579162+00:00"
+                "validatedAt": "2026-07-20T14:35:44.409220+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32294,7 +32271,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.628790+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.364211+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -32366,7 +32343,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:49.579225+00:00"
+                "validatedAt": "2026-07-20T14:35:44.409251+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32447,7 +32424,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:55:49.579269+00:00"
+                "validatedAt": "2026-07-20T14:35:44.409273+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32525,7 +32502,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:55:49.579324+00:00"
+                "validatedAt": "2026-07-20T14:35:44.409298+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32536,7 +32513,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.628843+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.364244+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -32622,7 +32599,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:49.579367+00:00"
+                "validatedAt": "2026-07-20T14:35:44.409318+00:00"
               },
               "deterministic": true
             },
@@ -32634,9 +32611,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.628889+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.364273+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -32667,7 +32643,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:49.579397+00:00"
+                "validatedAt": "2026-07-20T14:35:44.409333+00:00"
               },
               "deterministic": true
             },
@@ -32679,9 +32655,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.628908+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.364285+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -32750,7 +32725,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:49.579449+00:00"
+                "validatedAt": "2026-07-20T14:35:44.409355+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32762,7 +32737,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.628945+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.364310+00:00"
           },
           "uid": {
             "type": "string",
@@ -32779,7 +32754,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:49.579475+00:00"
+                "validatedAt": "2026-07-20T14:35:44.409366+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32792,7 +32767,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.628964+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.364323+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of BGP is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -32978,7 +32953,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:49.579530+00:00"
+                "validatedAt": "2026-07-20T14:35:44.409391+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33123,7 +33098,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:49.579598+00:00"
+                "validatedAt": "2026-07-20T14:35:44.409424+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33164,7 +33139,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:49.579664+00:00"
+                "validatedAt": "2026-07-20T14:35:44.409453+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33424,7 +33399,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:49.579747+00:00"
+                "validatedAt": "2026-07-20T14:35:44.409485+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33481,7 +33456,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:49.579783+00:00"
+                "validatedAt": "2026-07-20T14:35:44.409504+00:00"
               },
               "deterministic": true
             },
@@ -33804,7 +33779,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:49.579902+00:00"
+                "validatedAt": "2026-07-20T14:35:44.409558+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33991,7 +33966,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:49.579970+00:00"
+                "validatedAt": "2026-07-20T14:35:44.409585+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34003,7 +33978,7 @@
             "readOnly": true,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.629244+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.364491+00:00"
           },
           "name": {
             "type": "string",
@@ -34036,7 +34011,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:49.579998+00:00"
+                "validatedAt": "2026-07-20T14:35:44.409600+00:00"
               },
               "deterministic": true
             },
@@ -34048,9 +34023,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.629263+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.364504+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -34083,7 +34057,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:49.580025+00:00"
+                "validatedAt": "2026-07-20T14:35:44.409614+00:00"
               },
               "deterministic": true
             },
@@ -34095,9 +34069,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.629282+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.364516+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -34116,7 +34089,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:49.580057+00:00"
+                "validatedAt": "2026-07-20T14:35:44.409629+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34129,7 +34102,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.629300+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.364528+00:00"
           },
           "uid": {
             "type": "string",
@@ -34148,7 +34121,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:49.580083+00:00"
+                "validatedAt": "2026-07-20T14:35:44.409663+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34162,7 +34135,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.629320+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.364541+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -34306,7 +34279,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:49.580520+00:00"
+                "validatedAt": "2026-07-20T14:35:44.409872+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34376,7 +34349,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:49.580571+00:00"
+                "validatedAt": "2026-07-20T14:35:44.409899+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34448,7 +34421,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:49.580640+00:00"
+                "validatedAt": "2026-07-20T14:35:44.409935+00:00"
               },
               "deterministic": true
             },
@@ -34460,7 +34433,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.629521+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.364666+00:00"
           },
           "name": {
             "type": "string",
@@ -34504,7 +34477,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:49.580702+00:00"
+                "validatedAt": "2026-07-20T14:35:44.409964+00:00"
               },
               "deterministic": true
             },
@@ -34514,8 +34487,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "MessageMetaType is metadata (common attributes) of a message that only certain messages have.",
@@ -34693,7 +34665,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:49.581970+00:00"
+                "validatedAt": "2026-07-20T14:35:44.410552+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -34708,9 +34680,8 @@
               "read": false
             },
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.613568+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.522267+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -34749,7 +34720,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:49.582016+00:00"
+                "validatedAt": "2026-07-20T14:35:44.410578+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -34764,9 +34735,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.630163+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.365070+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -34795,7 +34765,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:49.582069+00:00"
+                "validatedAt": "2026-07-20T14:35:44.410605+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34808,7 +34778,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.630182+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.365082+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a direct reference from one object(the referrer) to another(the referred).",
@@ -34869,7 +34839,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:51.745171+00:00"
+                "validatedAt": "2026-07-20T14:35:45.360795+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34901,7 +34871,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:51.745249+00:00"
+                "validatedAt": "2026-07-20T14:35:45.360834+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35073,7 +35043,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:51.745367+00:00"
+                "validatedAt": "2026-07-20T14:35:45.360887+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35145,7 +35115,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:51.747009+00:00"
+                "validatedAt": "2026-07-20T14:35:45.361736+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35370,7 +35340,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:53.698240+00:00"
+                "validatedAt": "2026-07-20T14:35:46.213468+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35463,7 +35433,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:53.698292+00:00"
+                "validatedAt": "2026-07-20T14:35:46.213495+00:00"
               },
               "deterministic": true
             },
@@ -35475,9 +35445,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.711930+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.438723+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -35509,7 +35478,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:53.698323+00:00"
+                "validatedAt": "2026-07-20T14:35:46.213511+00:00"
               },
               "deterministic": true
             },
@@ -35521,9 +35490,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.711951+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.438737+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -35686,7 +35654,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.712020+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.438778+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -35783,7 +35751,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:53.698449+00:00"
+                "validatedAt": "2026-07-20T14:35:46.213568+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35865,7 +35833,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:55:53.698495+00:00"
+                "validatedAt": "2026-07-20T14:35:46.213591+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35944,7 +35912,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:55:53.698556+00:00"
+                "validatedAt": "2026-07-20T14:35:46.213618+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35955,7 +35923,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.712081+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.438814+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -36042,7 +36010,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:53.698597+00:00"
+                "validatedAt": "2026-07-20T14:35:46.213638+00:00"
               },
               "deterministic": true
             },
@@ -36054,9 +36022,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.712126+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.438843+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -36087,7 +36054,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:53.698625+00:00"
+                "validatedAt": "2026-07-20T14:35:46.213652+00:00"
               },
               "deterministic": true
             },
@@ -36099,9 +36066,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.712145+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.438855+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -36170,7 +36136,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:53.698690+00:00"
+                "validatedAt": "2026-07-20T14:35:46.213675+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36182,7 +36148,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.712182+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.438879+00:00"
           },
           "uid": {
             "type": "string",
@@ -36199,7 +36165,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:53.698719+00:00"
+                "validatedAt": "2026-07-20T14:35:46.213688+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36212,7 +36178,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.712202+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.438892+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of bgp_asn_set is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -36395,7 +36361,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:53.698778+00:00"
+                "validatedAt": "2026-07-20T14:35:46.213717+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36537,7 +36503,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:57.311521+00:00"
+                "validatedAt": "2026-07-20T14:35:47.670053+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36601,7 +36567,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:57.311630+00:00"
+                "validatedAt": "2026-07-20T14:35:47.670090+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36734,7 +36700,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:57.311704+00:00"
+                "validatedAt": "2026-07-20T14:35:47.670114+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36839,7 +36805,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:57.311770+00:00"
+                "validatedAt": "2026-07-20T14:35:47.670142+00:00"
               },
               "deterministic": true
             },
@@ -36851,9 +36817,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.763584+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.508951+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -36960,7 +36925,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:57.311840+00:00"
+                "validatedAt": "2026-07-20T14:35:47.670164+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37051,7 +37016,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:57.312135+00:00"
+                "validatedAt": "2026-07-20T14:35:47.670283+00:00"
               },
               "deterministic": true
             },
@@ -37063,9 +37028,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.763719+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.509026+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "peer": {
             "type": "array",
@@ -37149,7 +37113,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:57.312173+00:00"
+                "validatedAt": "2026-07-20T14:35:47.670301+00:00"
               },
               "deterministic": true
             },
@@ -37161,9 +37125,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.763747+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.509043+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "ri_table": {
             "type": "array",
@@ -37257,7 +37220,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:59.225757+00:00"
+                "validatedAt": "2026-07-20T14:35:48.432400+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37361,7 +37324,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:59.225846+00:00"
+                "validatedAt": "2026-07-20T14:35:48.432444+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37459,7 +37422,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:59.225911+00:00"
+                "validatedAt": "2026-07-20T14:35:48.432473+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37564,7 +37527,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:59.225977+00:00"
+                "validatedAt": "2026-07-20T14:35:48.432495+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37733,7 +37696,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:59.226082+00:00"
+                "validatedAt": "2026-07-20T14:35:48.432525+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38071,7 +38034,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:59.226208+00:00"
+                "validatedAt": "2026-07-20T14:35:48.432560+00:00"
               },
               "deterministic": true
             },
@@ -38083,9 +38046,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.778862+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.550992+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -38117,7 +38079,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:59.226240+00:00"
+                "validatedAt": "2026-07-20T14:35:48.432576+00:00"
               },
               "deterministic": true
             },
@@ -38129,9 +38091,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.778883+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.551005+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -38367,7 +38328,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:55:59.226349+00:00"
+                "validatedAt": "2026-07-20T14:35:48.432622+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38446,7 +38407,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:55:59.226405+00:00"
+                "validatedAt": "2026-07-20T14:35:48.432649+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38457,7 +38418,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.778979+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.551064+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -38544,7 +38505,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:59.226447+00:00"
+                "validatedAt": "2026-07-20T14:35:48.432670+00:00"
               },
               "deterministic": true
             },
@@ -38556,9 +38517,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.779024+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.551093+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -38589,7 +38549,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:59.226475+00:00"
+                "validatedAt": "2026-07-20T14:35:48.432685+00:00"
               },
               "deterministic": true
             },
@@ -38601,9 +38561,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.779043+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.551106+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -38656,7 +38615,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:59.226516+00:00"
+                "validatedAt": "2026-07-20T14:35:48.432703+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38668,7 +38627,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.779074+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.551127+00:00"
           },
           "uid": {
             "type": "string",
@@ -38686,7 +38645,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:59.226542+00:00"
+                "validatedAt": "2026-07-20T14:35:48.432715+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38699,7 +38658,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.779094+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.551140+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of bgp_routing_policy is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -38876,7 +38835,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:59.227864+00:00"
+                "validatedAt": "2026-07-20T14:35:48.433322+00:00"
               },
               "deterministic": true
             },
@@ -38960,7 +38919,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:59.227918+00:00"
+                "validatedAt": "2026-07-20T14:35:48.433350+00:00"
               },
               "deterministic": true
             },
@@ -39041,7 +39000,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:59.227968+00:00"
+                "validatedAt": "2026-07-20T14:35:48.433379+00:00"
               },
               "deterministic": true
             },
@@ -39401,7 +39360,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:50.091769+00:00"
+                "validatedAt": "2026-07-20T14:37:21.201322+00:00"
               },
               "deterministic": true
             },
@@ -39413,9 +39372,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.894859+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.388263+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -39447,7 +39405,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:50.091810+00:00"
+                "validatedAt": "2026-07-20T14:37:21.201340+00:00"
               },
               "deterministic": true
             },
@@ -39459,9 +39417,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.894880+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.388277+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -39624,7 +39581,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.894948+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.388319+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -39770,7 +39727,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:59:50.091989+00:00"
+                "validatedAt": "2026-07-20T14:37:21.201391+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39849,7 +39806,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:59:50.092079+00:00"
+                "validatedAt": "2026-07-20T14:37:21.201415+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39860,7 +39817,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.895007+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.388354+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -39947,7 +39904,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:50.092134+00:00"
+                "validatedAt": "2026-07-20T14:37:21.201434+00:00"
               },
               "deterministic": true
             },
@@ -39959,9 +39916,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.895052+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.388383+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -39992,7 +39948,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:50.092165+00:00"
+                "validatedAt": "2026-07-20T14:37:21.201468+00:00"
               },
               "deterministic": true
             },
@@ -40004,9 +39960,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.895071+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.388395+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -40075,7 +40030,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:50.092222+00:00"
+                "validatedAt": "2026-07-20T14:37:21.201496+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40087,7 +40042,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.895109+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.388419+00:00"
           },
           "uid": {
             "type": "string",
@@ -40105,7 +40060,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:50.092250+00:00"
+                "validatedAt": "2026-07-20T14:37:21.201508+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40118,7 +40073,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.895129+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.388432+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of dc_cluster_group is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -40312,7 +40267,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:50.092316+00:00"
+                "validatedAt": "2026-07-20T14:37:21.201535+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40357,7 +40312,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:50.092375+00:00"
+                "validatedAt": "2026-07-20T14:37:21.201564+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40384,7 +40339,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:50.092412+00:00"
+                "validatedAt": "2026-07-20T14:37:21.201579+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40439,7 +40394,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:50.092455+00:00"
+                "validatedAt": "2026-07-20T14:37:21.201600+00:00"
               },
               "deterministic": true
             },
@@ -40451,9 +40406,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.895199+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.388474+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "range": {
             "type": "string",
@@ -40478,7 +40432,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:50.092492+00:00"
+                "validatedAt": "2026-07-20T14:37:21.201616+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40511,7 +40465,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:50.092533+00:00"
+                "validatedAt": "2026-07-20T14:37:21.201632+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40544,7 +40498,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:50.092567+00:00"
+                "validatedAt": "2026-07-20T14:37:21.201646+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40638,7 +40592,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:50.092614+00:00"
+                "validatedAt": "2026-07-20T14:37:21.201665+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41033,7 +40987,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:50.093129+00:00"
+                "validatedAt": "2026-07-20T14:37:21.201874+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41044,7 +40998,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.895477+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.388643+00:00"
           }
         },
         "x-f5xc-description-short": "Metric data contains timestamp and the value.",
@@ -41135,7 +41089,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:50.093756+00:00"
+                "validatedAt": "2026-07-20T14:37:21.202168+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41241,7 +41195,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:59:50.094415+00:00"
+                "validatedAt": "2026-07-20T14:37:21.202440+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41252,7 +41206,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.896076+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.389014+00:00"
           },
           "previous_value": {
             "type": "string",
@@ -41270,7 +41224,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:50.094455+00:00"
+                "validatedAt": "2026-07-20T14:37:21.202456+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41308,7 +41262,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:50.094489+00:00"
+                "validatedAt": "2026-07-20T14:37:21.202471+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41319,7 +41273,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.896113+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.389034+00:00"
           }
         },
         "x-f5xc-description-short": "Trend value contains trend value, trend sentiment and trend calculation description and window size.",
@@ -41479,7 +41433,7 @@
             "maxLength": 16,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.896213+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.389096+00:00"
           },
           "value": {
             "type": "array",
@@ -41498,7 +41452,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.896234+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.389110+00:00"
           }
         },
         "x-f5xc-description-short": "Metric Type Data contains key/value pair that uniquely identifies the group_by labels specified in the request.",
@@ -42091,7 +42045,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:59.352039+00:00"
+                "validatedAt": "2026-07-20T14:38:12.277635+00:00"
               },
               "deterministic": true
             },
@@ -42103,9 +42057,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.066836+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.176871+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -42137,7 +42090,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:59.352087+00:00"
+                "validatedAt": "2026-07-20T14:38:12.277653+00:00"
               },
               "deterministic": true
             },
@@ -42149,9 +42102,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.066858+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.176884+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -42316,7 +42268,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.066925+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.176924+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -42657,7 +42609,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:01:59.352323+00:00"
+                "validatedAt": "2026-07-20T14:38:12.277718+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42738,7 +42690,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:01:59.352394+00:00"
+                "validatedAt": "2026-07-20T14:38:12.277743+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42749,7 +42701,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.067030+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.176983+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -42836,7 +42788,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:59.352437+00:00"
+                "validatedAt": "2026-07-20T14:38:12.277762+00:00"
               },
               "deterministic": true
             },
@@ -42848,9 +42800,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.067077+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.177011+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -42881,7 +42832,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:59.352468+00:00"
+                "validatedAt": "2026-07-20T14:38:12.277776+00:00"
               },
               "deterministic": true
             },
@@ -42893,9 +42844,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.067095+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.177022+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -42964,7 +42914,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:59.352522+00:00"
+                "validatedAt": "2026-07-20T14:38:12.277798+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42976,7 +42926,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.067133+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.177045+00:00"
           },
           "uid": {
             "type": "string",
@@ -42994,7 +42944,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:59.352549+00:00"
+                "validatedAt": "2026-07-20T14:38:12.277808+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43007,7 +42957,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.067153+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.177057+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of forwarding_class is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -43630,7 +43580,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:26.484217+00:00"
+                "validatedAt": "2026-07-20T14:38:22.982411+00:00"
               },
               "deterministic": true
             },
@@ -43642,9 +43592,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.501025+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.485425+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -43676,7 +43625,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:26.484253+00:00"
+                "validatedAt": "2026-07-20T14:38:22.982469+00:00"
               },
               "deterministic": true
             },
@@ -43688,9 +43637,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.501045+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.485437+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -43853,7 +43801,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.501113+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.485477+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -43948,7 +43896,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:02:26.484400+00:00"
+                "validatedAt": "2026-07-20T14:38:22.982520+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44026,7 +43974,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:02:26.484484+00:00"
+                "validatedAt": "2026-07-20T14:38:22.982545+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44037,7 +43985,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.501165+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.485507+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -44123,7 +44071,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:26.484551+00:00"
+                "validatedAt": "2026-07-20T14:38:22.982565+00:00"
               },
               "deterministic": true
             },
@@ -44135,9 +44083,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.501211+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.485535+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -44168,7 +44115,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:26.484596+00:00"
+                "validatedAt": "2026-07-20T14:38:22.982580+00:00"
               },
               "deterministic": true
             },
@@ -44180,9 +44127,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.501230+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.485546+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -44251,7 +44197,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:26.484679+00:00"
+                "validatedAt": "2026-07-20T14:38:22.982601+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44263,7 +44209,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.501267+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.485569+00:00"
           },
           "uid": {
             "type": "string",
@@ -44280,7 +44226,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:26.484708+00:00"
+                "validatedAt": "2026-07-20T14:38:22.982611+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44293,7 +44239,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.501286+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.485582+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of ike1 is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -45591,7 +45537,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:30.366563+00:00"
+                "validatedAt": "2026-07-20T14:38:24.587623+00:00"
               },
               "deterministic": true
             },
@@ -45603,9 +45549,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.558259+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.520597+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -45637,7 +45582,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:30.366620+00:00"
+                "validatedAt": "2026-07-20T14:38:24.587640+00:00"
               },
               "deterministic": true
             },
@@ -45649,9 +45594,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.558279+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.520611+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -45814,7 +45758,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.558345+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.520652+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -46154,7 +46098,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:02:30.366976+00:00"
+                "validatedAt": "2026-07-20T14:38:24.587734+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46233,7 +46177,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:02:30.367037+00:00"
+                "validatedAt": "2026-07-20T14:38:24.587805+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46244,7 +46188,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.558485+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.520735+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -46331,7 +46275,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:30.367080+00:00"
+                "validatedAt": "2026-07-20T14:38:24.587827+00:00"
               },
               "deterministic": true
             },
@@ -46343,9 +46287,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.558531+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.520763+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -46376,7 +46319,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:30.367111+00:00"
+                "validatedAt": "2026-07-20T14:38:24.587843+00:00"
               },
               "deterministic": true
             },
@@ -46388,9 +46331,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.558550+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.520776+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -46459,7 +46401,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:30.367167+00:00"
+                "validatedAt": "2026-07-20T14:38:24.587865+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46471,7 +46413,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.558587+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.520800+00:00"
           },
           "uid": {
             "type": "string",
@@ -46489,7 +46431,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:30.367194+00:00"
+                "validatedAt": "2026-07-20T14:38:24.587876+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46502,7 +46444,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.558608+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.520813+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of ike_phase1_profile is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -47391,7 +47333,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:33.882831+00:00"
+                "validatedAt": "2026-07-20T14:38:25.928908+00:00"
               },
               "deterministic": true
             },
@@ -47403,9 +47345,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.596446+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.549755+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -47437,7 +47378,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:33.882867+00:00"
+                "validatedAt": "2026-07-20T14:38:25.928925+00:00"
               },
               "deterministic": true
             },
@@ -47449,9 +47390,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.596467+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.549768+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -47614,7 +47554,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.596535+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.549808+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -47709,7 +47649,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:02:33.883031+00:00"
+                "validatedAt": "2026-07-20T14:38:25.928970+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47787,7 +47727,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:02:33.883120+00:00"
+                "validatedAt": "2026-07-20T14:38:25.928994+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47798,7 +47738,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.596586+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.549838+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -47884,7 +47824,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:33.883192+00:00"
+                "validatedAt": "2026-07-20T14:38:25.929012+00:00"
               },
               "deterministic": true
             },
@@ -47896,9 +47836,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.596632+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.549865+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -47929,7 +47868,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:33.883221+00:00"
+                "validatedAt": "2026-07-20T14:38:25.929026+00:00"
               },
               "deterministic": true
             },
@@ -47941,9 +47880,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.596651+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.549877+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -48012,7 +47950,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:33.883274+00:00"
+                "validatedAt": "2026-07-20T14:38:25.929047+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48024,7 +47962,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.596703+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.549900+00:00"
           },
           "uid": {
             "type": "string",
@@ -48041,7 +47979,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:33.883300+00:00"
+                "validatedAt": "2026-07-20T14:38:25.929058+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48054,7 +47992,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.596722+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.549912+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of ike2 is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -48932,7 +48870,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:38.039951+00:00"
+                "validatedAt": "2026-07-20T14:38:27.626964+00:00"
               },
               "deterministic": true
             },
@@ -48944,9 +48882,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.676526+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.607492+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -48978,7 +48915,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:38.039987+00:00"
+                "validatedAt": "2026-07-20T14:38:27.626983+00:00"
               },
               "deterministic": true
             },
@@ -48990,9 +48927,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.676547+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.607505+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -49155,7 +49091,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.676613+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.607544+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -49250,7 +49186,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:02:38.040127+00:00"
+                "validatedAt": "2026-07-20T14:38:27.627033+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49329,7 +49265,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:02:38.040184+00:00"
+                "validatedAt": "2026-07-20T14:38:27.627060+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49340,7 +49276,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.676680+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.607573+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -49427,7 +49363,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:38.040225+00:00"
+                "validatedAt": "2026-07-20T14:38:27.627080+00:00"
               },
               "deterministic": true
             },
@@ -49439,9 +49375,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.676728+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.607600+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -49472,7 +49407,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:38.040253+00:00"
+                "validatedAt": "2026-07-20T14:38:27.627095+00:00"
               },
               "deterministic": true
             },
@@ -49484,9 +49419,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.676746+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.607612+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -49555,7 +49489,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:38.040306+00:00"
+                "validatedAt": "2026-07-20T14:38:27.627117+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49567,7 +49501,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.676783+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.607635+00:00"
           },
           "uid": {
             "type": "string",
@@ -49585,7 +49519,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:38.040333+00:00"
+                "validatedAt": "2026-07-20T14:38:27.627128+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49598,7 +49532,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.676803+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.607647+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of ike_phase2_profile is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -50550,7 +50484,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:39.952908+00:00"
+                "validatedAt": "2026-07-20T14:38:28.597573+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50650,7 +50584,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:39.952963+00:00"
+                "validatedAt": "2026-07-20T14:38:28.597596+00:00"
               },
               "deterministic": true
             },
@@ -50662,9 +50596,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.705798+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.637016+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -50696,7 +50629,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:39.953010+00:00"
+                "validatedAt": "2026-07-20T14:38:28.597610+00:00"
               },
               "deterministic": true
             },
@@ -50708,9 +50641,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.705818+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.637029+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -50880,7 +50812,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.705885+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.637069+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -50972,7 +50904,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:39.953198+00:00"
+                "validatedAt": "2026-07-20T14:38:28.597659+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51051,7 +50983,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:39.953311+00:00"
+                "validatedAt": "2026-07-20T14:38:28.597695+00:00"
               },
               "byteLength": {
                 "max": 64
@@ -51066,7 +50998,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.705920+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.637091+00:00"
           },
           "ipv4_prefix": {
             "type": "string",
@@ -51094,7 +51026,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:39.953357+00:00"
+                "validatedAt": "2026-07-20T14:38:28.597713+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51183,7 +51115,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:02:39.953404+00:00"
+                "validatedAt": "2026-07-20T14:38:28.597733+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51269,7 +51201,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:02:39.953457+00:00"
+                "validatedAt": "2026-07-20T14:38:28.597756+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51280,7 +51212,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.705971+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.637121+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -51367,7 +51299,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:39.953500+00:00"
+                "validatedAt": "2026-07-20T14:38:28.597774+00:00"
               },
               "deterministic": true
             },
@@ -51379,9 +51311,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.706023+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.637149+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -51412,7 +51343,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:39.953529+00:00"
+                "validatedAt": "2026-07-20T14:38:28.597787+00:00"
               },
               "deterministic": true
             },
@@ -51424,9 +51355,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.706042+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.637160+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -51495,7 +51425,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:39.953583+00:00"
+                "validatedAt": "2026-07-20T14:38:28.597807+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51507,7 +51437,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.706081+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.637184+00:00"
           },
           "uid": {
             "type": "string",
@@ -51524,7 +51454,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:39.953609+00:00"
+                "validatedAt": "2026-07-20T14:38:28.597817+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51537,7 +51467,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.706100+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.637196+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of ip_prefix_set is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -51729,7 +51659,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:39.953676+00:00"
+                "validatedAt": "2026-07-20T14:38:28.597842+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52196,7 +52126,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:12.175737+00:00"
+                "validatedAt": "2026-07-20T14:39:28.059483+00:00"
               },
               "deterministic": true
             },
@@ -52208,9 +52138,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.051798+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.782119+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -52242,7 +52171,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:12.175781+00:00"
+                "validatedAt": "2026-07-20T14:39:28.059496+00:00"
               },
               "deterministic": true
             },
@@ -52254,9 +52183,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.051817+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.782132+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -52419,7 +52347,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.051883+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.782172+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -52645,7 +52573,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:05:12.175953+00:00"
+                "validatedAt": "2026-07-20T14:39:28.059545+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52724,7 +52652,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:05:12.176009+00:00"
+                "validatedAt": "2026-07-20T14:39:28.059567+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52735,7 +52663,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.051967+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.782223+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -52822,7 +52750,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:12.176053+00:00"
+                "validatedAt": "2026-07-20T14:39:28.059585+00:00"
               },
               "deterministic": true
             },
@@ -52834,9 +52762,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.052013+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.782251+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -52867,7 +52794,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:12.176081+00:00"
+                "validatedAt": "2026-07-20T14:39:28.059598+00:00"
               },
               "deterministic": true
             },
@@ -52879,9 +52806,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.052031+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.782263+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -52950,7 +52876,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:12.176135+00:00"
+                "validatedAt": "2026-07-20T14:39:28.059618+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52962,7 +52888,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.052069+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.782287+00:00"
           },
           "uid": {
             "type": "string",
@@ -52980,7 +52906,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:12.176162+00:00"
+                "validatedAt": "2026-07-20T14:39:28.059628+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52993,7 +52919,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.052089+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.782300+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of network_connector is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -53059,7 +52985,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:12.176201+00:00"
+                "validatedAt": "2026-07-20T14:39:28.059643+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53458,7 +53384,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.052202+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.782367+00:00"
           }
         },
         "x-f5xc-description-short": "Most recently observed status of object.",
@@ -53531,7 +53457,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:12.176884+00:00"
+                "validatedAt": "2026-07-20T14:39:28.059913+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53543,8 +53469,7 @@
             "x-f5xc-conflicts-with": [
               "regex_value",
               "suffix_value"
-            ],
-            "format": "hostname"
+            ]
           },
           "regex_value": {
             "type": "string",
@@ -53575,7 +53500,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:12.176947+00:00"
+                "validatedAt": "2026-07-20T14:39:28.059941+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53620,7 +53545,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:12.177010+00:00"
+                "validatedAt": "2026-07-20T14:39:28.059969+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53632,8 +53557,7 @@
             "x-f5xc-conflicts-with": [
               "exact_value",
               "regex_value"
-            ],
-            "format": "hostname"
+            ]
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -53783,7 +53707,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:12.177145+00:00"
+                "validatedAt": "2026-07-20T14:39:28.060022+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53825,7 +53749,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:12.177190+00:00"
+                "validatedAt": "2026-07-20T14:39:28.060044+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53950,7 +53874,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:12.178498+00:00"
+                "validatedAt": "2026-07-20T14:39:28.060580+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54167,7 +54091,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:12.178581+00:00"
+                "validatedAt": "2026-07-20T14:39:28.060614+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54424,7 +54348,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.143018+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.864021+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -54510,7 +54434,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:22.608411+00:00"
+                "validatedAt": "2026-07-20T14:39:55.197968+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54543,7 +54467,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:22.608464+00:00"
+                "validatedAt": "2026-07-20T14:39:55.197992+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54626,7 +54550,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:06:22.608513+00:00"
+                "validatedAt": "2026-07-20T14:39:55.198014+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54704,7 +54628,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:06:22.608574+00:00"
+                "validatedAt": "2026-07-20T14:39:55.198041+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54715,7 +54639,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.143087+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.864062+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -54802,7 +54726,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:22.608620+00:00"
+                "validatedAt": "2026-07-20T14:39:55.198062+00:00"
               },
               "deterministic": true
             },
@@ -54814,9 +54738,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.143133+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.864091+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -54847,7 +54770,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:22.608649+00:00"
+                "validatedAt": "2026-07-20T14:39:55.198076+00:00"
               },
               "deterministic": true
             },
@@ -54859,9 +54782,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.143151+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.864103+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -54930,7 +54852,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:22.608713+00:00"
+                "validatedAt": "2026-07-20T14:39:55.198097+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54942,7 +54864,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.143188+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.864127+00:00"
           },
           "uid": {
             "type": "string",
@@ -54959,7 +54881,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:22.608741+00:00"
+                "validatedAt": "2026-07-20T14:39:55.198109+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54972,7 +54894,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.143208+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.864140+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of public_ip is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -55141,7 +55063,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:22.608797+00:00"
+                "validatedAt": "2026-07-20T14:39:55.198136+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55301,7 +55223,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:59.099860+00:00"
+                "validatedAt": "2026-07-20T14:40:08.935434+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55372,7 +55294,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:59.099953+00:00"
+                "validatedAt": "2026-07-20T14:40:08.935471+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -55386,8 +55308,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "presence": {
             "type": "boolean",
@@ -55432,7 +55353,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:59.100025+00:00"
+                "validatedAt": "2026-07-20T14:40:08.935504+00:00"
               },
               "byteLength": {
                 "max": 256
@@ -55520,7 +55441,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:59.100239+00:00"
+                "validatedAt": "2026-07-20T14:40:08.935600+00:00"
               },
               "deterministic": true
             },
@@ -55560,7 +55481,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:59.100294+00:00"
+                "validatedAt": "2026-07-20T14:40:08.935626+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55601,7 +55522,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:59.100359+00:00"
+                "validatedAt": "2026-07-20T14:40:08.935657+00:00"
               },
               "byteLength": {
                 "max": 256,
@@ -55704,7 +55625,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:59.100401+00:00"
+                "validatedAt": "2026-07-20T14:40:08.935677+00:00"
               },
               "deterministic": true
             },
@@ -55748,7 +55669,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:59.100463+00:00"
+                "validatedAt": "2026-07-20T14:40:08.935705+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55816,7 +55737,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:59.100497+00:00"
+                "validatedAt": "2026-07-20T14:40:08.935719+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55863,7 +55784,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:59.100545+00:00"
+                "validatedAt": "2026-07-20T14:40:08.935742+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55899,7 +55820,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:59.100608+00:00"
+                "validatedAt": "2026-07-20T14:40:08.935772+00:00"
               },
               "byteLength": {
                 "max": 256,
@@ -56044,7 +55965,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:59.100752+00:00"
+                "validatedAt": "2026-07-20T14:40:08.935827+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56222,7 +56143,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:59.100822+00:00"
+                "validatedAt": "2026-07-20T14:40:08.935859+00:00"
               },
               "deterministic": true
             },
@@ -56232,8 +56153,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "path": {
             "type": "string",
@@ -56254,7 +56174,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:06:59.100862+00:00"
+                "validatedAt": "2026-07-20T14:40:08.935876+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56568,7 +56488,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:59.100930+00:00"
+                "validatedAt": "2026-07-20T14:40:08.935902+00:00"
               },
               "deterministic": true
             },
@@ -56580,9 +56500,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.776022+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.433577+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -56614,7 +56533,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:59.100957+00:00"
+                "validatedAt": "2026-07-20T14:40:08.935915+00:00"
               },
               "deterministic": true
             },
@@ -56626,9 +56545,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.776040+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.433590+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -56791,7 +56709,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.776108+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.433632+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -56897,7 +56815,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:59.101099+00:00"
+                "validatedAt": "2026-07-20T14:40:08.935969+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57059,7 +56977,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:59.101174+00:00"
+                "validatedAt": "2026-07-20T14:40:08.936001+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57096,7 +57014,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:59.101221+00:00"
+                "validatedAt": "2026-07-20T14:40:08.936025+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57178,7 +57096,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:06:59.101268+00:00"
+                "validatedAt": "2026-07-20T14:40:08.936044+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57256,7 +57174,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:06:59.101322+00:00"
+                "validatedAt": "2026-07-20T14:40:08.936066+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57267,7 +57185,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.776203+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.433690+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -57354,7 +57272,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:59.101364+00:00"
+                "validatedAt": "2026-07-20T14:40:08.936084+00:00"
               },
               "deterministic": true
             },
@@ -57366,9 +57284,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.776249+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.433721+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -57399,7 +57316,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:59.101392+00:00"
+                "validatedAt": "2026-07-20T14:40:08.936097+00:00"
               },
               "deterministic": true
             },
@@ -57411,9 +57328,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.776267+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.433733+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -57482,7 +57398,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:59.101444+00:00"
+                "validatedAt": "2026-07-20T14:40:08.936117+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57494,7 +57410,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.776304+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.433759+00:00"
           },
           "uid": {
             "type": "string",
@@ -57511,7 +57427,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:59.101470+00:00"
+                "validatedAt": "2026-07-20T14:40:08.936127+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57524,7 +57440,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.776324+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.433772+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of route is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -57605,7 +57521,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:59.101516+00:00"
+                "validatedAt": "2026-07-20T14:40:08.936148+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57711,7 +57627,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:59.101589+00:00"
+                "validatedAt": "2026-07-20T14:40:08.936179+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57905,7 +57821,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:59.101642+00:00"
+                "validatedAt": "2026-07-20T14:40:08.936203+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57962,7 +57878,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:06:59.101693+00:00"
+                "validatedAt": "2026-07-20T14:40:08.936220+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57997,7 +57913,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:06:59.101725+00:00"
+                "validatedAt": "2026-07-20T14:40:08.936234+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58140,7 +58056,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:59.101782+00:00"
+                "validatedAt": "2026-07-20T14:40:08.936261+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58214,7 +58130,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:59.101832+00:00"
+                "validatedAt": "2026-07-20T14:40:08.936285+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58252,7 +58168,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:59.101893+00:00"
+                "validatedAt": "2026-07-20T14:40:08.936314+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58305,7 +58221,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:59.101956+00:00"
+                "validatedAt": "2026-07-20T14:40:08.936343+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58432,7 +58348,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T13:06:59.102007+00:00"
+                "validatedAt": "2026-07-20T14:40:08.936365+00:00"
               },
               "deterministic": true
             },
@@ -58542,7 +58458,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:59.102076+00:00"
+                "validatedAt": "2026-07-20T14:40:08.936398+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58632,7 +58548,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:59.102133+00:00"
+                "validatedAt": "2026-07-20T14:40:08.936421+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58667,7 +58583,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:59.102192+00:00"
+                "validatedAt": "2026-07-20T14:40:08.936448+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58706,7 +58622,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:59.102251+00:00"
+                "validatedAt": "2026-07-20T14:40:08.936477+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58742,7 +58658,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:59.102292+00:00"
+                "validatedAt": "2026-07-20T14:40:08.936493+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58795,7 +58711,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:59.102356+00:00"
+                "validatedAt": "2026-07-20T14:40:08.936523+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58985,7 +58901,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:59.102426+00:00"
+                "validatedAt": "2026-07-20T14:40:08.936555+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59022,7 +58938,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:59.102471+00:00"
+                "validatedAt": "2026-07-20T14:40:08.936576+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59065,7 +58981,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:59.102515+00:00"
+                "validatedAt": "2026-07-20T14:40:08.936598+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59100,7 +59016,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:59.102558+00:00"
+                "validatedAt": "2026-07-20T14:40:08.936618+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59142,7 +59058,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:59.102601+00:00"
+                "validatedAt": "2026-07-20T14:40:08.936639+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59180,7 +59096,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:59.102646+00:00"
+                "validatedAt": "2026-07-20T14:40:08.936661+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59224,7 +59140,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:59.102701+00:00"
+                "validatedAt": "2026-07-20T14:40:08.936683+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59259,7 +59175,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:59.102744+00:00"
+                "validatedAt": "2026-07-20T14:40:08.936705+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59301,7 +59217,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:59.102788+00:00"
+                "validatedAt": "2026-07-20T14:40:08.936727+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59720,7 +59636,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:59.102916+00:00"
+                "validatedAt": "2026-07-20T14:40:08.936778+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59827,7 +59743,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:59.102952+00:00"
+                "validatedAt": "2026-07-20T14:40:08.936793+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59838,7 +59754,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.776814+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.434063+00:00"
           },
           "status": {
             "type": "string",
@@ -59863,7 +59779,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:59.102987+00:00"
+                "validatedAt": "2026-07-20T14:40:08.936807+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59874,7 +59790,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.776834+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.434076+00:00"
           }
         },
         "x-f5xc-description-short": "Status information sent for each route entry within route.",
@@ -60158,7 +60074,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:59.103514+00:00"
+                "validatedAt": "2026-07-20T14:40:08.937036+00:00"
               },
               "deterministic": true
             },
@@ -60170,9 +60086,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.777011+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.434189+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "overwrite": {
             "type": "boolean",
@@ -60226,7 +60141,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:59.103570+00:00"
+                "validatedAt": "2026-07-20T14:40:08.937062+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60237,7 +60152,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.777042+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:20.434208+00:00",
             "x-f5xc-conflicts-with": [
               "secret_value"
             ]
@@ -60313,7 +60228,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:59.103613+00:00"
+                "validatedAt": "2026-07-20T14:40:08.937079+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60345,7 +60260,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:59.103660+00:00"
+                "validatedAt": "2026-07-20T14:40:08.937095+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60391,7 +60306,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:59.103708+00:00"
+                "validatedAt": "2026-07-20T14:40:08.937117+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60439,7 +60354,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:59.103751+00:00"
+                "validatedAt": "2026-07-20T14:40:08.937139+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60481,7 +60396,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:59.103795+00:00"
+                "validatedAt": "2026-07-20T14:40:08.937157+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60518,7 +60433,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:59.103841+00:00"
+                "validatedAt": "2026-07-20T14:40:08.937179+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60751,7 +60666,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:59.103906+00:00"
+                "validatedAt": "2026-07-20T14:40:08.937210+00:00"
               },
               "deterministic": true
             },
@@ -60930,7 +60845,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:59.104018+00:00"
+                "validatedAt": "2026-07-20T14:40:08.937259+00:00"
               },
               "deterministic": true
             },
@@ -60942,9 +60857,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.777188+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.434296+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "secret_value": {
             "allOf": [
@@ -60983,7 +60897,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:59.104072+00:00"
+                "validatedAt": "2026-07-20T14:40:08.937285+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60994,7 +60908,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.777214+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:20.434313+00:00",
             "x-f5xc-conflicts-with": [
               "secret_value"
             ]
@@ -61115,7 +61029,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:59.104575+00:00"
+                "validatedAt": "2026-07-20T14:40:08.937520+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61149,7 +61063,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:59.104633+00:00"
+                "validatedAt": "2026-07-20T14:40:08.937546+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61365,7 +61279,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:59.104755+00:00"
+                "validatedAt": "2026-07-20T14:40:08.937595+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61414,7 +61328,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:59.104802+00:00"
+                "validatedAt": "2026-07-20T14:40:08.937617+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61493,7 +61407,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:59.104857+00:00"
+                "validatedAt": "2026-07-20T14:40:08.937644+00:00"
               },
               "deterministic": true
             },
@@ -61571,7 +61485,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:59.104906+00:00"
+                "validatedAt": "2026-07-20T14:40:08.937667+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61699,7 +61613,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:59.104973+00:00"
+                "validatedAt": "2026-07-20T14:40:08.937698+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61710,8 +61624,7 @@
             },
             "x-f5xc-conflicts-with": [
               "ignore_domain"
-            ],
-            "format": "hostname"
+            ]
           },
           "add_expiry": {
             "type": "string",
@@ -61734,7 +61647,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:59.105030+00:00"
+                "validatedAt": "2026-07-20T14:40:08.937724+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61804,7 +61717,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:59.105088+00:00"
+                "validatedAt": "2026-07-20T14:40:08.937751+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62050,7 +61963,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:59.105179+00:00"
+                "validatedAt": "2026-07-20T14:40:08.937792+00:00"
               },
               "deterministic": true
             },
@@ -62062,9 +61975,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.777732+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.434628+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "overwrite": {
             "type": "boolean",
@@ -62173,7 +62085,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:59.105244+00:00"
+                "validatedAt": "2026-07-20T14:40:08.937821+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62184,7 +62096,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.777782+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:20.434660+00:00",
             "x-f5xc-conflicts-with": [
               "ignore_value",
               "secret_value"
@@ -62387,7 +62299,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:59.106023+00:00"
+                "validatedAt": "2026-07-20T14:40:08.938129+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62464,7 +62376,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:59.106066+00:00"
+                "validatedAt": "2026-07-20T14:40:08.938150+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62538,7 +62450,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:59.106108+00:00"
+                "validatedAt": "2026-07-20T14:40:08.938170+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62614,7 +62526,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:03.000863+00:00"
+                "validatedAt": "2026-07-20T14:40:10.375131+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62721,7 +62633,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:03.000926+00:00"
+                "validatedAt": "2026-07-20T14:40:10.375157+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62781,7 +62693,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:03.000964+00:00"
+                "validatedAt": "2026-07-20T14:40:10.375173+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62841,7 +62753,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:03.001015+00:00"
+                "validatedAt": "2026-07-20T14:40:10.375188+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63064,7 +62976,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:03.001120+00:00"
+                "validatedAt": "2026-07-20T14:40:10.375217+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63168,7 +63080,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:03.001194+00:00"
+                "validatedAt": "2026-07-20T14:40:10.375236+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63228,7 +63140,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:03.001256+00:00"
+                "validatedAt": "2026-07-20T14:40:10.375251+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63381,7 +63293,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:03.001315+00:00"
+                "validatedAt": "2026-07-20T14:40:10.375270+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63436,7 +63348,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:03.001373+00:00"
+                "validatedAt": "2026-07-20T14:40:10.375292+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63461,7 +63373,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:03.001408+00:00"
+                "validatedAt": "2026-07-20T14:40:10.375307+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63573,7 +63485,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:03.001453+00:00"
+                "validatedAt": "2026-07-20T14:40:10.375327+00:00"
               },
               "deterministic": true
             },
@@ -63585,9 +63497,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.859649+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.505741+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "node": {
             "type": "string",
@@ -63616,7 +63527,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:03.001520+00:00"
+                "validatedAt": "2026-07-20T14:40:10.375358+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63658,7 +63569,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:03.001559+00:00"
+                "validatedAt": "2026-07-20T14:40:10.375374+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63688,7 +63599,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:03.001589+00:00"
+                "validatedAt": "2026-07-20T14:40:10.375386+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63714,7 +63625,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:03.001613+00:00"
+                "validatedAt": "2026-07-20T14:40:10.375397+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63900,7 +63811,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:03.001671+00:00"
+                "validatedAt": "2026-07-20T14:40:10.375417+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63975,7 +63886,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:03.001721+00:00"
+                "validatedAt": "2026-07-20T14:40:10.375437+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64040,7 +63951,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:07:03.001762+00:00"
+                "validatedAt": "2026-07-20T14:40:10.375455+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64268,7 +64179,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:03.001829+00:00"
+                "validatedAt": "2026-07-20T14:40:10.375481+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64378,7 +64289,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:03.001880+00:00"
+                "validatedAt": "2026-07-20T14:40:10.375501+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64423,7 +64334,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:03.001912+00:00"
+                "validatedAt": "2026-07-20T14:40:10.375516+00:00"
               },
               "deterministic": true
             },
@@ -64435,9 +64346,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.859839+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.505851+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "node": {
             "type": "string",
@@ -64466,7 +64376,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:03.001968+00:00"
+                "validatedAt": "2026-07-20T14:40:10.375543+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64508,7 +64418,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:03.002005+00:00"
+                "validatedAt": "2026-07-20T14:40:10.375558+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64539,7 +64449,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:03.002034+00:00"
+                "validatedAt": "2026-07-20T14:40:10.375571+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64700,7 +64610,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:03.002085+00:00"
+                "validatedAt": "2026-07-20T14:40:10.375592+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64790,7 +64700,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:03.002139+00:00"
+                "validatedAt": "2026-07-20T14:40:10.375613+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64851,7 +64761,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:03.002177+00:00"
+                "validatedAt": "2026-07-20T14:40:10.375629+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65025,7 +64935,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:03.002234+00:00"
+                "validatedAt": "2026-07-20T14:40:10.375652+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65159,7 +65069,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:03.002398+00:00"
+                "validatedAt": "2026-07-20T14:40:10.375732+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65290,7 +65200,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:09.209560+00:00"
+                "validatedAt": "2026-07-20T14:40:12.781775+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65429,7 +65339,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:09.209619+00:00"
+                "validatedAt": "2026-07-20T14:40:12.781801+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65562,7 +65472,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:09.209683+00:00"
+                "validatedAt": "2026-07-20T14:40:12.781827+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65798,7 +65708,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:09.209735+00:00"
+                "validatedAt": "2026-07-20T14:40:12.781848+00:00"
               },
               "deterministic": true
             },
@@ -65810,9 +65720,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.968210+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.606809+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -65844,7 +65753,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:09.209763+00:00"
+                "validatedAt": "2026-07-20T14:40:12.781861+00:00"
               },
               "deterministic": true
             },
@@ -65856,9 +65765,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.968229+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.606822+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -66021,7 +65929,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.968295+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.606862+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -66116,7 +66024,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:07:09.209878+00:00"
+                "validatedAt": "2026-07-20T14:40:12.781906+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66195,7 +66103,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:07:09.209928+00:00"
+                "validatedAt": "2026-07-20T14:40:12.781928+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66206,7 +66114,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.968345+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.606892+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -66293,7 +66201,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:09.209968+00:00"
+                "validatedAt": "2026-07-20T14:40:12.781946+00:00"
               },
               "deterministic": true
             },
@@ -66305,9 +66213,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.968391+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.606920+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -66338,7 +66245,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:09.209995+00:00"
+                "validatedAt": "2026-07-20T14:40:12.781959+00:00"
               },
               "deterministic": true
             },
@@ -66350,9 +66257,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.968409+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.606932+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -66421,7 +66327,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:09.210047+00:00"
+                "validatedAt": "2026-07-20T14:40:12.781979+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66433,7 +66339,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.968445+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.606955+00:00"
           },
           "uid": {
             "type": "string",
@@ -66451,7 +66357,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:09.210074+00:00"
+                "validatedAt": "2026-07-20T14:40:12.781990+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66464,7 +66370,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.968464+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.606968+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of srv6_network_slice is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -66780,7 +66686,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:52.443239+00:00"
+                "validatedAt": "2026-07-20T14:40:54.035500+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66861,7 +66767,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:52.443283+00:00"
+                "validatedAt": "2026-07-20T14:40:54.035518+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66935,7 +66841,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:52.443333+00:00"
+                "validatedAt": "2026-07-20T14:40:54.035542+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67069,7 +66975,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:52.443391+00:00"
+                "validatedAt": "2026-07-20T14:40:54.035567+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67454,7 +67360,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:52.443615+00:00"
+                "validatedAt": "2026-07-20T14:40:54.035669+00:00"
               },
               "deterministic": true
             },
@@ -67466,9 +67372,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.286125+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:22.682432+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -67500,7 +67405,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:52.443643+00:00"
+                "validatedAt": "2026-07-20T14:40:54.035682+00:00"
               },
               "deterministic": true
             },
@@ -67512,9 +67417,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.286144+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:22.682444+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -67677,7 +67581,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.286210+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.682484+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -67772,7 +67676,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:08:52.443765+00:00"
+                "validatedAt": "2026-07-20T14:40:54.035725+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67850,7 +67754,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:08:52.443817+00:00"
+                "validatedAt": "2026-07-20T14:40:54.035747+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67861,7 +67765,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.286261+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.682518+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -67948,7 +67852,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:52.443858+00:00"
+                "validatedAt": "2026-07-20T14:40:54.035765+00:00"
               },
               "deterministic": true
             },
@@ -67960,9 +67864,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.286306+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:22.682546+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -67993,7 +67896,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:52.443886+00:00"
+                "validatedAt": "2026-07-20T14:40:54.035778+00:00"
               },
               "deterministic": true
             },
@@ -68005,9 +67908,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.286325+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:22.682562+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -68076,7 +67978,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:52.443939+00:00"
+                "validatedAt": "2026-07-20T14:40:54.035798+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68088,7 +67990,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.286362+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.682586+00:00"
           },
           "uid": {
             "type": "string",
@@ -68105,7 +68007,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:52.443966+00:00"
+                "validatedAt": "2026-07-20T14:40:54.035808+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68118,7 +68020,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.286381+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.682598+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of subnet is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -68487,7 +68389,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:00.306810+00:00"
+                "validatedAt": "2026-07-20T14:41:19.634496+00:00"
               },
               "deterministic": true
             },
@@ -68501,8 +68403,7 @@
               "ip"
             ],
             "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "minLength": 1,
-            "format": "hostname"
+            "minLength": 1
           },
           "ip": {
             "type": "string",
@@ -68528,7 +68429,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:00.306865+00:00"
+                "validatedAt": "2026-07-20T14:41:19.634524+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68623,7 +68524,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:00.306929+00:00"
+                "validatedAt": "2026-07-20T14:41:19.634554+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68690,7 +68591,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:00.306981+00:00"
+                "validatedAt": "2026-07-20T14:41:19.634569+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68728,7 +68629,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:00.307058+00:00"
+                "validatedAt": "2026-07-20T14:41:19.634588+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68870,7 +68771,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:00.307126+00:00"
+                "validatedAt": "2026-07-20T14:41:19.634619+00:00"
               },
               "deterministic": true
             },
@@ -68882,9 +68783,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.508501+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.102001+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "node": {
             "type": "string",
@@ -68916,7 +68816,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:00.307181+00:00"
+                "validatedAt": "2026-07-20T14:41:19.634646+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68949,7 +68849,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:00.307216+00:00"
+                "validatedAt": "2026-07-20T14:41:19.634663+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68975,7 +68875,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:00.307245+00:00"
+                "validatedAt": "2026-07-20T14:41:19.634676+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69108,7 +69008,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:11.145987+00:00"
+                "validatedAt": "2026-07-20T14:41:45.903841+00:00"
               }
             }
           },
@@ -69126,7 +69026,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:05.793685+00:00"
+                "validatedAt": "2026-07-20T14:41:21.697004+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69615,7 +69515,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:05.794931+00:00"
+                "validatedAt": "2026-07-20T14:41:21.697559+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69706,7 +69606,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:05.794985+00:00"
+                "validatedAt": "2026-07-20T14:41:21.697581+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69781,7 +69681,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:05.795039+00:00"
+                "validatedAt": "2026-07-20T14:41:21.697608+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69804,7 +69704,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:05.795074+00:00"
+                "validatedAt": "2026-07-20T14:41:21.697623+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69836,7 +69736,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T13:10:05.795106+00:00"
+                "validatedAt": "2026-07-20T14:41:21.697638+00:00"
               },
               "deterministic": true
             },
@@ -69861,7 +69761,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:05.795143+00:00"
+                "validatedAt": "2026-07-20T14:41:21.697654+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69885,7 +69785,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:05.795182+00:00"
+                "validatedAt": "2026-07-20T14:41:21.697670+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69956,7 +69856,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:05.795222+00:00"
+                "validatedAt": "2026-07-20T14:41:21.697687+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69984,7 +69884,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T13:10:05.795260+00:00"
+                "validatedAt": "2026-07-20T14:41:21.697705+00:00"
               },
               "deterministic": true
             },
@@ -70298,7 +70198,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:05.795308+00:00"
+                "validatedAt": "2026-07-20T14:41:21.697727+00:00"
               },
               "deterministic": true
             },
@@ -70310,9 +70210,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.559876+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.206034+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -70344,7 +70243,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:05.795334+00:00"
+                "validatedAt": "2026-07-20T14:41:21.697741+00:00"
               },
               "deterministic": true
             },
@@ -70356,9 +70255,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.559896+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.206046+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -70521,7 +70419,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.559962+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.206085+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -70605,7 +70503,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:05.795445+00:00"
+                "validatedAt": "2026-07-20T14:41:21.697790+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -70738,7 +70636,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:10:05.795492+00:00"
+                "validatedAt": "2026-07-20T14:41:21.697811+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -70816,7 +70714,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:10:05.795543+00:00"
+                "validatedAt": "2026-07-20T14:41:21.697833+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -70827,7 +70725,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.560029+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.206124+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -70914,7 +70812,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:05.795583+00:00"
+                "validatedAt": "2026-07-20T14:41:21.697852+00:00"
               },
               "deterministic": true
             },
@@ -70926,9 +70824,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.560073+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.206151+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -70959,7 +70856,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:05.795610+00:00"
+                "validatedAt": "2026-07-20T14:41:21.697866+00:00"
               },
               "deterministic": true
             },
@@ -70971,9 +70868,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.560091+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.206163+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -71042,7 +70938,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:05.795668+00:00"
+                "validatedAt": "2026-07-20T14:41:21.697887+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71054,7 +70950,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.560129+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.206185+00:00"
           },
           "uid": {
             "type": "string",
@@ -71071,7 +70967,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:05.795695+00:00"
+                "validatedAt": "2026-07-20T14:41:21.697898+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71084,7 +70980,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.560148+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.206198+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of tunnel is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -71745,7 +71641,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:11.146066+00:00"
+                "validatedAt": "2026-07-20T14:41:45.903876+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71941,7 +71837,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.613100+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.522026+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Route Target\" BGP Two-Octet AS Specific Route Target as per RFC 4360.",
@@ -72010,7 +71906,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.613128+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.522042+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Four-Octet AS Specific Route Target\" BGP Four-Octet AS Specific Route Target as per RFC 5668.",
@@ -72063,7 +71959,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:11.146591+00:00"
+                "validatedAt": "2026-07-20T14:41:45.904104+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -72090,7 +71986,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.613156+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.522058+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"IPv4 Address Specific Route Target\" BGP IPv4 Address Specific Route Target as per RFC 4360.",
@@ -72431,7 +72327,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:11.147634+00:00"
+                "validatedAt": "2026-07-20T14:41:45.904520+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -72532,7 +72428,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:11.147677+00:00"
+                "validatedAt": "2026-07-20T14:41:45.904534+00:00"
               },
               "deterministic": true
             },
@@ -72544,9 +72440,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.613719+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.522343+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -72578,7 +72473,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:11.147705+00:00"
+                "validatedAt": "2026-07-20T14:41:45.904548+00:00"
               },
               "deterministic": true
             },
@@ -72590,9 +72485,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.613738+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.522354+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -72755,7 +72649,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.613803+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.522390+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -72916,7 +72810,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:11.147834+00:00"
+                "validatedAt": "2026-07-20T14:41:45.904599+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -72953,7 +72847,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:11.147878+00:00"
+                "validatedAt": "2026-07-20T14:41:45.904621+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -73040,7 +72934,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:11:11.147922+00:00"
+                "validatedAt": "2026-07-20T14:41:45.904641+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -73119,7 +73013,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:11:11.147975+00:00"
+                "validatedAt": "2026-07-20T14:41:45.904662+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -73130,7 +73024,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.613892+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.522438+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -73217,7 +73111,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:11.148015+00:00"
+                "validatedAt": "2026-07-20T14:41:45.904679+00:00"
               },
               "deterministic": true
             },
@@ -73229,9 +73123,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.613936+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.522463+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -73262,7 +73155,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:11.148043+00:00"
+                "validatedAt": "2026-07-20T14:41:45.904692+00:00"
               },
               "deterministic": true
             },
@@ -73274,9 +73167,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.613955+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.522474+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -73345,7 +73237,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:11.148096+00:00"
+                "validatedAt": "2026-07-20T14:41:45.904713+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -73357,7 +73249,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.613991+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.522496+00:00"
           },
           "uid": {
             "type": "string",
@@ -73374,7 +73266,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:11.148122+00:00"
+                "validatedAt": "2026-07-20T14:41:45.904723+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -73387,7 +73279,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.614010+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.522507+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of virtual_network is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -73634,7 +73526,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:11.148190+00:00"
+                "validatedAt": "2026-07-20T14:41:45.904753+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -73828,7 +73720,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:11.148247+00:00"
+                "validatedAt": "2026-07-20T14:41:45.904776+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -73873,7 +73765,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:11.148296+00:00"
+                "validatedAt": "2026-07-20T14:41:45.904799+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -73900,7 +73792,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:11.148330+00:00"
+                "validatedAt": "2026-07-20T14:41:45.904813+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -73955,7 +73847,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:11.148371+00:00"
+                "validatedAt": "2026-07-20T14:41:45.904831+00:00"
               },
               "deterministic": true
             },
@@ -73967,9 +73859,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.614127+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.522569+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "range": {
             "type": "string",
@@ -73994,7 +73885,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:11.148405+00:00"
+                "validatedAt": "2026-07-20T14:41:45.904845+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74027,7 +73918,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:11.148445+00:00"
+                "validatedAt": "2026-07-20T14:41:45.904861+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74060,7 +73951,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:11.148478+00:00"
+                "validatedAt": "2026-07-20T14:41:45.904874+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74152,7 +74043,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:11.148522+00:00"
+                "validatedAt": "2026-07-20T14:41:45.904891+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74255,7 +74146,7 @@
             "maxLength": 16,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.614183+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.522600+00:00"
           },
           "value": {
             "type": "array",
@@ -74274,7 +74165,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.614205+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.522612+00:00"
           }
         },
         "x-f5xc-description-short": "SID Counter Type Data contains key/value pairs that uniquely identifies the group_by labels specified in the request.",
@@ -74446,7 +74337,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:11.148577+00:00"
+                "validatedAt": "2026-07-20T14:41:45.904915+00:00"
               },
               "deterministic": true
             },
@@ -74458,9 +74349,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.614243+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.522633+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Srv6 Network Namespace Parameters\" Configure the how namespace network is connected to srv6 network.",
@@ -74528,7 +74418,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:11.148619+00:00"
+                "validatedAt": "2026-07-20T14:41:45.904936+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74582,7 +74472,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:11.148718+00:00"
+                "validatedAt": "2026-07-20T14:41:45.904965+00:00"
               },
               "deterministic": true
             },
@@ -74635,7 +74525,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:11.148767+00:00"
+                "validatedAt": "2026-07-20T14:41:45.904988+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74732,7 +74622,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:11.148812+00:00"
+                "validatedAt": "2026-07-20T14:41:45.905010+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74786,7 +74676,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:11.148870+00:00"
+                "validatedAt": "2026-07-20T14:41:45.905038+00:00"
               },
               "deterministic": true
             },
@@ -74839,7 +74729,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:11.148914+00:00"
+                "validatedAt": "2026-07-20T14:41:45.905060+00:00"
               }
             },
             "x-f5xc-required-for": {

--- a/docs/specifications/api/network_security.json
+++ b/docs/specifications/api/network_security.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Network Security",
     "description": "Perimeter defense through firewall configurations, address translation, and ingress/egress policies. Traffic steering directs packets according to defined criteria including origin, target, and service type. Segment boundaries create workload isolation zones while HTTP intermediaries manage client requests to external destinations. Port mappings employ static and dynamic address pools for flexible translation scenarios across multi-tenant environments.",
-    "version": "2.1.182",
+    "version": "2.1.181",
     "contact": {
       "name": "F5 Distributed Cloud",
       "url": "https://docs.cloud.f5.com"
@@ -17170,7 +17170,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:42.743500+00:00"
+                "validatedAt": "2026-07-20T14:36:54.302269+00:00"
               },
               "deterministic": true
             },
@@ -17182,9 +17182,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.055217+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.581783+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -17216,7 +17215,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:42.743548+00:00"
+                "validatedAt": "2026-07-20T14:36:54.302287+00:00"
               },
               "deterministic": true
             },
@@ -17228,9 +17227,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.055238+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.581797+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -17302,7 +17300,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:42.743633+00:00"
+                "validatedAt": "2026-07-20T14:36:54.302315+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17881,7 +17879,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:42.743808+00:00"
+                "validatedAt": "2026-07-20T14:36:54.302358+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17921,7 +17919,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:42.743842+00:00"
+                "validatedAt": "2026-07-20T14:36:54.302372+00:00"
               },
               "deterministic": true
             },
@@ -17933,9 +17931,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.055396+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.581891+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "policy": {
             "type": "string",
@@ -17952,7 +17949,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:42.743879+00:00"
+                "validatedAt": "2026-07-20T14:36:54.302387+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17977,7 +17974,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:42.743919+00:00"
+                "validatedAt": "2026-07-20T14:36:54.302402+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18002,7 +17999,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:42.743950+00:00"
+                "validatedAt": "2026-07-20T14:36:54.302414+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18027,7 +18024,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:42.743989+00:00"
+                "validatedAt": "2026-07-20T14:36:54.302430+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18110,7 +18107,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:42.744037+00:00"
+                "validatedAt": "2026-07-20T14:36:54.302449+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18184,7 +18181,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:42.744096+00:00"
+                "validatedAt": "2026-07-20T14:36:54.302472+00:00"
               },
               "deterministic": true
             },
@@ -18196,9 +18193,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.055462+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.581931+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "start_time": {
             "type": "string",
@@ -18223,7 +18219,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:42.744136+00:00"
+                "validatedAt": "2026-07-20T14:36:54.302488+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18256,7 +18252,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:42.744170+00:00"
+                "validatedAt": "2026-07-20T14:36:54.302502+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18354,7 +18350,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:42.744216+00:00"
+                "validatedAt": "2026-07-20T14:36:54.302520+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18500,7 +18496,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:42.744258+00:00"
+                "validatedAt": "2026-07-20T14:36:54.302536+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18511,7 +18507,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.055524+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.581968+00:00"
           }
         },
         "x-f5xc-description-short": "Label filter can be specified to filter metrics based on label match.",
@@ -18592,7 +18588,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:42.744319+00:00"
+                "validatedAt": "2026-07-20T14:36:54.302566+00:00"
               },
               "deterministic": true
             },
@@ -18727,7 +18723,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:42.744375+00:00"
+                "validatedAt": "2026-07-20T14:36:54.302592+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18763,7 +18759,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:42.744419+00:00"
+                "validatedAt": "2026-07-20T14:36:54.302613+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18799,7 +18795,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:42.744462+00:00"
+                "validatedAt": "2026-07-20T14:36:54.302634+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18981,7 +18977,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.055639+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.582036+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -19083,7 +19079,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:58:42.744577+00:00"
+                "validatedAt": "2026-07-20T14:36:54.302681+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19169,7 +19165,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:58:42.744632+00:00"
+                "validatedAt": "2026-07-20T14:36:54.302704+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19180,7 +19176,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.055699+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.582066+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -19267,7 +19263,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:42.744691+00:00"
+                "validatedAt": "2026-07-20T14:36:54.302722+00:00"
               },
               "deterministic": true
             },
@@ -19279,9 +19275,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.055745+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.582094+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -19312,7 +19307,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:42.744718+00:00"
+                "validatedAt": "2026-07-20T14:36:54.302735+00:00"
               },
               "deterministic": true
             },
@@ -19324,9 +19319,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.055763+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.582106+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -19395,7 +19389,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:42.744772+00:00"
+                "validatedAt": "2026-07-20T14:36:54.302755+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19407,7 +19401,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.055801+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.582130+00:00"
           },
           "uid": {
             "type": "string",
@@ -19425,7 +19419,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:42.744798+00:00"
+                "validatedAt": "2026-07-20T14:36:54.302766+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19438,7 +19432,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.055821+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.582143+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of forward_proxy_policy is returned in 'List'.",
@@ -19748,7 +19742,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:42.744886+00:00"
+                "validatedAt": "2026-07-20T14:36:54.302803+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19826,7 +19820,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:42.744934+00:00"
+                "validatedAt": "2026-07-20T14:36:54.302825+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19929,7 +19923,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:42.745004+00:00"
+                "validatedAt": "2026-07-20T14:36:54.302856+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19941,8 +19935,7 @@
             "x-f5xc-conflicts-with": [
               "regex_value",
               "suffix_value"
-            ],
-            "format": "hostname"
+            ]
           },
           "path_exact_value": {
             "type": "string",
@@ -19973,7 +19966,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:42.745067+00:00"
+                "validatedAt": "2026-07-20T14:36:54.302885+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20018,7 +20011,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:42.745129+00:00"
+                "validatedAt": "2026-07-20T14:36:54.302914+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20063,7 +20056,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:42.745192+00:00"
+                "validatedAt": "2026-07-20T14:36:54.302943+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20107,7 +20100,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:42.745252+00:00"
+                "validatedAt": "2026-07-20T14:36:54.302971+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20152,7 +20145,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:42.745313+00:00"
+                "validatedAt": "2026-07-20T14:36:54.302999+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20164,8 +20157,7 @@
             "x-f5xc-conflicts-with": [
               "exact_value",
               "regex_value"
-            ],
-            "format": "hostname"
+            ]
           }
         },
         "x-f5xc-description-short": "URL strings in form \"HTTP://<domian>/<path>\".",
@@ -20273,7 +20265,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:42.745345+00:00"
+                "validatedAt": "2026-07-20T14:36:54.303013+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20285,7 +20277,7 @@
             "readOnly": true,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.055942+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.582214+00:00"
           },
           "name": {
             "type": "string",
@@ -20318,7 +20310,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:42.745374+00:00"
+                "validatedAt": "2026-07-20T14:36:54.303026+00:00"
               },
               "deterministic": true
             },
@@ -20330,9 +20322,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.055960+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.582226+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -20365,7 +20356,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:42.745402+00:00"
+                "validatedAt": "2026-07-20T14:36:54.303039+00:00"
               },
               "deterministic": true
             },
@@ -20377,9 +20368,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.055979+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.582238+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -20398,7 +20388,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:42.745436+00:00"
+                "validatedAt": "2026-07-20T14:36:54.303052+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20411,7 +20401,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.055997+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.582251+00:00"
           },
           "uid": {
             "type": "string",
@@ -20430,7 +20420,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:42.745461+00:00"
+                "validatedAt": "2026-07-20T14:36:54.303063+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20444,7 +20434,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.056016+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.582264+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -20533,7 +20523,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:42.745510+00:00"
+                "validatedAt": "2026-07-20T14:36:54.303085+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20772,7 +20762,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:42.745547+00:00"
+                "validatedAt": "2026-07-20T14:36:54.303100+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20795,7 +20785,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:42.745581+00:00"
+                "validatedAt": "2026-07-20T14:36:54.303114+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20806,7 +20796,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.056053+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.582287+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -20875,7 +20865,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T12:58:42.745618+00:00"
+                "validatedAt": "2026-07-20T14:36:54.303130+00:00"
               },
               "deterministic": true
             },
@@ -20886,8 +20876,7 @@
               "read": false
             },
             "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "minLength": 1,
-            "format": "fqdn"
+            "minLength": 1
           },
           "last_update_time": {
             "type": "string",
@@ -20904,7 +20893,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:42.745668+00:00"
+                "validatedAt": "2026-07-20T14:36:54.303146+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20931,7 +20920,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:42.745704+00:00"
+                "validatedAt": "2026-07-20T14:36:54.303160+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20942,7 +20931,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.056088+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.582308+00:00"
           },
           "service_name": {
             "type": "string",
@@ -20959,7 +20948,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:42.745743+00:00"
+                "validatedAt": "2026-07-20T14:36:54.303176+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20992,7 +20981,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:42.745781+00:00"
+                "validatedAt": "2026-07-20T14:36:54.303190+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21003,7 +20992,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.056113+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.582324+00:00"
           },
           "type": {
             "type": "string",
@@ -21028,7 +21017,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:42.745814+00:00"
+                "validatedAt": "2026-07-20T14:36:54.303203+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21119,7 +21108,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:42.745878+00:00"
+                "validatedAt": "2026-07-20T14:36:54.303232+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21131,8 +21120,7 @@
             "x-f5xc-conflicts-with": [
               "regex_value",
               "suffix_value"
-            ],
-            "format": "hostname"
+            ]
           },
           "regex_value": {
             "type": "string",
@@ -21163,7 +21151,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:42.745937+00:00"
+                "validatedAt": "2026-07-20T14:36:54.303260+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21208,7 +21196,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:42.745998+00:00"
+                "validatedAt": "2026-07-20T14:36:54.303289+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21220,8 +21208,7 @@
             "x-f5xc-conflicts-with": [
               "exact_value",
               "regex_value"
-            ],
-            "format": "hostname"
+            ]
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -21362,7 +21349,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:42.746038+00:00"
+                "validatedAt": "2026-07-20T14:36:54.303305+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21447,7 +21434,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:42.746066+00:00"
+                "validatedAt": "2026-07-20T14:36:54.303319+00:00"
               },
               "deterministic": true
             },
@@ -21459,9 +21446,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.056181+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.582366+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -21614,7 +21600,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:42.746129+00:00"
+                "validatedAt": "2026-07-20T14:36:54.303348+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21657,7 +21643,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:42.746191+00:00"
+                "validatedAt": "2026-07-20T14:36:54.303377+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21699,7 +21685,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:42.746233+00:00"
+                "validatedAt": "2026-07-20T14:36:54.303398+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21792,7 +21778,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:42.746278+00:00"
+                "validatedAt": "2026-07-20T14:36:54.303420+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21865,7 +21851,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:42.746345+00:00"
+                "validatedAt": "2026-07-20T14:36:54.303452+00:00"
               },
               "deterministic": true
             },
@@ -21877,7 +21863,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.056249+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.582405+00:00"
           },
           "name": {
             "type": "string",
@@ -21921,7 +21907,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:42.746395+00:00"
+                "validatedAt": "2026-07-20T14:36:54.303477+00:00"
               },
               "deterministic": true
             },
@@ -21931,8 +21917,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "MessageMetaType is metadata (common attributes) of a message that only certain messages have.",
@@ -22069,7 +22054,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:42.746446+00:00"
+                "validatedAt": "2026-07-20T14:36:54.303498+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22080,7 +22065,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.056292+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.582430+00:00"
           }
         },
         "x-f5xc-description-short": "Metric data contains timestamp and the value.",
@@ -22181,7 +22166,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:42.746520+00:00"
+                "validatedAt": "2026-07-20T14:36:54.303533+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -22196,7 +22181,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.056320+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.582448+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -22266,7 +22251,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:42.746558+00:00"
+                "validatedAt": "2026-07-20T14:36:54.303550+00:00"
               },
               "deterministic": true
             },
@@ -22278,9 +22263,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.056353+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.582468+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -22313,7 +22297,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:42.746584+00:00"
+                "validatedAt": "2026-07-20T14:36:54.303562+00:00"
               },
               "deterministic": true
             },
@@ -22325,9 +22309,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.056372+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.582480+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -22432,7 +22415,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:42.746662+00:00"
+                "validatedAt": "2026-07-20T14:36:54.303597+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -22447,7 +22430,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.056400+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.582498+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -22519,7 +22502,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:42.746701+00:00"
+                "validatedAt": "2026-07-20T14:36:54.303614+00:00"
               },
               "deterministic": true
             },
@@ -22531,9 +22514,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.056433+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.582519+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -22566,7 +22548,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:42.746727+00:00"
+                "validatedAt": "2026-07-20T14:36:54.303626+00:00"
               },
               "deterministic": true
             },
@@ -22578,9 +22560,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.056451+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.582531+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -22685,7 +22666,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:42.746799+00:00"
+                "validatedAt": "2026-07-20T14:36:54.303661+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -22700,7 +22681,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.056479+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.582548+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -22770,7 +22751,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:42.746835+00:00"
+                "validatedAt": "2026-07-20T14:36:54.303678+00:00"
               },
               "deterministic": true
             },
@@ -22782,9 +22763,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.056511+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.582569+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -22817,7 +22797,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:42.746861+00:00"
+                "validatedAt": "2026-07-20T14:36:54.303690+00:00"
               },
               "deterministic": true
             },
@@ -22829,9 +22809,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.056529+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.582581+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -22899,7 +22878,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:42.746903+00:00"
+                "validatedAt": "2026-07-20T14:36:54.303708+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22927,7 +22906,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:42.746943+00:00"
+                "validatedAt": "2026-07-20T14:36:54.303723+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22955,7 +22934,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:42.746981+00:00"
+                "validatedAt": "2026-07-20T14:36:54.303738+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22994,7 +22973,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:42.747021+00:00"
+                "validatedAt": "2026-07-20T14:36:54.303754+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23021,7 +23000,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:42.747045+00:00"
+                "validatedAt": "2026-07-20T14:36:54.303765+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23034,7 +23013,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.056583+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.582614+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -23050,7 +23029,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:42.747079+00:00"
+                "validatedAt": "2026-07-20T14:36:54.303779+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23205,7 +23184,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:42.747128+00:00"
+                "validatedAt": "2026-07-20T14:36:54.303798+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23216,7 +23195,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.056622+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.582638+00:00"
           },
           "status": {
             "type": "string",
@@ -23234,7 +23213,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:42.747161+00:00"
+                "validatedAt": "2026-07-20T14:36:54.303811+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23245,7 +23224,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.056641+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.582650+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -23310,7 +23289,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:42.747203+00:00"
+                "validatedAt": "2026-07-20T14:36:54.303828+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23337,7 +23316,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:42.747245+00:00"
+                "validatedAt": "2026-07-20T14:36:54.303845+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23364,7 +23343,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:42.747282+00:00"
+                "validatedAt": "2026-07-20T14:36:54.303859+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23392,7 +23371,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:42.747324+00:00"
+                "validatedAt": "2026-07-20T14:36:54.303876+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23468,7 +23447,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:42.747388+00:00"
+                "validatedAt": "2026-07-20T14:36:54.303900+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23536,7 +23515,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:42.747438+00:00"
+                "validatedAt": "2026-07-20T14:36:54.303919+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23548,7 +23527,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.056736+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.582702+00:00"
           },
           "uid": {
             "type": "string",
@@ -23567,7 +23546,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:42.747463+00:00"
+                "validatedAt": "2026-07-20T14:36:54.303930+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23580,7 +23559,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.056755+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.582714+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -23704,7 +23683,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:58:42.747508+00:00"
+                "validatedAt": "2026-07-20T14:36:54.303949+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23715,7 +23694,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.056777+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.582727+00:00"
           },
           "previous_value": {
             "type": "string",
@@ -23733,7 +23712,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:42.747548+00:00"
+                "validatedAt": "2026-07-20T14:36:54.303965+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23771,7 +23750,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:42.747582+00:00"
+                "validatedAt": "2026-07-20T14:36:54.303979+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23782,7 +23761,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.056807+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.582747+00:00"
           }
         },
         "x-f5xc-description-short": "Trend value contains trend value, trend sentiment and trend calculation description and window size.",
@@ -23847,7 +23826,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:42.747614+00:00"
+                "validatedAt": "2026-07-20T14:36:54.303992+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23858,7 +23837,7 @@
             },
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.056827+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.582759+00:00"
           },
           "name": {
             "type": "string",
@@ -23891,7 +23870,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:42.747641+00:00"
+                "validatedAt": "2026-07-20T14:36:54.304004+00:00"
               },
               "deterministic": true
             },
@@ -23903,9 +23882,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.056845+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.582771+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -23938,7 +23916,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:42.747675+00:00"
+                "validatedAt": "2026-07-20T14:36:54.304017+00:00"
               },
               "deterministic": true
             },
@@ -23950,9 +23928,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.056863+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.582783+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "uid": {
             "type": "string",
@@ -23969,7 +23946,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:42.747698+00:00"
+                "validatedAt": "2026-07-20T14:36:54.304027+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23982,7 +23959,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.056882+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.582795+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -24079,7 +24056,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:42.747745+00:00"
+                "validatedAt": "2026-07-20T14:36:54.304051+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24178,7 +24155,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:42.747798+00:00"
+                "validatedAt": "2026-07-20T14:36:54.304079+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -24192,8 +24169,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -24232,7 +24208,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:42.747844+00:00"
+                "validatedAt": "2026-07-20T14:36:54.304105+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -24247,9 +24223,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.056924+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.582821+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -24278,7 +24253,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:42.747898+00:00"
+                "validatedAt": "2026-07-20T14:36:54.304131+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24291,7 +24266,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.056942+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.582833+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a direct reference from one object(the referrer) to another(the referred).",
@@ -24371,7 +24346,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:42.747941+00:00"
+                "validatedAt": "2026-07-20T14:36:54.304152+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25789,7 +25764,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:02.302936+00:00"
+                "validatedAt": "2026-07-20T14:37:02.457477+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25821,7 +25796,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:02.302980+00:00"
+                "validatedAt": "2026-07-20T14:37:02.457493+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26201,7 +26176,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:02.303041+00:00"
+                "validatedAt": "2026-07-20T14:37:02.457518+00:00"
               },
               "deterministic": true
             },
@@ -26213,9 +26188,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.716877+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:13.177230+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -26247,7 +26221,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:02.303068+00:00"
+                "validatedAt": "2026-07-20T14:37:02.457531+00:00"
               },
               "deterministic": true
             },
@@ -26259,9 +26233,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.716897+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:13.177243+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -26426,7 +26399,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.716965+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:13.177284+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -26523,7 +26496,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:59:02.303182+00:00"
+                "validatedAt": "2026-07-20T14:37:02.457574+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26604,7 +26577,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:59:02.303236+00:00"
+                "validatedAt": "2026-07-20T14:37:02.457597+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26615,7 +26588,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.717017+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:13.177316+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -26702,7 +26675,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:02.303277+00:00"
+                "validatedAt": "2026-07-20T14:37:02.457614+00:00"
               },
               "deterministic": true
             },
@@ -26714,9 +26687,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.717063+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:13.177345+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -26747,7 +26719,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:02.303305+00:00"
+                "validatedAt": "2026-07-20T14:37:02.457627+00:00"
               },
               "deterministic": true
             },
@@ -26759,9 +26731,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.717082+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:13.177358+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -26830,7 +26801,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:02.303357+00:00"
+                "validatedAt": "2026-07-20T14:37:02.457647+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26842,7 +26813,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.717120+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:13.177383+00:00"
           },
           "uid": {
             "type": "string",
@@ -26860,7 +26831,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:02.303383+00:00"
+                "validatedAt": "2026-07-20T14:37:02.457657+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26873,7 +26844,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.717139+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:13.177396+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of network_policy_view is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -27011,7 +26982,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:02.303436+00:00"
+                "validatedAt": "2026-07-20T14:37:02.457677+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27051,7 +27022,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:02.303465+00:00"
+                "validatedAt": "2026-07-20T14:37:02.457690+00:00"
               },
               "deterministic": true
             },
@@ -27063,9 +27034,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.717181+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:13.177422+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "policy": {
             "type": "string",
@@ -27082,7 +27052,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:02.303500+00:00"
+                "validatedAt": "2026-07-20T14:37:02.457703+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27107,7 +27077,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:02.303539+00:00"
+                "validatedAt": "2026-07-20T14:37:02.457718+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27132,7 +27102,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:02.303569+00:00"
+                "validatedAt": "2026-07-20T14:37:02.457730+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27209,7 +27179,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:02.303609+00:00"
+                "validatedAt": "2026-07-20T14:37:02.457746+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27283,7 +27253,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:02.303675+00:00"
+                "validatedAt": "2026-07-20T14:37:02.457768+00:00"
               },
               "deterministic": true
             },
@@ -27295,9 +27265,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.717240+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:13.177459+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "start_time": {
             "type": "string",
@@ -27322,7 +27291,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:02.303715+00:00"
+                "validatedAt": "2026-07-20T14:37:02.457783+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27355,7 +27324,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:02.303747+00:00"
+                "validatedAt": "2026-07-20T14:37:02.457796+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27448,7 +27417,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:02.303792+00:00"
+                "validatedAt": "2026-07-20T14:37:02.457813+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27582,7 +27551,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:02.303834+00:00"
+                "validatedAt": "2026-07-20T14:37:02.457829+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27593,7 +27562,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.717302+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:13.177497+00:00"
           }
         },
         "x-f5xc-description-short": "Label filter can be specified to filter metrics based on label match.",
@@ -27858,7 +27827,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:02.304284+00:00"
+                "validatedAt": "2026-07-20T14:37:02.458038+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27947,7 +27916,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:02.304327+00:00"
+                "validatedAt": "2026-07-20T14:37:02.458061+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28021,7 +27990,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:02.305889+00:00"
+                "validatedAt": "2026-07-20T14:37:02.458747+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28071,7 +28040,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:02.305937+00:00"
+                "validatedAt": "2026-07-20T14:37:02.458769+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28163,7 +28132,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:02.305979+00:00"
+                "validatedAt": "2026-07-20T14:37:02.458790+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28213,7 +28182,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:02.306026+00:00"
+                "validatedAt": "2026-07-20T14:37:02.458812+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28305,7 +28274,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:02.306068+00:00"
+                "validatedAt": "2026-07-20T14:37:02.458832+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28355,7 +28324,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:02.306112+00:00"
+                "validatedAt": "2026-07-20T14:37:02.458854+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28436,7 +28405,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:10.436455+00:00"
+                "validatedAt": "2026-07-20T14:37:53.608863+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28462,7 +28431,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:10.436532+00:00"
+                "validatedAt": "2026-07-20T14:37:53.608885+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28488,7 +28457,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:10.436595+00:00"
+                "validatedAt": "2026-07-20T14:37:53.608901+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28514,7 +28483,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:10.436627+00:00"
+                "validatedAt": "2026-07-20T14:37:53.608914+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28540,7 +28509,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:10.436678+00:00"
+                "validatedAt": "2026-07-20T14:37:53.608930+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28617,7 +28586,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:01:10.436721+00:00"
+                "validatedAt": "2026-07-20T14:37:53.608948+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28864,7 +28833,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:33.288013+00:00"
+                "validatedAt": "2026-07-20T14:38:02.235862+00:00"
               },
               "deterministic": true
             },
@@ -28876,9 +28845,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.696159+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.947042+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -28910,7 +28878,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:33.288064+00:00"
+                "validatedAt": "2026-07-20T14:38:02.235880+00:00"
               },
               "deterministic": true
             },
@@ -28922,9 +28890,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.696180+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.947055+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -29005,7 +28972,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:33.288134+00:00"
+                "validatedAt": "2026-07-20T14:38:02.235906+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29272,7 +29239,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:33.288252+00:00"
+                "validatedAt": "2026-07-20T14:38:02.235935+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29297,7 +29264,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:33.288293+00:00"
+                "validatedAt": "2026-07-20T14:38:02.235951+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29337,7 +29304,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:33.288324+00:00"
+                "validatedAt": "2026-07-20T14:38:02.235966+00:00"
               },
               "deterministic": true
             },
@@ -29349,9 +29316,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.696302+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.947121+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "site": {
             "type": "string",
@@ -29368,7 +29334,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:33.288356+00:00"
+                "validatedAt": "2026-07-20T14:38:02.235978+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29442,7 +29408,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:33.288400+00:00"
+                "validatedAt": "2026-07-20T14:38:02.235997+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29516,7 +29482,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:33.288455+00:00"
+                "validatedAt": "2026-07-20T14:38:02.236020+00:00"
               },
               "deterministic": true
             },
@@ -29528,9 +29494,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.696349+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.947149+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "start_time": {
             "type": "string",
@@ -29555,7 +29520,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:33.288496+00:00"
+                "validatedAt": "2026-07-20T14:38:02.236037+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29588,7 +29553,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:33.288529+00:00"
+                "validatedAt": "2026-07-20T14:38:02.236051+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29679,7 +29644,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:33.288574+00:00"
+                "validatedAt": "2026-07-20T14:38:02.236069+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29808,7 +29773,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:33.288615+00:00"
+                "validatedAt": "2026-07-20T14:38:02.236084+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29819,7 +29784,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.696411+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.947185+00:00"
           }
         },
         "x-f5xc-description-short": "Label filter can be specified to filter metrics based on label match.",
@@ -29941,7 +29906,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:33.288686+00:00"
+                "validatedAt": "2026-07-20T14:38:02.236112+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30130,7 +30095,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.696511+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.947242+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -30225,7 +30190,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:01:33.288802+00:00"
+                "validatedAt": "2026-07-20T14:38:02.236161+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30303,7 +30268,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:01:33.288858+00:00"
+                "validatedAt": "2026-07-20T14:38:02.236186+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30314,7 +30279,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.696561+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.947272+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -30401,7 +30366,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:33.288900+00:00"
+                "validatedAt": "2026-07-20T14:38:02.236205+00:00"
               },
               "deterministic": true
             },
@@ -30413,9 +30378,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.696606+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.947299+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -30446,7 +30410,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:33.288929+00:00"
+                "validatedAt": "2026-07-20T14:38:02.236218+00:00"
               },
               "deterministic": true
             },
@@ -30458,9 +30422,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.696625+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.947311+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -30529,7 +30492,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:33.288981+00:00"
+                "validatedAt": "2026-07-20T14:38:02.236238+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30541,7 +30504,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.696676+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.947334+00:00"
           },
           "uid": {
             "type": "string",
@@ -30558,7 +30521,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:33.289007+00:00"
+                "validatedAt": "2026-07-20T14:38:02.236250+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30571,7 +30534,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.696696+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.947346+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of fast_acl is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -30686,7 +30649,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:33.289061+00:00"
+                "validatedAt": "2026-07-20T14:38:02.236275+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30902,7 +30865,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:33.289124+00:00"
+                "validatedAt": "2026-07-20T14:38:02.236305+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31046,7 +31009,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:33.289185+00:00"
+                "validatedAt": "2026-07-20T14:38:02.236333+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31489,7 +31452,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:33.289854+00:00"
+                "validatedAt": "2026-07-20T14:38:02.236603+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31556,7 +31519,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:33.289884+00:00"
+                "validatedAt": "2026-07-20T14:38:02.236615+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31633,7 +31596,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:33.290505+00:00"
+                "validatedAt": "2026-07-20T14:38:02.236913+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31816,7 +31779,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:33.290571+00:00"
+                "validatedAt": "2026-07-20T14:38:02.236943+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31894,7 +31857,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:33.290610+00:00"
+                "validatedAt": "2026-07-20T14:38:02.236962+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32555,7 +32518,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:36.827109+00:00"
+                "validatedAt": "2026-07-20T14:38:03.524830+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32674,7 +32637,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:36.827175+00:00"
+                "validatedAt": "2026-07-20T14:38:03.524855+00:00"
               },
               "deterministic": true
             },
@@ -32686,9 +32649,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.741352+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.976101+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -32720,7 +32682,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:36.827207+00:00"
+                "validatedAt": "2026-07-20T14:38:03.524869+00:00"
               },
               "deterministic": true
             },
@@ -32732,9 +32694,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.741373+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.976115+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -32897,7 +32858,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.741461+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.976166+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -33026,7 +32987,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:36.827345+00:00"
+                "validatedAt": "2026-07-20T14:38:03.524923+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33136,7 +33097,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:01:36.827392+00:00"
+                "validatedAt": "2026-07-20T14:38:03.524944+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33215,7 +33176,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:01:36.827452+00:00"
+                "validatedAt": "2026-07-20T14:38:03.524969+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33226,7 +33187,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.741539+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.976213+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -33313,7 +33274,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:36.827494+00:00"
+                "validatedAt": "2026-07-20T14:38:03.524987+00:00"
               },
               "deterministic": true
             },
@@ -33325,9 +33286,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.741585+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.976240+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -33358,7 +33318,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:36.827521+00:00"
+                "validatedAt": "2026-07-20T14:38:03.525000+00:00"
               },
               "deterministic": true
             },
@@ -33370,9 +33330,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.741604+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.976253+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -33441,7 +33400,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:36.827575+00:00"
+                "validatedAt": "2026-07-20T14:38:03.525021+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33453,7 +33412,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.741642+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.976277+00:00"
           },
           "uid": {
             "type": "string",
@@ -33470,7 +33429,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:36.827603+00:00"
+                "validatedAt": "2026-07-20T14:38:03.525033+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33483,7 +33442,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.741669+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.976290+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of fast_acl_rule is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -33707,7 +33666,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:36.827671+00:00"
+                "validatedAt": "2026-07-20T14:38:03.525060+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33886,7 +33845,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:36.828447+00:00"
+                "validatedAt": "2026-07-20T14:38:03.525436+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33898,7 +33857,7 @@
             "readOnly": true,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.742071+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.976537+00:00"
           },
           "name": {
             "type": "string",
@@ -33931,7 +33890,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:36.828474+00:00"
+                "validatedAt": "2026-07-20T14:38:03.525449+00:00"
               },
               "deterministic": true
             },
@@ -33943,9 +33902,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.742089+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.976549+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -33978,7 +33936,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:36.828501+00:00"
+                "validatedAt": "2026-07-20T14:38:03.525462+00:00"
               },
               "deterministic": true
             },
@@ -33990,9 +33948,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.742108+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.976561+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -34011,7 +33968,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:36.828534+00:00"
+                "validatedAt": "2026-07-20T14:38:03.525475+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34024,7 +33981,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.742126+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.976573+00:00"
           },
           "uid": {
             "type": "string",
@@ -34043,7 +34000,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:36.828558+00:00"
+                "validatedAt": "2026-07-20T14:38:03.525486+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34057,7 +34014,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.742146+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.976585+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -34275,7 +34232,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:38.873084+00:00"
+                "validatedAt": "2026-07-20T14:38:04.320799+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34314,7 +34271,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:38.873162+00:00"
+                "validatedAt": "2026-07-20T14:38:04.320836+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34410,7 +34367,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:38.873222+00:00"
+                "validatedAt": "2026-07-20T14:38:04.320857+00:00"
               },
               "deterministic": true
             },
@@ -34422,9 +34379,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.772751+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.995150+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -34456,7 +34412,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:38.873263+00:00"
+                "validatedAt": "2026-07-20T14:38:04.320872+00:00"
               },
               "deterministic": true
             },
@@ -34468,9 +34424,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.772772+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.995163+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -34535,7 +34490,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:38.873326+00:00"
+                "validatedAt": "2026-07-20T14:38:04.320890+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34622,7 +34577,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:38.873398+00:00"
+                "validatedAt": "2026-07-20T14:38:04.320907+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34799,7 +34754,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:38.873491+00:00"
+                "validatedAt": "2026-07-20T14:38:04.320933+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34883,7 +34838,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:38.873540+00:00"
+                "validatedAt": "2026-07-20T14:38:04.320956+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34930,7 +34885,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:38.873574+00:00"
+                "validatedAt": "2026-07-20T14:38:04.320971+00:00"
               },
               "deterministic": true
             },
@@ -34942,9 +34897,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.772859+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.995210+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Find Filter Sets API returns FilterSets that match the given context key(s).",
@@ -35163,7 +35117,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.772933+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.995252+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -35246,7 +35200,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:38.873714+00:00"
+                "validatedAt": "2026-07-20T14:38:04.321019+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35285,7 +35239,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:38.873760+00:00"
+                "validatedAt": "2026-07-20T14:38:04.321042+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35356,7 +35310,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:38.873804+00:00"
+                "validatedAt": "2026-07-20T14:38:04.321058+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35396,7 +35350,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:38.873849+00:00"
+                "validatedAt": "2026-07-20T14:38:04.321082+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35480,7 +35434,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:01:38.873895+00:00"
+                "validatedAt": "2026-07-20T14:38:04.321102+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35561,7 +35515,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:01:38.873950+00:00"
+                "validatedAt": "2026-07-20T14:38:04.321126+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35572,7 +35526,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.773013+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.995297+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -35659,7 +35613,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:38.873992+00:00"
+                "validatedAt": "2026-07-20T14:38:04.321144+00:00"
               },
               "deterministic": true
             },
@@ -35671,9 +35625,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.773059+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.995323+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -35704,7 +35657,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:38.874020+00:00"
+                "validatedAt": "2026-07-20T14:38:04.321158+00:00"
               },
               "deterministic": true
             },
@@ -35716,9 +35669,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.773077+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.995334+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -35787,7 +35739,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:38.874073+00:00"
+                "validatedAt": "2026-07-20T14:38:04.321178+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35799,7 +35751,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.773115+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.995356+00:00"
           },
           "uid": {
             "type": "string",
@@ -35816,7 +35768,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:38.874100+00:00"
+                "validatedAt": "2026-07-20T14:38:04.321189+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35829,7 +35781,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.773135+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.995368+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of filter_set is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -36084,7 +36036,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:38.874161+00:00"
+                "validatedAt": "2026-07-20T14:38:04.321213+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36123,7 +36075,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:38.874205+00:00"
+                "validatedAt": "2026-07-20T14:38:04.321235+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36331,7 +36283,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:38.874566+00:00"
+                "validatedAt": "2026-07-20T14:38:04.321380+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36363,7 +36315,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:38.874605+00:00"
+                "validatedAt": "2026-07-20T14:38:04.321396+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36472,7 +36424,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:38.875062+00:00"
+                "validatedAt": "2026-07-20T14:38:04.321599+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -36487,7 +36439,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.773564+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.995620+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -36559,7 +36511,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:38.875100+00:00"
+                "validatedAt": "2026-07-20T14:38:04.321616+00:00"
               },
               "deterministic": true
             },
@@ -36571,9 +36523,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.773597+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.995640+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -36606,7 +36557,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:38.875127+00:00"
+                "validatedAt": "2026-07-20T14:38:04.321630+00:00"
               },
               "deterministic": true
             },
@@ -36618,9 +36569,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.773614+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.995651+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "uid": {
             "type": "string",
@@ -36639,7 +36589,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:38.875153+00:00"
+                "validatedAt": "2026-07-20T14:38:04.321640+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36653,7 +36603,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.773634+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.995663+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectMetaType is metadata(common attributes) of an object that all configuration objects will have.",
@@ -36723,7 +36673,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:38.876130+00:00"
+                "validatedAt": "2026-07-20T14:38:04.322024+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36751,7 +36701,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:38.876169+00:00"
+                "validatedAt": "2026-07-20T14:38:04.322040+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36780,7 +36730,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:38.876207+00:00"
+                "validatedAt": "2026-07-20T14:38:04.322055+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36807,7 +36757,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:38.876243+00:00"
+                "validatedAt": "2026-07-20T14:38:04.322070+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36836,7 +36786,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:38.876284+00:00"
+                "validatedAt": "2026-07-20T14:38:04.322086+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36861,7 +36811,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:38.876325+00:00"
+                "validatedAt": "2026-07-20T14:38:04.322102+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36937,7 +36887,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:38.876387+00:00"
+                "validatedAt": "2026-07-20T14:38:04.322126+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36975,7 +36925,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:38.876432+00:00"
+                "validatedAt": "2026-07-20T14:38:04.322147+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36987,7 +36937,7 @@
             "maxLength": 6,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.774120+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.995949+00:00"
           },
           "object_index": {
             "type": "integer",
@@ -37047,7 +36997,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:38.876481+00:00"
+                "validatedAt": "2026-07-20T14:38:04.322168+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37091,7 +37041,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:38.876517+00:00"
+                "validatedAt": "2026-07-20T14:38:04.322183+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37104,7 +37054,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.774164+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.995975+00:00"
           },
           "trace_info": {
             "type": "string",
@@ -37123,7 +37073,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:38.876554+00:00"
+                "validatedAt": "2026-07-20T14:38:04.322198+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37150,7 +37100,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:38.876581+00:00"
+                "validatedAt": "2026-07-20T14:38:04.322209+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37164,7 +37114,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.774189+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.995991+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -37179,7 +37129,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:38.876616+00:00"
+                "validatedAt": "2026-07-20T14:38:04.322223+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37308,7 +37258,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:34.332192+00:00"
+                "validatedAt": "2026-07-20T14:39:12.947074+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37531,7 +37481,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:34.332272+00:00"
+                "validatedAt": "2026-07-20T14:39:12.947116+00:00"
               },
               "deterministic": true
             },
@@ -37640,7 +37590,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:34.332310+00:00"
+                "validatedAt": "2026-07-20T14:39:12.947134+00:00"
               },
               "deterministic": true
             },
@@ -37652,9 +37602,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.470994+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.243070+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -37686,7 +37635,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:34.332338+00:00"
+                "validatedAt": "2026-07-20T14:39:12.947148+00:00"
               },
               "deterministic": true
             },
@@ -37698,9 +37647,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.471013+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.243083+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -37933,7 +37881,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.471095+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.243133+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -38023,7 +37971,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:34.332470+00:00"
+                "validatedAt": "2026-07-20T14:39:12.947207+00:00"
               },
               "deterministic": true
             },
@@ -38121,7 +38069,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:04:34.332512+00:00"
+                "validatedAt": "2026-07-20T14:39:12.947227+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38200,7 +38148,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:04:34.332565+00:00"
+                "validatedAt": "2026-07-20T14:39:12.947252+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38211,7 +38159,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.471160+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.243173+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -38298,7 +38246,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:34.332606+00:00"
+                "validatedAt": "2026-07-20T14:39:12.947272+00:00"
               },
               "deterministic": true
             },
@@ -38310,9 +38258,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.471207+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.243201+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -38343,7 +38290,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:34.332632+00:00"
+                "validatedAt": "2026-07-20T14:39:12.947286+00:00"
               },
               "deterministic": true
             },
@@ -38355,9 +38302,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.471225+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.243213+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -38426,7 +38372,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:34.332695+00:00"
+                "validatedAt": "2026-07-20T14:39:12.947308+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38438,7 +38384,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.471262+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.243237+00:00"
           },
           "uid": {
             "type": "string",
@@ -38455,7 +38401,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:34.332721+00:00"
+                "validatedAt": "2026-07-20T14:39:12.947320+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38468,7 +38414,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.471282+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.243250+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of nat_policy is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -38984,7 +38930,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:34.332846+00:00"
+                "validatedAt": "2026-07-20T14:39:12.947377+00:00"
               },
               "deterministic": true
             },
@@ -39173,7 +39119,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:34.332894+00:00"
+                "validatedAt": "2026-07-20T14:39:12.947399+00:00"
               },
               "deterministic": true
             },
@@ -39185,9 +39131,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.471452+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.243351+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "network_interface": {
             "allOf": [
@@ -39437,7 +39382,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:34.333044+00:00"
+                "validatedAt": "2026-07-20T14:39:12.947466+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39510,7 +39455,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:34.333084+00:00"
+                "validatedAt": "2026-07-20T14:39:12.947488+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39584,7 +39529,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:34.333420+00:00"
+                "validatedAt": "2026-07-20T14:39:12.947646+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39658,7 +39603,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:56.179595+00:00"
+                "validatedAt": "2026-07-20T14:39:21.657051+00:00"
               }
             }
           },
@@ -39676,7 +39621,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:34.333465+00:00"
+                "validatedAt": "2026-07-20T14:39:12.947665+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39781,7 +39726,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:34.333916+00:00"
+                "validatedAt": "2026-07-20T14:39:12.947938+00:00"
               },
               "deterministic": true
             },
@@ -39825,7 +39770,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:34.333980+00:00"
+                "validatedAt": "2026-07-20T14:39:12.947973+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39958,7 +39903,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:34.334021+00:00"
+                "validatedAt": "2026-07-20T14:39:12.947997+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40092,7 +40037,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:34.334791+00:00"
+                "validatedAt": "2026-07-20T14:39:12.948352+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40164,7 +40109,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:56.179676+00:00"
+                "validatedAt": "2026-07-20T14:39:21.657085+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40249,7 +40194,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:15.978687+00:00"
+                "validatedAt": "2026-07-20T14:39:29.446637+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40328,7 +40273,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:15.978736+00:00"
+                "validatedAt": "2026-07-20T14:39:29.446660+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40405,7 +40350,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:15.978786+00:00"
+                "validatedAt": "2026-07-20T14:39:29.446683+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40483,7 +40428,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:15.978832+00:00"
+                "validatedAt": "2026-07-20T14:39:29.446705+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40883,7 +40828,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:15.978912+00:00"
+                "validatedAt": "2026-07-20T14:39:29.446735+00:00"
               },
               "deterministic": true
             },
@@ -40895,9 +40840,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.111011+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.824198+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -40929,7 +40873,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:15.978940+00:00"
+                "validatedAt": "2026-07-20T14:39:29.446747+00:00"
               },
               "deterministic": true
             },
@@ -40941,9 +40885,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.111029+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.824210+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -41106,7 +41049,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.111095+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.824252+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -41370,7 +41313,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:05:15.979075+00:00"
+                "validatedAt": "2026-07-20T14:39:29.446798+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41449,7 +41392,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:05:15.979130+00:00"
+                "validatedAt": "2026-07-20T14:39:29.446822+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41460,7 +41403,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.111192+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.824309+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -41547,7 +41490,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:15.979170+00:00"
+                "validatedAt": "2026-07-20T14:39:29.446840+00:00"
               },
               "deterministic": true
             },
@@ -41559,9 +41502,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.111237+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.824337+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -41592,7 +41534,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:15.979197+00:00"
+                "validatedAt": "2026-07-20T14:39:29.446852+00:00"
               },
               "deterministic": true
             },
@@ -41604,9 +41546,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.111256+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.824350+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -41675,7 +41616,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:15.979250+00:00"
+                "validatedAt": "2026-07-20T14:39:29.446872+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41687,7 +41628,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.111293+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.824373+00:00"
           },
           "uid": {
             "type": "string",
@@ -41705,7 +41646,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:15.979276+00:00"
+                "validatedAt": "2026-07-20T14:39:29.446882+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41718,7 +41659,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.111313+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.824386+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of network_firewall is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -42144,7 +42085,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.111788+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.824656+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -42387,7 +42328,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:26.454332+00:00"
+                "validatedAt": "2026-07-20T14:39:33.409307+00:00"
               },
               "deterministic": true
             },
@@ -42399,9 +42340,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.319781+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.010278+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -42433,7 +42373,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:26.454359+00:00"
+                "validatedAt": "2026-07-20T14:39:33.409320+00:00"
               },
               "deterministic": true
             },
@@ -42445,9 +42385,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.319800+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.010290+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -42612,7 +42551,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.319902+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.010350+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -42703,7 +42642,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:26.454508+00:00"
+                "validatedAt": "2026-07-20T14:39:33.409378+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42742,7 +42681,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:26.454554+00:00"
+                "validatedAt": "2026-07-20T14:39:33.409401+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42826,7 +42765,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:05:26.454601+00:00"
+                "validatedAt": "2026-07-20T14:39:33.409421+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42907,7 +42846,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:05:26.454668+00:00"
+                "validatedAt": "2026-07-20T14:39:33.409445+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42918,7 +42857,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.319971+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.010390+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -43005,7 +42944,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:26.454711+00:00"
+                "validatedAt": "2026-07-20T14:39:33.409462+00:00"
               },
               "deterministic": true
             },
@@ -43017,9 +42956,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.320018+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.010417+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -43050,7 +42988,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:26.454739+00:00"
+                "validatedAt": "2026-07-20T14:39:33.409475+00:00"
               },
               "deterministic": true
             },
@@ -43062,9 +43000,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.320037+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.010430+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -43133,7 +43070,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:26.454793+00:00"
+                "validatedAt": "2026-07-20T14:39:33.409495+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43145,7 +43082,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.320075+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.010453+00:00"
           },
           "uid": {
             "type": "string",
@@ -43162,7 +43099,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:26.454819+00:00"
+                "validatedAt": "2026-07-20T14:39:33.409505+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43175,7 +43112,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.320095+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.010465+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of network_policy is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -43313,7 +43250,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:26.454871+00:00"
+                "validatedAt": "2026-07-20T14:39:33.409525+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43353,7 +43290,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:26.454900+00:00"
+                "validatedAt": "2026-07-20T14:39:33.409538+00:00"
               },
               "deterministic": true
             },
@@ -43365,9 +43302,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.320136+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.010490+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "policy": {
             "type": "string",
@@ -43384,7 +43320,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:26.454936+00:00"
+                "validatedAt": "2026-07-20T14:39:33.409552+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43409,7 +43345,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:26.454975+00:00"
+                "validatedAt": "2026-07-20T14:39:33.409567+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43434,7 +43370,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:26.455013+00:00"
+                "validatedAt": "2026-07-20T14:39:33.409583+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43459,7 +43395,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:26.455043+00:00"
+                "validatedAt": "2026-07-20T14:39:33.409595+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43537,7 +43473,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:26.455088+00:00"
+                "validatedAt": "2026-07-20T14:39:33.409612+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43611,7 +43547,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:26.455142+00:00"
+                "validatedAt": "2026-07-20T14:39:33.409635+00:00"
               },
               "deterministic": true
             },
@@ -43623,9 +43559,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.320203+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.010531+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "start_time": {
             "type": "string",
@@ -43650,7 +43585,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:26.455182+00:00"
+                "validatedAt": "2026-07-20T14:39:33.409651+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43683,7 +43618,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:26.455214+00:00"
+                "validatedAt": "2026-07-20T14:39:33.409664+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43776,7 +43711,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:26.455260+00:00"
+                "validatedAt": "2026-07-20T14:39:33.409683+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43911,7 +43846,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:26.455299+00:00"
+                "validatedAt": "2026-07-20T14:39:33.409699+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43922,7 +43857,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.320265+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.010568+00:00"
           }
         },
         "x-f5xc-description-short": "Label filter can be specified to filter metrics based on label match.",
@@ -43992,7 +43927,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:26.455347+00:00"
+                "validatedAt": "2026-07-20T14:39:33.409721+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44029,7 +43964,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:26.455391+00:00"
+                "validatedAt": "2026-07-20T14:39:33.409743+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44830,7 +44765,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:30.242132+00:00"
+                "validatedAt": "2026-07-20T14:39:34.813823+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44896,7 +44831,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:30.242184+00:00"
+                "validatedAt": "2026-07-20T14:39:34.813843+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45003,7 +44938,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:30.242220+00:00"
+                "validatedAt": "2026-07-20T14:39:34.813859+00:00"
               },
               "deterministic": true
             },
@@ -45015,9 +44950,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.398874+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.100587+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -45049,7 +44983,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:30.242248+00:00"
+                "validatedAt": "2026-07-20T14:39:34.813872+00:00"
               },
               "deterministic": true
             },
@@ -45061,9 +44995,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.398893+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.100599+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -45226,7 +45159,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.398959+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.100641+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -45382,7 +45315,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:30.242376+00:00"
+                "validatedAt": "2026-07-20T14:39:34.813925+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45448,7 +45381,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:30.242422+00:00"
+                "validatedAt": "2026-07-20T14:39:34.813943+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45547,7 +45480,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:05:30.242466+00:00"
+                "validatedAt": "2026-07-20T14:39:34.813962+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45626,7 +45559,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:05:30.242520+00:00"
+                "validatedAt": "2026-07-20T14:39:34.813986+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45637,7 +45570,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.399064+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.100703+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -45724,7 +45657,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:30.242561+00:00"
+                "validatedAt": "2026-07-20T14:39:34.814003+00:00"
               },
               "deterministic": true
             },
@@ -45736,9 +45669,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.399110+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.100731+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -45769,7 +45701,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:30.242587+00:00"
+                "validatedAt": "2026-07-20T14:39:34.814017+00:00"
               },
               "deterministic": true
             },
@@ -45781,9 +45713,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.399129+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.100743+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -45852,7 +45783,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:30.242640+00:00"
+                "validatedAt": "2026-07-20T14:39:34.814037+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45864,7 +45795,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.399166+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.100767+00:00"
           },
           "uid": {
             "type": "string",
@@ -45882,7 +45813,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:30.242677+00:00"
+                "validatedAt": "2026-07-20T14:39:34.814047+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45895,7 +45826,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.399185+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.100780+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of network_policy_rule is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -46150,7 +46081,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:30.242748+00:00"
+                "validatedAt": "2026-07-20T14:39:34.814077+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46216,7 +46147,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:30.242792+00:00"
+                "validatedAt": "2026-07-20T14:39:34.814095+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46459,7 +46390,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.426813+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.119014+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -46540,7 +46471,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:32.047797+00:00"
+                "validatedAt": "2026-07-20T14:39:35.469451+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46639,7 +46570,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:05:32.047871+00:00"
+                "validatedAt": "2026-07-20T14:39:35.469475+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46718,7 +46649,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:05:32.047960+00:00"
+                "validatedAt": "2026-07-20T14:39:35.469501+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46729,7 +46660,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.426875+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.119052+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -46816,7 +46747,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:32.048029+00:00"
+                "validatedAt": "2026-07-20T14:39:35.469521+00:00"
               },
               "deterministic": true
             },
@@ -46828,9 +46759,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.426921+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.119081+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -46861,7 +46791,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:32.048074+00:00"
+                "validatedAt": "2026-07-20T14:39:35.469535+00:00"
               },
               "deterministic": true
             },
@@ -46873,9 +46803,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.426940+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.119094+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -46944,7 +46873,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:32.048149+00:00"
+                "validatedAt": "2026-07-20T14:39:35.469557+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46956,7 +46885,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.426977+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.119118+00:00"
           },
           "uid": {
             "type": "string",
@@ -46974,7 +46903,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:32.048177+00:00"
+                "validatedAt": "2026-07-20T14:39:35.469568+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46987,7 +46916,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.426998+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.119132+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of network_policy_set is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -47308,7 +47237,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:07.447248+00:00"
+                "validatedAt": "2026-07-20T14:39:49.440211+00:00"
               },
               "deterministic": true
             },
@@ -47320,9 +47249,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.907724+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.635515+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -47354,7 +47282,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:07.447276+00:00"
+                "validatedAt": "2026-07-20T14:39:49.440225+00:00"
               },
               "deterministic": true
             },
@@ -47366,9 +47294,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.907743+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.635526+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -47478,7 +47405,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:07.447333+00:00"
+                "validatedAt": "2026-07-20T14:39:49.440254+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47672,7 +47599,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:07.447398+00:00"
+                "validatedAt": "2026-07-20T14:39:49.440285+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47841,7 +47768,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.907877+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.635605+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -47936,7 +47863,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:06:07.447513+00:00"
+                "validatedAt": "2026-07-20T14:39:49.440333+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48015,7 +47942,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:06:07.447567+00:00"
+                "validatedAt": "2026-07-20T14:39:49.440357+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48026,7 +47953,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.907928+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.635634+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -48113,7 +48040,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:07.447608+00:00"
+                "validatedAt": "2026-07-20T14:39:49.440376+00:00"
               },
               "deterministic": true
             },
@@ -48125,9 +48052,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.907973+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.635661+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -48158,7 +48084,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:07.447635+00:00"
+                "validatedAt": "2026-07-20T14:39:49.440390+00:00"
               },
               "deterministic": true
             },
@@ -48170,9 +48096,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.907991+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.635673+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -48241,7 +48166,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:07.447695+00:00"
+                "validatedAt": "2026-07-20T14:39:49.440411+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48253,7 +48178,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.908029+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.635696+00:00"
           },
           "uid": {
             "type": "string",
@@ -48271,7 +48196,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:07.447722+00:00"
+                "validatedAt": "2026-07-20T14:39:49.440423+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48284,7 +48209,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.908048+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.635708+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of policy_based_routing is returned in 'List'.",
@@ -48469,7 +48394,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:07.447795+00:00"
+                "validatedAt": "2026-07-20T14:39:49.440459+00:00"
               },
               "deterministic": true
             },
@@ -48485,8 +48410,7 @@
               "prefix_list"
             ],
             "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "minLength": 1,
-            "format": "hostname"
+            "minLength": 1
           },
           "forwarding_class_list": {
             "type": "array",
@@ -48519,7 +48443,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:07.447842+00:00"
+                "validatedAt": "2026-07-20T14:39:49.440483+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48717,7 +48641,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:07.447905+00:00"
+                "validatedAt": "2026-07-20T14:39:49.440513+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49011,7 +48935,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:07.450089+00:00"
+                "validatedAt": "2026-07-20T14:39:49.441555+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49131,7 +49055,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:07.450141+00:00"
+                "validatedAt": "2026-07-20T14:39:49.441582+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49246,7 +49170,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:07.450193+00:00"
+                "validatedAt": "2026-07-20T14:39:49.441608+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49568,7 +49492,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:29.899088+00:00"
+                "validatedAt": "2026-07-20T14:40:20.933264+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49600,7 +49524,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:29.899128+00:00"
+                "validatedAt": "2026-07-20T14:40:20.933287+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49832,7 +49756,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:29.899186+00:00"
+                "validatedAt": "2026-07-20T14:40:20.933312+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49843,7 +49767,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.364491+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.946269+00:00"
           }
         },
         "x-f5xc-description-short": "Label Filter. Filters that will use segment labels to filter out timeseries.",
@@ -49933,7 +49857,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.364525+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.946291+00:00"
           }
         },
         "x-f5xc-description-short": "Node Metric Data. Metric Data for each metric type in the segments node.",
@@ -50072,7 +49996,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:29.899252+00:00"
+                "validatedAt": "2026-07-20T14:40:20.933339+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50095,7 +50019,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:29.899292+00:00"
+                "validatedAt": "2026-07-20T14:40:20.933357+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50133,7 +50057,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:29.899320+00:00"
+                "validatedAt": "2026-07-20T14:40:20.933372+00:00"
               },
               "deterministic": true
             },
@@ -50145,9 +50069,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.364574+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.946321+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "site": {
             "type": "string",
@@ -50162,7 +50085,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:29.899350+00:00"
+                "validatedAt": "2026-07-20T14:40:20.933386+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50185,7 +50108,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:29.899380+00:00"
+                "validatedAt": "2026-07-20T14:40:20.933399+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50441,7 +50364,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:29.899428+00:00"
+                "validatedAt": "2026-07-20T14:40:20.933423+00:00"
               },
               "deterministic": true
             },
@@ -50453,9 +50376,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.364648+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.946366+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -50487,7 +50409,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:29.899454+00:00"
+                "validatedAt": "2026-07-20T14:40:20.933437+00:00"
               },
               "deterministic": true
             },
@@ -50499,9 +50421,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.364676+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.946378+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -50671,7 +50592,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.364743+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.946418+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -50773,7 +50694,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:07:29.899562+00:00"
+                "validatedAt": "2026-07-20T14:40:20.933484+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50858,7 +50779,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:07:29.899611+00:00"
+                "validatedAt": "2026-07-20T14:40:20.933507+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50869,7 +50790,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.364794+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.946448+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -50956,7 +50877,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:29.899652+00:00"
+                "validatedAt": "2026-07-20T14:40:20.933526+00:00"
               },
               "deterministic": true
             },
@@ -50968,9 +50889,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.364838+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.946476+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -51001,7 +50921,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:29.899687+00:00"
+                "validatedAt": "2026-07-20T14:40:20.933539+00:00"
               },
               "deterministic": true
             },
@@ -51013,9 +50933,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.364857+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.946489+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -51084,7 +51003,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:29.899737+00:00"
+                "validatedAt": "2026-07-20T14:40:20.933561+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51096,7 +51015,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.364894+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.946512+00:00"
           },
           "uid": {
             "type": "string",
@@ -51113,7 +51032,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:29.899761+00:00"
+                "validatedAt": "2026-07-20T14:40:20.933572+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51126,7 +51045,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.364913+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.946525+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of segment is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -51246,7 +51165,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:29.899804+00:00"
+                "validatedAt": "2026-07-20T14:40:20.933590+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51460,7 +51379,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:29.899865+00:00"
+                "validatedAt": "2026-07-20T14:40:20.933616+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51547,7 +51466,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:29.899920+00:00"
+                "validatedAt": "2026-07-20T14:40:20.933641+00:00"
               },
               "deterministic": true
             },
@@ -51559,9 +51478,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.364998+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.946575+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "start_time": {
             "type": "string",
@@ -51586,7 +51504,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:29.899959+00:00"
+                "validatedAt": "2026-07-20T14:40:20.933658+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51619,7 +51537,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:29.899991+00:00"
+                "validatedAt": "2026-07-20T14:40:20.933672+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51734,7 +51652,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:29.900043+00:00"
+                "validatedAt": "2026-07-20T14:40:20.933696+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51991,7 +51909,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.395873+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.971736+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -52080,7 +51998,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:31.757546+00:00"
+                "validatedAt": "2026-07-20T14:40:21.659434+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52169,7 +52087,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:07:31.757590+00:00"
+                "validatedAt": "2026-07-20T14:40:21.659455+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52255,7 +52173,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:07:31.757641+00:00"
+                "validatedAt": "2026-07-20T14:40:21.659478+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52266,7 +52184,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.395932+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.971772+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -52353,7 +52271,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:31.757690+00:00"
+                "validatedAt": "2026-07-20T14:40:21.659498+00:00"
               },
               "deterministic": true
             },
@@ -52365,9 +52283,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.395977+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.971801+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -52398,7 +52315,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:31.757717+00:00"
+                "validatedAt": "2026-07-20T14:40:21.659512+00:00"
               },
               "deterministic": true
             },
@@ -52410,9 +52327,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.395995+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.971814+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -52481,7 +52397,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:31.757769+00:00"
+                "validatedAt": "2026-07-20T14:40:21.659534+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52493,7 +52409,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.396033+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.971838+00:00"
           },
           "uid": {
             "type": "string",
@@ -52511,7 +52427,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:31.757794+00:00"
+                "validatedAt": "2026-07-20T14:40:21.659545+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52524,7 +52440,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.396052+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.971851+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of segment_connection is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -52714,7 +52630,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:31.757848+00:00"
+                "validatedAt": "2026-07-20T14:40:21.659572+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52802,7 +52718,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:31.757895+00:00"
+                "validatedAt": "2026-07-20T14:40:21.659598+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52858,7 +52774,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:31.757944+00:00"
+                "validatedAt": "2026-07-20T14:40:21.659624+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53197,7 +53113,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.662808+00:00"
+                "validatedAt": "2026-07-20T14:40:27.398706+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53293,7 +53209,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.662866+00:00"
+                "validatedAt": "2026-07-20T14:40:27.398732+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53331,7 +53247,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.662913+00:00"
+                "validatedAt": "2026-07-20T14:40:27.398755+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53368,7 +53284,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.662961+00:00"
+                "validatedAt": "2026-07-20T14:40:27.398779+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53405,7 +53321,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.663006+00:00"
+                "validatedAt": "2026-07-20T14:40:27.398801+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53500,7 +53416,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.663071+00:00"
+                "validatedAt": "2026-07-20T14:40:27.398831+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53622,7 +53538,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.663155+00:00"
+                "validatedAt": "2026-07-20T14:40:27.398867+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53802,7 +53718,7 @@
             "maxLength": 26,
             "minLength": 15,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.650717+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:21.173278+00:00",
             "x-f5xc-conflicts-with": [
               "check_not_present",
               "check_present"
@@ -53849,7 +53765,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.663226+00:00"
+                "validatedAt": "2026-07-20T14:40:27.398900+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -53864,9 +53780,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.650737+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.173290+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Argument matcher specifies the name of a single argument in the body and the criteria to match it.",
@@ -53944,7 +53859,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.663315+00:00"
+                "validatedAt": "2026-07-20T14:40:27.398943+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54091,7 +54006,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:46.663373+00:00"
+                "validatedAt": "2026-07-20T14:40:27.398966+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54102,7 +54017,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.650798+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.173332+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"BotAdvanced Domain Matcher Type\" Bot Advanced Domain Matcher Type.",
@@ -54264,7 +54179,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.650858+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.173362+00:00"
           },
           "http_methods": {
             "type": "array",
@@ -54448,7 +54363,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:46.663468+00:00"
+                "validatedAt": "2026-07-20T14:40:27.399002+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54459,7 +54374,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.650949+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.173400+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Bot Advanced Path Matcher Type\" Bot Advanced Path Matcher Type.",
@@ -54627,7 +54542,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:46.663523+00:00"
+                "validatedAt": "2026-07-20T14:40:27.399024+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54786,7 +54701,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:46.663568+00:00"
+                "validatedAt": "2026-07-20T14:40:27.399041+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54810,7 +54725,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:46.663608+00:00"
+                "validatedAt": "2026-07-20T14:40:27.399057+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54960,7 +54875,7 @@
             "maxLength": 26,
             "minLength": 15,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.651079+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:21.173464+00:00",
             "x-f5xc-conflicts-with": [
               "check_not_present",
               "check_present"
@@ -55005,7 +54920,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.663692+00:00"
+                "validatedAt": "2026-07-20T14:40:27.399091+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -55020,9 +54935,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.651099+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.173476+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Cookie matcher specifies the name of a single cookie and the criteria to match it.",
@@ -55519,7 +55433,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:46.663794+00:00"
+                "validatedAt": "2026-07-20T14:40:27.399129+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55669,7 +55583,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.663841+00:00"
+                "validatedAt": "2026-07-20T14:40:27.399151+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55821,7 +55735,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.663889+00:00"
+                "validatedAt": "2026-07-20T14:40:27.399174+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55906,7 +55820,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.663933+00:00"
+                "validatedAt": "2026-07-20T14:40:27.399196+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56027,7 +55941,7 @@
             "maxLength": 26,
             "minLength": 15,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.651229+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:21.173553+00:00",
             "x-f5xc-conflicts-with": [
               "check_not_present",
               "check_present"
@@ -56071,7 +55985,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.663998+00:00"
+                "validatedAt": "2026-07-20T14:40:27.399227+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -56086,9 +56000,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.651247+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.173566+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "JWT claim matcher specifies the name of a single JWT claim and the criteria for the input request to match it.",
@@ -56374,7 +56287,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.664064+00:00"
+                "validatedAt": "2026-07-20T14:40:27.399256+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56420,7 +56333,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.664105+00:00"
+                "validatedAt": "2026-07-20T14:40:27.399277+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56458,7 +56371,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.664146+00:00"
+                "validatedAt": "2026-07-20T14:40:27.399298+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56549,7 +56462,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.664191+00:00"
+                "validatedAt": "2026-07-20T14:40:27.399320+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56595,7 +56508,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.664232+00:00"
+                "validatedAt": "2026-07-20T14:40:27.399341+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57014,7 +56927,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.664337+00:00"
+                "validatedAt": "2026-07-20T14:40:27.399385+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57727,7 +57640,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:46.664638+00:00"
+                "validatedAt": "2026-07-20T14:40:27.399499+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57931,7 +57844,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:46.664698+00:00"
+                "validatedAt": "2026-07-20T14:40:27.399518+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57955,7 +57868,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:46.664735+00:00"
+                "validatedAt": "2026-07-20T14:40:27.399533+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57981,7 +57894,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.651638+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.173799+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Block bot mitigation\" Block request and respond with custom content.",
@@ -58111,7 +58024,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:46.664791+00:00"
+                "validatedAt": "2026-07-20T14:40:27.399555+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58135,7 +58048,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:46.664833+00:00"
+                "validatedAt": "2026-07-20T14:40:27.399571+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58301,7 +58214,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:46.664874+00:00"
+                "validatedAt": "2026-07-20T14:40:27.399587+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58393,7 +58306,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:46.664921+00:00"
+                "validatedAt": "2026-07-20T14:40:27.399605+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58541,7 +58454,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.664977+00:00"
+                "validatedAt": "2026-07-20T14:40:27.399630+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58625,7 +58538,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.665021+00:00"
+                "validatedAt": "2026-07-20T14:40:27.399651+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58666,7 +58579,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.665068+00:00"
+                "validatedAt": "2026-07-20T14:40:27.399674+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58708,7 +58621,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.665110+00:00"
+                "validatedAt": "2026-07-20T14:40:27.399695+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58829,7 +58742,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:46.665150+00:00"
+                "validatedAt": "2026-07-20T14:40:27.399711+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58853,7 +58766,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:46.665188+00:00"
+                "validatedAt": "2026-07-20T14:40:27.399726+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58877,7 +58790,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:46.665226+00:00"
+                "validatedAt": "2026-07-20T14:40:27.399741+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58901,7 +58814,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:46.665262+00:00"
+                "validatedAt": "2026-07-20T14:40:27.399756+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58925,7 +58838,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:46.665299+00:00"
+                "validatedAt": "2026-07-20T14:40:27.399771+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59829,7 +59742,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.665543+00:00"
+                "validatedAt": "2026-07-20T14:40:27.399864+00:00"
               },
               "deterministic": true
             },
@@ -59841,9 +59754,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.652024+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.174023+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "regex_values": {
             "type": "array",
@@ -59877,7 +59789,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.652050+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.174040+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Bot Defense Transaction Result Condition\" Bot Defense Transaction Result Condition.",
@@ -60346,7 +60258,7 @@
             "maxLength": 26,
             "minLength": 15,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.652913+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:21.174583+00:00",
             "x-f5xc-conflicts-with": [
               "check_not_present",
               "check_present"
@@ -60393,7 +60305,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.667466+00:00"
+                "validatedAt": "2026-07-20T14:40:27.400673+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -60408,9 +60320,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.652932+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.174596+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Header matcher specifies the name of a single HTTP header and the criteria for the input request to match it.",
@@ -60497,7 +60408,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.667509+00:00"
+                "validatedAt": "2026-07-20T14:40:27.400694+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60556,7 +60467,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.667556+00:00"
+                "validatedAt": "2026-07-20T14:40:27.400717+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60602,7 +60513,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.667599+00:00"
+                "validatedAt": "2026-07-20T14:40:27.400738+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60646,7 +60557,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.667643+00:00"
+                "validatedAt": "2026-07-20T14:40:27.400760+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60684,7 +60595,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.667696+00:00"
+                "validatedAt": "2026-07-20T14:40:27.400781+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60810,7 +60721,7 @@
             "maxLength": 26,
             "minLength": 15,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.653027+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:21.174653+00:00",
             "x-f5xc-conflicts-with": [
               "check_not_present",
               "check_present"
@@ -60845,7 +60756,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.667808+00:00"
+                "validatedAt": "2026-07-20T14:40:27.400831+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60856,7 +60767,7 @@
             },
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.653046+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.174666+00:00"
           }
         },
         "x-f5xc-description-short": "Query parameter matcher specifies the name of a single query parameter and the criteria for the input request to match it.",
@@ -61157,7 +61068,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.667923+00:00"
+                "validatedAt": "2026-07-20T14:40:27.400877+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61463,7 +61374,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.668014+00:00"
+                "validatedAt": "2026-07-20T14:40:27.400916+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61769,7 +61680,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.668106+00:00"
+                "validatedAt": "2026-07-20T14:40:27.400955+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62012,7 +61923,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.668174+00:00"
+                "validatedAt": "2026-07-20T14:40:27.400985+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62110,7 +62021,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.668248+00:00"
+                "validatedAt": "2026-07-20T14:40:27.401018+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62191,7 +62102,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.668297+00:00"
+                "validatedAt": "2026-07-20T14:40:27.401041+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62234,7 +62145,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:46.668345+00:00"
+                "validatedAt": "2026-07-20T14:40:27.401061+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62271,7 +62182,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.668401+00:00"
+                "validatedAt": "2026-07-20T14:40:27.401089+00:00"
               },
               "deterministic": true
             },
@@ -62392,7 +62303,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.668458+00:00"
+                "validatedAt": "2026-07-20T14:40:27.401114+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62482,7 +62393,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.668514+00:00"
+                "validatedAt": "2026-07-20T14:40:27.401140+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62677,7 +62588,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.668578+00:00"
+                "validatedAt": "2026-07-20T14:40:27.401168+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62949,7 +62860,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.668792+00:00"
+                "validatedAt": "2026-07-20T14:40:27.401265+00:00"
               },
               "deterministic": true
             },
@@ -62961,9 +62872,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.653580+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.174988+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -62995,7 +62905,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.668818+00:00"
+                "validatedAt": "2026-07-20T14:40:27.401277+00:00"
               },
               "deterministic": true
             },
@@ -63007,9 +62917,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.653598+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.175000+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -63179,7 +63088,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.653672+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.175040+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -63273,7 +63182,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.668940+00:00"
+                "validatedAt": "2026-07-20T14:40:27.401328+00:00"
               },
               "deterministic": true
             },
@@ -63364,7 +63273,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:07:46.668980+00:00"
+                "validatedAt": "2026-07-20T14:40:27.401345+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63450,7 +63359,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:07:46.669030+00:00"
+                "validatedAt": "2026-07-20T14:40:27.401366+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63461,7 +63370,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.653732+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.175074+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -63548,7 +63457,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.669070+00:00"
+                "validatedAt": "2026-07-20T14:40:27.401383+00:00"
               },
               "deterministic": true
             },
@@ -63560,9 +63469,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.653777+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.175102+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -63593,7 +63501,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.669097+00:00"
+                "validatedAt": "2026-07-20T14:40:27.401396+00:00"
               },
               "deterministic": true
             },
@@ -63605,9 +63513,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.653802+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.175114+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -63676,7 +63583,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:46.669150+00:00"
+                "validatedAt": "2026-07-20T14:40:27.401417+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63688,7 +63595,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.653840+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.175138+00:00"
           },
           "uid": {
             "type": "string",
@@ -63705,7 +63612,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:46.669175+00:00"
+                "validatedAt": "2026-07-20T14:40:27.401428+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63718,7 +63625,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.653859+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.175150+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of service_policy is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -64008,7 +63915,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.669240+00:00"
+                "validatedAt": "2026-07-20T14:40:27.401459+00:00"
               },
               "deterministic": true
             },
@@ -64152,7 +64059,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:46.669291+00:00"
+                "validatedAt": "2026-07-20T14:40:27.401479+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64192,7 +64099,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.669318+00:00"
+                "validatedAt": "2026-07-20T14:40:27.401492+00:00"
               },
               "deterministic": true
             },
@@ -64204,9 +64111,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.653937+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.175199+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "policy": {
             "type": "string",
@@ -64223,7 +64129,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:46.669351+00:00"
+                "validatedAt": "2026-07-20T14:40:27.401506+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64248,7 +64154,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:46.669388+00:00"
+                "validatedAt": "2026-07-20T14:40:27.401522+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64273,7 +64179,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:46.669425+00:00"
+                "validatedAt": "2026-07-20T14:40:27.401536+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64298,7 +64204,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:46.669455+00:00"
+                "validatedAt": "2026-07-20T14:40:27.401549+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64323,7 +64229,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:46.669492+00:00"
+                "validatedAt": "2026-07-20T14:40:27.401565+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64407,7 +64313,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:46.669531+00:00"
+                "validatedAt": "2026-07-20T14:40:27.401580+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64481,7 +64387,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.669583+00:00"
+                "validatedAt": "2026-07-20T14:40:27.401603+00:00"
               },
               "deterministic": true
             },
@@ -64493,9 +64399,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.654010+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.175243+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "start_time": {
             "type": "string",
@@ -64520,7 +64425,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:46.669621+00:00"
+                "validatedAt": "2026-07-20T14:40:27.401618+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64553,7 +64458,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:46.669661+00:00"
+                "validatedAt": "2026-07-20T14:40:27.401632+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64651,7 +64556,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:46.669706+00:00"
+                "validatedAt": "2026-07-20T14:40:27.401650+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64797,7 +64702,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:46.669747+00:00"
+                "validatedAt": "2026-07-20T14:40:27.401665+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64808,7 +64713,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.654072+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.175280+00:00"
           }
         },
         "x-f5xc-description-short": "Label filter can be specified to filter metrics based on label match.",
@@ -64899,7 +64804,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.669796+00:00"
+                "validatedAt": "2026-07-20T14:40:27.401689+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64941,7 +64846,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.669840+00:00"
+                "validatedAt": "2026-07-20T14:40:27.401711+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65030,7 +64935,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.669892+00:00"
+                "validatedAt": "2026-07-20T14:40:27.401737+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65080,7 +64985,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.669939+00:00"
+                "validatedAt": "2026-07-20T14:40:27.401760+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65121,7 +65026,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.669981+00:00"
+                "validatedAt": "2026-07-20T14:40:27.401781+00:00"
               }
             },
             "x-f5xc-required-for": {

--- a/docs/specifications/api/nginx_one.json
+++ b/docs/specifications/api/nginx_one.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Nginx One",
     "description": "Dataplane server registration with health status tracking and location awareness. Service discovery bindings for dynamic upstream resolution. Cloud service gateway integration for hybrid deployments. WAF policy attachment and instance-level security controls.",
-    "version": "2.1.182",
+    "version": "2.1.181",
     "contact": {
       "name": "F5 Distributed Cloud",
       "url": "https://docs.cloud.f5.com"
@@ -3365,7 +3365,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:42.339102+00:00"
+                "validatedAt": "2026-07-20T14:39:16.127009+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3377,7 +3377,7 @@
             "readOnly": true,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.624310+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.369069+00:00"
           },
           "name": {
             "type": "string",
@@ -3410,7 +3410,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:42.339160+00:00"
+                "validatedAt": "2026-07-20T14:39:16.127035+00:00"
               },
               "deterministic": true
             },
@@ -3422,9 +3422,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.624332+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.369083+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -3457,7 +3456,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:42.339192+00:00"
+                "validatedAt": "2026-07-20T14:39:16.127051+00:00"
               },
               "deterministic": true
             },
@@ -3469,9 +3468,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.624352+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.369095+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -3490,7 +3488,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:42.339226+00:00"
+                "validatedAt": "2026-07-20T14:39:16.127066+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3503,7 +3501,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.624371+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.369108+00:00"
           },
           "uid": {
             "type": "string",
@@ -3522,7 +3520,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:42.339267+00:00"
+                "validatedAt": "2026-07-20T14:39:16.127076+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3536,7 +3534,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.624390+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.369121+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -3746,7 +3744,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:04:42.339412+00:00"
+                "validatedAt": "2026-07-20T14:39:16.127118+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3824,7 +3822,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:04:42.339499+00:00"
+                "validatedAt": "2026-07-20T14:39:16.127142+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3835,7 +3833,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.624477+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.369175+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -3922,7 +3920,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:42.339574+00:00"
+                "validatedAt": "2026-07-20T14:39:16.127161+00:00"
               },
               "deterministic": true
             },
@@ -3934,9 +3932,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.624523+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.369204+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -3967,7 +3964,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:42.339604+00:00"
+                "validatedAt": "2026-07-20T14:39:16.127174+00:00"
               },
               "deterministic": true
             },
@@ -3979,9 +3976,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.624542+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.369216+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -4034,7 +4030,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:42.339645+00:00"
+                "validatedAt": "2026-07-20T14:39:16.127190+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4046,7 +4042,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.624572+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.369237+00:00"
           },
           "uid": {
             "type": "string",
@@ -4063,7 +4059,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:42.339681+00:00"
+                "validatedAt": "2026-07-20T14:39:16.127200+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4076,7 +4072,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.624592+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.369269+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of nginx_csg is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -4304,7 +4300,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:42.339757+00:00"
+                "validatedAt": "2026-07-20T14:39:16.127229+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4336,7 +4332,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:42.339799+00:00"
+                "validatedAt": "2026-07-20T14:39:16.127245+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4447,7 +4443,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:42.339861+00:00"
+                "validatedAt": "2026-07-20T14:39:16.127269+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4470,7 +4466,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:42.339899+00:00"
+                "validatedAt": "2026-07-20T14:39:16.127285+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4543,7 +4539,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:42.339941+00:00"
+                "validatedAt": "2026-07-20T14:39:16.127301+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4566,7 +4562,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:42.339975+00:00"
+                "validatedAt": "2026-07-20T14:39:16.127315+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4577,7 +4573,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.624732+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.369353+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -4705,7 +4701,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:42.340019+00:00"
+                "validatedAt": "2026-07-20T14:39:16.127331+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4783,7 +4779,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:42.340051+00:00"
+                "validatedAt": "2026-07-20T14:39:16.127346+00:00"
               },
               "deterministic": true
             },
@@ -4795,9 +4791,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.624776+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.369380+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -4958,7 +4953,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:42.340150+00:00"
+                "validatedAt": "2026-07-20T14:39:16.127390+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -4973,7 +4968,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.624819+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.369407+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -5045,7 +5040,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:42.340188+00:00"
+                "validatedAt": "2026-07-20T14:39:16.127408+00:00"
               },
               "deterministic": true
             },
@@ -5057,9 +5052,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.624853+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.369429+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -5092,7 +5086,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:42.340215+00:00"
+                "validatedAt": "2026-07-20T14:39:16.127423+00:00"
               },
               "deterministic": true
             },
@@ -5104,9 +5098,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.624872+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.369441+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -5183,7 +5176,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:42.340262+00:00"
+                "validatedAt": "2026-07-20T14:39:16.127441+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5194,7 +5187,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.624898+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.369458+00:00"
           },
           "status": {
             "type": "string",
@@ -5212,7 +5205,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:42.340296+00:00"
+                "validatedAt": "2026-07-20T14:39:16.127454+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5223,7 +5216,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.624917+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.369470+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -5281,7 +5274,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:42.340339+00:00"
+                "validatedAt": "2026-07-20T14:39:16.127473+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5308,7 +5301,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:42.340380+00:00"
+                "validatedAt": "2026-07-20T14:39:16.127490+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5335,7 +5328,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:42.340417+00:00"
+                "validatedAt": "2026-07-20T14:39:16.127505+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5363,7 +5356,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:42.340460+00:00"
+                "validatedAt": "2026-07-20T14:39:16.127523+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5439,7 +5432,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:42.340522+00:00"
+                "validatedAt": "2026-07-20T14:39:16.127548+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5507,7 +5500,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:42.340573+00:00"
+                "validatedAt": "2026-07-20T14:39:16.127569+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5519,7 +5512,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.625003+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.369524+00:00"
           },
           "uid": {
             "type": "string",
@@ -5538,7 +5531,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:42.340598+00:00"
+                "validatedAt": "2026-07-20T14:39:16.127581+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5551,7 +5544,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.625023+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.369537+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -5617,7 +5610,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:42.340630+00:00"
+                "validatedAt": "2026-07-20T14:39:16.127593+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5628,7 +5621,7 @@
             },
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.625043+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.369550+00:00"
           },
           "name": {
             "type": "string",
@@ -5661,7 +5654,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:42.340675+00:00"
+                "validatedAt": "2026-07-20T14:39:16.127606+00:00"
               },
               "deterministic": true
             },
@@ -5673,9 +5666,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.625061+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.369563+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -5708,7 +5700,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:42.340711+00:00"
+                "validatedAt": "2026-07-20T14:39:16.127620+00:00"
               },
               "deterministic": true
             },
@@ -5720,9 +5712,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.625079+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.369575+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "uid": {
             "type": "string",
@@ -5739,7 +5730,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:42.340735+00:00"
+                "validatedAt": "2026-07-20T14:39:16.127630+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5752,7 +5743,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.625098+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.369588+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -5952,7 +5943,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:45.661704+00:00"
+                "validatedAt": "2026-07-20T14:39:17.420112+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5975,7 +5966,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:45.661743+00:00"
+                "validatedAt": "2026-07-20T14:39:17.420128+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6073,7 +6064,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:04:45.661793+00:00"
+                "validatedAt": "2026-07-20T14:39:17.420153+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6152,7 +6143,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:04:45.661849+00:00"
+                "validatedAt": "2026-07-20T14:39:17.420179+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6163,7 +6154,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.649306+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.405827+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -6250,7 +6241,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:45.661892+00:00"
+                "validatedAt": "2026-07-20T14:39:17.420199+00:00"
               },
               "deterministic": true
             },
@@ -6262,9 +6253,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.649352+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.405856+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -6295,7 +6285,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:45.661920+00:00"
+                "validatedAt": "2026-07-20T14:39:17.420213+00:00"
               },
               "deterministic": true
             },
@@ -6307,9 +6297,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.649371+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.405868+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -6362,7 +6351,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:45.661960+00:00"
+                "validatedAt": "2026-07-20T14:39:17.420230+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6374,7 +6363,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.649402+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.405888+00:00"
           },
           "uid": {
             "type": "string",
@@ -6391,7 +6380,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:45.661986+00:00"
+                "validatedAt": "2026-07-20T14:39:17.420241+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6404,7 +6393,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.649421+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.405901+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of nginx_instance is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -6666,7 +6655,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:49.193105+00:00"
+                "validatedAt": "2026-07-20T14:39:18.887009+00:00"
               },
               "deterministic": true
             },
@@ -6678,9 +6667,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.681829+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.426236+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "GET NGINX One Dataplane servers request.",
@@ -6746,7 +6734,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:04:49.193143+00:00"
+                "validatedAt": "2026-07-20T14:39:18.887030+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6888,7 +6876,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.681891+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.426274+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -6981,7 +6969,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:04:49.193250+00:00"
+                "validatedAt": "2026-07-20T14:39:18.887079+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7060,7 +7048,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:04:49.193304+00:00"
+                "validatedAt": "2026-07-20T14:39:18.887105+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7071,7 +7059,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.681942+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.426305+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -7158,7 +7146,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:49.193344+00:00"
+                "validatedAt": "2026-07-20T14:39:18.887126+00:00"
               },
               "deterministic": true
             },
@@ -7170,9 +7158,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.681988+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.426333+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -7203,7 +7190,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:49.193372+00:00"
+                "validatedAt": "2026-07-20T14:39:18.887141+00:00"
               },
               "deterministic": true
             },
@@ -7215,9 +7202,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.682006+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.426346+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -7286,7 +7272,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:49.193422+00:00"
+                "validatedAt": "2026-07-20T14:39:18.887164+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7298,7 +7284,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.682044+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.426370+00:00"
           },
           "uid": {
             "type": "string",
@@ -7315,7 +7301,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:49.193448+00:00"
+                "validatedAt": "2026-07-20T14:39:18.887225+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7328,7 +7314,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.682063+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.426382+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of nginx_server is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -7416,7 +7402,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:49.193483+00:00"
+                "validatedAt": "2026-07-20T14:39:18.887304+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7450,7 +7436,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:49.193532+00:00"
+                "validatedAt": "2026-07-20T14:39:18.887347+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7474,7 +7460,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:49.193575+00:00"
+                "validatedAt": "2026-07-20T14:39:18.887372+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7500,7 +7486,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:49.193617+00:00"
+                "validatedAt": "2026-07-20T14:39:18.887391+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7537,7 +7523,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:49.193665+00:00"
+                "validatedAt": "2026-07-20T14:39:18.887413+00:00"
               },
               "deterministic": true
             },
@@ -7564,7 +7550,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:49.193704+00:00"
+                "validatedAt": "2026-07-20T14:39:18.887431+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7827,7 +7813,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:49.193804+00:00"
+                "validatedAt": "2026-07-20T14:39:18.887476+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7874,7 +7860,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:49.193837+00:00"
+                "validatedAt": "2026-07-20T14:39:18.887496+00:00"
               },
               "deterministic": true
             },
@@ -7886,9 +7872,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.682192+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.426460+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "waf_spec": {
             "allOf": [
@@ -7963,7 +7948,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T13:04:49.193945+00:00"
+                "validatedAt": "2026-07-20T14:39:18.887549+00:00"
               },
               "deterministic": true
             },
@@ -7974,8 +7959,7 @@
               "read": false
             },
             "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "minLength": 1,
-            "format": "fqdn"
+            "minLength": 1
           },
           "last_update_time": {
             "type": "string",
@@ -7992,7 +7976,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:49.193986+00:00"
+                "validatedAt": "2026-07-20T14:39:18.887567+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8019,7 +8003,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:49.194021+00:00"
+                "validatedAt": "2026-07-20T14:39:18.887583+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8030,7 +8014,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.682260+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.426502+00:00"
           },
           "service_name": {
             "type": "string",
@@ -8047,7 +8031,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:49.194060+00:00"
+                "validatedAt": "2026-07-20T14:39:18.887600+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8080,7 +8064,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:49.194096+00:00"
+                "validatedAt": "2026-07-20T14:39:18.887617+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8091,7 +8075,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.682285+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.426518+00:00"
           },
           "type": {
             "type": "string",
@@ -8116,7 +8100,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:49.194130+00:00"
+                "validatedAt": "2026-07-20T14:39:18.887631+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8186,7 +8170,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:49.194402+00:00"
+                "validatedAt": "2026-07-20T14:39:18.887768+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8214,7 +8198,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:49.194441+00:00"
+                "validatedAt": "2026-07-20T14:39:18.887786+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8242,7 +8226,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:49.194479+00:00"
+                "validatedAt": "2026-07-20T14:39:18.887801+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8281,7 +8265,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:49.194518+00:00"
+                "validatedAt": "2026-07-20T14:39:18.887818+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8308,7 +8292,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:49.194544+00:00"
+                "validatedAt": "2026-07-20T14:39:18.887830+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8321,7 +8305,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.682482+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.426640+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -8337,7 +8321,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:49.194579+00:00"
+                "validatedAt": "2026-07-20T14:39:18.887845+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8488,7 +8472,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:49.195144+00:00"
+                "validatedAt": "2026-07-20T14:39:18.888095+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -8502,8 +8486,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -8542,7 +8525,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:49.195193+00:00"
+                "validatedAt": "2026-07-20T14:39:18.888123+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -8557,9 +8540,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.682765+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.426809+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -8588,7 +8570,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:49.195248+00:00"
+                "validatedAt": "2026-07-20T14:39:18.888149+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8601,7 +8583,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.682783+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.426821+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a direct reference from one object(the referrer) to another(the referred).",
@@ -8798,7 +8780,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:58.116548+00:00"
+                "validatedAt": "2026-07-20T14:39:22.432544+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9029,7 +9011,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:58.116676+00:00"
+                "validatedAt": "2026-07-20T14:39:22.432594+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9124,7 +9106,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:58.116742+00:00"
+                "validatedAt": "2026-07-20T14:39:22.432635+00:00"
               },
               "deterministic": true
             },
@@ -9136,9 +9118,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.803030+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.578608+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -9170,7 +9151,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:58.116788+00:00"
+                "validatedAt": "2026-07-20T14:39:22.432653+00:00"
               },
               "deterministic": true
             },
@@ -9182,9 +9163,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.803050+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.578622+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -9417,7 +9397,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.803131+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.578671+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -9503,7 +9483,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:58.116957+00:00"
+                "validatedAt": "2026-07-20T14:39:22.432715+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9528,7 +9508,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:58.117004+00:00"
+                "validatedAt": "2026-07-20T14:39:22.432736+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9566,7 +9546,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:58.117053+00:00"
+                "validatedAt": "2026-07-20T14:39:22.432764+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9651,7 +9631,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:04:58.117101+00:00"
+                "validatedAt": "2026-07-20T14:39:22.432789+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9730,7 +9710,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:04:58.117157+00:00"
+                "validatedAt": "2026-07-20T14:39:22.432815+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9741,7 +9721,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.803210+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.578718+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -9829,7 +9809,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:58.117201+00:00"
+                "validatedAt": "2026-07-20T14:39:22.432836+00:00"
               },
               "deterministic": true
             },
@@ -9841,9 +9821,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.803255+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.578746+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -9874,7 +9853,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:58.117229+00:00"
+                "validatedAt": "2026-07-20T14:39:22.432850+00:00"
               },
               "deterministic": true
             },
@@ -9886,9 +9865,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.803273+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.578759+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -9957,7 +9935,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:58.117283+00:00"
+                "validatedAt": "2026-07-20T14:39:22.432872+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9969,7 +9947,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.803310+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.578783+00:00"
           },
           "uid": {
             "type": "string",
@@ -9987,7 +9965,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:58.117310+00:00"
+                "validatedAt": "2026-07-20T14:39:22.432884+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10000,7 +9978,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.803330+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.578796+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of nginx_service_discovery is returned in 'List'.",
@@ -10079,7 +10057,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:58.117359+00:00"
+                "validatedAt": "2026-07-20T14:39:22.432909+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10262,7 +10240,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:58.117420+00:00"
+                "validatedAt": "2026-07-20T14:39:22.432938+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10333,7 +10311,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:58.117488+00:00"
+                "validatedAt": "2026-07-20T14:39:22.432973+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10373,7 +10351,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:58.117550+00:00"
+                "validatedAt": "2026-07-20T14:39:22.433004+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10556,7 +10534,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:58.118065+00:00"
+                "validatedAt": "2026-07-20T14:39:22.433223+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -10571,7 +10549,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.803581+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.578948+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -10641,7 +10619,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:58.118104+00:00"
+                "validatedAt": "2026-07-20T14:39:22.433241+00:00"
               },
               "deterministic": true
             },
@@ -10653,9 +10631,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.803614+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.578968+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -10688,7 +10665,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:58.118132+00:00"
+                "validatedAt": "2026-07-20T14:39:22.433255+00:00"
               },
               "deterministic": true
             },
@@ -10700,9 +10677,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.803632+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.578980+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -10763,7 +10739,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:58.118303+00:00"
+                "validatedAt": "2026-07-20T14:39:22.433336+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10775,7 +10751,7 @@
             "readOnly": true,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.803740+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.579042+00:00"
           },
           "name": {
             "type": "string",
@@ -10808,7 +10784,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:58.118331+00:00"
+                "validatedAt": "2026-07-20T14:39:22.433349+00:00"
               },
               "deterministic": true
             },
@@ -10820,9 +10796,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.803759+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.579054+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -10855,7 +10830,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:58.118359+00:00"
+                "validatedAt": "2026-07-20T14:39:22.433363+00:00"
               },
               "deterministic": true
             },
@@ -10867,9 +10842,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.803777+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.579066+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -10888,7 +10862,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:58.118391+00:00"
+                "validatedAt": "2026-07-20T14:39:22.433377+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10901,7 +10875,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.803796+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.579079+00:00"
           },
           "uid": {
             "type": "string",
@@ -10920,7 +10894,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:58.118418+00:00"
+                "validatedAt": "2026-07-20T14:39:22.433388+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10934,7 +10908,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.803815+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.579091+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -11032,7 +11006,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:58.118493+00:00"
+                "validatedAt": "2026-07-20T14:39:22.433455+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -11047,7 +11021,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.803843+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.579109+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -11117,7 +11091,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:58.118530+00:00"
+                "validatedAt": "2026-07-20T14:39:22.433478+00:00"
               },
               "deterministic": true
             },
@@ -11129,9 +11103,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.803876+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.579130+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -11164,7 +11137,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:58.118556+00:00"
+                "validatedAt": "2026-07-20T14:39:22.433494+00:00"
               },
               "deterministic": true
             },
@@ -11176,9 +11149,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.803894+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.579142+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",

--- a/docs/specifications/api/object_storage.json
+++ b/docs/specifications/api/object_storage.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Object Storage",
     "description": "Blob management for application component delivery across namespaces. Time-limited download links with cryptographic signing protect asset retrieval. Version-controlled packages organized by operating system type support artifact discovery. Query filtering by name, type, and release number enables programmatic access to integrator libraries and protection modules for mobile deployments.",
-    "version": "2.1.182",
+    "version": "2.1.181",
     "contact": {
       "name": "F5 Distributed Cloud",
       "url": "https://docs.cloud.f5.com"
@@ -2930,7 +2930,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:48.431861+00:00"
+                "validatedAt": "2026-07-20T14:40:52.533294+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2965,7 +2965,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:48.431937+00:00"
+                "validatedAt": "2026-07-20T14:40:52.533320+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3001,7 +3001,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:48.432020+00:00"
+                "validatedAt": "2026-07-20T14:40:52.533358+00:00"
               },
               "deterministic": true
             },
@@ -3013,7 +3013,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.216903+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.621322+00:00"
           },
           "mobile_app_shield": {
             "allOf": [
@@ -3116,7 +3116,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:48.432089+00:00"
+                "validatedAt": "2026-07-20T14:40:52.533392+00:00"
               },
               "deterministic": true
             },
@@ -3126,8 +3126,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -3166,7 +3165,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:48.432120+00:00"
+                "validatedAt": "2026-07-20T14:40:52.533407+00:00"
               },
               "deterministic": true
             },
@@ -3178,9 +3177,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.216952+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:22.621352+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "no_attributes": {
             "allOf": [
@@ -3226,7 +3224,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:48.432167+00:00"
+                "validatedAt": "2026-07-20T14:40:52.533425+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3257,7 +3255,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:48.432226+00:00"
+                "validatedAt": "2026-07-20T14:40:52.533452+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3396,7 +3394,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.217013+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.621390+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -3520,7 +3518,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:48.432304+00:00"
+                "validatedAt": "2026-07-20T14:40:52.533481+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3550,7 +3548,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:48.432344+00:00"
+                "validatedAt": "2026-07-20T14:40:52.533497+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3613,7 +3611,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:48.432410+00:00"
+                "validatedAt": "2026-07-20T14:40:52.533526+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3755,7 +3753,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:48.432447+00:00"
+                "validatedAt": "2026-07-20T14:40:52.533543+00:00"
               },
               "deterministic": true
             },
@@ -3767,9 +3765,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.217097+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:22.621440+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "no_attributes": {
             "allOf": [
@@ -3805,7 +3802,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:48.432484+00:00"
+                "validatedAt": "2026-07-20T14:40:52.533557+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3817,7 +3814,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.217122+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.621456+00:00"
           },
           "versions": {
             "type": "array",
@@ -3912,7 +3909,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:08:48.432534+00:00"
+                "validatedAt": "2026-07-20T14:40:52.533576+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3997,7 +3994,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:48.432598+00:00"
+                "validatedAt": "2026-07-20T14:40:52.533606+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4084,7 +4081,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:48.432671+00:00"
+                "validatedAt": "2026-07-20T14:40:52.533634+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4162,7 +4159,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:48.432716+00:00"
+                "validatedAt": "2026-07-20T14:40:52.533651+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4342,7 +4339,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T13:08:48.432756+00:00"
+                "validatedAt": "2026-07-20T14:40:52.533668+00:00"
               },
               "deterministic": true
             },
@@ -4416,7 +4413,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:48.432803+00:00"
+                "validatedAt": "2026-07-20T14:40:52.533687+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4451,7 +4448,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:48.432871+00:00"
+                "validatedAt": "2026-07-20T14:40:52.533718+00:00"
               },
               "deterministic": true
             },
@@ -4463,7 +4460,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.217230+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.621522+00:00"
           },
           "mobile_app_shield": {
             "allOf": [
@@ -4558,7 +4555,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:48.432910+00:00"
+                "validatedAt": "2026-07-20T14:40:52.533734+00:00"
               },
               "deterministic": true
             },
@@ -4570,9 +4567,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.217268+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:22.621547+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -4610,7 +4606,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:48.432941+00:00"
+                "validatedAt": "2026-07-20T14:40:52.533749+00:00"
               },
               "deterministic": true
             },
@@ -4622,9 +4618,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.217286+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:22.621560+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "no_attributes": {
             "allOf": [
@@ -4673,7 +4668,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T13:08:48.432977+00:00"
+                "validatedAt": "2026-07-20T14:40:52.533764+00:00"
               },
               "deterministic": true
             },
@@ -4706,7 +4701,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:48.433014+00:00"
+                "validatedAt": "2026-07-20T14:40:52.533778+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4717,7 +4712,7 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.217318+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.621580+00:00"
           },
           "mobile_sdk_self_serve": {
             "allOf": [
@@ -4846,7 +4841,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:48.433061+00:00"
+                "validatedAt": "2026-07-20T14:40:52.533797+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4881,7 +4876,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:48.433127+00:00"
+                "validatedAt": "2026-07-20T14:40:52.533828+00:00"
               },
               "deterministic": true
             },
@@ -4893,7 +4888,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.217345+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.621597+00:00"
           },
           "latest_version": {
             "type": "boolean",
@@ -4937,7 +4932,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T13:08:48.433162+00:00"
+                "validatedAt": "2026-07-20T14:40:52.533844+00:00"
               },
               "deterministic": true
             },
@@ -4962,7 +4957,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:48.433194+00:00"
+                "validatedAt": "2026-07-20T14:40:52.533857+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4973,7 +4968,7 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.217379+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.621619+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {

--- a/docs/specifications/api/observability.json
+++ b/docs/specifications/api/observability.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Observability",
     "description": "Telemetry systems execute scheduled availability checks from distributed AWS locations worldwide. Response code validation and timing metrics feed into historical trend analysis. DNS resolution accuracy verification ensures name service reliability. Certificate lifecycle tracking generates expiration warnings before outages occur. Regional probe distribution provides geographic coverage insights. Health summaries aggregate results into actionable dashboards with configurable alerting thresholds.",
-    "version": "2.1.182",
+    "version": "2.1.181",
     "contact": {
       "name": "F5 Distributed Cloud",
       "url": "https://docs.cloud.f5.com"
@@ -14849,7 +14849,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:14.598476+00:00"
+                "validatedAt": "2026-07-20T14:35:30.842206+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14875,7 +14875,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:14.598556+00:00"
+                "validatedAt": "2026-07-20T14:35:30.842232+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14916,7 +14916,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:14.598615+00:00"
+                "validatedAt": "2026-07-20T14:35:30.842253+00:00"
               },
               "deterministic": true
             },
@@ -14928,9 +14928,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.946187+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.648591+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "start_time": {
             "type": "string",
@@ -14955,7 +14954,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:14.598700+00:00"
+                "validatedAt": "2026-07-20T14:35:30.842273+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15038,7 +15037,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:14.598748+00:00"
+                "validatedAt": "2026-07-20T14:35:30.842295+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15121,7 +15120,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:14.598803+00:00"
+                "validatedAt": "2026-07-20T14:35:30.842320+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15150,7 +15149,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:14.598841+00:00"
+                "validatedAt": "2026-07-20T14:35:30.842338+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15228,7 +15227,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:14.598874+00:00"
+                "validatedAt": "2026-07-20T14:35:30.842356+00:00"
               },
               "deterministic": true
             },
@@ -15240,9 +15239,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.946259+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.648633+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "scroll_id": {
             "type": "string",
@@ -15260,7 +15258,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:14.598911+00:00"
+                "validatedAt": "2026-07-20T14:35:30.842373+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15325,7 +15323,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:14.598945+00:00"
+                "validatedAt": "2026-07-20T14:35:30.842389+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15417,7 +15415,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:12.349815+00:00"
+                "validatedAt": "2026-07-20T14:37:29.975946+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15440,7 +15438,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:12.349887+00:00"
+                "validatedAt": "2026-07-20T14:37:29.975971+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15451,7 +15449,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.284560+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.844479+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -15515,7 +15513,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T13:00:12.349950+00:00"
+                "validatedAt": "2026-07-20T14:37:29.975991+00:00"
               },
               "deterministic": true
             },
@@ -15526,8 +15524,7 @@
               "read": false
             },
             "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "minLength": 1,
-            "format": "fqdn"
+            "minLength": 1
           },
           "last_update_time": {
             "type": "string",
@@ -15544,7 +15541,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:12.349997+00:00"
+                "validatedAt": "2026-07-20T14:37:29.976010+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15571,7 +15568,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:12.350032+00:00"
+                "validatedAt": "2026-07-20T14:37:29.976024+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15582,7 +15579,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.284598+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.844502+00:00"
           },
           "service_name": {
             "type": "string",
@@ -15599,7 +15596,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:12.350073+00:00"
+                "validatedAt": "2026-07-20T14:37:29.976046+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15632,7 +15629,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:12.350116+00:00"
+                "validatedAt": "2026-07-20T14:37:29.976064+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15643,7 +15640,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.284624+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.844519+00:00"
           },
           "type": {
             "type": "string",
@@ -15668,7 +15665,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:12.350149+00:00"
+                "validatedAt": "2026-07-20T14:37:29.976081+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15812,7 +15809,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:12.350192+00:00"
+                "validatedAt": "2026-07-20T14:37:29.976102+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15892,7 +15889,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:12.350227+00:00"
+                "validatedAt": "2026-07-20T14:37:29.976120+00:00"
               },
               "deterministic": true
             },
@@ -15904,9 +15901,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.284682+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.844550+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -16070,7 +16066,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:12.350334+00:00"
+                "validatedAt": "2026-07-20T14:37:29.976175+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -16085,7 +16081,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.284727+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.844577+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -16155,7 +16151,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:12.350375+00:00"
+                "validatedAt": "2026-07-20T14:37:29.976195+00:00"
               },
               "deterministic": true
             },
@@ -16167,9 +16163,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.284760+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.844599+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -16202,7 +16197,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:12.350403+00:00"
+                "validatedAt": "2026-07-20T14:37:29.976209+00:00"
               },
               "deterministic": true
             },
@@ -16214,9 +16209,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.284779+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.844612+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -16316,7 +16310,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:12.350477+00:00"
+                "validatedAt": "2026-07-20T14:37:29.976246+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -16331,7 +16325,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.284807+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.844629+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -16403,7 +16397,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:12.350515+00:00"
+                "validatedAt": "2026-07-20T14:37:29.976270+00:00"
               },
               "deterministic": true
             },
@@ -16415,9 +16409,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.284840+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.844651+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -16450,7 +16443,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:12.350541+00:00"
+                "validatedAt": "2026-07-20T14:37:29.976284+00:00"
               },
               "deterministic": true
             },
@@ -16462,9 +16455,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.284859+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.844663+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -16564,7 +16556,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:12.350612+00:00"
+                "validatedAt": "2026-07-20T14:37:29.976320+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -16579,7 +16571,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.284887+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.844681+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -16651,7 +16643,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:12.350649+00:00"
+                "validatedAt": "2026-07-20T14:37:29.976339+00:00"
               },
               "deterministic": true
             },
@@ -16663,9 +16655,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.284919+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.844702+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -16698,7 +16689,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:12.350688+00:00"
+                "validatedAt": "2026-07-20T14:37:29.976352+00:00"
               },
               "deterministic": true
             },
@@ -16710,9 +16701,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.284938+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.844714+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "uid": {
             "type": "string",
@@ -16731,7 +16721,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:12.350714+00:00"
+                "validatedAt": "2026-07-20T14:37:29.976363+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16745,7 +16735,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.284958+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.844727+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectMetaType is metadata(common attributes) of an object that all configuration objects will have.",
@@ -16810,7 +16800,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:12.350745+00:00"
+                "validatedAt": "2026-07-20T14:37:29.976376+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16822,7 +16812,7 @@
             "readOnly": true,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.284979+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.844740+00:00"
           },
           "name": {
             "type": "string",
@@ -16855,7 +16845,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:12.350772+00:00"
+                "validatedAt": "2026-07-20T14:37:29.976390+00:00"
               },
               "deterministic": true
             },
@@ -16867,9 +16857,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.284997+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.844752+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -16902,7 +16891,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:12.350798+00:00"
+                "validatedAt": "2026-07-20T14:37:29.976403+00:00"
               },
               "deterministic": true
             },
@@ -16914,9 +16903,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.285015+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.844764+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -16935,7 +16923,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:12.350831+00:00"
+                "validatedAt": "2026-07-20T14:37:29.976418+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16948,7 +16936,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.285034+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.844776+00:00"
           },
           "uid": {
             "type": "string",
@@ -16967,7 +16955,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:12.350857+00:00"
+                "validatedAt": "2026-07-20T14:37:29.976428+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16981,7 +16969,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.285052+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.844789+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -17081,7 +17069,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:12.350932+00:00"
+                "validatedAt": "2026-07-20T14:37:29.976466+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -17096,7 +17084,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.285079+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.844806+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -17166,7 +17154,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:12.350969+00:00"
+                "validatedAt": "2026-07-20T14:37:29.976484+00:00"
               },
               "deterministic": true
             },
@@ -17178,9 +17166,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.285111+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.844827+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -17213,7 +17200,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:12.350994+00:00"
+                "validatedAt": "2026-07-20T14:37:29.976497+00:00"
               },
               "deterministic": true
             },
@@ -17225,9 +17212,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.285130+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.844839+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -17290,7 +17276,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:12.351036+00:00"
+                "validatedAt": "2026-07-20T14:37:29.976515+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17318,7 +17304,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:12.351076+00:00"
+                "validatedAt": "2026-07-20T14:37:29.976531+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17346,7 +17332,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:12.351113+00:00"
+                "validatedAt": "2026-07-20T14:37:29.976547+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17385,7 +17371,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:12.351153+00:00"
+                "validatedAt": "2026-07-20T14:37:29.976563+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17412,7 +17398,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:12.351179+00:00"
+                "validatedAt": "2026-07-20T14:37:29.976574+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17425,7 +17411,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.285183+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.844872+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -17441,7 +17427,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:12.351214+00:00"
+                "validatedAt": "2026-07-20T14:37:29.976589+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17586,7 +17572,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:12.351266+00:00"
+                "validatedAt": "2026-07-20T14:37:29.976610+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17597,7 +17583,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.285223+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.844897+00:00"
           },
           "status": {
             "type": "string",
@@ -17615,7 +17601,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:12.351300+00:00"
+                "validatedAt": "2026-07-20T14:37:29.976624+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17626,7 +17612,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.285242+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.844909+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -17686,7 +17672,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:12.351344+00:00"
+                "validatedAt": "2026-07-20T14:37:29.976643+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17713,7 +17699,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:12.351383+00:00"
+                "validatedAt": "2026-07-20T14:37:29.976659+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17740,7 +17726,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:12.351420+00:00"
+                "validatedAt": "2026-07-20T14:37:29.976674+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17768,7 +17754,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:12.351461+00:00"
+                "validatedAt": "2026-07-20T14:37:29.976692+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17844,7 +17830,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:12.351524+00:00"
+                "validatedAt": "2026-07-20T14:37:29.976723+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17912,7 +17898,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:12.351574+00:00"
+                "validatedAt": "2026-07-20T14:37:29.976747+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17924,7 +17910,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.285328+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.844962+00:00"
           },
           "uid": {
             "type": "string",
@@ -17943,7 +17929,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:12.351600+00:00"
+                "validatedAt": "2026-07-20T14:37:29.976759+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17956,7 +17942,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.285346+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.844975+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -18026,7 +18012,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:12.351642+00:00"
+                "validatedAt": "2026-07-20T14:37:29.976776+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18054,7 +18040,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:12.351689+00:00"
+                "validatedAt": "2026-07-20T14:37:29.976793+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18083,7 +18069,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:12.351730+00:00"
+                "validatedAt": "2026-07-20T14:37:29.976813+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18110,7 +18096,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:12.351766+00:00"
+                "validatedAt": "2026-07-20T14:37:29.976829+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18139,7 +18125,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:12.351807+00:00"
+                "validatedAt": "2026-07-20T14:37:29.976847+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18164,7 +18150,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:12.351847+00:00"
+                "validatedAt": "2026-07-20T14:37:29.976864+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18240,7 +18226,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:12.351910+00:00"
+                "validatedAt": "2026-07-20T14:37:29.976889+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18278,7 +18264,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:12.351957+00:00"
+                "validatedAt": "2026-07-20T14:37:29.976913+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18290,7 +18276,7 @@
             "maxLength": 6,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.285433+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.845028+00:00"
           },
           "object_index": {
             "type": "integer",
@@ -18350,7 +18336,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:12.352007+00:00"
+                "validatedAt": "2026-07-20T14:37:29.976934+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18394,7 +18380,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:12.352043+00:00"
+                "validatedAt": "2026-07-20T14:37:29.976950+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18407,7 +18393,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.285477+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.845057+00:00"
           },
           "trace_info": {
             "type": "string",
@@ -18426,7 +18412,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:12.352081+00:00"
+                "validatedAt": "2026-07-20T14:37:29.976966+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18453,7 +18439,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:12.352108+00:00"
+                "validatedAt": "2026-07-20T14:37:29.976977+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18467,7 +18453,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.285503+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.845074+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -18482,7 +18468,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:12.352142+00:00"
+                "validatedAt": "2026-07-20T14:37:29.976992+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18581,7 +18567,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:12.352177+00:00"
+                "validatedAt": "2026-07-20T14:37:29.977008+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18592,7 +18578,7 @@
             },
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.285536+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.845095+00:00"
           },
           "name": {
             "type": "string",
@@ -18625,7 +18611,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:12.352204+00:00"
+                "validatedAt": "2026-07-20T14:37:29.977022+00:00"
               },
               "deterministic": true
             },
@@ -18637,9 +18623,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.285554+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.845108+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -18672,7 +18657,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:12.352230+00:00"
+                "validatedAt": "2026-07-20T14:37:29.977036+00:00"
               },
               "deterministic": true
             },
@@ -18684,9 +18669,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.285572+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.845120+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "uid": {
             "type": "string",
@@ -18703,7 +18687,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:12.352256+00:00"
+                "validatedAt": "2026-07-20T14:37:29.977047+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18716,7 +18700,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.285591+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.845132+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -18790,7 +18774,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:12.352298+00:00"
+                "validatedAt": "2026-07-20T14:37:29.977069+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18869,7 +18853,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:12.352338+00:00"
+                "validatedAt": "2026-07-20T14:37:29.977091+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19201,7 +19185,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:12.352407+00:00"
+                "validatedAt": "2026-07-20T14:37:29.977124+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19280,7 +19264,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:12.352446+00:00"
+                "validatedAt": "2026-07-20T14:37:29.977146+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19849,7 +19833,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:12.352585+00:00"
+                "validatedAt": "2026-07-20T14:37:29.977207+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19861,7 +19845,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.285800+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.845251+00:00"
           },
           "external_sources": {
             "type": "array",
@@ -19896,7 +19880,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:12.352633+00:00"
+                "validatedAt": "2026-07-20T14:37:29.977233+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20260,7 +20244,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:12.352774+00:00"
+                "validatedAt": "2026-07-20T14:37:29.977282+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20294,7 +20278,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:12.352832+00:00"
+                "validatedAt": "2026-07-20T14:37:29.977309+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20327,7 +20311,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:12.352874+00:00"
+                "validatedAt": "2026-07-20T14:37:29.977327+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20470,7 +20454,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:12.352928+00:00"
+                "validatedAt": "2026-07-20T14:37:29.977349+00:00"
               },
               "deterministic": true
             },
@@ -20482,9 +20466,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.285954+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.845344+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -20516,7 +20499,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:12.352955+00:00"
+                "validatedAt": "2026-07-20T14:37:29.977363+00:00"
               },
               "deterministic": true
             },
@@ -20528,9 +20511,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.285972+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.845356+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -20605,7 +20587,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:00:12.353001+00:00"
+                "validatedAt": "2026-07-20T14:37:29.977384+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20776,7 +20758,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.286053+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.845405+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -20867,7 +20849,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:12.353130+00:00"
+                "validatedAt": "2026-07-20T14:37:29.977440+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20879,7 +20861,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.286080+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.845422+00:00"
           },
           "external_sources": {
             "type": "array",
@@ -20914,7 +20896,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:12.353179+00:00"
+                "validatedAt": "2026-07-20T14:37:29.977465+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21278,7 +21260,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:12.353299+00:00"
+                "validatedAt": "2026-07-20T14:37:29.977514+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21312,7 +21294,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:12.353355+00:00"
+                "validatedAt": "2026-07-20T14:37:29.977541+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21345,7 +21327,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:12.353398+00:00"
+                "validatedAt": "2026-07-20T14:37:29.977558+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21470,7 +21452,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:12.353475+00:00"
+                "validatedAt": "2026-07-20T14:37:29.977594+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21482,7 +21464,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.286232+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.845511+00:00"
           },
           "external_sources": {
             "type": "array",
@@ -21518,7 +21500,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:12.353523+00:00"
+                "validatedAt": "2026-07-20T14:37:29.977619+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21886,7 +21868,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:12.353642+00:00"
+                "validatedAt": "2026-07-20T14:37:29.977666+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21921,7 +21903,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:12.353706+00:00"
+                "validatedAt": "2026-07-20T14:37:29.977693+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21955,7 +21937,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:12.353749+00:00"
+                "validatedAt": "2026-07-20T14:37:29.977711+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22084,7 +22066,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:00:12.353811+00:00"
+                "validatedAt": "2026-07-20T14:37:29.977738+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22163,7 +22145,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:00:12.353861+00:00"
+                "validatedAt": "2026-07-20T14:37:29.977761+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22174,7 +22156,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.286402+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.845616+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -22261,7 +22243,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:12.353902+00:00"
+                "validatedAt": "2026-07-20T14:37:29.977781+00:00"
               },
               "deterministic": true
             },
@@ -22273,9 +22255,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.286447+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.845645+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -22306,7 +22287,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:12.353930+00:00"
+                "validatedAt": "2026-07-20T14:37:29.977795+00:00"
               },
               "deterministic": true
             },
@@ -22318,9 +22299,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.286465+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.845657+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -22389,7 +22369,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:12.353982+00:00"
+                "validatedAt": "2026-07-20T14:37:29.977817+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22401,7 +22381,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.286502+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.845682+00:00"
           },
           "uid": {
             "type": "string",
@@ -22418,7 +22398,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:12.354008+00:00"
+                "validatedAt": "2026-07-20T14:37:29.977829+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22431,7 +22411,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.286522+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.845694+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of v1_dns_monitor is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -22510,7 +22490,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:12.354067+00:00"
+                "validatedAt": "2026-07-20T14:37:29.977859+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22548,7 +22528,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:12.354100+00:00"
+                "validatedAt": "2026-07-20T14:37:29.977876+00:00"
               },
               "deterministic": true
             },
@@ -22802,7 +22782,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:12.354175+00:00"
+                "validatedAt": "2026-07-20T14:37:29.977911+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22814,7 +22794,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.286592+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.845738+00:00"
           },
           "external_sources": {
             "type": "array",
@@ -22849,7 +22829,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:12.354221+00:00"
+                "validatedAt": "2026-07-20T14:37:29.977935+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23213,7 +23193,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:12.354340+00:00"
+                "validatedAt": "2026-07-20T14:37:29.977983+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23247,7 +23227,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:12.354394+00:00"
+                "validatedAt": "2026-07-20T14:37:29.978011+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23280,7 +23260,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:12.354434+00:00"
+                "validatedAt": "2026-07-20T14:37:29.978028+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23705,7 +23685,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:18.904165+00:00"
+                "validatedAt": "2026-07-20T14:38:20.014306+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24150,7 +24130,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:18.904295+00:00"
+                "validatedAt": "2026-07-20T14:38:20.014371+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24211,7 +24191,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:18.904352+00:00"
+                "validatedAt": "2026-07-20T14:38:20.014402+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24268,7 +24248,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:18.904424+00:00"
+                "validatedAt": "2026-07-20T14:38:20.014436+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24276,8 +24256,7 @@
               "create": false,
               "update": false,
               "read": false
-            },
-            "format": "hostname"
+            }
           },
           "source_critical_threshold": {
             "type": "integer",
@@ -24339,7 +24318,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:18.904494+00:00"
+                "validatedAt": "2026-07-20T14:38:20.014477+00:00"
               },
               "deterministic": true
             },
@@ -24463,7 +24442,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:18.904526+00:00"
+                "validatedAt": "2026-07-20T14:38:20.014495+00:00"
               },
               "deterministic": true
             },
@@ -24475,9 +24454,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.381597+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.404981+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -24509,7 +24487,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:18.904553+00:00"
+                "validatedAt": "2026-07-20T14:38:20.014511+00:00"
               },
               "deterministic": true
             },
@@ -24521,9 +24499,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.381615+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.404992+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -24598,7 +24575,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:02:18.904595+00:00"
+                "validatedAt": "2026-07-20T14:38:20.014538+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24769,7 +24746,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.381705+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.405039+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -24885,7 +24862,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:18.904724+00:00"
+                "validatedAt": "2026-07-20T14:38:20.014593+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25330,7 +25307,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:18.904846+00:00"
+                "validatedAt": "2026-07-20T14:38:20.014654+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25391,7 +25368,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:18.904902+00:00"
+                "validatedAt": "2026-07-20T14:38:20.014683+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25448,7 +25425,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:18.904973+00:00"
+                "validatedAt": "2026-07-20T14:38:20.014718+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25456,8 +25433,7 @@
               "create": false,
               "update": false,
               "read": false
-            },
-            "format": "hostname"
+            }
           },
           "source_critical_threshold": {
             "type": "integer",
@@ -25519,7 +25495,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:18.905041+00:00"
+                "validatedAt": "2026-07-20T14:38:20.014755+00:00"
               },
               "deterministic": true
             },
@@ -25650,7 +25626,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:18.905091+00:00"
+                "validatedAt": "2026-07-20T14:38:20.014784+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26099,7 +26075,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:18.905210+00:00"
+                "validatedAt": "2026-07-20T14:38:20.014840+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26162,7 +26138,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:18.905266+00:00"
+                "validatedAt": "2026-07-20T14:38:20.014870+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26221,7 +26197,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:18.905336+00:00"
+                "validatedAt": "2026-07-20T14:38:20.014907+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26229,8 +26205,7 @@
               "create": false,
               "update": false,
               "read": false
-            },
-            "format": "hostname"
+            }
           },
           "source_critical_threshold": {
             "type": "integer",
@@ -26294,7 +26269,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:18.905402+00:00"
+                "validatedAt": "2026-07-20T14:38:20.014942+00:00"
               },
               "deterministic": true
             },
@@ -26393,7 +26368,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:18.905447+00:00"
+                "validatedAt": "2026-07-20T14:38:20.014966+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26404,7 +26379,7 @@
             },
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.382087+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.405281+00:00"
           },
           "value": {
             "type": "string",
@@ -26427,7 +26402,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:18.905497+00:00"
+                "validatedAt": "2026-07-20T14:38:20.014992+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26438,7 +26413,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.382106+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.405296+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -26512,7 +26487,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:02:18.905537+00:00"
+                "validatedAt": "2026-07-20T14:38:20.015012+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26591,7 +26566,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:02:18.905586+00:00"
+                "validatedAt": "2026-07-20T14:38:20.015039+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26602,7 +26577,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.382149+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.405322+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -26689,7 +26664,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:18.905625+00:00"
+                "validatedAt": "2026-07-20T14:38:20.015060+00:00"
               },
               "deterministic": true
             },
@@ -26701,9 +26676,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.382194+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.405349+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -26734,7 +26708,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:18.905651+00:00"
+                "validatedAt": "2026-07-20T14:38:20.015075+00:00"
               },
               "deterministic": true
             },
@@ -26746,9 +26720,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.382213+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.405360+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -26817,7 +26790,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:18.905712+00:00"
+                "validatedAt": "2026-07-20T14:38:20.015096+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26829,7 +26802,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.382250+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.405383+00:00"
           },
           "uid": {
             "type": "string",
@@ -26846,7 +26819,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:18.905737+00:00"
+                "validatedAt": "2026-07-20T14:38:20.015108+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26859,7 +26832,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.382269+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.405395+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of v1_http_monitor is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -27141,7 +27114,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:18.905806+00:00"
+                "validatedAt": "2026-07-20T14:38:20.015141+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27586,7 +27559,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:18.905929+00:00"
+                "validatedAt": "2026-07-20T14:38:20.015197+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27647,7 +27620,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:18.905985+00:00"
+                "validatedAt": "2026-07-20T14:38:20.015225+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27704,7 +27677,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:18.906057+00:00"
+                "validatedAt": "2026-07-20T14:38:20.015261+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27712,8 +27685,7 @@
               "create": false,
               "update": false,
               "read": false
-            },
-            "format": "hostname"
+            }
           },
           "source_critical_threshold": {
             "type": "integer",
@@ -27775,7 +27747,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:18.906124+00:00"
+                "validatedAt": "2026-07-20T14:38:20.015296+00:00"
               },
               "deterministic": true
             },
@@ -27870,7 +27842,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:18.906183+00:00"
+                "validatedAt": "2026-07-20T14:38:20.015325+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28399,7 +28371,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.658425+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540229+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28439,7 +28411,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:06.658485+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540255+00:00"
               },
               "deterministic": true
             },
@@ -28451,9 +28423,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.048895+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.842295+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query": {
             "type": "string",
@@ -28473,7 +28444,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.658548+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540274+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28506,7 +28477,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.658604+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540291+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28596,7 +28567,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.658682+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540309+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28625,7 +28596,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.658740+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540326+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28665,7 +28636,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:06.658785+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540340+00:00"
               },
               "deterministic": true
             },
@@ -28677,9 +28648,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.048953+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.842329+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query": {
             "type": "string",
@@ -28699,7 +28669,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.658839+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540357+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28763,7 +28733,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.658886+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540375+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28886,7 +28856,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.658931+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540393+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28926,7 +28896,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:06.658959+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540406+00:00"
               },
               "deterministic": true
             },
@@ -28938,9 +28908,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.049015+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.842365+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query": {
             "type": "string",
@@ -28960,7 +28929,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.658998+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540423+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28993,7 +28962,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.659037+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540439+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29083,7 +29052,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.659080+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540455+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29112,7 +29081,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.659110+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540469+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29151,7 +29120,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:06.659138+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540482+00:00"
               },
               "deterministic": true
             },
@@ -29163,9 +29132,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.049068+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.842398+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query": {
             "type": "string",
@@ -29185,7 +29153,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.659176+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540499+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29249,7 +29217,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.659224+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540518+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29347,7 +29315,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.049115+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.842426+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Avg Aggregation Data\" Average Aggregation data.",
@@ -29401,7 +29369,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.659270+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540536+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29479,7 +29447,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.659308+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540551+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29518,7 +29486,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T13:04:06.659351+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540569+00:00"
               },
               "deterministic": true
             },
@@ -29614,7 +29582,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.659401+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540588+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29687,7 +29655,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.659441+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540604+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29713,7 +29681,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.659484+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540620+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29751,7 +29719,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:06.659536+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540644+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29786,7 +29754,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.659573+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540661+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29826,7 +29794,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:06.659601+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540674+00:00"
               },
               "deterministic": true
             },
@@ -29838,9 +29806,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.049223+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.842489+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "site": {
             "type": "string",
@@ -29857,7 +29824,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.659631+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540686+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29890,7 +29857,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.659682+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540702+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29958,7 +29925,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.659719+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540715+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29981,7 +29948,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.659745+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540725+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29992,7 +29959,7 @@
             },
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.049264+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.842515+00:00"
           },
           "order_by": {
             "allOf": [
@@ -30142,7 +30109,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.659804+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540748+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30166,7 +30133,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.659830+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540759+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30177,7 +30144,7 @@
             },
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.049319+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.842549+00:00"
           },
           "order_by": {
             "allOf": [
@@ -30247,7 +30214,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.659868+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540774+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30271,7 +30238,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.659894+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540784+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30282,7 +30249,7 @@
             },
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.049353+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.842570+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Field Sub Field Aggregation Bucket\" Field sub aggregation bucket containing field values and the number of logs.",
@@ -30338,7 +30305,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.659928+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540797+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30413,7 +30380,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.659965+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540813+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30437,7 +30404,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.659991+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540824+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30448,7 +30415,7 @@
             },
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.049397+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.842595+00:00"
           },
           "sub_aggs": {
             "type": "object",
@@ -30541,7 +30508,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.660039+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540843+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30581,7 +30548,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:06.660068+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540856+00:00"
               },
               "deterministic": true
             },
@@ -30593,9 +30560,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.049439+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.842620+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query": {
             "type": "string",
@@ -30615,7 +30581,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.660107+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540873+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30648,7 +30614,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.660147+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540889+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30738,7 +30704,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.660190+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540906+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30767,7 +30733,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.660221+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540920+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30807,7 +30773,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:06.660248+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540932+00:00"
               },
               "deterministic": true
             },
@@ -30819,9 +30785,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.049492+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.842651+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query": {
             "type": "string",
@@ -30841,7 +30806,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.660286+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540949+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30905,7 +30870,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.660331+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540967+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31028,7 +30993,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.660374+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540983+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31068,7 +31033,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:06.660401+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540996+00:00"
               },
               "deterministic": true
             },
@@ -31080,9 +31045,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.049553+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.842687+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query": {
             "type": "string",
@@ -31102,7 +31066,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.660440+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541012+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31127,7 +31091,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.660468+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541024+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31160,7 +31124,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.660507+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541039+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31251,7 +31215,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.660550+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541056+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31280,7 +31244,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.660580+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541070+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31320,7 +31284,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:06.660607+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541083+00:00"
               },
               "deterministic": true
             },
@@ -31332,9 +31296,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.049613+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.842723+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query": {
             "type": "string",
@@ -31354,7 +31317,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.660644+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541100+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31396,7 +31359,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.660685+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541112+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31443,7 +31406,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.660729+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541129+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31567,7 +31530,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.660772+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541145+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31607,7 +31570,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:06.660800+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541158+00:00"
               },
               "deterministic": true
             },
@@ -31619,9 +31582,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.049688+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.842762+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query": {
             "type": "string",
@@ -31641,7 +31603,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.660839+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541175+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31666,7 +31628,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.660868+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541187+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31699,7 +31661,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.660907+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541202+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31790,7 +31752,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.660950+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541219+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31819,7 +31781,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.660981+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541232+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31859,7 +31821,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:06.661008+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541246+00:00"
               },
               "deterministic": true
             },
@@ -31871,9 +31833,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.049749+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.842797+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query": {
             "type": "string",
@@ -31893,7 +31854,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.661046+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541264+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31935,7 +31896,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.661078+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541277+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31982,7 +31943,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.661120+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541293+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32120,7 +32081,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:06.661183+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541321+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32131,7 +32092,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.049815+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.842835+00:00"
           }
         },
         "x-f5xc-description-short": "Label Filter is used to filter th that match the logs specified label key/value and the operator.",
@@ -32206,7 +32167,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.661227+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541339+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32306,7 +32267,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.661277+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541359+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32335,7 +32296,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.661315+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541373+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32431,7 +32392,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:06.661345+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541387+00:00"
               },
               "deterministic": true
             },
@@ -32443,9 +32404,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.049880+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.842873+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "scroll_id": {
             "type": "string",
@@ -32463,7 +32423,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.661380+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541401+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32527,7 +32487,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.049907+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.842889+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Max Aggregation Data\" Max Aggregation data.",
@@ -32630,7 +32590,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.049936+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.842906+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Min Aggregation Data\" Min Aggregation data.",
@@ -32684,7 +32644,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.661443+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541426+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32841,7 +32801,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.661502+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541448+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32954,7 +32914,7 @@
             "maxLength": 16,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.050010+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.842950+00:00"
           },
           "value": {
             "type": "number",
@@ -32970,7 +32930,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.050028+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.842961+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Percentile Aggregation Data\" Percentile Aggregation data.",
@@ -33049,7 +33009,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.661573+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541475+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33089,7 +33049,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:06.661601+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541488+00:00"
               },
               "deterministic": true
             },
@@ -33101,9 +33061,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.050062+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.842983+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query": {
             "type": "string",
@@ -33123,7 +33082,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.661640+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541505+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33156,7 +33115,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.661688+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541521+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33246,7 +33205,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.661732+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541538+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33290,7 +33249,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.661766+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541553+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33329,7 +33288,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:06.661793+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541566+00:00"
               },
               "deterministic": true
             },
@@ -33341,9 +33300,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.050123+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.843018+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query": {
             "type": "string",
@@ -33363,7 +33321,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.661831+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541583+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33427,7 +33385,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.661876+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541600+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33527,7 +33485,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.661909+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541613+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33629,7 +33587,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.661964+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541635+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33669,7 +33627,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:06.661990+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541648+00:00"
               },
               "deterministic": true
             },
@@ -33681,9 +33639,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.050196+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.843065+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query": {
             "type": "string",
@@ -33703,7 +33660,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.662029+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541666+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33736,7 +33693,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.662068+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541681+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33826,7 +33783,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.662111+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541697+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33855,7 +33812,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.662140+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541711+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33895,7 +33852,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:06.662168+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541725+00:00"
               },
               "deterministic": true
             },
@@ -33907,9 +33864,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.050249+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.843098+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query": {
             "type": "string",
@@ -33929,7 +33885,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.662206+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541742+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33993,7 +33949,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.662250+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541759+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34117,7 +34073,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.662292+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541776+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34157,7 +34113,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:06.662318+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541789+00:00"
               },
               "deterministic": true
             },
@@ -34169,9 +34125,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.050309+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.843133+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query": {
             "type": "string",
@@ -34191,7 +34146,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.662356+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541806+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34224,7 +34179,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.662393+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541821+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34314,7 +34269,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.662435+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541838+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34343,7 +34298,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.662463+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541851+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34383,7 +34338,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:06.662490+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541865+00:00"
               },
               "deterministic": true
             },
@@ -34395,9 +34350,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.050362+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.843165+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query": {
             "type": "string",
@@ -34417,7 +34371,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.662527+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541882+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34481,7 +34435,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.662575+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541899+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34631,7 +34585,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.662611+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541914+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34853,7 +34807,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.662671+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541934+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35082,7 +35036,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.662723+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541953+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35266,7 +35220,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.662773+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541973+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35328,7 +35282,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.662805+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541986+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35498,7 +35452,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.662851+00:00"
+                "validatedAt": "2026-07-20T14:39:02.542003+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35664,7 +35618,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.662897+00:00"
+                "validatedAt": "2026-07-20T14:39:02.542021+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35726,7 +35680,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.662927+00:00"
+                "validatedAt": "2026-07-20T14:39:02.542033+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36020,7 +35974,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:04:06.662992+00:00"
+                "validatedAt": "2026-07-20T14:39:02.542058+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36031,7 +35985,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.050605+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.843301+00:00"
           },
           "previous_value": {
             "type": "string",
@@ -36046,7 +36000,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.663031+00:00"
+                "validatedAt": "2026-07-20T14:39:02.542074+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36082,7 +36036,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.663066+00:00"
+                "validatedAt": "2026-07-20T14:39:02.542089+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36093,7 +36047,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.050636+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.843320+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Trend Value\" Trend value contains trend value, trend sentiment and trend calculation description and window size.",
@@ -36196,7 +36150,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:26.939672+00:00"
+                "validatedAt": "2026-07-20T14:39:10.147887+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36516,7 +36470,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.904716+00:00"
+                "validatedAt": "2026-07-20T14:40:58.529996+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36542,7 +36496,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.904780+00:00"
+                "validatedAt": "2026-07-20T14:40:58.530012+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36606,7 +36560,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.904825+00:00"
+                "validatedAt": "2026-07-20T14:40:58.530030+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36631,7 +36585,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.904866+00:00"
+                "validatedAt": "2026-07-20T14:40:58.530046+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36657,7 +36611,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.904909+00:00"
+                "validatedAt": "2026-07-20T14:40:58.530064+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36682,7 +36636,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.904949+00:00"
+                "validatedAt": "2026-07-20T14:40:58.530079+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36707,7 +36661,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.904989+00:00"
+                "validatedAt": "2026-07-20T14:40:58.530095+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36732,7 +36686,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.905025+00:00"
+                "validatedAt": "2026-07-20T14:40:58.530109+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36757,7 +36711,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.905065+00:00"
+                "validatedAt": "2026-07-20T14:40:58.530125+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36822,7 +36776,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.905101+00:00"
+                "validatedAt": "2026-07-20T14:40:58.530139+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36847,7 +36801,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.905138+00:00"
+                "validatedAt": "2026-07-20T14:40:58.530154+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36873,7 +36827,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.905178+00:00"
+                "validatedAt": "2026-07-20T14:40:58.530169+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36898,7 +36852,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.905223+00:00"
+                "validatedAt": "2026-07-20T14:40:58.530189+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36924,7 +36878,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.905265+00:00"
+                "validatedAt": "2026-07-20T14:40:58.530206+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36949,7 +36903,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.905310+00:00"
+                "validatedAt": "2026-07-20T14:40:58.530224+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36974,7 +36928,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.905348+00:00"
+                "validatedAt": "2026-07-20T14:40:58.530240+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37001,7 +36955,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.905388+00:00"
+                "validatedAt": "2026-07-20T14:40:58.530255+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37027,7 +36981,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.905428+00:00"
+                "validatedAt": "2026-07-20T14:40:58.530271+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37053,7 +37007,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.905474+00:00"
+                "validatedAt": "2026-07-20T14:40:58.530289+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37079,7 +37033,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.905514+00:00"
+                "validatedAt": "2026-07-20T14:40:58.530305+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37105,7 +37059,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.905555+00:00"
+                "validatedAt": "2026-07-20T14:40:58.530320+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37131,7 +37085,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.905594+00:00"
+                "validatedAt": "2026-07-20T14:40:58.530336+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37156,7 +37110,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.905629+00:00"
+                "validatedAt": "2026-07-20T14:40:58.530350+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37182,7 +37136,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.905680+00:00"
+                "validatedAt": "2026-07-20T14:40:58.530363+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37207,7 +37161,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.905719+00:00"
+                "validatedAt": "2026-07-20T14:40:58.530378+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37232,7 +37186,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.905753+00:00"
+                "validatedAt": "2026-07-20T14:40:58.530392+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37358,7 +37312,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:09:03.905794+00:00"
+                "validatedAt": "2026-07-20T14:40:58.530409+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37522,7 +37476,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:03.905864+00:00"
+                "validatedAt": "2026-07-20T14:40:58.530438+00:00"
               },
               "deterministic": true
             },
@@ -37534,9 +37488,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.633552+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:22.979628+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -37593,7 +37546,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.905900+00:00"
+                "validatedAt": "2026-07-20T14:40:58.530452+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37618,7 +37571,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.905939+00:00"
+                "validatedAt": "2026-07-20T14:40:58.530468+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37705,7 +37658,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:09:03.905982+00:00"
+                "validatedAt": "2026-07-20T14:40:58.530486+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37769,7 +37722,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.906022+00:00"
+                "validatedAt": "2026-07-20T14:40:58.530503+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37794,7 +37747,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.906056+00:00"
+                "validatedAt": "2026-07-20T14:40:58.530516+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37820,7 +37773,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.906102+00:00"
+                "validatedAt": "2026-07-20T14:40:58.530534+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37845,7 +37798,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.906137+00:00"
+                "validatedAt": "2026-07-20T14:40:58.530548+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37870,7 +37823,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.906176+00:00"
+                "validatedAt": "2026-07-20T14:40:58.530563+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37895,7 +37848,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.906209+00:00"
+                "validatedAt": "2026-07-20T14:40:58.530576+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37968,7 +37921,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:09:03.906239+00:00"
+                "validatedAt": "2026-07-20T14:40:58.530590+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38121,7 +38074,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:09:03.906315+00:00"
+                "validatedAt": "2026-07-20T14:40:58.530621+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38230,7 +38183,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:03.906363+00:00"
+                "validatedAt": "2026-07-20T14:40:58.530642+00:00"
               },
               "deterministic": true
             },
@@ -38242,9 +38195,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.633704+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:22.979714+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -38301,7 +38253,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.906398+00:00"
+                "validatedAt": "2026-07-20T14:40:58.530656+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38326,7 +38278,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.906436+00:00"
+                "validatedAt": "2026-07-20T14:40:58.530671+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38413,7 +38365,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:09:03.906478+00:00"
+                "validatedAt": "2026-07-20T14:40:58.530689+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38477,7 +38429,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.906518+00:00"
+                "validatedAt": "2026-07-20T14:40:58.530705+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38502,7 +38454,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.906559+00:00"
+                "validatedAt": "2026-07-20T14:40:58.530721+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38527,7 +38479,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.906593+00:00"
+                "validatedAt": "2026-07-20T14:40:58.530735+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38553,7 +38505,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.906640+00:00"
+                "validatedAt": "2026-07-20T14:40:58.530753+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38578,7 +38530,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.906682+00:00"
+                "validatedAt": "2026-07-20T14:40:58.530767+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38603,7 +38555,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.906722+00:00"
+                "validatedAt": "2026-07-20T14:40:58.530781+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38628,7 +38580,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.906758+00:00"
+                "validatedAt": "2026-07-20T14:40:58.530796+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38653,7 +38605,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.906791+00:00"
+                "validatedAt": "2026-07-20T14:40:58.530808+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38725,7 +38677,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.906829+00:00"
+                "validatedAt": "2026-07-20T14:40:58.530824+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38781,7 +38733,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:03.906872+00:00"
+                "validatedAt": "2026-07-20T14:40:58.530842+00:00"
               },
               "deterministic": true
             },
@@ -38793,9 +38745,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.633822+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:22.979785+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "start_time": {
             "type": "string",
@@ -38813,7 +38764,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.906909+00:00"
+                "validatedAt": "2026-07-20T14:40:58.530857+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38838,7 +38789,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.906945+00:00"
+                "validatedAt": "2026-07-20T14:40:58.530872+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39015,7 +38966,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.907006+00:00"
+                "validatedAt": "2026-07-20T14:40:58.530895+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39026,7 +38977,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.633870+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.979816+00:00"
           },
           "segments": {
             "type": "array",
@@ -39061,7 +39012,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.907052+00:00"
+                "validatedAt": "2026-07-20T14:40:58.530913+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39181,7 +39132,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.907103+00:00"
+                "validatedAt": "2026-07-20T14:40:58.530933+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39206,7 +39157,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.907138+00:00"
+                "validatedAt": "2026-07-20T14:40:58.530947+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39231,7 +39182,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.907177+00:00"
+                "validatedAt": "2026-07-20T14:40:58.530963+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39257,7 +39208,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.907214+00:00"
+                "validatedAt": "2026-07-20T14:40:58.530977+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39327,7 +39278,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:09:03.907244+00:00"
+                "validatedAt": "2026-07-20T14:40:58.530991+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39448,7 +39399,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.907302+00:00"
+                "validatedAt": "2026-07-20T14:40:58.531014+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39511,7 +39462,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.907337+00:00"
+                "validatedAt": "2026-07-20T14:40:58.531029+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39536,7 +39487,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.907376+00:00"
+                "validatedAt": "2026-07-20T14:40:58.531044+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39579,7 +39530,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.907420+00:00"
+                "validatedAt": "2026-07-20T14:40:58.531062+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39649,7 +39600,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:09:03.907449+00:00"
+                "validatedAt": "2026-07-20T14:40:58.531076+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39709,7 +39660,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.907480+00:00"
+                "validatedAt": "2026-07-20T14:40:58.531088+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39735,7 +39686,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.907519+00:00"
+                "validatedAt": "2026-07-20T14:40:58.531104+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39761,7 +39712,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.907562+00:00"
+                "validatedAt": "2026-07-20T14:40:58.531121+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39787,7 +39738,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.907602+00:00"
+                "validatedAt": "2026-07-20T14:40:58.531137+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39812,7 +39763,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.907637+00:00"
+                "validatedAt": "2026-07-20T14:40:58.531150+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39837,7 +39788,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.907677+00:00"
+                "validatedAt": "2026-07-20T14:40:58.531164+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39863,7 +39814,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.907713+00:00"
+                "validatedAt": "2026-07-20T14:40:58.531177+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39889,7 +39840,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.907756+00:00"
+                "validatedAt": "2026-07-20T14:40:58.531193+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39914,7 +39865,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.907796+00:00"
+                "validatedAt": "2026-07-20T14:40:58.531209+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39940,7 +39891,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.907837+00:00"
+                "validatedAt": "2026-07-20T14:40:58.531226+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39965,7 +39916,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.907878+00:00"
+                "validatedAt": "2026-07-20T14:40:58.531242+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39991,7 +39942,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.907918+00:00"
+                "validatedAt": "2026-07-20T14:40:58.531258+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40017,7 +39968,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.907961+00:00"
+                "validatedAt": "2026-07-20T14:40:58.531275+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40043,7 +39994,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.908002+00:00"
+                "validatedAt": "2026-07-20T14:40:58.531290+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40069,7 +40020,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.908045+00:00"
+                "validatedAt": "2026-07-20T14:40:58.531307+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40094,7 +40045,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.908086+00:00"
+                "validatedAt": "2026-07-20T14:40:58.531323+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40119,7 +40070,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.908125+00:00"
+                "validatedAt": "2026-07-20T14:40:58.531338+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40144,7 +40095,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.908160+00:00"
+                "validatedAt": "2026-07-20T14:40:58.531352+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40170,7 +40121,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.908202+00:00"
+                "validatedAt": "2026-07-20T14:40:58.531369+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40196,7 +40147,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.908240+00:00"
+                "validatedAt": "2026-07-20T14:40:58.531384+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40347,7 +40298,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.908303+00:00"
+                "validatedAt": "2026-07-20T14:40:58.531408+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40385,7 +40336,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.908344+00:00"
+                "validatedAt": "2026-07-20T14:40:58.531425+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40413,7 +40364,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T13:09:03.908371+00:00"
+                "validatedAt": "2026-07-20T14:40:58.531438+00:00"
               },
               "deterministic": true
             },
@@ -40480,7 +40431,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.908406+00:00"
+                "validatedAt": "2026-07-20T14:40:58.531452+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40570,7 +40521,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.908454+00:00"
+                "validatedAt": "2026-07-20T14:40:58.531471+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40595,7 +40546,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.908491+00:00"
+                "validatedAt": "2026-07-20T14:40:58.531486+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40620,7 +40571,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.908531+00:00"
+                "validatedAt": "2026-07-20T14:40:58.531502+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40666,7 +40617,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.908581+00:00"
+                "validatedAt": "2026-07-20T14:40:58.531522+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40691,7 +40642,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.908618+00:00"
+                "validatedAt": "2026-07-20T14:40:58.531537+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40702,7 +40653,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.634221+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.980030+00:00"
           },
           "source": {
             "type": "string",
@@ -40719,7 +40670,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.908652+00:00"
+                "validatedAt": "2026-07-20T14:40:58.531550+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40865,7 +40816,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.908760+00:00"
+                "validatedAt": "2026-07-20T14:40:58.531577+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40890,7 +40841,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.908796+00:00"
+                "validatedAt": "2026-07-20T14:40:58.531591+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40980,7 +40931,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.908853+00:00"
+                "validatedAt": "2026-07-20T14:40:58.531614+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41019,7 +40970,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.908899+00:00"
+                "validatedAt": "2026-07-20T14:40:58.531632+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41030,7 +40981,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.634303+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.980081+00:00"
           },
           "region": {
             "type": "string",
@@ -41047,7 +40998,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.908932+00:00"
+                "validatedAt": "2026-07-20T14:40:58.531646+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41179,7 +41130,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.634339+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.980103+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -41236,7 +41187,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:09:03.908992+00:00"
+                "validatedAt": "2026-07-20T14:40:58.531670+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41261,7 +41212,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.909029+00:00"
+                "validatedAt": "2026-07-20T14:40:58.531685+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41326,7 +41277,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.909067+00:00"
+                "validatedAt": "2026-07-20T14:40:58.531701+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41352,7 +41303,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.909100+00:00"
+                "validatedAt": "2026-07-20T14:40:58.531715+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41378,7 +41329,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.909133+00:00"
+                "validatedAt": "2026-07-20T14:40:58.531728+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41404,7 +41355,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.909173+00:00"
+                "validatedAt": "2026-07-20T14:40:58.531744+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41429,7 +41380,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.909207+00:00"
+                "validatedAt": "2026-07-20T14:40:58.531759+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41440,7 +41391,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.634399+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.980140+00:00"
           },
           "region": {
             "type": "string",
@@ -41457,7 +41408,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.909241+00:00"
+                "validatedAt": "2026-07-20T14:40:58.531772+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41483,7 +41434,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.909272+00:00"
+                "validatedAt": "2026-07-20T14:40:58.531785+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41553,7 +41504,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.909306+00:00"
+                "validatedAt": "2026-07-20T14:40:58.531799+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41578,7 +41529,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.909339+00:00"
+                "validatedAt": "2026-07-20T14:40:58.531812+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41603,7 +41554,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.909373+00:00"
+                "validatedAt": "2026-07-20T14:40:58.531826+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41614,7 +41565,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.634444+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.980169+00:00"
           },
           "source": {
             "type": "string",
@@ -41631,7 +41582,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.909406+00:00"
+                "validatedAt": "2026-07-20T14:40:58.531839+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41705,7 +41656,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:03.909473+00:00"
+                "validatedAt": "2026-07-20T14:40:58.531870+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41739,7 +41690,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:03.909534+00:00"
+                "validatedAt": "2026-07-20T14:40:58.531898+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41779,7 +41730,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:03.909564+00:00"
+                "validatedAt": "2026-07-20T14:40:58.531912+00:00"
               },
               "deterministic": true
             },
@@ -41791,9 +41742,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.634484+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:22.980194+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "request_body": {
             "allOf": [
@@ -41867,7 +41817,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:09:03.909597+00:00"
+                "validatedAt": "2026-07-20T14:40:58.531926+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41933,7 +41883,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:09:03.909644+00:00"
+                "validatedAt": "2026-07-20T14:40:58.531946+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41944,7 +41894,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.634519+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.980216+00:00"
           },
           "value": {
             "type": "string",
@@ -41959,7 +41909,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.909683+00:00"
+                "validatedAt": "2026-07-20T14:40:58.531959+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41970,7 +41920,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.634539+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.980230+00:00"
           }
         },
         "x-f5xc-description-short": "Tuple with a suggested value and it's description.",
@@ -42115,7 +42065,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:03.909742+00:00"
+                "validatedAt": "2026-07-20T14:40:58.531982+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42126,7 +42076,7 @@
             },
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.634581+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.980255+00:00"
           },
           "values": {
             "type": "array",

--- a/docs/specifications/api/other.json
+++ b/docs/specifications/api/other.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Other",
     "description": "F5 Distributed Cloud Other",
-    "version": "2.1.182",
+    "version": "2.1.181",
     "contact": {
       "name": "F5 Distributed Cloud",
       "url": "https://docs.cloud.f5.com"

--- a/docs/specifications/api/rate_limiting.json
+++ b/docs/specifications/api/rate_limiting.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Rate Limiting",
     "description": "Threshold-based request blocking using sliding window calculations. Burst smoothing algorithms maintain sustained throughput without exceeding defined maximums. Per-connection controls apply granular restrictions by protocol type. Automatic block actions trigger when request counts surpass configured limits within specified intervals.",
-    "version": "2.1.182",
+    "version": "2.1.181",
     "contact": {
       "name": "F5 Distributed Cloud",
       "url": "https://docs.cloud.f5.com"
@@ -3903,7 +3903,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:03.209482+00:00"
+                "validatedAt": "2026-07-20T14:39:47.686227+00:00"
               },
               "deterministic": true
             },
@@ -3915,9 +3915,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.807457+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.565254+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -3949,7 +3948,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:03.209526+00:00"
+                "validatedAt": "2026-07-20T14:39:47.686247+00:00"
               },
               "deterministic": true
             },
@@ -3961,9 +3960,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.807477+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.565268+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -4128,7 +4126,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.807545+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.565309+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -4352,7 +4350,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:06:03.209770+00:00"
+                "validatedAt": "2026-07-20T14:39:47.686320+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4432,7 +4430,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:06:03.209850+00:00"
+                "validatedAt": "2026-07-20T14:39:47.686348+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4443,7 +4441,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.807623+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.565362+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -4530,7 +4528,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:03.209893+00:00"
+                "validatedAt": "2026-07-20T14:39:47.686370+00:00"
               },
               "deterministic": true
             },
@@ -4542,9 +4540,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.807677+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.565390+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -4575,7 +4572,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:03.209922+00:00"
+                "validatedAt": "2026-07-20T14:39:47.686386+00:00"
               },
               "deterministic": true
             },
@@ -4587,9 +4584,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.807696+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.565402+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -4658,7 +4654,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:03.209977+00:00"
+                "validatedAt": "2026-07-20T14:39:47.686412+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4670,7 +4666,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.807734+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.565425+00:00"
           },
           "uid": {
             "type": "string",
@@ -4687,7 +4683,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:03.210003+00:00"
+                "validatedAt": "2026-07-20T14:39:47.686426+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4700,7 +4696,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.807754+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.565438+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of policer is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -5159,7 +5155,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:03.210120+00:00"
+                "validatedAt": "2026-07-20T14:39:47.686478+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5182,7 +5178,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:03.210154+00:00"
+                "validatedAt": "2026-07-20T14:39:47.686496+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5193,7 +5189,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.807845+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.565492+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -5257,7 +5253,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T13:06:03.210189+00:00"
+                "validatedAt": "2026-07-20T14:39:47.686514+00:00"
               },
               "deterministic": true
             },
@@ -5268,8 +5264,7 @@
               "read": false
             },
             "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "minLength": 1,
-            "format": "fqdn"
+            "minLength": 1
           },
           "last_update_time": {
             "type": "string",
@@ -5286,7 +5281,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:03.210229+00:00"
+                "validatedAt": "2026-07-20T14:39:47.686533+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5313,7 +5308,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:03.210265+00:00"
+                "validatedAt": "2026-07-20T14:39:47.686550+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5324,7 +5319,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.807880+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.565513+00:00"
           },
           "service_name": {
             "type": "string",
@@ -5341,7 +5336,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:03.210304+00:00"
+                "validatedAt": "2026-07-20T14:39:47.686568+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5374,7 +5369,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:03.210345+00:00"
+                "validatedAt": "2026-07-20T14:39:47.686586+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5385,7 +5380,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.807905+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.565529+00:00"
           },
           "type": {
             "type": "string",
@@ -5410,7 +5405,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:03.210379+00:00"
+                "validatedAt": "2026-07-20T14:39:47.686602+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5554,7 +5549,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:03.210421+00:00"
+                "validatedAt": "2026-07-20T14:39:47.686621+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5634,7 +5629,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:03.210451+00:00"
+                "validatedAt": "2026-07-20T14:39:47.686638+00:00"
               },
               "deterministic": true
             },
@@ -5646,9 +5641,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.807953+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.565559+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -5812,7 +5806,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:03.210549+00:00"
+                "validatedAt": "2026-07-20T14:39:47.686689+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -5827,7 +5821,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.807996+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.565585+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -5897,7 +5891,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:03.210588+00:00"
+                "validatedAt": "2026-07-20T14:39:47.686711+00:00"
               },
               "deterministic": true
             },
@@ -5909,9 +5903,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.808029+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.565605+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -5944,7 +5937,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:03.210615+00:00"
+                "validatedAt": "2026-07-20T14:39:47.686726+00:00"
               },
               "deterministic": true
             },
@@ -5956,9 +5949,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.808047+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.565617+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -6058,7 +6050,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:03.210702+00:00"
+                "validatedAt": "2026-07-20T14:39:47.686766+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -6073,7 +6065,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.808075+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.565634+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -6145,7 +6137,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:03.210741+00:00"
+                "validatedAt": "2026-07-20T14:39:47.686786+00:00"
               },
               "deterministic": true
             },
@@ -6157,9 +6149,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.808107+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.565654+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -6192,7 +6183,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:03.210768+00:00"
+                "validatedAt": "2026-07-20T14:39:47.686801+00:00"
               },
               "deterministic": true
             },
@@ -6204,9 +6195,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.808126+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.565666+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -6269,7 +6259,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:03.210800+00:00"
+                "validatedAt": "2026-07-20T14:39:47.686816+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6281,7 +6271,7 @@
             "readOnly": true,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.808146+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.565679+00:00"
           },
           "name": {
             "type": "string",
@@ -6314,7 +6304,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:03.210827+00:00"
+                "validatedAt": "2026-07-20T14:39:47.686831+00:00"
               },
               "deterministic": true
             },
@@ -6326,9 +6316,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.808164+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.565690+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -6361,7 +6350,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:03.210854+00:00"
+                "validatedAt": "2026-07-20T14:39:47.686846+00:00"
               },
               "deterministic": true
             },
@@ -6373,9 +6362,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.808183+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.565703+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -6394,7 +6382,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:03.210887+00:00"
+                "validatedAt": "2026-07-20T14:39:47.686861+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6407,7 +6395,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.808201+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.565715+00:00"
           },
           "uid": {
             "type": "string",
@@ -6426,7 +6414,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:03.210912+00:00"
+                "validatedAt": "2026-07-20T14:39:47.686874+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6440,7 +6428,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.808220+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.565727+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -6540,7 +6528,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:03.210986+00:00"
+                "validatedAt": "2026-07-20T14:39:47.686915+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -6555,7 +6543,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.808249+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.565744+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -6625,7 +6613,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:03.211023+00:00"
+                "validatedAt": "2026-07-20T14:39:47.686935+00:00"
               },
               "deterministic": true
             },
@@ -6637,9 +6625,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.808283+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.565764+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -6672,7 +6659,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:03.211049+00:00"
+                "validatedAt": "2026-07-20T14:39:47.686950+00:00"
               },
               "deterministic": true
             },
@@ -6684,9 +6671,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.808301+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.565776+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -6749,7 +6735,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:03.211092+00:00"
+                "validatedAt": "2026-07-20T14:39:47.686970+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6777,7 +6763,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:03.211132+00:00"
+                "validatedAt": "2026-07-20T14:39:47.686989+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6805,7 +6791,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:03.211170+00:00"
+                "validatedAt": "2026-07-20T14:39:47.687006+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6844,7 +6830,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:03.211210+00:00"
+                "validatedAt": "2026-07-20T14:39:47.687025+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6871,7 +6857,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:03.211236+00:00"
+                "validatedAt": "2026-07-20T14:39:47.687037+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6884,7 +6870,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.808356+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.565809+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -6900,7 +6886,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:03.211270+00:00"
+                "validatedAt": "2026-07-20T14:39:47.687054+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7045,7 +7031,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:03.211319+00:00"
+                "validatedAt": "2026-07-20T14:39:47.687076+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7056,7 +7042,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.808397+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.565833+00:00"
           },
           "status": {
             "type": "string",
@@ -7074,7 +7060,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:03.211353+00:00"
+                "validatedAt": "2026-07-20T14:39:47.687092+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7085,7 +7071,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.808415+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.565845+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -7145,7 +7131,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:03.211396+00:00"
+                "validatedAt": "2026-07-20T14:39:47.687112+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7172,7 +7158,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:03.211437+00:00"
+                "validatedAt": "2026-07-20T14:39:47.687131+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7199,7 +7185,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:03.211476+00:00"
+                "validatedAt": "2026-07-20T14:39:47.687149+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7227,7 +7213,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:03.211518+00:00"
+                "validatedAt": "2026-07-20T14:39:47.687168+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7303,7 +7289,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:03.211583+00:00"
+                "validatedAt": "2026-07-20T14:39:47.687197+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7371,7 +7357,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:03.211633+00:00"
+                "validatedAt": "2026-07-20T14:39:47.687220+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7383,7 +7369,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.808501+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.565896+00:00"
           },
           "uid": {
             "type": "string",
@@ -7402,7 +7388,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:03.211669+00:00"
+                "validatedAt": "2026-07-20T14:39:47.687232+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7415,7 +7401,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.808520+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.565908+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -7483,7 +7469,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:03.211702+00:00"
+                "validatedAt": "2026-07-20T14:39:47.687247+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7494,7 +7480,7 @@
             },
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.808540+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.565920+00:00"
           },
           "name": {
             "type": "string",
@@ -7527,7 +7513,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:03.211730+00:00"
+                "validatedAt": "2026-07-20T14:39:47.687262+00:00"
               },
               "deterministic": true
             },
@@ -7539,9 +7525,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.808558+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.565932+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -7574,7 +7559,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:03.211758+00:00"
+                "validatedAt": "2026-07-20T14:39:47.687277+00:00"
               },
               "deterministic": true
             },
@@ -7586,9 +7571,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.808577+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.565943+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "uid": {
             "type": "string",
@@ -7605,7 +7589,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:03.211784+00:00"
+                "validatedAt": "2026-07-20T14:39:47.687289+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7618,7 +7602,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.808596+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.565955+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -7833,7 +7817,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:15.085864+00:00"
+                "validatedAt": "2026-07-20T14:39:52.380777+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7934,7 +7918,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:15.085927+00:00"
+                "validatedAt": "2026-07-20T14:39:52.380799+00:00"
               },
               "deterministic": true
             },
@@ -7946,9 +7930,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.033417+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.751844+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -7980,7 +7963,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:15.085957+00:00"
+                "validatedAt": "2026-07-20T14:39:52.380813+00:00"
               },
               "deterministic": true
             },
@@ -7992,9 +7975,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.033436+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.751857+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -8190,7 +8172,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.033504+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.751899+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -8277,7 +8259,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:15.086079+00:00"
+                "validatedAt": "2026-07-20T14:39:52.380866+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8458,7 +8440,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:06:15.086137+00:00"
+                "validatedAt": "2026-07-20T14:39:52.380891+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8537,7 +8519,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:06:15.086192+00:00"
+                "validatedAt": "2026-07-20T14:39:52.380915+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8548,7 +8530,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.033572+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.751941+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -8635,7 +8617,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:15.086232+00:00"
+                "validatedAt": "2026-07-20T14:39:52.380934+00:00"
               },
               "deterministic": true
             },
@@ -8647,9 +8629,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.033617+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.751970+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -8680,7 +8661,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:15.086260+00:00"
+                "validatedAt": "2026-07-20T14:39:52.380948+00:00"
               },
               "deterministic": true
             },
@@ -8692,9 +8673,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.033635+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.751983+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -8763,7 +8743,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:15.086313+00:00"
+                "validatedAt": "2026-07-20T14:39:52.380969+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8775,7 +8755,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.033682+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.752007+00:00"
           },
           "uid": {
             "type": "string",
@@ -8793,7 +8773,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:15.086339+00:00"
+                "validatedAt": "2026-07-20T14:39:52.380980+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8806,7 +8786,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.033702+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.752021+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of protocol_policer is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -8889,7 +8869,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:15.086387+00:00"
+                "validatedAt": "2026-07-20T14:39:52.381005+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9187,7 +9167,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:15.086457+00:00"
+                "validatedAt": "2026-07-20T14:39:52.381036+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9672,7 +9652,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:32.313892+00:00"
+                "validatedAt": "2026-07-20T14:39:58.849091+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9706,7 +9686,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:32.313942+00:00"
+                "validatedAt": "2026-07-20T14:39:58.849115+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9811,7 +9791,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:32.313985+00:00"
+                "validatedAt": "2026-07-20T14:39:58.849134+00:00"
               },
               "deterministic": true
             },
@@ -9823,9 +9803,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.283589+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.982774+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -9857,7 +9836,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:32.314018+00:00"
+                "validatedAt": "2026-07-20T14:39:58.849149+00:00"
               },
               "deterministic": true
             },
@@ -9869,9 +9848,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.283608+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.982787+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -10041,7 +10019,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.283684+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.982829+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -10135,7 +10113,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:32.314134+00:00"
+                "validatedAt": "2026-07-20T14:39:58.849198+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10169,7 +10147,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:32.314179+00:00"
+                "validatedAt": "2026-07-20T14:39:58.849220+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10494,7 +10472,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:06:32.314277+00:00"
+                "validatedAt": "2026-07-20T14:39:58.849261+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10580,7 +10558,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:06:32.314334+00:00"
+                "validatedAt": "2026-07-20T14:39:58.849285+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10591,7 +10569,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.283776+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.982883+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -10678,7 +10656,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:32.314375+00:00"
+                "validatedAt": "2026-07-20T14:39:58.849304+00:00"
               },
               "deterministic": true
             },
@@ -10690,9 +10668,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.283821+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.982911+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -10723,7 +10700,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:32.314403+00:00"
+                "validatedAt": "2026-07-20T14:39:58.849317+00:00"
               },
               "deterministic": true
             },
@@ -10735,9 +10712,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.283839+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.982923+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -10806,7 +10782,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:32.314457+00:00"
+                "validatedAt": "2026-07-20T14:39:58.849338+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10818,7 +10794,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.283877+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.982947+00:00"
           },
           "uid": {
             "type": "string",
@@ -10835,7 +10811,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:32.314482+00:00"
+                "validatedAt": "2026-07-20T14:39:58.849349+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10848,7 +10824,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.283896+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.982961+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of rate_limiter is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -11395,7 +11371,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:32.314612+00:00"
+                "validatedAt": "2026-07-20T14:39:58.849403+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11429,7 +11405,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:32.314670+00:00"
+                "validatedAt": "2026-07-20T14:39:58.849426+00:00"
               }
             },
             "x-f5xc-required-for": {

--- a/docs/specifications/api/secops_and_incident_response.json
+++ b/docs/specifications/api/secops_and_incident_response.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Secops And Incident Response",
     "description": "User threat assessment with configurable risk thresholds and mitigation rules. Detection covers high, medium, and low threat levels with corresponding actions like blocking, rate limiting, or alerting. Mitigation policies link to load balancers for real-time enforcement against identified bad actors.",
-    "version": "2.1.182",
+    "version": "2.1.181",
     "contact": {
       "name": "F5 Distributed Cloud",
       "url": "https://docs.cloud.f5.com"
@@ -1584,7 +1584,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:10.292321+00:00"
+                "validatedAt": "2026-07-20T14:39:03.927229+00:00"
               },
               "deterministic": true
             },
@@ -1596,9 +1596,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.126798+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.911259+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -1630,7 +1629,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:10.292374+00:00"
+                "validatedAt": "2026-07-20T14:39:03.927247+00:00"
               },
               "deterministic": true
             },
@@ -1642,9 +1641,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.126818+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.911273+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -1809,7 +1807,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.126886+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.911315+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -1962,7 +1960,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:04:10.292563+00:00"
+                "validatedAt": "2026-07-20T14:39:03.927295+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2043,7 +2041,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:04:10.292624+00:00"
+                "validatedAt": "2026-07-20T14:39:03.927320+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2054,7 +2052,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.126946+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.911352+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -2142,7 +2140,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:10.292679+00:00"
+                "validatedAt": "2026-07-20T14:39:03.927338+00:00"
               },
               "deterministic": true
             },
@@ -2154,9 +2152,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.126993+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.911380+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -2187,7 +2184,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:10.292710+00:00"
+                "validatedAt": "2026-07-20T14:39:03.927353+00:00"
               },
               "deterministic": true
             },
@@ -2199,9 +2196,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.127011+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.911392+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -2270,7 +2266,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:10.292765+00:00"
+                "validatedAt": "2026-07-20T14:39:03.927373+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2282,7 +2278,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.127049+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.911416+00:00"
           },
           "uid": {
             "type": "string",
@@ -2300,7 +2296,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:10.292797+00:00"
+                "validatedAt": "2026-07-20T14:39:03.927384+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2313,7 +2309,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.127069+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.911430+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of malicious_user_mitigation is returned in 'List'.",
@@ -2564,7 +2560,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:10.292883+00:00"
+                "validatedAt": "2026-07-20T14:39:03.927424+00:00"
               },
               "deterministic": true
             },
@@ -2959,7 +2955,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:10.292979+00:00"
+                "validatedAt": "2026-07-20T14:39:03.927459+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2982,7 +2978,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:10.293014+00:00"
+                "validatedAt": "2026-07-20T14:39:03.927472+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2993,7 +2989,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.127208+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.911510+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -3057,7 +3053,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T13:04:10.293050+00:00"
+                "validatedAt": "2026-07-20T14:39:03.927488+00:00"
               },
               "deterministic": true
             },
@@ -3068,8 +3064,7 @@
               "read": false
             },
             "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "minLength": 1,
-            "format": "fqdn"
+            "minLength": 1
           },
           "last_update_time": {
             "type": "string",
@@ -3086,7 +3081,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:10.293093+00:00"
+                "validatedAt": "2026-07-20T14:39:03.927504+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3113,7 +3108,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:10.293128+00:00"
+                "validatedAt": "2026-07-20T14:39:03.927517+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3124,7 +3119,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.127243+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.911533+00:00"
           },
           "service_name": {
             "type": "string",
@@ -3141,7 +3136,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:10.293167+00:00"
+                "validatedAt": "2026-07-20T14:39:03.927532+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3174,7 +3169,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:10.293209+00:00"
+                "validatedAt": "2026-07-20T14:39:03.927548+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3185,7 +3180,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.127268+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.911549+00:00"
           },
           "type": {
             "type": "string",
@@ -3210,7 +3205,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:10.293244+00:00"
+                "validatedAt": "2026-07-20T14:39:03.927561+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3354,7 +3349,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:10.293288+00:00"
+                "validatedAt": "2026-07-20T14:39:03.927577+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3434,7 +3429,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:10.293318+00:00"
+                "validatedAt": "2026-07-20T14:39:03.927591+00:00"
               },
               "deterministic": true
             },
@@ -3446,9 +3441,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.127317+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.911579+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -3612,7 +3606,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:10.293414+00:00"
+                "validatedAt": "2026-07-20T14:39:03.927633+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -3627,7 +3621,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.127361+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.911605+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -3697,7 +3691,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:10.293452+00:00"
+                "validatedAt": "2026-07-20T14:39:03.927650+00:00"
               },
               "deterministic": true
             },
@@ -3709,9 +3703,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.127394+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.911626+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -3744,7 +3737,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:10.293478+00:00"
+                "validatedAt": "2026-07-20T14:39:03.927663+00:00"
               },
               "deterministic": true
             },
@@ -3756,9 +3749,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.127412+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.911639+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -3858,7 +3850,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:10.293553+00:00"
+                "validatedAt": "2026-07-20T14:39:03.927697+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -3873,7 +3865,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.127440+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.911657+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -3945,7 +3937,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:10.293590+00:00"
+                "validatedAt": "2026-07-20T14:39:03.927714+00:00"
               },
               "deterministic": true
             },
@@ -3957,9 +3949,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.127473+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.911678+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -3992,7 +3983,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:10.293616+00:00"
+                "validatedAt": "2026-07-20T14:39:03.927727+00:00"
               },
               "deterministic": true
             },
@@ -4004,9 +3995,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.127491+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.911690+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -4069,7 +4059,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:10.293647+00:00"
+                "validatedAt": "2026-07-20T14:39:03.927740+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4081,7 +4071,7 @@
             "readOnly": true,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.127511+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.911704+00:00"
           },
           "name": {
             "type": "string",
@@ -4114,7 +4104,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:10.293683+00:00"
+                "validatedAt": "2026-07-20T14:39:03.927753+00:00"
               },
               "deterministic": true
             },
@@ -4126,9 +4116,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.127530+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.911716+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -4161,7 +4150,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:10.293711+00:00"
+                "validatedAt": "2026-07-20T14:39:03.927766+00:00"
               },
               "deterministic": true
             },
@@ -4173,9 +4162,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.127548+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.911728+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -4194,7 +4182,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:10.293744+00:00"
+                "validatedAt": "2026-07-20T14:39:03.927780+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4207,7 +4195,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.127567+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.911741+00:00"
           },
           "uid": {
             "type": "string",
@@ -4226,7 +4214,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:10.293769+00:00"
+                "validatedAt": "2026-07-20T14:39:03.927790+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4240,7 +4228,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.127586+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.911754+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -4340,7 +4328,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:10.293843+00:00"
+                "validatedAt": "2026-07-20T14:39:03.927824+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -4355,7 +4343,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.127614+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.911772+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -4425,7 +4413,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:10.293880+00:00"
+                "validatedAt": "2026-07-20T14:39:03.927842+00:00"
               },
               "deterministic": true
             },
@@ -4437,9 +4425,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.127647+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.911793+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -4472,7 +4459,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:10.293906+00:00"
+                "validatedAt": "2026-07-20T14:39:03.927855+00:00"
               },
               "deterministic": true
             },
@@ -4484,9 +4471,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.127674+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.911806+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -4549,7 +4535,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:10.293949+00:00"
+                "validatedAt": "2026-07-20T14:39:03.927872+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4577,7 +4563,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:10.293989+00:00"
+                "validatedAt": "2026-07-20T14:39:03.927887+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4605,7 +4591,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:10.294026+00:00"
+                "validatedAt": "2026-07-20T14:39:03.927902+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4644,7 +4630,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:10.294067+00:00"
+                "validatedAt": "2026-07-20T14:39:03.927917+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4671,7 +4657,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:10.294093+00:00"
+                "validatedAt": "2026-07-20T14:39:03.927928+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4684,7 +4670,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.127730+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.911840+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -4700,7 +4686,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:10.294126+00:00"
+                "validatedAt": "2026-07-20T14:39:03.927940+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4845,7 +4831,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:10.294178+00:00"
+                "validatedAt": "2026-07-20T14:39:03.927960+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4856,7 +4842,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.127771+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.911865+00:00"
           },
           "status": {
             "type": "string",
@@ -4874,7 +4860,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:10.294212+00:00"
+                "validatedAt": "2026-07-20T14:39:03.927973+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4885,7 +4871,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.127790+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.911877+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -4945,7 +4931,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:10.294256+00:00"
+                "validatedAt": "2026-07-20T14:39:03.927991+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4972,7 +4958,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:10.294297+00:00"
+                "validatedAt": "2026-07-20T14:39:03.928006+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4999,7 +4985,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:10.294335+00:00"
+                "validatedAt": "2026-07-20T14:39:03.928020+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5027,7 +5013,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:10.294377+00:00"
+                "validatedAt": "2026-07-20T14:39:03.928036+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5103,7 +5089,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:10.294441+00:00"
+                "validatedAt": "2026-07-20T14:39:03.928060+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5171,7 +5157,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:10.294495+00:00"
+                "validatedAt": "2026-07-20T14:39:03.928079+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5183,7 +5169,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.127879+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.911930+00:00"
           },
           "uid": {
             "type": "string",
@@ -5202,7 +5188,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:10.294520+00:00"
+                "validatedAt": "2026-07-20T14:39:03.928089+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5215,7 +5201,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.127898+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.911943+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -5283,7 +5269,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:10.294552+00:00"
+                "validatedAt": "2026-07-20T14:39:03.928102+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5294,7 +5280,7 @@
             },
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.127918+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.911956+00:00"
           },
           "name": {
             "type": "string",
@@ -5327,7 +5313,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:10.294580+00:00"
+                "validatedAt": "2026-07-20T14:39:03.928115+00:00"
               },
               "deterministic": true
             },
@@ -5339,9 +5325,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.127936+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.911968+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -5374,7 +5359,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:10.294608+00:00"
+                "validatedAt": "2026-07-20T14:39:03.928127+00:00"
               },
               "deterministic": true
             },
@@ -5386,9 +5371,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.127955+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.911981+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "uid": {
             "type": "string",
@@ -5405,7 +5389,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:10.294633+00:00"
+                "validatedAt": "2026-07-20T14:39:03.928138+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5418,7 +5402,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.127974+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.911993+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",

--- a/docs/specifications/api/service_mesh.json
+++ b/docs/specifications/api/service_mesh.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Service Mesh",
     "description": "NFV service lifecycle and software version tracking. Machine learning-driven classification with security risk assessment and PII detection. Override management for application behavior customization. Sidecar proxy orchestration with automatic mTLS certificate rotation and policy enforcement across distributed workloads.",
-    "version": "2.1.182",
+    "version": "2.1.181",
     "contact": {
       "name": "F5 Distributed Cloud",
       "url": "https://docs.cloud.f5.com"
@@ -966,7 +966,7 @@
           },
           {
             "name": "response_format",
-            "description": "The format in which the configuration object is to be fetched. This could be for example\n - in GetSpec form for the contents of object\n - in CreateRequest form to create a new similar object\n - to ReplaceRequest form to replace changeable values\n\nDefault format of returned resource\nResponse should be in CreateRequest format\nResponse should be in ReplaceRequest format\nResponse should be in StatusObject(s) format\nResponse should be in format of GetSpecType\nResponse should have other objects referring to this object\nResponse should have deleted and disabled objects referred by this object.",
+            "description": "The format in which the configuration object is to be fetched. This could be for example\n - in GetSpec form for the contents of object\n - in CreateRequest form to create a new similar object\n - to ReplaceRequest form to replace changeable values\n\nDefault format of returned resource\nResponse should be in CreateRequest format\nResponse should be in ReplaceRequest format\nResponse should be in StatusObject(s) format\nResponse should be in format of GetSpecType\nResponse should have other objects referring to this object\nResponse should have deleted and disabled objects referrred by this object.",
             "in": "query",
             "required": false,
             "x-displayname": "Broken Referred Objects.",
@@ -4423,7 +4423,7 @@
           },
           {
             "name": "response_format",
-            "description": "The format in which the configuration object is to be fetched. This could be for example\n - in GetSpec form for the contents of object\n - in CreateRequest form to create a new similar object\n - to ReplaceRequest form to replace changeable values\n\nDefault format of returned resource\nResponse should be in CreateRequest format\nResponse should be in ReplaceRequest format\nResponse should be in StatusObject(s) format\nResponse should be in format of GetSpecType\nResponse should have other objects referring to this object\nResponse should have deleted and disabled objects referred by this object.",
+            "description": "The format in which the configuration object is to be fetched. This could be for example\n - in GetSpec form for the contents of object\n - in CreateRequest form to create a new similar object\n - to ReplaceRequest form to replace changeable values\n\nDefault format of returned resource\nResponse should be in CreateRequest format\nResponse should be in ReplaceRequest format\nResponse should be in StatusObject(s) format\nResponse should be in format of GetSpecType\nResponse should have other objects referring to this object\nResponse should have deleted and disabled objects referrred by this object.",
             "in": "query",
             "required": false,
             "x-displayname": "Broken Referred Objects.",
@@ -10218,7 +10218,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:20.509092+00:00"
+                "validatedAt": "2026-07-20T14:35:33.219889+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10567,7 +10567,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:20.509190+00:00"
+                "validatedAt": "2026-07-20T14:35:33.219926+00:00"
               },
               "deterministic": true
             },
@@ -10579,9 +10579,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.035746+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.769461+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -10613,7 +10612,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:20.509221+00:00"
+                "validatedAt": "2026-07-20T14:35:33.219941+00:00"
               },
               "deterministic": true
             },
@@ -10625,9 +10624,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.035767+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.769475+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -10917,7 +10915,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.035852+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.769531+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -11012,7 +11010,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:55:20.509380+00:00"
+                "validatedAt": "2026-07-20T14:35:33.220007+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11091,7 +11089,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:55:20.509436+00:00"
+                "validatedAt": "2026-07-20T14:35:33.220032+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11102,7 +11100,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.035902+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.769565+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -11189,7 +11187,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:20.509479+00:00"
+                "validatedAt": "2026-07-20T14:35:33.220052+00:00"
               },
               "deterministic": true
             },
@@ -11201,9 +11199,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.035949+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.769596+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -11234,7 +11231,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:20.509507+00:00"
+                "validatedAt": "2026-07-20T14:35:33.220066+00:00"
               },
               "deterministic": true
             },
@@ -11246,9 +11243,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.035968+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.769609+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -11317,7 +11313,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:20.509560+00:00"
+                "validatedAt": "2026-07-20T14:35:33.220088+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11329,7 +11325,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.036005+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.769635+00:00"
           },
           "uid": {
             "type": "string",
@@ -11346,7 +11342,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:20.509586+00:00"
+                "validatedAt": "2026-07-20T14:35:33.220100+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11359,7 +11355,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.036025+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.769649+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of app_setting is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -11440,7 +11436,7 @@
           },
           "cooling_off_period": {
             "type": "integer",
-            "description": "Exclusive with []\nMalicious user detection assigns a threat level to each user based on their activity.\nOnce a threat level is assigned, the system continues tracking activity from this user\nand if no further malicious activity is seen, it gradually reduces the threat assessment to lower levels.\nThis field specifies the time period, in minutes, used by the system to decay a user's threat level from\na high to medium or medium to low or low to none.",
+            "description": "Exclusive with []\nMalicious user detection assigns a threat level to each user based on their activity.\nOnce a threat level is assigned, the system continues tracking activity from this user\nand if no further malicious activity is seen, it gradually reduces the threat assesment to lower levels.\nThis field specifies the time period, in minutes, used by the system to decay a user's threat level from\na high to medium or medium to low or low to none.",
             "title": "Cooling Off Period",
             "format": "int64",
             "x-displayname": "Cooling off period.",
@@ -11453,7 +11449,7 @@
               "ves.io.schema.rules.uint32.lte": "120"
             },
             "x-f5xc-description-short": "Exclusive with [] Malicious user detection assigns a threat level to each user based on their activity.",
-            "x-f5xc-description-medium": "Exclusive with [] Malicious user detection assigns a threat level to each user based on their activity. Once a threat level is assigned, the system continues tracking activity from this user and if no further malicious activity is seen, it gradually reduces the threat assessment to lower levels...",
+            "x-f5xc-description-medium": "Exclusive with [] Malicious user detection assigns a threat level to each user based on their activity. Once a threat level is assigned, the system continues tracking activity from this user and if no further malicious activity is seen, it gradually reduces the threat assesment to lower levels...",
             "x-f5xc-required-for": {
               "minimum_config": false,
               "create": false,
@@ -11850,7 +11846,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:20.509740+00:00"
+                "validatedAt": "2026-07-20T14:35:33.220152+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12332,7 +12328,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:20.509874+00:00"
+                "validatedAt": "2026-07-20T14:35:33.220206+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12458,7 +12454,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:20.509934+00:00"
+                "validatedAt": "2026-07-20T14:35:33.220234+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12663,7 +12659,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:20.509981+00:00"
+                "validatedAt": "2026-07-20T14:35:33.220253+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12675,7 +12671,7 @@
             "readOnly": true,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.036307+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.769826+00:00"
           },
           "name": {
             "type": "string",
@@ -12708,7 +12704,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:20.510011+00:00"
+                "validatedAt": "2026-07-20T14:35:33.220267+00:00"
               },
               "deterministic": true
             },
@@ -12720,9 +12716,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.036325+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.769840+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -12755,7 +12750,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:20.510039+00:00"
+                "validatedAt": "2026-07-20T14:35:33.220281+00:00"
               },
               "deterministic": true
             },
@@ -12767,9 +12762,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.036344+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.769853+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -12788,7 +12782,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:20.510074+00:00"
+                "validatedAt": "2026-07-20T14:35:33.220296+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12801,7 +12795,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.036363+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.769866+00:00"
           },
           "uid": {
             "type": "string",
@@ -12820,7 +12814,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:20.510100+00:00"
+                "validatedAt": "2026-07-20T14:35:33.220307+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12834,7 +12828,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.036382+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.769880+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -12888,7 +12882,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:20.510140+00:00"
+                "validatedAt": "2026-07-20T14:35:33.220323+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12911,7 +12905,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:20.510174+00:00"
+                "validatedAt": "2026-07-20T14:35:33.220341+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12922,7 +12916,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.036410+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.769898+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -12984,7 +12978,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T12:55:20.510209+00:00"
+                "validatedAt": "2026-07-20T14:35:33.220356+00:00"
               },
               "deterministic": true
             },
@@ -12995,8 +12989,7 @@
               "read": false
             },
             "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "minLength": 1,
-            "format": "fqdn"
+            "minLength": 1
           },
           "last_update_time": {
             "type": "string",
@@ -13013,7 +13006,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:20.510251+00:00"
+                "validatedAt": "2026-07-20T14:35:33.220373+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13039,7 +13032,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:20.510286+00:00"
+                "validatedAt": "2026-07-20T14:35:33.220388+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13050,7 +13043,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.036444+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.769921+00:00"
           },
           "service_name": {
             "type": "string",
@@ -13067,7 +13060,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:20.510326+00:00"
+                "validatedAt": "2026-07-20T14:35:33.220404+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13079,7 +13072,7 @@
           },
           "status": {
             "type": "string",
-            "description": "Status of the condition\n\"Success\" Validation has succeeded. Requested operation was successful.\n\"Failed\" Validation has failed.\n\"Incomplete\" Validation of configuration has failed due to missing configuration.\n\"Installed\" Validation has passed and configuration has been installed in data path or K8s\n\"Down\" Configuration is operationally down. E.g. Down interface\n\"Disabled\" Configuration is administratively disabled i.e. objectmetatype.disable = true.\n\"NotApplicable\" Configuration is not applicable e.g. Tenant service_policy_set(s) in system namespace are not applicable on REs.",
+            "description": "Status of the condition\n\"Success\" Validtion has succeded. Requested operation was successful.\n\"Failed\" Validation has failed.\n\"Incomplete\" Validation of configuration has failed due to missing configuration.\n\"Installed\" Validation has passed and configuration has been installed in data path or K8s\n\"Down\" Configuration is operationally down. E.g. Down interface\n\"Disabled\" Configuration is administratively disabled i.e. objectmetatype.disable = true.\n\"NotApplicable\" Configuration is not applicable e.g. Tenant service_policy_set(s) in system namespace are not applicable on REs.",
             "title": "status",
             "x-displayname": "Status",
             "x-ves-example": "Failed",
@@ -13090,8 +13083,8 @@
             "x-validation-rules": {
               "ves.io.schema.rules.string.in": "[\\\"Success\\\",\\\"Failed\\\",\\\"Incomplete\\\",\\\"Installed\\\",\\\"Down\\\",\\\"Disabled\\\",\\\"NotApplicable\\\"]"
             },
-            "x-f5xc-description-short": "Status of the condition \"Success\" Validation has succeeded.",
-            "x-f5xc-description-medium": "Status of the condition \"Success\" Validation has succeeded. Requested operation was successful. \"Failed\" Validation has failed. \"Incomplete\" Validation of configuration has failed due to missing configuration. \"Installed\" Validation has passed and configuration has been installed in data path or...",
+            "x-f5xc-description-short": "Status of the condition \"Success\" Validtion has succeded.",
+            "x-f5xc-description-medium": "Status of the condition \"Success\" Validtion has succeded. Requested operation was successful. \"Failed\" Validation has failed. \"Incomplete\" Validation of configuration has failed due to missing configuration. \"Installed\" Validation has passed and configuration has been installed in data path or...",
             "maxLength": 1024,
             "x-f5xc-constraints": {
               "constraintType": "string",
@@ -13100,7 +13093,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:20.510369+00:00"
+                "validatedAt": "2026-07-20T14:35:33.220422+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13111,7 +13104,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.036470+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.769938+00:00"
           },
           "type": {
             "type": "string",
@@ -13136,7 +13129,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:20.510402+00:00"
+                "validatedAt": "2026-07-20T14:35:33.220436+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13276,7 +13269,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:20.510445+00:00"
+                "validatedAt": "2026-07-20T14:35:33.220454+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13354,7 +13347,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:20.510474+00:00"
+                "validatedAt": "2026-07-20T14:35:33.220469+00:00"
               },
               "deterministic": true
             },
@@ -13366,9 +13359,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.036518+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.769970+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -13528,7 +13520,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:20.510569+00:00"
+                "validatedAt": "2026-07-20T14:35:33.220513+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -13543,7 +13535,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.036561+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.769998+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -13613,7 +13605,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:20.510609+00:00"
+                "validatedAt": "2026-07-20T14:35:33.220532+00:00"
               },
               "deterministic": true
             },
@@ -13625,9 +13617,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.036594+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.770019+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -13660,7 +13651,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:20.510636+00:00"
+                "validatedAt": "2026-07-20T14:35:33.220545+00:00"
               },
               "deterministic": true
             },
@@ -13672,9 +13663,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.036612+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.770032+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -13772,7 +13762,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:20.510720+00:00"
+                "validatedAt": "2026-07-20T14:35:33.220582+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -13787,7 +13777,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.036640+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.770051+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -13859,7 +13849,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:20.510757+00:00"
+                "validatedAt": "2026-07-20T14:35:33.220599+00:00"
               },
               "deterministic": true
             },
@@ -13871,9 +13861,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.036681+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.770073+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -13906,7 +13895,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:20.510783+00:00"
+                "validatedAt": "2026-07-20T14:35:33.220613+00:00"
               },
               "deterministic": true
             },
@@ -13918,9 +13907,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.036701+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.770086+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -14018,7 +14006,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:20.510856+00:00"
+                "validatedAt": "2026-07-20T14:35:33.220650+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -14033,7 +14021,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.036729+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.770105+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -14103,7 +14091,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:20.510895+00:00"
+                "validatedAt": "2026-07-20T14:35:33.220668+00:00"
               },
               "deterministic": true
             },
@@ -14115,9 +14103,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.036761+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.770127+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -14150,7 +14137,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:20.510921+00:00"
+                "validatedAt": "2026-07-20T14:35:33.220682+00:00"
               },
               "deterministic": true
             },
@@ -14162,9 +14149,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.036780+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.770139+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -14225,7 +14211,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:20.510964+00:00"
+                "validatedAt": "2026-07-20T14:35:33.220700+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14253,7 +14239,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:20.511004+00:00"
+                "validatedAt": "2026-07-20T14:35:33.220717+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14281,7 +14267,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:20.511042+00:00"
+                "validatedAt": "2026-07-20T14:35:33.220732+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14320,7 +14306,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:20.511082+00:00"
+                "validatedAt": "2026-07-20T14:35:33.220749+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14347,7 +14333,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:20.511108+00:00"
+                "validatedAt": "2026-07-20T14:35:33.220760+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14360,7 +14346,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.036833+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.770174+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -14376,7 +14362,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:20.511144+00:00"
+                "validatedAt": "2026-07-20T14:35:33.220775+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14517,7 +14503,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:20.511192+00:00"
+                "validatedAt": "2026-07-20T14:35:33.220795+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14528,7 +14514,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.036880+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.770200+00:00"
           },
           "status": {
             "type": "string",
@@ -14546,7 +14532,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:20.511225+00:00"
+                "validatedAt": "2026-07-20T14:35:33.220809+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14557,7 +14543,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.036899+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.770214+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -14615,7 +14601,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:20.511268+00:00"
+                "validatedAt": "2026-07-20T14:35:33.220827+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14642,7 +14628,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:20.511307+00:00"
+                "validatedAt": "2026-07-20T14:35:33.220844+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14669,7 +14655,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:20.511345+00:00"
+                "validatedAt": "2026-07-20T14:35:33.220859+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14697,7 +14683,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:20.511386+00:00"
+                "validatedAt": "2026-07-20T14:35:33.220877+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14773,7 +14759,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:20.511448+00:00"
+                "validatedAt": "2026-07-20T14:35:33.220902+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14841,7 +14827,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:20.511498+00:00"
+                "validatedAt": "2026-07-20T14:35:33.220923+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14853,7 +14839,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.036986+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.770269+00:00"
           },
           "uid": {
             "type": "string",
@@ -14872,7 +14858,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:20.511523+00:00"
+                "validatedAt": "2026-07-20T14:35:33.220934+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14885,7 +14871,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.037006+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.770283+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -14951,7 +14937,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:20.511554+00:00"
+                "validatedAt": "2026-07-20T14:35:33.220947+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14962,7 +14948,7 @@
             },
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.037026+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.770296+00:00"
           },
           "name": {
             "type": "string",
@@ -14995,7 +14981,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:20.511580+00:00"
+                "validatedAt": "2026-07-20T14:35:33.220961+00:00"
               },
               "deterministic": true
             },
@@ -15007,9 +14993,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.037044+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.770309+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -15042,7 +15027,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:20.511607+00:00"
+                "validatedAt": "2026-07-20T14:35:33.220975+00:00"
               },
               "deterministic": true
             },
@@ -15054,9 +15039,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.037062+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.770322+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "uid": {
             "type": "string",
@@ -15073,7 +15057,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:20.511632+00:00"
+                "validatedAt": "2026-07-20T14:35:33.220986+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15086,7 +15070,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.037081+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.770335+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -15159,7 +15143,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:20.511690+00:00"
+                "validatedAt": "2026-07-20T14:35:33.221012+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15240,7 +15224,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:20.511738+00:00"
+                "validatedAt": "2026-07-20T14:35:33.221036+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15318,7 +15302,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:20.511784+00:00"
+                "validatedAt": "2026-07-20T14:35:33.221060+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15375,7 +15359,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:22.745744+00:00"
+                "validatedAt": "2026-07-20T14:35:34.148049+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15400,7 +15384,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:22.745804+00:00"
+                "validatedAt": "2026-07-20T14:35:34.148071+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15541,7 +15525,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:22.745882+00:00"
+                "validatedAt": "2026-07-20T14:35:34.148102+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15608,7 +15592,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:22.745927+00:00"
+                "validatedAt": "2026-07-20T14:35:34.148127+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15724,7 +15708,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:22.746026+00:00"
+                "validatedAt": "2026-07-20T14:35:34.148166+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15766,7 +15750,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:22.746079+00:00"
+                "validatedAt": "2026-07-20T14:35:34.148187+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15812,7 +15796,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:22.746126+00:00"
+                "validatedAt": "2026-07-20T14:35:34.148208+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15875,7 +15859,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:22.746190+00:00"
+                "validatedAt": "2026-07-20T14:35:34.148234+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15916,7 +15900,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:22.746231+00:00"
+                "validatedAt": "2026-07-20T14:35:34.148251+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15956,7 +15940,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:22.746279+00:00"
+                "validatedAt": "2026-07-20T14:35:34.148271+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16083,7 +16067,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:22.746378+00:00"
+                "validatedAt": "2026-07-20T14:35:34.148315+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16262,7 +16246,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:22.746480+00:00"
+                "validatedAt": "2026-07-20T14:35:34.148382+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16642,7 +16626,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:22.746643+00:00"
+                "validatedAt": "2026-07-20T14:35:34.148455+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16667,7 +16651,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:22.746694+00:00"
+                "validatedAt": "2026-07-20T14:35:34.148472+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16693,7 +16677,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:22.746736+00:00"
+                "validatedAt": "2026-07-20T14:35:34.148489+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16719,7 +16703,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:22.746771+00:00"
+                "validatedAt": "2026-07-20T14:35:34.148503+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16759,7 +16743,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:22.746807+00:00"
+                "validatedAt": "2026-07-20T14:35:34.148520+00:00"
               },
               "deterministic": true
             },
@@ -16771,9 +16755,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.076154+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.807447+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Shape of request to GET learnt schema request for a given API endpoint.",
@@ -16849,7 +16832,7 @@
             "title": "Inventory OpenAPI Spec",
             "x-displayname": "Inventory OpenAPI Spec.",
             "x-ves-example": "{\\\"info\\\":{\\\"description\\\":\\\"\\\",\\\"title\\\":\\\"\\\",\\\"version\\\":\\\"\\\"},\\\"paths\\\":{\\\"\\/API\\/Addresss\\\":{\\\"GET\\\":{\\\"consumes\\\":[\\\"application\\/JSON\\\"],\\\"description\\\":\\\"Swagger auto-generated from learnt schema\\\",\\\"parameters\\\":[{\\\"description\\\":\\\"\\\",\\\"in\\\":\\\"query\\\",\\\"name\\\":\\\"test\\\",\\\"type\\\":\\\"string\\\"},{\\\"description\\\":\\\"\\\",\\\"in\\\":\\\"query\\\",\\\"name\\\":\\\"test1\\\",\\\"type\\\":\\\"string\\\"}],\\\"responses\\\":{\\\"200\\\":{\\\"description\\\":\\\"\\\"}}}}},\\\"schemes\\\":[\\\"HTTPS\\\",\\\"HTTP\\\"],\\\"swagger\\\":\\\"2.0\\\"}",
-            "x-f5xc-example": "\"{\\\"info\\\":{\\\"description\\\":\\\"\\\",\\\"title\\\":\\\"\\\",\\\"version\\\":\\\"\\\"},\\\"paths\\\":{\\\"\\/api\\/Address\\\":{\\\"get\\\":{\\\"consumes\\\":[\\\"application\\/json\\\"],\\\"description\\\":\\\"Swagger auto-generated from learnt schema\\\",\\\"parameters\\\":[{\\\"description\\\":\\\"\\\",\\\"in\\\":\\\"query\\\",\\\"name\\\":\\\"test\\\",\\\"type\\\":\\\"string\\\"},{\\\"description\\\":\\\"\\\",\\\"in\\\":\\\"query\\\",\\\"name\\\":\\\"test1\\\",\\\"type\\\":\\\"string\\\"}],\\\"responses\\\":{\\\"200\\\":{\\\"description\\\":\\\"\\\"}}}}},\\\"schemes\\\":[\\\"https\\\",\\\"http\\\"],\\\"swagger\\\":\\\"2.0\\\"}\"",
+            "x-f5xc-example": "\"{\\\"info\\\":{\\\"description\\\":\\\"\\\",\\\"title\\\":\\\"\\\",\\\"version\\\":\\\"\\\"},\\\"paths\\\":{\\\"\\/api\\/Addresss\\\":{\\\"get\\\":{\\\"consumes\\\":[\\\"application\\/json\\\"],\\\"description\\\":\\\"Swagger auto-generated from learnt schema\\\",\\\"parameters\\\":[{\\\"description\\\":\\\"\\\",\\\"in\\\":\\\"query\\\",\\\"name\\\":\\\"test\\\",\\\"type\\\":\\\"string\\\"},{\\\"description\\\":\\\"\\\",\\\"in\\\":\\\"query\\\",\\\"name\\\":\\\"test1\\\",\\\"type\\\":\\\"string\\\"}],\\\"responses\\\":{\\\"200\\\":{\\\"description\\\":\\\"\\\"}}}}},\\\"schemes\\\":[\\\"https\\\",\\\"http\\\"],\\\"swagger\\\":\\\"2.0\\\"}\"",
             "x-f5xc-description-short": "Inventory OpenAPI spec for request API endpoint.",
             "maxLength": 1024,
             "x-f5xc-constraints": {
@@ -16859,7 +16842,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:22.746863+00:00"
+                "validatedAt": "2026-07-20T14:35:34.148543+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17266,7 +17249,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:22.746940+00:00"
+                "validatedAt": "2026-07-20T14:35:34.148573+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17291,7 +17274,7 @@
             "maxLength": 4,
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.076248+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.807493+00:00"
           },
           "type": {
             "allOf": [
@@ -17609,7 +17592,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:22.747021+00:00"
+                "validatedAt": "2026-07-20T14:35:34.148608+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17704,7 +17687,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:22.747057+00:00"
+                "validatedAt": "2026-07-20T14:35:34.148624+00:00"
               },
               "deterministic": true
             },
@@ -17716,9 +17699,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.076360+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.807550+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -17750,7 +17732,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:22.747086+00:00"
+                "validatedAt": "2026-07-20T14:35:34.148638+00:00"
               },
               "deterministic": true
             },
@@ -17762,9 +17744,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.076380+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.807562+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -17884,7 +17865,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:22.747155+00:00"
+                "validatedAt": "2026-07-20T14:35:34.148665+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18175,7 +18156,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.076492+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.807620+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -18271,7 +18252,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:22.747283+00:00"
+                "validatedAt": "2026-07-20T14:35:34.148718+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18354,7 +18335,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:55:22.747327+00:00"
+                "validatedAt": "2026-07-20T14:35:34.148737+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18432,7 +18413,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:55:22.747383+00:00"
+                "validatedAt": "2026-07-20T14:35:34.148760+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18443,7 +18424,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.076562+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.807657+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -18530,7 +18511,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:22.747425+00:00"
+                "validatedAt": "2026-07-20T14:35:34.148778+00:00"
               },
               "deterministic": true
             },
@@ -18542,9 +18523,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.076609+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.807682+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -18575,7 +18555,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:22.747452+00:00"
+                "validatedAt": "2026-07-20T14:35:34.148791+00:00"
               },
               "deterministic": true
             },
@@ -18587,9 +18567,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.076629+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.807693+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -18658,7 +18637,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:22.747507+00:00"
+                "validatedAt": "2026-07-20T14:35:34.148823+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18670,7 +18649,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.076677+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.807715+00:00"
           },
           "uid": {
             "type": "string",
@@ -18687,7 +18666,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:22.747533+00:00"
+                "validatedAt": "2026-07-20T14:35:34.148834+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18700,7 +18679,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.076698+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.807726+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of app_type is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -18768,7 +18747,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:22.747576+00:00"
+                "validatedAt": "2026-07-20T14:35:34.148851+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18848,7 +18827,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:22.747621+00:00"
+                "validatedAt": "2026-07-20T14:35:34.148873+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18888,7 +18867,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:22.747649+00:00"
+                "validatedAt": "2026-07-20T14:35:34.148887+00:00"
               },
               "deterministic": true
             },
@@ -18900,9 +18879,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.076739+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.807750+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Shape of remove to remove override for API endpoints.",
@@ -18944,13 +18922,13 @@
         "properties": {
           "status": {
             "type": "boolean",
-            "description": "Status of the add operation (success or fail)",
+            "description": "Status of the add operation (sucess or fail)",
             "title": "Status",
             "format": "boolean",
             "x-displayname": "Status",
             "x-ves-example": "True",
             "x-f5xc-example": "true",
-            "x-f5xc-description-short": "Status of the add operation (success or fail).",
+            "x-f5xc-description-short": "Status of the add operation (sucess or fail).",
             "x-f5xc-required-for": {
               "minimum_config": false,
               "create": false,
@@ -18960,7 +18938,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.076760+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.807762+00:00"
           },
           "status_msg": {
             "type": "string",
@@ -18978,7 +18956,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:22.747700+00:00"
+                "validatedAt": "2026-07-20T14:35:34.148904+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19041,7 +19019,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:22.747742+00:00"
+                "validatedAt": "2026-07-20T14:35:34.148920+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19081,7 +19059,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:22.747770+00:00"
+                "validatedAt": "2026-07-20T14:35:34.148933+00:00"
               },
               "deterministic": true
             },
@@ -19093,9 +19071,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.076793+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.807781+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "override_info": {
             "allOf": [
@@ -19152,13 +19129,13 @@
         "properties": {
           "status": {
             "type": "boolean",
-            "description": "Status of the add operation (success or fail)",
+            "description": "Status of the add operation (sucess or fail)",
             "title": "Status",
             "format": "boolean",
             "x-displayname": "Status",
             "x-ves-example": "True",
             "x-f5xc-example": "true",
-            "x-f5xc-description-short": "Status of the add operation (success or fail).",
+            "x-f5xc-description-short": "Status of the add operation (sucess or fail).",
             "x-f5xc-required-for": {
               "minimum_config": false,
               "create": false,
@@ -19168,7 +19145,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.076820+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.807797+00:00"
           },
           "status_msg": {
             "type": "string",
@@ -19186,7 +19163,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:22.747815+00:00"
+                "validatedAt": "2026-07-20T14:35:34.148951+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19556,7 +19533,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:22.747928+00:00"
+                "validatedAt": "2026-07-20T14:35:34.148998+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19792,7 +19769,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:22.748003+00:00"
+                "validatedAt": "2026-07-20T14:35:34.149027+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19883,7 +19860,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:22.748060+00:00"
+                "validatedAt": "2026-07-20T14:35:34.149050+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19921,7 +19898,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:22.748098+00:00"
+                "validatedAt": "2026-07-20T14:35:34.149065+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19945,7 +19922,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:22.748141+00:00"
+                "validatedAt": "2026-07-20T14:35:34.149083+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20111,7 +20088,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:22.748185+00:00"
+                "validatedAt": "2026-07-20T14:35:34.149100+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20137,7 +20114,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:22.748225+00:00"
+                "validatedAt": "2026-07-20T14:35:34.149123+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20163,7 +20140,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:22.748257+00:00"
+                "validatedAt": "2026-07-20T14:35:34.149137+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20203,7 +20180,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:22.748286+00:00"
+                "validatedAt": "2026-07-20T14:35:34.149151+00:00"
               },
               "deterministic": true
             },
@@ -20215,9 +20192,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.077043+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.807915+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "service_name": {
             "type": "string",
@@ -20234,7 +20210,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:22.748324+00:00"
+                "validatedAt": "2026-07-20T14:35:34.149167+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20309,7 +20285,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:22.748370+00:00"
+                "validatedAt": "2026-07-20T14:35:34.149190+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20334,7 +20310,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:22.748409+00:00"
+                "validatedAt": "2026-07-20T14:35:34.149206+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20374,7 +20350,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:22.748436+00:00"
+                "validatedAt": "2026-07-20T14:35:34.149219+00:00"
               },
               "deterministic": true
             },
@@ -20386,9 +20362,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.077083+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.807937+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "service_name": {
             "type": "string",
@@ -20405,7 +20380,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:22.748474+00:00"
+                "validatedAt": "2026-07-20T14:35:34.149234+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20555,7 +20530,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:22.749191+00:00"
+                "validatedAt": "2026-07-20T14:35:34.149543+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20567,7 +20542,7 @@
             "readOnly": true,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.077440+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.808144+00:00"
           },
           "name": {
             "type": "string",
@@ -20600,7 +20575,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:22.749217+00:00"
+                "validatedAt": "2026-07-20T14:35:34.149556+00:00"
               },
               "deterministic": true
             },
@@ -20612,9 +20587,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.077457+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.808155+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -20647,7 +20621,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:22.749244+00:00"
+                "validatedAt": "2026-07-20T14:35:34.149569+00:00"
               },
               "deterministic": true
             },
@@ -20659,9 +20633,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.077476+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.808166+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -20680,7 +20653,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:22.749276+00:00"
+                "validatedAt": "2026-07-20T14:35:34.149582+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20693,7 +20666,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.077495+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.808178+00:00"
           },
           "uid": {
             "type": "string",
@@ -20712,7 +20685,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:22.749301+00:00"
+                "validatedAt": "2026-07-20T14:35:34.149592+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20726,7 +20699,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.077514+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.808189+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -20786,7 +20759,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:22.749475+00:00"
+                "validatedAt": "2026-07-20T14:35:34.149672+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20826,7 +20799,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:22.749500+00:00"
+                "validatedAt": "2026-07-20T14:35:34.149685+00:00"
               },
               "deterministic": true
             },
@@ -20838,9 +20811,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.077619+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.808256+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Represents a category of vulnerability as defined in the OWASP API Top 10.",
@@ -21199,7 +21171,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:58.955228+00:00"
+                "validatedAt": "2026-07-20T14:37:49.092920+00:00"
               },
               "deterministic": true
             },
@@ -21211,9 +21183,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.159115+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.595714+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -21245,7 +21216,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:58.955266+00:00"
+                "validatedAt": "2026-07-20T14:37:49.092938+00:00"
               },
               "deterministic": true
             },
@@ -21257,9 +21228,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.159135+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.595726+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -21434,7 +21404,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:58.955345+00:00"
+                "validatedAt": "2026-07-20T14:37:49.092975+00:00"
               },
               "deterministic": true
             },
@@ -21446,9 +21416,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.159177+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "hostname"
+            "x-reconciled-at": "2026-07-20T14:42:15.595752+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "refresh_interval": {
             "type": "integer",
@@ -21637,7 +21606,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.159250+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.595797+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -21736,7 +21705,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:58.955492+00:00"
+                "validatedAt": "2026-07-20T14:37:49.093030+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21760,7 +21729,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:58.955543+00:00"
+                "validatedAt": "2026-07-20T14:37:49.093050+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21784,7 +21753,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:58.955591+00:00"
+                "validatedAt": "2026-07-20T14:37:49.093070+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21809,7 +21778,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:58.955638+00:00"
+                "validatedAt": "2026-07-20T14:37:49.093088+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21833,7 +21802,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:58.955699+00:00"
+                "validatedAt": "2026-07-20T14:37:49.093108+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21857,7 +21826,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:58.955748+00:00"
+                "validatedAt": "2026-07-20T14:37:49.093128+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21882,7 +21851,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:58.955797+00:00"
+                "validatedAt": "2026-07-20T14:37:49.093148+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22065,7 +22034,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:00:58.955869+00:00"
+                "validatedAt": "2026-07-20T14:37:49.093178+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22145,7 +22114,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:00:58.955924+00:00"
+                "validatedAt": "2026-07-20T14:37:49.093201+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22156,7 +22125,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.159376+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.595871+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -22243,7 +22212,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:58.955966+00:00"
+                "validatedAt": "2026-07-20T14:37:49.093222+00:00"
               },
               "deterministic": true
             },
@@ -22255,9 +22224,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.159422+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.595900+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -22288,7 +22256,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:58.955993+00:00"
+                "validatedAt": "2026-07-20T14:37:49.093235+00:00"
               },
               "deterministic": true
             },
@@ -22300,9 +22268,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.159440+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.595912+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -22371,7 +22338,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:58.956046+00:00"
+                "validatedAt": "2026-07-20T14:37:49.093256+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22383,7 +22350,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.159478+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.595935+00:00"
           },
           "uid": {
             "type": "string",
@@ -22400,7 +22367,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:58.956073+00:00"
+                "validatedAt": "2026-07-20T14:37:49.093267+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22413,7 +22380,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.159497+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.595947+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of endpoint is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -22648,7 +22615,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:58.956151+00:00"
+                "validatedAt": "2026-07-20T14:37:49.093302+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22928,7 +22895,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:58.956282+00:00"
+                "validatedAt": "2026-07-20T14:37:49.093353+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22953,7 +22920,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:58.956313+00:00"
+                "validatedAt": "2026-07-20T14:37:49.093366+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23150,7 +23117,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:58.956908+00:00"
+                "validatedAt": "2026-07-20T14:37:49.093626+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23220,7 +23187,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:58.956960+00:00"
+                "validatedAt": "2026-07-20T14:37:49.093651+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23304,7 +23271,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:58.957007+00:00"
+                "validatedAt": "2026-07-20T14:37:49.093676+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23379,7 +23346,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:58.957047+00:00"
+                "validatedAt": "2026-07-20T14:37:49.093697+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23624,7 +23591,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:58.957518+00:00"
+                "validatedAt": "2026-07-20T14:37:49.093922+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23747,7 +23714,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:58.958188+00:00"
+                "validatedAt": "2026-07-20T14:37:49.094188+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23883,7 +23850,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:58.958362+00:00"
+                "validatedAt": "2026-07-20T14:37:49.094267+00:00"
               },
               "deterministic": true
             },
@@ -23899,8 +23866,7 @@
               "service_info"
             ],
             "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "minLength": 1,
-            "format": "hostname"
+            "minLength": 1
           },
           "dns_name_advanced": {
             "allOf": [
@@ -23967,7 +23933,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:58.958426+00:00"
+                "validatedAt": "2026-07-20T14:37:49.094297+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24007,7 +23973,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:58.958460+00:00"
+                "validatedAt": "2026-07-20T14:37:49.094314+00:00"
               },
               "deterministic": true
             },
@@ -24038,7 +24004,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:58.958497+00:00"
+                "validatedAt": "2026-07-20T14:37:49.094329+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24192,7 +24158,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:58.958561+00:00"
+                "validatedAt": "2026-07-20T14:37:49.094361+00:00"
               },
               "deterministic": true
             },
@@ -24208,8 +24174,7 @@
               "service_info"
             ],
             "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "minLength": 1,
-            "format": "hostname"
+            "minLength": 1
           },
           "dns_name_advanced": {
             "allOf": [
@@ -24276,7 +24241,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:58.958624+00:00"
+                "validatedAt": "2026-07-20T14:37:49.094390+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24316,7 +24281,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:58.958661+00:00"
+                "validatedAt": "2026-07-20T14:37:49.094405+00:00"
               },
               "deterministic": true
             },
@@ -24347,7 +24312,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:58.958699+00:00"
+                "validatedAt": "2026-07-20T14:37:49.094420+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24494,7 +24459,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:58.958762+00:00"
+                "validatedAt": "2026-07-20T14:37:49.094451+00:00"
               },
               "deterministic": true
             },
@@ -24510,8 +24475,7 @@
               "service_info"
             ],
             "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "minLength": 1,
-            "format": "hostname"
+            "minLength": 1
           },
           "dns_name_advanced": {
             "allOf": [
@@ -24578,7 +24542,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:58.958827+00:00"
+                "validatedAt": "2026-07-20T14:37:49.094481+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24618,7 +24582,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:58.958857+00:00"
+                "validatedAt": "2026-07-20T14:37:49.094496+00:00"
               },
               "deterministic": true
             },
@@ -24649,7 +24613,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:58.958893+00:00"
+                "validatedAt": "2026-07-20T14:37:49.094510+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24804,7 +24768,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:58.958954+00:00"
+                "validatedAt": "2026-07-20T14:37:49.094541+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -24819,9 +24783,8 @@
               "read": false
             },
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.613568+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.522267+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -24860,7 +24823,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:58.959000+00:00"
+                "validatedAt": "2026-07-20T14:37:49.094565+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -24875,9 +24838,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.160738+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.596702+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -24906,7 +24868,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:58.959052+00:00"
+                "validatedAt": "2026-07-20T14:37:49.094590+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24919,7 +24881,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.160758+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.596714+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a direct reference from one object(the referrer) to another(the referred).",
@@ -24992,7 +24954,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:58.959095+00:00"
+                "validatedAt": "2026-07-20T14:37:49.094612+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25348,7 +25310,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:38.951088+00:00"
+                "validatedAt": "2026-07-20T14:39:14.848012+00:00"
               },
               "deterministic": true
             },
@@ -25360,9 +25322,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.570121+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.319235+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -25394,7 +25355,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:38.951115+00:00"
+                "validatedAt": "2026-07-20T14:39:14.848025+00:00"
               },
               "deterministic": true
             },
@@ -25406,9 +25367,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.570139+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.319247+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -25756,7 +25716,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:38.951230+00:00"
+                "validatedAt": "2026-07-20T14:39:14.848071+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26216,7 +26176,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:38.951354+00:00"
+                "validatedAt": "2026-07-20T14:39:14.848121+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26298,7 +26258,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:38.951414+00:00"
+                "validatedAt": "2026-07-20T14:39:14.848150+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26338,7 +26298,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:38.951473+00:00"
+                "validatedAt": "2026-07-20T14:39:14.848177+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26447,7 +26407,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:38.951510+00:00"
+                "validatedAt": "2026-07-20T14:39:14.848194+00:00"
               },
               "deterministic": true
             },
@@ -26459,9 +26419,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.570394+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.319392+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -26688,7 +26647,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.570463+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.319431+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -26783,7 +26742,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:04:38.951625+00:00"
+                "validatedAt": "2026-07-20T14:39:14.848238+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26862,7 +26821,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:04:38.951689+00:00"
+                "validatedAt": "2026-07-20T14:39:14.848262+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26873,7 +26832,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.570512+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.319461+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -26960,7 +26919,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:38.951732+00:00"
+                "validatedAt": "2026-07-20T14:39:14.848280+00:00"
               },
               "deterministic": true
             },
@@ -26972,9 +26931,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.570558+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.319487+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -27005,7 +26963,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:38.951759+00:00"
+                "validatedAt": "2026-07-20T14:39:14.848293+00:00"
               },
               "deterministic": true
             },
@@ -27017,9 +26975,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.570576+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.319499+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -27088,7 +27045,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:38.951812+00:00"
+                "validatedAt": "2026-07-20T14:39:14.848313+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27100,7 +27057,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.570614+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.319522+00:00"
           },
           "uid": {
             "type": "string",
@@ -27117,7 +27074,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:38.951840+00:00"
+                "validatedAt": "2026-07-20T14:39:14.848324+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27130,7 +27087,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.570633+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.319534+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of nfv_service is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -27325,7 +27282,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:38.951898+00:00"
+                "validatedAt": "2026-07-20T14:39:14.848346+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27370,7 +27327,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:38.951947+00:00"
+                "validatedAt": "2026-07-20T14:39:14.848370+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27397,7 +27354,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:38.951981+00:00"
+                "validatedAt": "2026-07-20T14:39:14.848384+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27452,7 +27409,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:38.952021+00:00"
+                "validatedAt": "2026-07-20T14:39:14.848402+00:00"
               },
               "deterministic": true
             },
@@ -27464,9 +27421,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.570710+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.319574+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "start_time": {
             "type": "string",
@@ -27491,7 +27447,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:38.952060+00:00"
+                "validatedAt": "2026-07-20T14:39:14.848417+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27524,7 +27480,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:38.952093+00:00"
+                "validatedAt": "2026-07-20T14:39:14.848431+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27617,7 +27573,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:38.952138+00:00"
+                "validatedAt": "2026-07-20T14:39:14.848448+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27679,7 +27635,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:38.952179+00:00"
+                "validatedAt": "2026-07-20T14:39:14.848464+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27703,7 +27659,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:38.952218+00:00"
+                "validatedAt": "2026-07-20T14:39:14.848479+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27791,7 +27747,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:38.952285+00:00"
+                "validatedAt": "2026-07-20T14:39:14.848508+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27884,7 +27840,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:38.952334+00:00"
+                "validatedAt": "2026-07-20T14:39:14.848532+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28224,7 +28180,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:38.952425+00:00"
+                "validatedAt": "2026-07-20T14:39:14.848570+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28284,7 +28240,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:38.952468+00:00"
+                "validatedAt": "2026-07-20T14:39:14.848587+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28295,7 +28251,7 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.570878+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.319674+00:00"
           }
         },
         "x-f5xc-description-short": "Palo Alto Networks VM-Series next-generation firewall configuration.",
@@ -28373,7 +28329,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:38.952541+00:00"
+                "validatedAt": "2026-07-20T14:39:14.848622+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28433,7 +28389,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:38.952606+00:00"
+                "validatedAt": "2026-07-20T14:39:14.848652+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28441,8 +28397,7 @@
               "create": true,
               "update": false,
               "read": false
-            },
-            "format": "hostname"
+            }
           },
           "reserved_mgmt_subnet": {
             "allOf": [
@@ -28537,7 +28492,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:38.952685+00:00"
+                "validatedAt": "2026-07-20T14:39:14.848683+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28574,7 +28529,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:38.952739+00:00"
+                "validatedAt": "2026-07-20T14:39:14.848708+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28606,7 +28561,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:38.952800+00:00"
+                "validatedAt": "2026-07-20T14:39:14.848735+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28802,7 +28757,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:38.952882+00:00"
+                "validatedAt": "2026-07-20T14:39:14.848772+00:00"
               },
               "deterministic": true
             },
@@ -28884,7 +28839,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:38.952944+00:00"
+                "validatedAt": "2026-07-20T14:39:14.848799+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28892,8 +28847,7 @@
               "create": true,
               "update": false,
               "read": false
-            },
-            "format": "hostname"
+            }
           },
           "ssh_port": {
             "type": "integer",
@@ -29041,7 +28995,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:38.953032+00:00"
+                "validatedAt": "2026-07-20T14:39:14.848836+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29049,8 +29003,7 @@
               "create": true,
               "update": false,
               "read": false
-            },
-            "format": "hostname"
+            }
           },
           "node_ssh_ports": {
             "type": "array",
@@ -29079,7 +29032,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:38.953074+00:00"
+                "validatedAt": "2026-07-20T14:39:14.848857+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29298,7 +29251,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:38.953158+00:00"
+                "validatedAt": "2026-07-20T14:39:14.848893+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29306,8 +29259,7 @@
               "create": true,
               "update": false,
               "read": false
-            },
-            "format": "hostname"
+            }
           },
           "https_port": {
             "type": "integer",
@@ -29425,7 +29377,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:38.953250+00:00"
+                "validatedAt": "2026-07-20T14:39:14.848934+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29485,7 +29437,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:38.953313+00:00"
+                "validatedAt": "2026-07-20T14:39:14.848963+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29493,8 +29445,7 @@
               "create": true,
               "update": false,
               "read": false
-            },
-            "format": "hostname"
+            }
           },
           "reserved_mgmt_subnet": {
             "allOf": [
@@ -29535,7 +29486,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:38.953359+00:00"
+                "validatedAt": "2026-07-20T14:39:14.848980+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29635,7 +29586,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:38.953416+00:00"
+                "validatedAt": "2026-07-20T14:39:14.849002+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29701,7 +29652,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:38.953474+00:00"
+                "validatedAt": "2026-07-20T14:39:14.849025+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29724,7 +29675,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:38.953501+00:00"
+                "validatedAt": "2026-07-20T14:39:14.849036+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29796,7 +29747,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:38.953618+00:00"
+                "validatedAt": "2026-07-20T14:39:14.849082+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29837,7 +29788,7 @@
                 "confidence": 1.0,
                 "category": "content",
                 "note": "Blindfold envelope encryption (AES-256-GCM + RSA-OAEP) of an RSA-2048 TLS private key produces ~3700 char string:/// URL. 128KB max secret size = ~175KB base64. Discovery reported 1024 which is incorrect.",
-                "validatedAt": "2026-07-20T13:04:38.953661+00:00"
+                "validatedAt": "2026-07-20T14:39:14.849102+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29848,7 +29799,7 @@
             },
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.571216+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.319870+00:00"
           },
           "store_provider": {
             "type": "string",
@@ -29867,7 +29818,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:38.953709+00:00"
+                "validatedAt": "2026-07-20T14:39:14.849121+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29934,7 +29885,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:38.953745+00:00"
+                "validatedAt": "2026-07-20T14:39:14.849135+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29945,7 +29896,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.571243+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.319886+00:00"
           },
           "url": {
             "type": "string",
@@ -29983,7 +29934,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:38.953804+00:00"
+                "validatedAt": "2026-07-20T14:39:14.849165+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -30109,7 +30060,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:38.954114+00:00"
+                "validatedAt": "2026-07-20T14:39:14.849291+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30200,7 +30151,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:38.954210+00:00"
+                "validatedAt": "2026-07-20T14:39:14.849328+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30211,7 +30162,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.571414+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.319986+00:00"
           }
         },
         "x-f5xc-description-short": "Metric data contains timestamp and the value.",
@@ -30284,7 +30235,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:38.954681+00:00"
+                "validatedAt": "2026-07-20T14:39:14.849534+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30476,7 +30427,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:38.955362+00:00"
+                "validatedAt": "2026-07-20T14:39:14.849797+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30523,7 +30474,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:04:38.955411+00:00"
+                "validatedAt": "2026-07-20T14:39:14.849816+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30534,7 +30485,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.571934+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.320293+00:00"
           },
           "disable_ocsp_stapling": {
             "allOf": [
@@ -30729,7 +30680,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:04:38.955466+00:00"
+                "validatedAt": "2026-07-20T14:39:14.849839+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30740,7 +30691,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.571974+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.320316+00:00"
           },
           "previous_value": {
             "type": "string",
@@ -30758,7 +30709,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:38.955505+00:00"
+                "validatedAt": "2026-07-20T14:39:14.849854+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30796,7 +30747,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:38.955541+00:00"
+                "validatedAt": "2026-07-20T14:39:14.849868+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30807,7 +30758,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.572005+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.320335+00:00"
           }
         },
         "x-f5xc-description-short": "Trend value contains trend value, trend sentiment and trend calculation description and window size.",
@@ -31396,7 +31347,7 @@
             "maxLength": 16,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.572205+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.320455+00:00"
           },
           "value": {
             "type": "array",
@@ -31415,7 +31366,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.572226+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.320468+00:00"
           }
         },
         "x-f5xc-description-short": "Metric Type Data contains key/value pair that uniquely identifies the group_by labels specified in the request.",
@@ -31672,7 +31623,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:38.955961+00:00"
+                "validatedAt": "2026-07-20T14:39:14.850040+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31715,7 +31666,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:38.956004+00:00"
+                "validatedAt": "2026-07-20T14:39:14.850057+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31760,7 +31711,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:38.956051+00:00"
+                "validatedAt": "2026-07-20T14:39:14.850074+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31786,7 +31737,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:38.956092+00:00"
+                "validatedAt": "2026-07-20T14:39:14.850090+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31812,7 +31763,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:38.956128+00:00"
+                "validatedAt": "2026-07-20T14:39:14.850104+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31835,7 +31786,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:38.956165+00:00"
+                "validatedAt": "2026-07-20T14:39:14.850118+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32055,7 +32006,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:38.956205+00:00"
+                "validatedAt": "2026-07-20T14:39:14.850135+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32129,7 +32080,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:38.956283+00:00"
+                "validatedAt": "2026-07-20T14:39:14.850170+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32228,7 +32179,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:38.956332+00:00"
+                "validatedAt": "2026-07-20T14:39:14.850194+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32352,7 +32303,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:38.956389+00:00"
+                "validatedAt": "2026-07-20T14:39:14.850221+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32550,7 +32501,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:38.956475+00:00"
+                "validatedAt": "2026-07-20T14:39:14.850258+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32830,7 +32781,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.572552+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.320656+00:00"
           },
           "status_output": {
             "type": "string",
@@ -32845,7 +32796,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:38.956559+00:00"
+                "validatedAt": "2026-07-20T14:39:14.850289+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32942,7 +32893,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:41.012891+00:00"
+                "validatedAt": "2026-07-20T14:40:49.823538+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33173,7 +33124,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:41.013725+00:00"
+                "validatedAt": "2026-07-20T14:40:49.823867+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33377,7 +33328,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:41.013785+00:00"
+                "validatedAt": "2026-07-20T14:40:49.823894+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33574,7 +33525,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:41.013844+00:00"
+                "validatedAt": "2026-07-20T14:40:49.823921+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33844,7 +33795,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:41.014048+00:00"
+                "validatedAt": "2026-07-20T14:40:49.824019+00:00"
               },
               "deterministic": true
             },
@@ -33856,9 +33807,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.097520+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:22.491218+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -33890,7 +33840,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:41.014076+00:00"
+                "validatedAt": "2026-07-20T14:40:49.824032+00:00"
               },
               "deterministic": true
             },
@@ -33902,9 +33852,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.097539+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:22.491230+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -34139,7 +34088,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.097619+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.491277+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -34306,7 +34255,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:08:41.014201+00:00"
+                "validatedAt": "2026-07-20T14:40:49.824082+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34385,7 +34334,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:08:41.014251+00:00"
+                "validatedAt": "2026-07-20T14:40:49.824104+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34396,7 +34345,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.097692+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.491314+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -34483,7 +34432,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:41.014290+00:00"
+                "validatedAt": "2026-07-20T14:40:49.824122+00:00"
               },
               "deterministic": true
             },
@@ -34495,9 +34444,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.097738+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:22.491341+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -34528,7 +34476,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:41.014317+00:00"
+                "validatedAt": "2026-07-20T14:40:49.824134+00:00"
               },
               "deterministic": true
             },
@@ -34540,9 +34488,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.097757+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:22.491353+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -34611,7 +34558,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:41.014369+00:00"
+                "validatedAt": "2026-07-20T14:40:49.824154+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34623,7 +34570,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.097794+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.491376+00:00"
           },
           "uid": {
             "type": "string",
@@ -34640,7 +34587,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:41.014394+00:00"
+                "validatedAt": "2026-07-20T14:40:49.824164+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34653,7 +34600,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.097814+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.491389+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of site_mesh_group is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -35147,7 +35094,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:28.422339+00:00"
+                "validatedAt": "2026-07-20T14:41:29.931992+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35264,7 +35211,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:11.145987+00:00"
+                "validatedAt": "2026-07-20T14:41:45.903841+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35289,7 +35236,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:11.146021+00:00"
+                "validatedAt": "2026-07-20T14:41:45.903855+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35362,7 +35309,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:11.146066+00:00"
+                "validatedAt": "2026-07-20T14:41:45.903876+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35558,7 +35505,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.613100+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.522026+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Route Target\" BGP Two-Octet AS Specific Route Target as per RFC 4360.",
@@ -35627,7 +35574,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.613128+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.522042+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Four-Octet AS Specific Route Target\" BGP Four-Octet AS Specific Route Target as per RFC 5668.",
@@ -35680,7 +35627,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:11.146591+00:00"
+                "validatedAt": "2026-07-20T14:41:45.904104+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35707,7 +35654,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.613156+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.522058+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"IPv4 Address Specific Route Target\" BGP IPv4 Address Specific Route Target as per RFC 4360.",
@@ -36048,7 +35995,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:11.147634+00:00"
+                "validatedAt": "2026-07-20T14:41:45.904520+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36149,7 +36096,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:11.147677+00:00"
+                "validatedAt": "2026-07-20T14:41:45.904534+00:00"
               },
               "deterministic": true
             },
@@ -36161,9 +36108,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.613719+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.522343+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -36195,7 +36141,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:11.147705+00:00"
+                "validatedAt": "2026-07-20T14:41:45.904548+00:00"
               },
               "deterministic": true
             },
@@ -36207,9 +36153,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.613738+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.522354+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -36372,7 +36317,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.613803+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.522390+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -36533,7 +36478,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:11.147834+00:00"
+                "validatedAt": "2026-07-20T14:41:45.904599+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36570,7 +36515,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:11.147878+00:00"
+                "validatedAt": "2026-07-20T14:41:45.904621+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36657,7 +36602,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:11:11.147922+00:00"
+                "validatedAt": "2026-07-20T14:41:45.904641+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36736,7 +36681,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:11:11.147975+00:00"
+                "validatedAt": "2026-07-20T14:41:45.904662+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36747,7 +36692,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.613892+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.522438+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -36834,7 +36779,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:11.148015+00:00"
+                "validatedAt": "2026-07-20T14:41:45.904679+00:00"
               },
               "deterministic": true
             },
@@ -36846,9 +36791,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.613936+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.522463+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -36879,7 +36823,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:11.148043+00:00"
+                "validatedAt": "2026-07-20T14:41:45.904692+00:00"
               },
               "deterministic": true
             },
@@ -36891,9 +36835,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.613955+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.522474+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -36962,7 +36905,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:11.148096+00:00"
+                "validatedAt": "2026-07-20T14:41:45.904713+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36974,7 +36917,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.613991+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.522496+00:00"
           },
           "uid": {
             "type": "string",
@@ -36991,7 +36934,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:11.148122+00:00"
+                "validatedAt": "2026-07-20T14:41:45.904723+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37004,7 +36947,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.614010+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.522507+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of virtual_network is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -37251,7 +37194,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:11.148190+00:00"
+                "validatedAt": "2026-07-20T14:41:45.904753+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37445,7 +37388,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:11.148247+00:00"
+                "validatedAt": "2026-07-20T14:41:45.904776+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37490,7 +37433,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:11.148296+00:00"
+                "validatedAt": "2026-07-20T14:41:45.904799+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37517,7 +37460,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:11.148330+00:00"
+                "validatedAt": "2026-07-20T14:41:45.904813+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37572,7 +37515,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:11.148371+00:00"
+                "validatedAt": "2026-07-20T14:41:45.904831+00:00"
               },
               "deterministic": true
             },
@@ -37584,9 +37527,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.614127+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.522569+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "range": {
             "type": "string",
@@ -37611,7 +37553,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:11.148405+00:00"
+                "validatedAt": "2026-07-20T14:41:45.904845+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37644,7 +37586,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:11.148445+00:00"
+                "validatedAt": "2026-07-20T14:41:45.904861+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37677,7 +37619,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:11.148478+00:00"
+                "validatedAt": "2026-07-20T14:41:45.904874+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37769,7 +37711,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:11.148522+00:00"
+                "validatedAt": "2026-07-20T14:41:45.904891+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37872,7 +37814,7 @@
             "maxLength": 16,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.614183+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.522600+00:00"
           },
           "value": {
             "type": "array",
@@ -37891,7 +37833,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.614205+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.522612+00:00"
           }
         },
         "x-f5xc-description-short": "SID Counter Type Data contains key/value pairs that uniquely identifies the group_by labels specified in the request.",
@@ -38063,7 +38005,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:11.148577+00:00"
+                "validatedAt": "2026-07-20T14:41:45.904915+00:00"
               },
               "deterministic": true
             },
@@ -38075,9 +38017,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.614243+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.522633+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Srv6 Network Namespace Parameters\" Configure the how namespace network is connected to srv6 network.",
@@ -38145,7 +38086,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:11.148619+00:00"
+                "validatedAt": "2026-07-20T14:41:45.904936+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38199,7 +38140,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:11.148718+00:00"
+                "validatedAt": "2026-07-20T14:41:45.904965+00:00"
               },
               "deterministic": true
             },
@@ -38252,7 +38193,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:11.148767+00:00"
+                "validatedAt": "2026-07-20T14:41:45.904988+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38349,7 +38290,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:11.148812+00:00"
+                "validatedAt": "2026-07-20T14:41:45.905010+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38403,7 +38344,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:11.148870+00:00"
+                "validatedAt": "2026-07-20T14:41:45.905038+00:00"
               },
               "deterministic": true
             },
@@ -38456,7 +38397,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:11.148914+00:00"
+                "validatedAt": "2026-07-20T14:41:45.905060+00:00"
               }
             },
             "x-f5xc-required-for": {

--- a/docs/specifications/api/shape.json
+++ b/docs/specifications/api/shape.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Shape",
     "description": "Bot infrastructure policies with deployment tracking and subscription management. SafeAP protection against credential stuffing and account takeover. Mobile application shielding through SDK integration with OS-specific configurations. Real-time threat intelligence updates and automated response actions based on risk scoring and traffic patterns.",
-    "version": "2.1.182",
+    "version": "2.1.181",
     "contact": {
       "name": "F5 Distributed Cloud",
       "url": "https://docs.cloud.f5.com"
@@ -3208,7 +3208,7 @@
     },
     "/api/shape/dip/namespaces/system/provision/regions": {
       "get": {
-        "summary": "GET available Regions for Application Traffic Insights.",
+        "summary": "GET avaialable Regions for Application Traffic Insights.",
         "description": "Returns Application Traffic Insights regions information for the tenant.",
         "operationId": "ves.io.schema.shape.device_id.CustomAPI.GetRegions",
         "responses": {
@@ -4816,7 +4816,7 @@
           },
           {
             "name": "response_format",
-            "description": "The format in which the configuration object is to be fetched. This could be for example\n - in GetSpec form for the contents of object\n - in CreateRequest form to create a new similar object\n - to ReplaceRequest form to replace changeable values\n\nDefault format of returned resource\nResponse should be in CreateRequest format\nResponse should be in ReplaceRequest format\nResponse should be in StatusObject(s) format\nResponse should be in format of GetSpecType\nResponse should have other objects referring to this object\nResponse should have deleted and disabled objects referred by this object.",
+            "description": "The format in which the configuration object is to be fetched. This could be for example\n - in GetSpec form for the contents of object\n - in CreateRequest form to create a new similar object\n - to ReplaceRequest form to replace changeable values\n\nDefault format of returned resource\nResponse should be in CreateRequest format\nResponse should be in ReplaceRequest format\nResponse should be in StatusObject(s) format\nResponse should be in format of GetSpecType\nResponse should have other objects referring to this object\nResponse should have deleted and disabled objects referrred by this object.",
             "in": "query",
             "required": false,
             "x-displayname": "Broken Referred Objects.",
@@ -5727,7 +5727,7 @@
           },
           {
             "name": "response_format",
-            "description": "The format in which the configuration object is to be fetched. This could be for example\n - in GetSpec form for the contents of object\n - in CreateRequest form to create a new similar object\n - to ReplaceRequest form to replace changeable values\n\nDefault format of returned resource\nResponse should be in CreateRequest format\nResponse should be in StatusObject(s) format\nResponse should be in format of GetSpecType\nResponse should have other objects referring to this object\nResponse should have deleted and disabled objects referred by this object.",
+            "description": "The format in which the configuration object is to be fetched. This could be for example\n - in GetSpec form for the contents of object\n - in CreateRequest form to create a new similar object\n - to ReplaceRequest form to replace changeable values\n\nDefault format of returned resource\nResponse should be in CreateRequest format\nResponse should be in StatusObject(s) format\nResponse should be in format of GetSpecType\nResponse should have other objects referring to this object\nResponse should have deleted and disabled objects referrred by this object.",
             "in": "query",
             "required": false,
             "x-displayname": "Broken Referred Objects.",
@@ -62252,7 +62252,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:37.078067+00:00"
+                "validatedAt": "2026-07-20T14:35:39.848976+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62319,7 +62319,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:37.078133+00:00"
+                "validatedAt": "2026-07-20T14:35:39.848999+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62387,7 +62387,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:37.078168+00:00"
+                "validatedAt": "2026-07-20T14:35:39.849013+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62452,7 +62452,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:37.078207+00:00"
+                "validatedAt": "2026-07-20T14:35:39.849028+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62519,7 +62519,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:37.078240+00:00"
+                "validatedAt": "2026-07-20T14:35:39.849041+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62545,7 +62545,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:37.078277+00:00"
+                "validatedAt": "2026-07-20T14:35:39.849054+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62556,7 +62556,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.495694+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.133337+00:00"
           }
         },
         "x-f5xc-description-short": "Any payload to be return by Provision API.",
@@ -62617,7 +62617,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:37.078310+00:00"
+                "validatedAt": "2026-07-20T14:35:39.849067+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62683,7 +62683,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:37.078344+00:00"
+                "validatedAt": "2026-07-20T14:35:39.849081+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62750,7 +62750,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:37.078377+00:00"
+                "validatedAt": "2026-07-20T14:35:39.849093+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62816,7 +62816,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:37.078411+00:00"
+                "validatedAt": "2026-07-20T14:35:39.849106+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62883,7 +62883,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:37.078443+00:00"
+                "validatedAt": "2026-07-20T14:35:39.849118+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62950,7 +62950,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:37.078475+00:00"
+                "validatedAt": "2026-07-20T14:35:39.849131+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63017,7 +63017,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:37.078508+00:00"
+                "validatedAt": "2026-07-20T14:35:39.849143+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63084,7 +63084,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:37.078539+00:00"
+                "validatedAt": "2026-07-20T14:35:39.849156+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63151,7 +63151,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:37.078571+00:00"
+                "validatedAt": "2026-07-20T14:35:39.849168+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63177,7 +63177,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:37.078605+00:00"
+                "validatedAt": "2026-07-20T14:35:39.849180+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63188,7 +63188,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.495789+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.133396+00:00"
           }
         },
         "x-f5xc-description-short": "Any payload to be return by Dashboard Age API.",
@@ -63248,7 +63248,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:37.078638+00:00"
+                "validatedAt": "2026-07-20T14:35:39.849193+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63315,7 +63315,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:37.078682+00:00"
+                "validatedAt": "2026-07-20T14:35:39.849206+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63341,7 +63341,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:37.078719+00:00"
+                "validatedAt": "2026-07-20T14:35:39.849219+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63352,7 +63352,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.495825+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.133420+00:00"
           }
         },
         "x-f5xc-description-short": "Any payload to be return by Dashboard Application API.",
@@ -63412,7 +63412,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:37.078751+00:00"
+                "validatedAt": "2026-07-20T14:35:39.849231+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63479,7 +63479,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:37.078783+00:00"
+                "validatedAt": "2026-07-20T14:35:39.849243+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63505,7 +63505,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:37.078818+00:00"
+                "validatedAt": "2026-07-20T14:35:39.849256+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63516,7 +63516,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.495859+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.133444+00:00"
           }
         },
         "x-f5xc-description-short": "Any payload to be return by Dashboard ASN API.",
@@ -63576,7 +63576,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:37.078851+00:00"
+                "validatedAt": "2026-07-20T14:35:39.849268+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63643,7 +63643,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:37.078884+00:00"
+                "validatedAt": "2026-07-20T14:35:39.849280+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63669,7 +63669,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:37.078919+00:00"
+                "validatedAt": "2026-07-20T14:35:39.849294+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63680,7 +63680,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.495894+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.133467+00:00"
           }
         },
         "x-f5xc-description-short": "Any payload to be return by Dashboard Country API.",
@@ -63740,7 +63740,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:37.078953+00:00"
+                "validatedAt": "2026-07-20T14:35:39.849307+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63807,7 +63807,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:37.078986+00:00"
+                "validatedAt": "2026-07-20T14:35:39.849319+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63833,7 +63833,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:37.079021+00:00"
+                "validatedAt": "2026-07-20T14:35:39.849331+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63844,7 +63844,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.495929+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.133491+00:00"
           }
         },
         "x-f5xc-description-short": "Any payload to be return by Dashboard Session API.",
@@ -63904,7 +63904,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:37.079053+00:00"
+                "validatedAt": "2026-07-20T14:35:39.849344+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63971,7 +63971,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:37.079087+00:00"
+                "validatedAt": "2026-07-20T14:35:39.849356+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63997,7 +63997,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:37.079123+00:00"
+                "validatedAt": "2026-07-20T14:35:39.849369+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64008,7 +64008,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.495963+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.133514+00:00"
           }
         },
         "x-f5xc-description-short": "Any payload to be return by Dashboard UA API.",
@@ -64068,7 +64068,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:37.079156+00:00"
+                "validatedAt": "2026-07-20T14:35:39.849381+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64135,7 +64135,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:37.079189+00:00"
+                "validatedAt": "2026-07-20T14:35:39.849393+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64161,7 +64161,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:37.079226+00:00"
+                "validatedAt": "2026-07-20T14:35:39.849407+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64172,7 +64172,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.495998+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.133537+00:00"
           }
         },
         "x-f5xc-description-short": "Any payload to be return by Dashboard Unique API.",
@@ -64232,7 +64232,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:37.079259+00:00"
+                "validatedAt": "2026-07-20T14:35:39.849419+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64258,7 +64258,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:37.079294+00:00"
+                "validatedAt": "2026-07-20T14:35:39.849433+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64269,7 +64269,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.496025+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.133556+00:00"
           }
         },
         "x-f5xc-description-short": "Any payload to be return by GET Regions API.",
@@ -64329,7 +64329,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:37.079327+00:00"
+                "validatedAt": "2026-07-20T14:35:39.849446+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64355,7 +64355,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:37.079361+00:00"
+                "validatedAt": "2026-07-20T14:35:39.849460+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64366,7 +64366,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.496052+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.133574+00:00"
           }
         },
         "x-f5xc-description-short": "Any payload to be return by GET Provision API.",
@@ -64427,7 +64427,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:37.079394+00:00"
+                "validatedAt": "2026-07-20T14:35:39.849472+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64495,7 +64495,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:37.079430+00:00"
+                "validatedAt": "2026-07-20T14:35:39.849485+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64560,7 +64560,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:37.079459+00:00"
+                "validatedAt": "2026-07-20T14:35:39.849497+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64594,7 +64594,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T12:55:37.079498+00:00"
+                "validatedAt": "2026-07-20T14:35:39.849514+00:00"
               },
               "deterministic": true
             },
@@ -64661,7 +64661,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:37.079535+00:00"
+                "validatedAt": "2026-07-20T14:35:39.849529+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64776,7 +64776,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:10.982760+00:00"
+                "validatedAt": "2026-07-20T14:35:53.225911+00:00"
               },
               "deterministic": true
             },
@@ -64788,9 +64788,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.983326+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.778589+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -64821,7 +64820,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:10.982811+00:00"
+                "validatedAt": "2026-07-20T14:35:53.225930+00:00"
               },
               "deterministic": true
             },
@@ -64833,9 +64832,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.983347+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.778603+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "status": {
             "allOf": [
@@ -64853,7 +64851,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.983368+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.778616+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -65110,7 +65108,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:10.982894+00:00"
+                "validatedAt": "2026-07-20T14:35:53.225955+00:00"
               },
               "deterministic": true
             },
@@ -65122,9 +65120,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.983434+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.778656+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -65156,7 +65153,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:10.982939+00:00"
+                "validatedAt": "2026-07-20T14:35:53.225969+00:00"
               },
               "deterministic": true
             },
@@ -65168,9 +65165,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.983453+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.778669+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -65333,7 +65329,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.983520+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.778710+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -65428,7 +65424,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:56:10.983095+00:00"
+                "validatedAt": "2026-07-20T14:35:53.226019+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65507,7 +65503,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:56:10.983156+00:00"
+                "validatedAt": "2026-07-20T14:35:53.226046+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65518,7 +65514,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.983571+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.778741+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -65605,7 +65601,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:10.983198+00:00"
+                "validatedAt": "2026-07-20T14:35:53.226065+00:00"
               },
               "deterministic": true
             },
@@ -65617,9 +65613,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.983617+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.778770+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -65650,7 +65645,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:10.983225+00:00"
+                "validatedAt": "2026-07-20T14:35:53.226080+00:00"
               },
               "deterministic": true
             },
@@ -65662,9 +65657,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.983635+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.778782+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -65733,7 +65727,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:10.983280+00:00"
+                "validatedAt": "2026-07-20T14:35:53.226102+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65745,7 +65739,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.983682+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.778806+00:00"
           },
           "uid": {
             "type": "string",
@@ -65763,7 +65757,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:10.983308+00:00"
+                "validatedAt": "2026-07-20T14:35:53.226115+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65776,7 +65770,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.983703+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.778820+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of alert_gen_policy is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -65851,7 +65845,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:10.983384+00:00"
+                "validatedAt": "2026-07-20T14:35:53.226150+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65884,7 +65878,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:10.983430+00:00"
+                "validatedAt": "2026-07-20T14:35:53.226171+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65918,7 +65912,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:10.983490+00:00"
+                "validatedAt": "2026-07-20T14:35:53.226200+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66409,7 +66403,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:10.983594+00:00"
+                "validatedAt": "2026-07-20T14:35:53.226242+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66432,7 +66426,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:10.983628+00:00"
+                "validatedAt": "2026-07-20T14:35:53.226257+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66443,7 +66437,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.983838+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.778900+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -66507,7 +66501,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T12:56:10.983673+00:00"
+                "validatedAt": "2026-07-20T14:35:53.226273+00:00"
               },
               "deterministic": true
             },
@@ -66518,8 +66512,7 @@
               "read": false
             },
             "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "minLength": 1,
-            "format": "fqdn"
+            "minLength": 1
           },
           "last_update_time": {
             "type": "string",
@@ -66536,7 +66529,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:10.983717+00:00"
+                "validatedAt": "2026-07-20T14:35:53.226291+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66562,7 +66555,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:10.983753+00:00"
+                "validatedAt": "2026-07-20T14:35:53.226306+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66573,7 +66566,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.983872+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.778922+00:00"
           },
           "service_name": {
             "type": "string",
@@ -66590,7 +66583,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:10.983793+00:00"
+                "validatedAt": "2026-07-20T14:35:53.226322+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66602,7 +66595,7 @@
           },
           "status": {
             "type": "string",
-            "description": "Status of the condition\n\"Success\" Validation has succeeded. Requested operation was successful.\n\"Failed\" Validation has failed.\n\"Incomplete\" Validation of configuration has failed due to missing configuration.\n\"Installed\" Validation has passed and configuration has been installed in data path or K8s\n\"Down\" Configuration is operationally down. E.g. Down interface\n\"Disabled\" Configuration is administratively disabled i.e. objectmetatype.disable = true.\n\"NotApplicable\" Configuration is not applicable e.g. Tenant service_policy_set(s) in system namespace are not applicable on REs.",
+            "description": "Status of the condition\n\"Success\" Validtion has succeded. Requested operation was successful.\n\"Failed\" Validation has failed.\n\"Incomplete\" Validation of configuration has failed due to missing configuration.\n\"Installed\" Validation has passed and configuration has been installed in data path or K8s\n\"Down\" Configuration is operationally down. E.g. Down interface\n\"Disabled\" Configuration is administratively disabled i.e. objectmetatype.disable = true.\n\"NotApplicable\" Configuration is not applicable e.g. Tenant service_policy_set(s) in system namespace are not applicable on REs.",
             "title": "status",
             "x-displayname": "Status",
             "x-ves-example": "Failed",
@@ -66613,8 +66606,8 @@
             "x-validation-rules": {
               "ves.io.schema.rules.string.in": "[\\\"Success\\\",\\\"Failed\\\",\\\"Incomplete\\\",\\\"Installed\\\",\\\"Down\\\",\\\"Disabled\\\",\\\"NotApplicable\\\"]"
             },
-            "x-f5xc-description-short": "Status of the condition \"Success\" Validation has succeeded.",
-            "x-f5xc-description-medium": "Status of the condition \"Success\" Validation has succeeded. Requested operation was successful. \"Failed\" Validation has failed. \"Incomplete\" Validation of configuration has failed due to missing configuration. \"Installed\" Validation has passed and configuration has been installed in data path or...",
+            "x-f5xc-description-short": "Status of the condition \"Success\" Validtion has succeded.",
+            "x-f5xc-description-medium": "Status of the condition \"Success\" Validtion has succeded. Requested operation was successful. \"Failed\" Validation has failed. \"Incomplete\" Validation of configuration has failed due to missing configuration. \"Installed\" Validation has passed and configuration has been installed in data path or...",
             "maxLength": 1024,
             "x-f5xc-constraints": {
               "constraintType": "string",
@@ -66623,7 +66616,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:10.983831+00:00"
+                "validatedAt": "2026-07-20T14:35:53.226338+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66634,7 +66627,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.983897+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.778939+00:00"
           },
           "type": {
             "type": "string",
@@ -66659,7 +66652,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:10.983864+00:00"
+                "validatedAt": "2026-07-20T14:35:53.226353+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66803,7 +66796,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:10.983907+00:00"
+                "validatedAt": "2026-07-20T14:35:53.226370+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66883,7 +66876,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:10.983936+00:00"
+                "validatedAt": "2026-07-20T14:35:53.226385+00:00"
               },
               "deterministic": true
             },
@@ -66895,9 +66888,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.983946+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.778969+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -67061,7 +67053,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:10.984031+00:00"
+                "validatedAt": "2026-07-20T14:35:53.226430+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -67076,7 +67068,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.983988+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.778996+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -67146,7 +67138,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:10.984069+00:00"
+                "validatedAt": "2026-07-20T14:35:53.226448+00:00"
               },
               "deterministic": true
             },
@@ -67158,9 +67150,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.984021+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.779017+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -67193,7 +67184,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:10.984098+00:00"
+                "validatedAt": "2026-07-20T14:35:53.226463+00:00"
               },
               "deterministic": true
             },
@@ -67205,9 +67196,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.984039+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.779029+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -67307,7 +67297,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:10.984172+00:00"
+                "validatedAt": "2026-07-20T14:35:53.226500+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -67322,7 +67312,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.984067+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.779046+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -67394,7 +67384,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:10.984209+00:00"
+                "validatedAt": "2026-07-20T14:35:53.226518+00:00"
               },
               "deterministic": true
             },
@@ -67406,9 +67396,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.984100+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.779067+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -67441,7 +67430,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:10.984235+00:00"
+                "validatedAt": "2026-07-20T14:35:53.226532+00:00"
               },
               "deterministic": true
             },
@@ -67453,9 +67442,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.984118+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.779079+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -67518,7 +67506,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:10.984266+00:00"
+                "validatedAt": "2026-07-20T14:35:53.226545+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67530,7 +67518,7 @@
             "readOnly": true,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.984139+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.779093+00:00"
           },
           "name": {
             "type": "string",
@@ -67563,7 +67551,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:10.984293+00:00"
+                "validatedAt": "2026-07-20T14:35:53.226559+00:00"
               },
               "deterministic": true
             },
@@ -67575,9 +67563,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.984157+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.779105+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -67610,7 +67597,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:10.984321+00:00"
+                "validatedAt": "2026-07-20T14:35:53.226573+00:00"
               },
               "deterministic": true
             },
@@ -67622,9 +67609,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.984175+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.779117+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -67643,7 +67629,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:10.984353+00:00"
+                "validatedAt": "2026-07-20T14:35:53.226587+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67656,7 +67642,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.984194+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.779129+00:00"
           },
           "uid": {
             "type": "string",
@@ -67675,7 +67661,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:10.984380+00:00"
+                "validatedAt": "2026-07-20T14:35:53.226599+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67689,7 +67675,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.984213+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.779142+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -67789,7 +67775,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:10.984453+00:00"
+                "validatedAt": "2026-07-20T14:35:53.226636+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -67804,7 +67790,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.984241+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.779160+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -67874,7 +67860,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:10.984489+00:00"
+                "validatedAt": "2026-07-20T14:35:53.226655+00:00"
               },
               "deterministic": true
             },
@@ -67886,9 +67872,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.984274+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.779181+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -67921,7 +67906,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:10.984516+00:00"
+                "validatedAt": "2026-07-20T14:35:53.226669+00:00"
               },
               "deterministic": true
             },
@@ -67933,9 +67918,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.984292+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.779193+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -67998,7 +67982,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:10.984559+00:00"
+                "validatedAt": "2026-07-20T14:35:53.226687+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68026,7 +68010,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:10.984599+00:00"
+                "validatedAt": "2026-07-20T14:35:53.226706+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68054,7 +68038,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:10.984636+00:00"
+                "validatedAt": "2026-07-20T14:35:53.226721+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68093,7 +68077,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:10.984685+00:00"
+                "validatedAt": "2026-07-20T14:35:53.226738+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68120,7 +68104,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:10.984713+00:00"
+                "validatedAt": "2026-07-20T14:35:53.226750+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68133,7 +68117,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.984347+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.779227+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -68149,7 +68133,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:10.984748+00:00"
+                "validatedAt": "2026-07-20T14:35:53.226765+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68294,7 +68278,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:10.984801+00:00"
+                "validatedAt": "2026-07-20T14:35:53.226785+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68305,7 +68289,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.984387+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.779253+00:00"
           },
           "status": {
             "type": "string",
@@ -68323,7 +68307,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:10.984835+00:00"
+                "validatedAt": "2026-07-20T14:35:53.226800+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68334,7 +68318,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.984406+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.779265+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -68394,7 +68378,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:10.984879+00:00"
+                "validatedAt": "2026-07-20T14:35:53.226817+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68421,7 +68405,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:10.984919+00:00"
+                "validatedAt": "2026-07-20T14:35:53.226834+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68448,7 +68432,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:10.984955+00:00"
+                "validatedAt": "2026-07-20T14:35:53.226850+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68476,7 +68460,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:10.984998+00:00"
+                "validatedAt": "2026-07-20T14:35:53.226868+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68552,7 +68536,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:10.985063+00:00"
+                "validatedAt": "2026-07-20T14:35:53.226894+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68620,7 +68604,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:10.985114+00:00"
+                "validatedAt": "2026-07-20T14:35:53.226915+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68632,7 +68616,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.984493+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.779318+00:00"
           },
           "uid": {
             "type": "string",
@@ -68651,7 +68635,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:10.985139+00:00"
+                "validatedAt": "2026-07-20T14:35:53.226926+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68664,7 +68648,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.984512+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.779331+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -68732,7 +68716,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:10.985171+00:00"
+                "validatedAt": "2026-07-20T14:35:53.226939+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68743,7 +68727,7 @@
             },
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.984531+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.779344+00:00"
           },
           "name": {
             "type": "string",
@@ -68776,7 +68760,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:10.985199+00:00"
+                "validatedAt": "2026-07-20T14:35:53.226954+00:00"
               },
               "deterministic": true
             },
@@ -68788,9 +68772,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.984549+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.779356+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -68823,7 +68806,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:10.985226+00:00"
+                "validatedAt": "2026-07-20T14:35:53.226967+00:00"
               },
               "deterministic": true
             },
@@ -68835,9 +68818,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.984568+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.779368+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "uid": {
             "type": "string",
@@ -68854,7 +68836,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:10.985250+00:00"
+                "validatedAt": "2026-07-20T14:35:53.226979+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68867,7 +68849,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.984587+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.779381+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -68940,7 +68922,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:12.885546+00:00"
+                "validatedAt": "2026-07-20T14:35:53.975933+00:00"
               },
               "deterministic": true
             },
@@ -68952,9 +68934,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.012971+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.814016+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -68985,7 +68966,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:12.885584+00:00"
+                "validatedAt": "2026-07-20T14:35:53.975953+00:00"
               },
               "deterministic": true
             },
@@ -68997,9 +68978,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.012992+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.814030+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -69053,7 +69033,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:12.885629+00:00"
+                "validatedAt": "2026-07-20T14:35:53.975972+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69284,7 +69264,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:12.885717+00:00"
+                "validatedAt": "2026-07-20T14:35:53.976003+00:00"
               },
               "deterministic": true
             },
@@ -69296,9 +69276,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.013065+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.814072+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -69330,7 +69309,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:12.885755+00:00"
+                "validatedAt": "2026-07-20T14:35:53.976016+00:00"
               },
               "deterministic": true
             },
@@ -69342,9 +69321,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.013084+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.814085+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -69493,7 +69471,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.013145+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.814122+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -69587,7 +69565,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:56:12.885934+00:00"
+                "validatedAt": "2026-07-20T14:35:53.976066+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69666,7 +69644,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:56:12.886002+00:00"
+                "validatedAt": "2026-07-20T14:35:53.976091+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69677,7 +69655,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.013195+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.814153+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -69764,7 +69742,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:12.886045+00:00"
+                "validatedAt": "2026-07-20T14:35:53.976111+00:00"
               },
               "deterministic": true
             },
@@ -69776,9 +69754,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.013240+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.814181+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -69809,7 +69786,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:12.886073+00:00"
+                "validatedAt": "2026-07-20T14:35:53.976126+00:00"
               },
               "deterministic": true
             },
@@ -69821,9 +69798,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.013259+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.814193+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -69892,7 +69868,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:12.886130+00:00"
+                "validatedAt": "2026-07-20T14:35:53.976149+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69904,7 +69880,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.013296+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.814217+00:00"
           },
           "uid": {
             "type": "string",
@@ -69921,7 +69897,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:12.886157+00:00"
+                "validatedAt": "2026-07-20T14:35:53.976160+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69934,7 +69910,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.013316+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.814230+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of alert_template is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -70092,7 +70068,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:12.886268+00:00"
+                "validatedAt": "2026-07-20T14:35:53.976210+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -70122,7 +70098,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:12.886317+00:00"
+                "validatedAt": "2026-07-20T14:35:53.976231+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -70155,7 +70131,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:12.886378+00:00"
+                "validatedAt": "2026-07-20T14:35:53.976262+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -70247,7 +70223,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:12.886445+00:00"
+                "validatedAt": "2026-07-20T14:35:53.976300+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -70277,7 +70253,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:12.886491+00:00"
+                "validatedAt": "2026-07-20T14:35:53.976320+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -70310,7 +70286,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:12.886549+00:00"
+                "validatedAt": "2026-07-20T14:35:53.976349+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -70541,7 +70517,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:18.369228+00:00"
+                "validatedAt": "2026-07-20T14:35:56.054840+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -70566,7 +70542,7 @@
             "maxLength": 43,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.078365+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.942167+00:00"
           },
           "rule_id": {
             "type": "string",
@@ -70583,7 +70559,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:18.369287+00:00"
+                "validatedAt": "2026-07-20T14:35:56.054864+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -70608,7 +70584,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:18.369343+00:00"
+                "validatedAt": "2026-07-20T14:35:56.054879+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -70689,7 +70665,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:18.369399+00:00"
+                "validatedAt": "2026-07-20T14:35:56.054895+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -70891,7 +70867,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:18.369498+00:00"
+                "validatedAt": "2026-07-20T14:35:56.054920+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -70917,7 +70893,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:18.369566+00:00"
+                "validatedAt": "2026-07-20T14:35:56.054937+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71080,7 +71056,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:18.369640+00:00"
+                "validatedAt": "2026-07-20T14:35:56.054960+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71105,7 +71081,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:18.369691+00:00"
+                "validatedAt": "2026-07-20T14:35:56.054976+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71147,7 +71123,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:18.369736+00:00"
+                "validatedAt": "2026-07-20T14:35:56.054993+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71172,7 +71148,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:18.369777+00:00"
+                "validatedAt": "2026-07-20T14:35:56.055008+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71215,7 +71191,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:56:18.369830+00:00"
+                "validatedAt": "2026-07-20T14:35:56.055031+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71344,7 +71320,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:18.369881+00:00"
+                "validatedAt": "2026-07-20T14:35:56.055050+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71420,7 +71396,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:18.369973+00:00"
+                "validatedAt": "2026-07-20T14:35:56.055095+00:00"
               },
               "deterministic": true
             },
@@ -71430,8 +71406,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -71737,7 +71712,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:18.370082+00:00"
+                "validatedAt": "2026-07-20T14:35:56.055136+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71795,7 +71770,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:18.370144+00:00"
+                "validatedAt": "2026-07-20T14:35:56.055160+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71914,7 +71889,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:18.370199+00:00"
+                "validatedAt": "2026-07-20T14:35:56.055181+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -72195,7 +72170,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:56:18.370315+00:00"
+                "validatedAt": "2026-07-20T14:35:56.055226+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -72274,7 +72249,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:56:18.370370+00:00"
+                "validatedAt": "2026-07-20T14:35:56.055249+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -72285,7 +72260,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.078749+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.942389+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -72372,7 +72347,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:18.370411+00:00"
+                "validatedAt": "2026-07-20T14:35:56.055268+00:00"
               },
               "deterministic": true
             },
@@ -72384,9 +72359,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.078797+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.942417+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -72417,7 +72391,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:18.370439+00:00"
+                "validatedAt": "2026-07-20T14:35:56.055281+00:00"
               },
               "deterministic": true
             },
@@ -72429,9 +72403,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.078815+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.942430+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -72484,7 +72457,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:18.370479+00:00"
+                "validatedAt": "2026-07-20T14:35:56.055296+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -72496,7 +72469,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.078847+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.942451+00:00"
           },
           "uid": {
             "type": "string",
@@ -72514,7 +72487,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:18.370504+00:00"
+                "validatedAt": "2026-07-20T14:35:56.055306+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -72527,7 +72500,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.078867+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.942464+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of bot_detection_rule is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -72664,7 +72637,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:18.370551+00:00"
+                "validatedAt": "2026-07-20T14:35:56.055325+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -72748,7 +72721,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T12:56:18.370600+00:00"
+                "validatedAt": "2026-07-20T14:35:56.055346+00:00"
               },
               "deterministic": true
             },
@@ -72815,7 +72788,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:18.370637+00:00"
+                "validatedAt": "2026-07-20T14:35:56.055360+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -73201,7 +73174,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:18.370737+00:00"
+                "validatedAt": "2026-07-20T14:35:56.055395+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -73213,7 +73186,7 @@
             "readOnly": true,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.078997+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.942543+00:00"
           },
           "name": {
             "type": "string",
@@ -73246,7 +73219,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:18.370766+00:00"
+                "validatedAt": "2026-07-20T14:35:56.055408+00:00"
               },
               "deterministic": true
             },
@@ -73258,9 +73231,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.079016+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.942555+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -73293,7 +73265,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:18.370792+00:00"
+                "validatedAt": "2026-07-20T14:35:56.055421+00:00"
               },
               "deterministic": true
             },
@@ -73305,9 +73277,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.079034+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.942568+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -73326,7 +73297,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:18.370825+00:00"
+                "validatedAt": "2026-07-20T14:35:56.055435+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -73339,7 +73310,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.079052+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.942580+00:00"
           },
           "uid": {
             "type": "string",
@@ -73358,7 +73329,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:18.370850+00:00"
+                "validatedAt": "2026-07-20T14:35:56.055445+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -73372,7 +73343,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.079072+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.942593+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -73434,7 +73405,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:18.371676+00:00"
+                "validatedAt": "2026-07-20T14:35:56.055782+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -73619,7 +73590,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:18.371735+00:00"
+                "validatedAt": "2026-07-20T14:35:56.055803+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -73710,7 +73681,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:18.371765+00:00"
+                "validatedAt": "2026-07-20T14:35:56.055817+00:00"
               },
               "deterministic": true
             },
@@ -73722,9 +73693,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.079539+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.942887+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -73928,7 +73898,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T12:56:18.371857+00:00"
+                "validatedAt": "2026-07-20T14:35:56.055854+00:00"
               },
               "deterministic": true
             },
@@ -73958,7 +73928,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:56:18.371901+00:00"
+                "validatedAt": "2026-07-20T14:35:56.055873+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -73969,7 +73939,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.079596+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.942922+00:00"
           },
           "last_modified_at": {
             "type": "string",
@@ -73986,7 +73956,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:18.371942+00:00"
+                "validatedAt": "2026-07-20T14:35:56.055891+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74009,7 +73979,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:18.371983+00:00"
+                "validatedAt": "2026-07-20T14:35:56.055908+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74033,7 +74003,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:18.372021+00:00"
+                "validatedAt": "2026-07-20T14:35:56.055923+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74086,7 +74056,7 @@
             "maxLength": 1,
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.079648+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.942954+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -74159,7 +74129,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:20.028975+00:00"
+                "validatedAt": "2026-07-20T14:35:56.643984+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74193,7 +74163,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:20.029053+00:00"
+                "validatedAt": "2026-07-20T14:35:56.644017+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74233,7 +74203,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:20.029102+00:00"
+                "validatedAt": "2026-07-20T14:35:56.644035+00:00"
               },
               "deterministic": true
             },
@@ -74245,9 +74215,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.109248+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.977337+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "request_body": {
             "allOf": [
@@ -74321,7 +74290,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:56:20.029155+00:00"
+                "validatedAt": "2026-07-20T14:35:56.644053+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74388,7 +74357,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:56:20.029226+00:00"
+                "validatedAt": "2026-07-20T14:35:56.644074+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74399,7 +74368,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.109287+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.977361+00:00"
           },
           "ref_value": {
             "allOf": [
@@ -74441,7 +74410,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:20.029293+00:00"
+                "validatedAt": "2026-07-20T14:35:56.644091+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74470,7 +74439,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:20.029346+00:00"
+                "validatedAt": "2026-07-20T14:35:56.644105+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74481,7 +74450,7 @@
             },
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.109320+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.977382+00:00"
           },
           "value": {
             "type": "string",
@@ -74497,7 +74466,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:20.029379+00:00"
+                "validatedAt": "2026-07-20T14:35:56.644118+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74508,7 +74477,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.109339+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.977394+00:00"
           }
         },
         "x-f5xc-description-short": "Tuple with a suggested value and it's description.",
@@ -74596,7 +74565,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:20.029512+00:00"
+                "validatedAt": "2026-07-20T14:35:56.644177+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -74610,8 +74579,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -74650,7 +74618,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:20.029562+00:00"
+                "validatedAt": "2026-07-20T14:35:56.644202+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -74665,9 +74633,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.109395+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.977430+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -74696,7 +74663,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:20.029615+00:00"
+                "validatedAt": "2026-07-20T14:35:56.644227+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74709,7 +74676,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.109414+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.977443+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a direct reference from one object(the referrer) to another(the referred).",
@@ -74785,7 +74752,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:21.653346+00:00"
+                "validatedAt": "2026-07-20T14:35:57.224647+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74898,7 +74865,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:21.653420+00:00"
+                "validatedAt": "2026-07-20T14:35:57.224676+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74983,7 +74950,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:21.653486+00:00"
+                "validatedAt": "2026-07-20T14:35:57.224694+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75148,7 +75115,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:21.653567+00:00"
+                "validatedAt": "2026-07-20T14:35:57.224715+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75173,7 +75140,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:21.653626+00:00"
+                "validatedAt": "2026-07-20T14:35:57.224729+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75486,7 +75453,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:25.696709+00:00"
+                "validatedAt": "2026-07-20T14:35:58.749252+00:00"
               },
               "deterministic": true
             },
@@ -75498,9 +75465,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.166097+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.012530+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "not_present_cookie": {
             "allOf": [
@@ -75590,7 +75556,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:25.696783+00:00"
+                "validatedAt": "2026-07-20T14:35:58.749282+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75806,7 +75772,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:25.696871+00:00"
+                "validatedAt": "2026-07-20T14:35:58.749320+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75881,7 +75847,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:25.696916+00:00"
+                "validatedAt": "2026-07-20T14:35:58.749342+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -76105,7 +76071,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:25.696971+00:00"
+                "validatedAt": "2026-07-20T14:35:58.749367+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -76173,7 +76139,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:25.697017+00:00"
+                "validatedAt": "2026-07-20T14:35:58.749386+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -76203,7 +76169,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:25.697058+00:00"
+                "validatedAt": "2026-07-20T14:35:58.749403+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -76365,7 +76331,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:25.697104+00:00"
+                "validatedAt": "2026-07-20T14:35:58.749423+00:00"
               },
               "deterministic": true
             },
@@ -76377,9 +76343,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.166273+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.012633+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "not_present_header": {
             "allOf": [
@@ -76650,7 +76615,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:25.697187+00:00"
+                "validatedAt": "2026-07-20T14:35:58.749458+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -76765,7 +76730,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:25.697230+00:00"
+                "validatedAt": "2026-07-20T14:35:58.749481+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -76866,7 +76831,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:25.697293+00:00"
+                "validatedAt": "2026-07-20T14:35:58.749510+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -77064,7 +77029,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:25.697362+00:00"
+                "validatedAt": "2026-07-20T14:35:58.749539+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -77089,7 +77054,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:25.697401+00:00"
+                "validatedAt": "2026-07-20T14:35:58.749555+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -77112,7 +77077,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:25.697441+00:00"
+                "validatedAt": "2026-07-20T14:35:58.749572+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -77136,7 +77101,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:25.697482+00:00"
+                "validatedAt": "2026-07-20T14:35:58.749588+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -77207,7 +77172,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:25.697523+00:00"
+                "validatedAt": "2026-07-20T14:35:58.749605+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -77326,7 +77291,7 @@
             "maxLength": 0,
             "minLength": 0,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.166475+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:10.012752+00:00",
             "x-f5xc-conflicts-with": [
               "block",
               "transform"
@@ -77350,7 +77315,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.166496+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.012766+00:00"
           },
           "flow_label_choice": {
             "allOf": [
@@ -77382,7 +77347,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:56:25.697578+00:00"
+                "validatedAt": "2026-07-20T14:35:58.749630+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -77427,7 +77392,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:25.697628+00:00"
+                "validatedAt": "2026-07-20T14:35:58.749654+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -77550,7 +77515,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:25.697700+00:00"
+                "validatedAt": "2026-07-20T14:35:58.749683+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -77669,7 +77634,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:25.697745+00:00"
+                "validatedAt": "2026-07-20T14:35:58.749706+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -77753,7 +77718,7 @@
             "maxLength": 0,
             "minLength": 0,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.166596+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:10.012828+00:00",
             "x-f5xc-conflicts-with": [
               "block",
               "redirect",
@@ -77778,7 +77743,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.166617+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.012841+00:00"
           },
           "flow_label_choice": {
             "allOf": [
@@ -77810,7 +77775,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:56:25.697790+00:00"
+                "validatedAt": "2026-07-20T14:35:58.749725+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -77855,7 +77820,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:25.697837+00:00"
+                "validatedAt": "2026-07-20T14:35:58.749748+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -77997,7 +77962,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:25.697902+00:00"
+                "validatedAt": "2026-07-20T14:35:58.749777+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78117,7 +78082,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:25.697946+00:00"
+                "validatedAt": "2026-07-20T14:35:58.749799+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78190,7 +78155,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:25.697986+00:00"
+                "validatedAt": "2026-07-20T14:35:58.749819+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78378,7 +78343,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:25.698042+00:00"
+                "validatedAt": "2026-07-20T14:35:58.749848+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78680,7 +78645,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:25.698109+00:00"
+                "validatedAt": "2026-07-20T14:35:58.749879+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78895,7 +78860,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:25.698185+00:00"
+                "validatedAt": "2026-07-20T14:35:58.749913+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -79083,7 +79048,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:25.698239+00:00"
+                "validatedAt": "2026-07-20T14:35:58.749937+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -79167,7 +79132,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.166915+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.013017+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -79366,7 +79331,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:25.698306+00:00"
+                "validatedAt": "2026-07-20T14:35:58.749964+00:00"
               },
               "deterministic": true
             },
@@ -79378,9 +79343,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.166966+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.013045+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "not_present_header": {
             "allOf": [
@@ -79470,7 +79434,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:25.698351+00:00"
+                "validatedAt": "2026-07-20T14:35:58.749986+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -79685,7 +79649,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:25.698426+00:00"
+                "validatedAt": "2026-07-20T14:35:58.750019+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -79927,7 +79891,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:25.698528+00:00"
+                "validatedAt": "2026-07-20T14:35:58.750062+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -79998,7 +79962,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:25.698571+00:00"
+                "validatedAt": "2026-07-20T14:35:58.750085+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -80067,7 +80031,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:25.698622+00:00"
+                "validatedAt": "2026-07-20T14:35:58.750109+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -80100,7 +80064,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:25.698669+00:00"
+                "validatedAt": "2026-07-20T14:35:58.750128+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -80126,7 +80090,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.167122+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.013138+00:00"
           }
         },
         "x-f5xc-description-short": "Web Client Block request and respond with custom content.",
@@ -80273,7 +80237,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:25.698748+00:00"
+                "validatedAt": "2026-07-20T14:35:58.750162+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -80338,7 +80302,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.167166+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.013166+00:00"
           },
           "uri": {
             "type": "string",
@@ -80365,7 +80329,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:25.698781+00:00"
+                "validatedAt": "2026-07-20T14:35:58.750177+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -80516,7 +80480,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:25.698819+00:00"
+                "validatedAt": "2026-07-20T14:35:58.750193+00:00"
               },
               "deterministic": true
             },
@@ -80528,9 +80492,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.167207+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.013191+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -80561,7 +80524,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:25.698847+00:00"
+                "validatedAt": "2026-07-20T14:35:58.750206+00:00"
               },
               "deterministic": true
             },
@@ -80573,9 +80536,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.167226+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.013203+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "spec": {
             "allOf": [
@@ -80866,7 +80828,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.167309+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.013253+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -80952,7 +80914,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:25.698977+00:00"
+                "validatedAt": "2026-07-20T14:35:58.750257+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81034,7 +80996,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:56:25.699021+00:00"
+                "validatedAt": "2026-07-20T14:35:58.750276+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81113,7 +81075,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:56:25.699073+00:00"
+                "validatedAt": "2026-07-20T14:35:58.750298+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81124,7 +81086,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.167374+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.013292+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -81211,7 +81173,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:25.699113+00:00"
+                "validatedAt": "2026-07-20T14:35:58.750316+00:00"
               },
               "deterministic": true
             },
@@ -81223,9 +81185,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.167419+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.013321+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -81256,7 +81217,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:25.699139+00:00"
+                "validatedAt": "2026-07-20T14:35:58.750329+00:00"
               },
               "deterministic": true
             },
@@ -81268,9 +81229,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.167437+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.013333+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -81339,7 +81299,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:25.699191+00:00"
+                "validatedAt": "2026-07-20T14:35:58.750349+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81351,7 +81311,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.167474+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.013356+00:00"
           },
           "uid": {
             "type": "string",
@@ -81369,7 +81329,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:25.699216+00:00"
+                "validatedAt": "2026-07-20T14:35:58.750359+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81382,7 +81342,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.167493+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.013369+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of bot_endpoint_policy is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -81447,7 +81407,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:25.699255+00:00"
+                "validatedAt": "2026-07-20T14:35:58.750375+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -85188,7 +85148,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:25.700247+00:00"
+                "validatedAt": "2026-07-20T14:35:58.750771+00:00"
               },
               "deterministic": true
             },
@@ -85200,7 +85160,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.168477+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.013971+00:00"
           },
           "name": {
             "type": "string",
@@ -85244,7 +85204,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:25.700296+00:00"
+                "validatedAt": "2026-07-20T14:35:58.750796+00:00"
               },
               "deterministic": true
             },
@@ -85254,8 +85214,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "MessageMetaType is metadata (common attributes) of a message that only certain messages have.",
@@ -85351,7 +85310,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:25.701327+00:00"
+                "validatedAt": "2026-07-20T14:35:58.751233+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -86290,7 +86249,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:29.862070+00:00"
+                "validatedAt": "2026-07-20T14:36:00.380562+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -86338,7 +86297,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:29.862173+00:00"
+                "validatedAt": "2026-07-20T14:36:00.380607+00:00"
               },
               "deterministic": true
             },
@@ -86348,8 +86307,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -86389,7 +86347,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:29.862229+00:00"
+                "validatedAt": "2026-07-20T14:36:00.380637+00:00"
               },
               "deterministic": true
             },
@@ -86399,8 +86357,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "policy_metadata": {
             "type": "array",
@@ -86510,7 +86467,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:29.862302+00:00"
+                "validatedAt": "2026-07-20T14:36:00.380672+00:00"
               },
               "deterministic": true
             },
@@ -86520,8 +86477,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -86589,7 +86545,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:29.862366+00:00"
+                "validatedAt": "2026-07-20T14:36:00.380702+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -86598,8 +86554,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "policy_type": {
             "allOf": [
@@ -86629,7 +86584,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:29.862406+00:00"
+                "validatedAt": "2026-07-20T14:36:00.380719+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -86640,7 +86595,7 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.262918+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.073626+00:00"
           }
         },
         "x-f5xc-description-short": "The metadata for deployed policy config.",
@@ -86705,7 +86660,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:29.862451+00:00"
+                "validatedAt": "2026-07-20T14:36:00.380738+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -86751,7 +86706,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:29.862492+00:00"
+                "validatedAt": "2026-07-20T14:36:00.380756+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -86784,7 +86739,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:29.862537+00:00"
+                "validatedAt": "2026-07-20T14:36:00.380775+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -86818,7 +86773,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:29.862583+00:00"
+                "validatedAt": "2026-07-20T14:36:00.380793+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -86864,7 +86819,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:29.862615+00:00"
+                "validatedAt": "2026-07-20T14:36:00.380809+00:00"
               },
               "deterministic": true
             },
@@ -86876,9 +86831,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.262975+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.073661+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "policies": {
             "type": "array",
@@ -86927,7 +86881,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:29.862678+00:00"
+                "validatedAt": "2026-07-20T14:36:00.380831+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -87006,7 +86960,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:29.862738+00:00"
+                "validatedAt": "2026-07-20T14:36:00.380858+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -87030,7 +86984,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:29.862778+00:00"
+                "validatedAt": "2026-07-20T14:36:00.380875+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -87074,7 +87028,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:29.862824+00:00"
+                "validatedAt": "2026-07-20T14:36:00.380894+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -87085,7 +87039,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.263029+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.073695+00:00"
           },
           "timestamp": {
             "type": "string",
@@ -87110,7 +87064,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T12:56:29.862868+00:00"
+                "validatedAt": "2026-07-20T14:36:00.380913+00:00"
               },
               "deterministic": true
             },
@@ -87140,7 +87094,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:29.862896+00:00"
+                "validatedAt": "2026-07-20T14:36:00.380927+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -87400,7 +87354,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:29.862975+00:00"
+                "validatedAt": "2026-07-20T14:36:00.380959+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -87423,7 +87377,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:29.863019+00:00"
+                "validatedAt": "2026-07-20T14:36:00.380977+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -87447,7 +87401,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:29.863058+00:00"
+                "validatedAt": "2026-07-20T14:36:00.380993+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -87539,7 +87493,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:29.863119+00:00"
+                "validatedAt": "2026-07-20T14:36:00.381024+00:00"
               },
               "deterministic": true
             },
@@ -87638,7 +87592,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:29.863155+00:00"
+                "validatedAt": "2026-07-20T14:36:00.381041+00:00"
               },
               "deterministic": true
             },
@@ -87650,9 +87604,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.263123+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.073752+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "type": {
             "allOf": [
@@ -87687,7 +87640,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:29.863195+00:00"
+                "validatedAt": "2026-07-20T14:36:00.381057+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -87698,7 +87651,7 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.263148+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.073769+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -87863,7 +87816,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.263216+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.073811+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -87946,7 +87899,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:29.863319+00:00"
+                "validatedAt": "2026-07-20T14:36:00.381110+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -87977,7 +87930,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:29.863372+00:00"
+                "validatedAt": "2026-07-20T14:36:00.381136+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -88008,7 +87961,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:29.863417+00:00"
+                "validatedAt": "2026-07-20T14:36:00.381159+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -88080,7 +88033,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:29.863457+00:00"
+                "validatedAt": "2026-07-20T14:36:00.381180+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -88104,7 +88057,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:29.863497+00:00"
+                "validatedAt": "2026-07-20T14:36:00.381197+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -88161,7 +88114,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:29.863574+00:00"
+                "validatedAt": "2026-07-20T14:36:00.381231+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -88169,8 +88122,7 @@
               "create": false,
               "update": false,
               "read": false
-            },
-            "format": "hostname"
+            }
           },
           "ingress": {
             "type": "array",
@@ -88194,7 +88146,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:29.863612+00:00"
+                "validatedAt": "2026-07-20T14:36:00.381252+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -88298,7 +88250,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:29.863692+00:00"
+                "validatedAt": "2026-07-20T14:36:00.381279+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -88322,7 +88274,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:29.863734+00:00"
+                "validatedAt": "2026-07-20T14:36:00.381296+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -88396,7 +88348,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:29.863792+00:00"
+                "validatedAt": "2026-07-20T14:36:00.381323+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -88407,8 +88359,7 @@
             },
             "x-f5xc-conflicts-with": [
               "ip_address"
-            ],
-            "format": "hostname"
+            ]
           },
           "ip_address": {
             "type": "string",
@@ -88435,7 +88386,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:29.863848+00:00"
+                "validatedAt": "2026-07-20T14:36:00.381351+00:00"
               },
               "deterministic": true
             },
@@ -88539,7 +88490,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:56:29.863897+00:00"
+                "validatedAt": "2026-07-20T14:36:00.381372+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -88620,7 +88571,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:56:29.863952+00:00"
+                "validatedAt": "2026-07-20T14:36:00.381396+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -88631,7 +88582,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.263374+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.073908+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -88718,7 +88669,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:29.863999+00:00"
+                "validatedAt": "2026-07-20T14:36:00.381415+00:00"
               },
               "deterministic": true
             },
@@ -88730,9 +88681,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.263419+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.073937+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -88763,7 +88713,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:29.864027+00:00"
+                "validatedAt": "2026-07-20T14:36:00.381429+00:00"
               },
               "deterministic": true
             },
@@ -88775,9 +88725,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.263438+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.073950+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -88846,7 +88795,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:29.864079+00:00"
+                "validatedAt": "2026-07-20T14:36:00.381450+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -88858,7 +88807,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.263476+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.073974+00:00"
           },
           "uid": {
             "type": "string",
@@ -88876,7 +88825,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:29.864105+00:00"
+                "validatedAt": "2026-07-20T14:36:00.381461+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -88889,7 +88838,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.263496+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.073987+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of bot_infrastructure is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -88977,7 +88926,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:29.864136+00:00"
+                "validatedAt": "2026-07-20T14:36:00.381476+00:00"
               },
               "deterministic": true
             },
@@ -88989,9 +88938,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.263516+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.074000+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "version": {
             "type": "string",
@@ -89013,7 +88961,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:29.864173+00:00"
+                "validatedAt": "2026-07-20T14:36:00.381492+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89024,7 +88972,7 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.263535+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.074013+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -89128,7 +89076,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:29.864212+00:00"
+                "validatedAt": "2026-07-20T14:36:00.381508+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89160,7 +89108,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:29.864251+00:00"
+                "validatedAt": "2026-07-20T14:36:00.381547+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89416,7 +89364,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:29.864352+00:00"
+                "validatedAt": "2026-07-20T14:36:00.381598+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89450,7 +89398,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:29.864413+00:00"
+                "validatedAt": "2026-07-20T14:36:00.381629+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89490,7 +89438,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:29.864441+00:00"
+                "validatedAt": "2026-07-20T14:36:00.381646+00:00"
               },
               "deterministic": true
             },
@@ -89502,9 +89450,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.263620+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.074065+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "request_body": {
             "allOf": [
@@ -89578,7 +89525,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:56:29.864475+00:00"
+                "validatedAt": "2026-07-20T14:36:00.381663+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89645,7 +89592,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:56:29.864521+00:00"
+                "validatedAt": "2026-07-20T14:36:00.381685+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89656,7 +89603,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.263663+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.074088+00:00"
           },
           "ref_value": {
             "allOf": [
@@ -89698,7 +89645,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:29.864561+00:00"
+                "validatedAt": "2026-07-20T14:36:00.381702+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89727,7 +89674,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:29.864594+00:00"
+                "validatedAt": "2026-07-20T14:36:00.381716+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89738,7 +89685,7 @@
             },
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.263696+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.074109+00:00"
           },
           "value": {
             "type": "string",
@@ -89754,7 +89701,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:29.864627+00:00"
+                "validatedAt": "2026-07-20T14:36:00.381730+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89765,7 +89712,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.263715+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.074122+00:00"
           }
         },
         "x-f5xc-description-short": "Tuple with a suggested value and it's description.",
@@ -89831,7 +89778,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:29.864673+00:00"
+                "validatedAt": "2026-07-20T14:36:00.381747+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89907,7 +89854,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:33.439793+00:00"
+                "validatedAt": "2026-07-20T14:36:01.778084+00:00"
               },
               "deterministic": true
             },
@@ -89919,9 +89866,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.313577+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.107328+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -89952,7 +89898,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:33.439843+00:00"
+                "validatedAt": "2026-07-20T14:36:01.778105+00:00"
               },
               "deterministic": true
             },
@@ -89964,9 +89910,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.313599+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.107342+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "spec": {
             "allOf": [
@@ -90257,7 +90202,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.313698+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.107395+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -90342,7 +90287,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:33.439988+00:00"
+                "validatedAt": "2026-07-20T14:36:01.778164+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -90424,7 +90369,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:56:33.440034+00:00"
+                "validatedAt": "2026-07-20T14:36:01.778187+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -90503,7 +90448,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:56:33.440089+00:00"
+                "validatedAt": "2026-07-20T14:36:01.778214+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -90514,7 +90459,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.313766+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.107435+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -90601,7 +90546,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:33.440131+00:00"
+                "validatedAt": "2026-07-20T14:36:01.778235+00:00"
               },
               "deterministic": true
             },
@@ -90613,9 +90558,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.313812+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.107464+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -90646,7 +90590,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:33.440160+00:00"
+                "validatedAt": "2026-07-20T14:36:01.778250+00:00"
               },
               "deterministic": true
             },
@@ -90658,9 +90602,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.313830+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.107477+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -90729,7 +90672,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:33.440212+00:00"
+                "validatedAt": "2026-07-20T14:36:01.778273+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -90741,7 +90684,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.313869+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.107501+00:00"
           },
           "uid": {
             "type": "string",
@@ -90759,7 +90702,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:33.440237+00:00"
+                "validatedAt": "2026-07-20T14:36:01.778284+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -90772,7 +90715,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.313889+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.107514+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of bot_allowlist_policy is returned in 'List'.",
@@ -90837,7 +90780,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:33.440277+00:00"
+                "validatedAt": "2026-07-20T14:36:01.778302+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -91273,7 +91216,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:33.440405+00:00"
+                "validatedAt": "2026-07-20T14:36:01.778365+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -91306,7 +91249,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:33.440447+00:00"
+                "validatedAt": "2026-07-20T14:36:01.778388+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -91368,7 +91311,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:33.440487+00:00"
+                "validatedAt": "2026-07-20T14:36:01.778406+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -91404,7 +91347,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:33.440547+00:00"
+                "validatedAt": "2026-07-20T14:36:01.778439+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -91466,7 +91409,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:33.440589+00:00"
+                "validatedAt": "2026-07-20T14:36:01.778457+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -91501,7 +91444,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:33.440627+00:00"
+                "validatedAt": "2026-07-20T14:36:01.778474+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -91576,7 +91519,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:33.440693+00:00"
+                "validatedAt": "2026-07-20T14:36:01.778503+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -91599,7 +91542,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:33.440736+00:00"
+                "validatedAt": "2026-07-20T14:36:01.778521+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -91635,7 +91578,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:33.440794+00:00"
+                "validatedAt": "2026-07-20T14:36:01.778551+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -91703,7 +91646,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:56:35.671522+00:00"
+                "validatedAt": "2026-07-20T14:36:02.743446+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -91714,7 +91657,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.352721+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.130965+00:00"
           },
           "name": {
             "type": "string",
@@ -91744,7 +91687,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:35.671550+00:00"
+                "validatedAt": "2026-07-20T14:36:02.743461+00:00"
               },
               "deterministic": true
             },
@@ -91756,9 +91699,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.352741+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.130978+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Cookie name and description records for endpoint policies.",
@@ -91863,7 +91805,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:35.671984+00:00"
+                "validatedAt": "2026-07-20T14:36:02.743663+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -91897,7 +91839,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:35.672023+00:00"
+                "validatedAt": "2026-07-20T14:36:02.743685+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -91921,7 +91863,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:35.672059+00:00"
+                "validatedAt": "2026-07-20T14:36:02.743701+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -92027,7 +91969,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:35.673815+00:00"
+                "validatedAt": "2026-07-20T14:36:02.744849+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -92145,7 +92087,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:35.673925+00:00"
+                "validatedAt": "2026-07-20T14:36:02.744931+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -92184,7 +92126,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:35.673952+00:00"
+                "validatedAt": "2026-07-20T14:36:02.744946+00:00"
               },
               "deterministic": true
             },
@@ -92196,9 +92138,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.353982+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.131726+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -92277,7 +92218,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:39.749562+00:00"
+                "validatedAt": "2026-07-20T14:36:04.420418+00:00"
               },
               "deterministic": true
             },
@@ -92288,8 +92229,7 @@
               "read": false
             },
             "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "minLength": 1,
-            "format": "hostname"
+            "minLength": 1
           },
           "http": {
             "allOf": [
@@ -92347,7 +92287,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:39.749629+00:00"
+                "validatedAt": "2026-07-20T14:36:04.420445+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -92384,7 +92324,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:39.749688+00:00"
+                "validatedAt": "2026-07-20T14:36:04.420465+00:00"
               },
               "deterministic": true
             },
@@ -92496,7 +92436,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:39.749745+00:00"
+                "validatedAt": "2026-07-20T14:36:04.420492+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -92646,7 +92586,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:39.749997+00:00"
+                "validatedAt": "2026-07-20T14:36:04.420601+00:00"
               },
               "deterministic": true
             },
@@ -92657,8 +92597,7 @@
               "read": false
             },
             "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "minLength": 1,
-            "format": "hostname"
+            "minLength": 1
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -92721,7 +92660,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:39.750042+00:00"
+                "validatedAt": "2026-07-20T14:36:04.420624+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -92797,7 +92736,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:39.750073+00:00"
+                "validatedAt": "2026-07-20T14:36:04.420639+00:00"
               },
               "deterministic": true
             },
@@ -92809,9 +92748,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.452841+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.193291+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -92842,7 +92780,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:39.750103+00:00"
+                "validatedAt": "2026-07-20T14:36:04.420653+00:00"
               },
               "deterministic": true
             },
@@ -92854,9 +92792,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.452862+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.193305+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "spec": {
             "allOf": [
@@ -93159,7 +93096,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.452947+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.193354+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -93230,7 +93167,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:39.750232+00:00"
+                "validatedAt": "2026-07-20T14:36:04.420704+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -93342,7 +93279,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:56:39.750279+00:00"
+                "validatedAt": "2026-07-20T14:36:04.420726+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -93421,7 +93358,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:56:39.750333+00:00"
+                "validatedAt": "2026-07-20T14:36:04.420750+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -93432,7 +93369,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.453012+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.193393+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -93519,7 +93456,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:39.750374+00:00"
+                "validatedAt": "2026-07-20T14:36:04.420769+00:00"
               },
               "deterministic": true
             },
@@ -93531,9 +93468,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.453058+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.193420+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -93564,7 +93500,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:39.750402+00:00"
+                "validatedAt": "2026-07-20T14:36:04.420783+00:00"
               },
               "deterministic": true
             },
@@ -93576,9 +93512,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.453076+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.193432+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -93647,7 +93582,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:39.750455+00:00"
+                "validatedAt": "2026-07-20T14:36:04.420805+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -93659,7 +93594,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.453114+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.193456+00:00"
           },
           "uid": {
             "type": "string",
@@ -93677,7 +93612,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:39.750480+00:00"
+                "validatedAt": "2026-07-20T14:36:04.420816+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -93690,7 +93625,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:09.453134+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.193471+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of bot_network_policy is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -93755,7 +93690,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:39.750519+00:00"
+                "validatedAt": "2026-07-20T14:36:04.420832+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -94237,7 +94172,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.131955+00:00"
+                "validatedAt": "2026-07-20T14:36:24.781454+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -94313,7 +94248,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.131999+00:00"
+                "validatedAt": "2026-07-20T14:36:24.781474+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -94377,7 +94312,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.132044+00:00"
+                "validatedAt": "2026-07-20T14:36:24.781491+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -94402,7 +94337,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.132083+00:00"
+                "validatedAt": "2026-07-20T14:36:24.781507+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -94428,7 +94363,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.132121+00:00"
+                "validatedAt": "2026-07-20T14:36:24.781523+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -94463,7 +94398,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:30.132190+00:00"
+                "validatedAt": "2026-07-20T14:36:24.781558+00:00"
               },
               "deterministic": true
             },
@@ -94490,7 +94425,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.132229+00:00"
+                "validatedAt": "2026-07-20T14:36:24.781574+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -94515,7 +94450,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.132266+00:00"
+                "validatedAt": "2026-07-20T14:36:24.781589+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -94607,7 +94542,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:30.132319+00:00"
+                "validatedAt": "2026-07-20T14:36:24.781616+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -94791,7 +94726,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:30.132384+00:00"
+                "validatedAt": "2026-07-20T14:36:24.781646+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -94894,7 +94829,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:30.132433+00:00"
+                "validatedAt": "2026-07-20T14:36:24.781670+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -94971,7 +94906,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.132476+00:00"
+                "validatedAt": "2026-07-20T14:36:24.781687+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -94997,7 +94932,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.132509+00:00"
+                "validatedAt": "2026-07-20T14:36:24.781699+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -95008,7 +94943,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.486257+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.996308+00:00"
           }
         },
         "x-f5xc-description-short": "Analysis of the form field by Client Side Defense.",
@@ -95065,7 +95000,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.132545+00:00"
+                "validatedAt": "2026-07-20T14:36:24.781714+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -95091,7 +95026,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.132583+00:00"
+                "validatedAt": "2026-07-20T14:36:24.781730+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -95117,7 +95052,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.132619+00:00"
+                "validatedAt": "2026-07-20T14:36:24.781744+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -95156,7 +95091,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:30.132650+00:00"
+                "validatedAt": "2026-07-20T14:36:24.781760+00:00"
               },
               "deterministic": true
             },
@@ -95168,9 +95103,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.486299+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.996335+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "recommendation": {
             "type": "string",
@@ -95188,7 +95122,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.132701+00:00"
+                "validatedAt": "2026-07-20T14:36:24.781778+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -95214,7 +95148,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.132739+00:00"
+                "validatedAt": "2026-07-20T14:36:24.781794+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -95357,7 +95291,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:30.132809+00:00"
+                "validatedAt": "2026-07-20T14:36:24.781824+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -95437,7 +95371,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.132851+00:00"
+                "validatedAt": "2026-07-20T14:36:24.781841+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -95462,7 +95396,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.132886+00:00"
+                "validatedAt": "2026-07-20T14:36:24.781856+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -95487,7 +95421,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.132920+00:00"
+                "validatedAt": "2026-07-20T14:36:24.781871+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -95499,7 +95433,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.486369+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.996377+00:00"
           },
           "firstSeenDate": {
             "type": "string",
@@ -95518,7 +95452,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.132959+00:00"
+                "validatedAt": "2026-07-20T14:36:24.781887+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -95545,7 +95479,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.132999+00:00"
+                "validatedAt": "2026-07-20T14:36:24.781904+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -95620,7 +95554,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.133072+00:00"
+                "validatedAt": "2026-07-20T14:36:24.781933+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -95631,7 +95565,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.486421+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.996409+00:00"
           }
         },
         "x-f5xc-description-short": "Client-Side defense usage details per domain.",
@@ -95852,7 +95786,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T12:57:30.133143+00:00"
+                "validatedAt": "2026-07-20T14:36:24.781962+00:00"
               },
               "deterministic": true
             },
@@ -96129,7 +96063,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.133243+00:00"
+                "validatedAt": "2026-07-20T14:36:24.782001+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -96156,7 +96090,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.133267+00:00"
+                "validatedAt": "2026-07-20T14:36:24.782011+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -96182,7 +96116,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.133304+00:00"
+                "validatedAt": "2026-07-20T14:36:24.782026+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -96239,7 +96173,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:30.133346+00:00"
+                "validatedAt": "2026-07-20T14:36:24.782045+00:00"
               },
               "deterministic": true
             },
@@ -96251,9 +96185,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.486572+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.996498+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -96338,7 +96271,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:30.133395+00:00"
+                "validatedAt": "2026-07-20T14:36:24.782069+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -96417,7 +96350,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.133438+00:00"
+                "validatedAt": "2026-07-20T14:36:24.782087+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -96444,7 +96377,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.133464+00:00"
+                "validatedAt": "2026-07-20T14:36:24.782098+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -96470,7 +96403,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.133500+00:00"
+                "validatedAt": "2026-07-20T14:36:24.782114+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -96509,7 +96442,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:30.133527+00:00"
+                "validatedAt": "2026-07-20T14:36:24.782127+00:00"
               },
               "deterministic": true
             },
@@ -96521,9 +96454,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.486628+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.996532+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "risk_level": {
             "type": "string",
@@ -96541,7 +96473,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.133565+00:00"
+                "validatedAt": "2026-07-20T14:36:24.782142+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -96633,7 +96565,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:30.133611+00:00"
+                "validatedAt": "2026-07-20T14:36:24.782166+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -96881,7 +96813,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:42.589573+00:00"
+                "validatedAt": "2026-07-20T14:36:30.097753+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -97013,7 +96945,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.133695+00:00"
+                "validatedAt": "2026-07-20T14:36:24.782196+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -97038,7 +96970,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.133744+00:00"
+                "validatedAt": "2026-07-20T14:36:24.782210+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -97063,7 +96995,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.133799+00:00"
+                "validatedAt": "2026-07-20T14:36:24.782224+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -97075,7 +97007,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.486736+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.996590+00:00"
           },
           "firstSeenDate": {
             "type": "string",
@@ -97094,7 +97026,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.133858+00:00"
+                "validatedAt": "2026-07-20T14:36:24.782241+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -97121,7 +97053,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.133898+00:00"
+                "validatedAt": "2026-07-20T14:36:24.782257+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -97196,7 +97128,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.133976+00:00"
+                "validatedAt": "2026-07-20T14:36:24.782284+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -97207,7 +97139,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.486787+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.996622+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -97289,7 +97221,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.134018+00:00"
+                "validatedAt": "2026-07-20T14:36:24.782300+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -97328,7 +97260,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:30.134048+00:00"
+                "validatedAt": "2026-07-20T14:36:24.782314+00:00"
               },
               "deterministic": true
             },
@@ -97340,9 +97272,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.486821+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.996642+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -97400,7 +97331,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.134086+00:00"
+                "validatedAt": "2026-07-20T14:36:24.782329+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -97711,7 +97642,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:30.134204+00:00"
+                "validatedAt": "2026-07-20T14:36:24.782378+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -97810,7 +97741,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:30.134266+00:00"
+                "validatedAt": "2026-07-20T14:36:24.782417+00:00"
               },
               "deterministic": true
             },
@@ -97850,7 +97781,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:30.134295+00:00"
+                "validatedAt": "2026-07-20T14:36:24.782430+00:00"
               },
               "deterministic": true
             },
@@ -97862,9 +97793,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.486919+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.996701+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "serviceType": {
             "type": "string",
@@ -97887,7 +97817,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.134336+00:00"
+                "validatedAt": "2026-07-20T14:36:24.782447+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -98008,7 +97938,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.134382+00:00"
+                "validatedAt": "2026-07-20T14:36:24.782465+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -98033,7 +97963,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.134423+00:00"
+                "validatedAt": "2026-07-20T14:36:24.782481+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -98058,7 +97988,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.134465+00:00"
+                "validatedAt": "2026-07-20T14:36:24.782499+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -98084,7 +98014,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.134501+00:00"
+                "validatedAt": "2026-07-20T14:36:24.782512+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -98162,7 +98092,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.134540+00:00"
+                "validatedAt": "2026-07-20T14:36:24.782528+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -98214,7 +98144,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:30.134571+00:00"
+                "validatedAt": "2026-07-20T14:36:24.782545+00:00"
               },
               "deterministic": true
             },
@@ -98226,9 +98156,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.486994+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.996746+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "page_number": {
             "type": "integer",
@@ -98300,7 +98229,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:30.134672+00:00"
+                "validatedAt": "2026-07-20T14:36:24.782591+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -98332,7 +98261,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.134714+00:00"
+                "validatedAt": "2026-07-20T14:36:24.782610+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -98385,7 +98314,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.134765+00:00"
+                "validatedAt": "2026-07-20T14:36:24.782632+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -98473,7 +98402,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.134821+00:00"
+                "validatedAt": "2026-07-20T14:36:24.782656+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -98690,7 +98619,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.134950+00:00"
+                "validatedAt": "2026-07-20T14:36:24.782708+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -98701,7 +98630,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.487115+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.996817+00:00"
           },
           "total_size": {
             "type": "integer",
@@ -98852,7 +98781,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.135030+00:00"
+                "validatedAt": "2026-07-20T14:36:24.782741+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -98904,7 +98833,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:30.135062+00:00"
+                "validatedAt": "2026-07-20T14:36:24.782758+00:00"
               },
               "deterministic": true
             },
@@ -98916,9 +98845,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.487169+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.996850+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "page_number": {
             "type": "integer",
@@ -98969,7 +98897,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.135124+00:00"
+                "validatedAt": "2026-07-20T14:36:24.782784+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -99019,7 +98947,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.135176+00:00"
+                "validatedAt": "2026-07-20T14:36:24.782805+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -99107,7 +99035,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.135232+00:00"
+                "validatedAt": "2026-07-20T14:36:24.782828+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -99325,7 +99253,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.135367+00:00"
+                "validatedAt": "2026-07-20T14:36:24.782882+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -99480,7 +99408,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.135469+00:00"
+                "validatedAt": "2026-07-20T14:36:24.782924+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -99532,7 +99460,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:30.135502+00:00"
+                "validatedAt": "2026-07-20T14:36:24.782941+00:00"
               },
               "deterministic": true
             },
@@ -99544,9 +99472,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.487333+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.996949+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "page_number": {
             "type": "integer",
@@ -99597,7 +99524,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.135565+00:00"
+                "validatedAt": "2026-07-20T14:36:24.782966+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -99646,7 +99573,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.135615+00:00"
+                "validatedAt": "2026-07-20T14:36:24.782986+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -99717,7 +99644,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.135666+00:00"
+                "validatedAt": "2026-07-20T14:36:24.783003+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -99865,7 +99792,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.135769+00:00"
+                "validatedAt": "2026-07-20T14:36:24.783042+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -99891,7 +99818,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.135807+00:00"
+                "validatedAt": "2026-07-20T14:36:24.783058+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -99930,7 +99857,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:30.135835+00:00"
+                "validatedAt": "2026-07-20T14:36:24.783073+00:00"
               },
               "deterministic": true
             },
@@ -99942,9 +99869,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.487440+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.997012+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "risk_level": {
             "type": "string",
@@ -99961,7 +99887,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.135871+00:00"
+                "validatedAt": "2026-07-20T14:36:24.783088+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -99986,7 +99912,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.135905+00:00"
+                "validatedAt": "2026-07-20T14:36:24.783102+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -99997,7 +99923,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.487464+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.997028+00:00"
           }
         },
         "x-f5xc-description-short": "Network interaction information by script.",
@@ -100090,7 +100016,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:30.135956+00:00"
+                "validatedAt": "2026-07-20T14:36:24.783127+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -100170,7 +100096,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.136009+00:00"
+                "validatedAt": "2026-07-20T14:36:24.783153+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -100211,7 +100137,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.136047+00:00"
+                "validatedAt": "2026-07-20T14:36:24.783168+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -100253,7 +100179,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.136097+00:00"
+                "validatedAt": "2026-07-20T14:36:24.783188+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -100323,7 +100249,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.136174+00:00"
+                "validatedAt": "2026-07-20T14:36:24.783219+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -100348,7 +100274,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.136212+00:00"
+                "validatedAt": "2026-07-20T14:36:24.783234+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -100373,7 +100299,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.136245+00:00"
+                "validatedAt": "2026-07-20T14:36:24.783247+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -100384,7 +100310,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.487569+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.997091+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -100487,7 +100413,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:30.136296+00:00"
+                "validatedAt": "2026-07-20T14:36:24.783271+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -100589,7 +100515,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:30.136347+00:00"
+                "validatedAt": "2026-07-20T14:36:24.783294+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -100654,7 +100580,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.136379+00:00"
+                "validatedAt": "2026-07-20T14:36:24.783307+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -100731,7 +100657,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.136418+00:00"
+                "validatedAt": "2026-07-20T14:36:24.783322+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -100743,7 +100669,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.487633+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.997130+00:00"
           },
           "first_seen": {
             "type": "string",
@@ -100761,7 +100687,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.136455+00:00"
+                "validatedAt": "2026-07-20T14:36:24.783339+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -100787,7 +100713,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.136492+00:00"
+                "validatedAt": "2026-07-20T14:36:24.783353+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -100812,7 +100738,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.136529+00:00"
+                "validatedAt": "2026-07-20T14:36:24.783368+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -100837,7 +100763,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.136559+00:00"
+                "validatedAt": "2026-07-20T14:36:24.783380+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -100915,7 +100841,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:30.136617+00:00"
+                "validatedAt": "2026-07-20T14:36:24.783407+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -100927,7 +100853,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.487689+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.997159+00:00"
           },
           "namespace": {
             "type": "string",
@@ -100958,7 +100884,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:30.136646+00:00"
+                "validatedAt": "2026-07-20T14:36:24.783421+00:00"
               },
               "deterministic": true
             },
@@ -100970,9 +100896,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.487709+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.997171+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "pageURL": {
             "type": "string",
@@ -100997,7 +100922,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:30.136708+00:00"
+                "validatedAt": "2026-07-20T14:36:24.783446+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -101063,7 +100988,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.136744+00:00"
+                "validatedAt": "2026-07-20T14:36:24.783461+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -101089,7 +101014,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.487743+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.997193+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -101236,7 +101161,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:30.136783+00:00"
+                "validatedAt": "2026-07-20T14:36:24.783479+00:00"
               },
               "deterministic": true
             },
@@ -101248,9 +101173,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.487778+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.997214+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -101364,7 +101288,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:30.136814+00:00"
+                "validatedAt": "2026-07-20T14:36:24.783494+00:00"
               },
               "deterministic": true
             },
@@ -101376,9 +101300,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.487799+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.997227+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -101409,7 +101332,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:30.136842+00:00"
+                "validatedAt": "2026-07-20T14:36:24.783509+00:00"
               },
               "deterministic": true
             },
@@ -101421,9 +101344,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.487817+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.997239+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "type": {
             "allOf": [
@@ -101492,7 +101414,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.136879+00:00"
+                "validatedAt": "2026-07-20T14:36:24.783524+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -101503,7 +101425,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.487844+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.997256+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -101565,7 +101487,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.136920+00:00"
+                "validatedAt": "2026-07-20T14:36:24.783542+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -101604,7 +101526,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:30.136949+00:00"
+                "validatedAt": "2026-07-20T14:36:24.783556+00:00"
               },
               "deterministic": true
             },
@@ -101616,9 +101538,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.487870+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.997273+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "script_id": {
             "type": "string",
@@ -101642,7 +101563,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.136987+00:00"
+                "validatedAt": "2026-07-20T14:36:24.783572+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -101676,7 +101597,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.137025+00:00"
+                "validatedAt": "2026-07-20T14:36:24.783588+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -101743,7 +101664,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.137066+00:00"
+                "validatedAt": "2026-07-20T14:36:24.783604+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -101816,7 +101737,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.137093+00:00"
+                "validatedAt": "2026-07-20T14:36:24.783615+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -101855,7 +101776,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:30.137121+00:00"
+                "validatedAt": "2026-07-20T14:36:24.783630+00:00"
               },
               "deterministic": true
             },
@@ -101867,9 +101788,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.487918+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.997302+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "type": {
             "allOf": [
@@ -101941,7 +101861,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.137149+00:00"
+                "validatedAt": "2026-07-20T14:36:24.783642+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -101966,7 +101886,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.137188+00:00"
+                "validatedAt": "2026-07-20T14:36:24.783659+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -101992,7 +101912,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.137220+00:00"
+                "validatedAt": "2026-07-20T14:36:24.783672+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -102003,7 +101923,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.487957+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.997326+00:00"
           }
         },
         "x-f5xc-description-short": "Payload about status of script read status result.",
@@ -102063,7 +101983,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:57:30.137256+00:00"
+                "validatedAt": "2026-07-20T14:36:24.783690+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -102090,7 +102010,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.137293+00:00"
+                "validatedAt": "2026-07-20T14:36:24.783705+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -102212,7 +102132,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:30.137343+00:00"
+                "validatedAt": "2026-07-20T14:36:24.783725+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -102223,7 +102143,7 @@
             },
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.487999+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.997352+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -102437,7 +102357,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:32.052091+00:00"
+                "validatedAt": "2026-07-20T14:36:25.546699+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -102445,8 +102365,7 @@
               "create": true,
               "update": false,
               "read": false
-            },
-            "format": "hostname"
+            }
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -102530,7 +102449,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:32.052148+00:00"
+                "validatedAt": "2026-07-20T14:36:25.546723+00:00"
               },
               "deterministic": true
             },
@@ -102542,9 +102461,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.543917+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.035001+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -102576,7 +102494,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:32.052197+00:00"
+                "validatedAt": "2026-07-20T14:36:25.546738+00:00"
               },
               "deterministic": true
             },
@@ -102588,9 +102506,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.543938+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.035014+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -102739,7 +102656,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.543998+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.035051+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -102829,7 +102746,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:32.052340+00:00"
+                "validatedAt": "2026-07-20T14:36:25.546797+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -102837,8 +102754,7 @@
               "create": true,
               "update": false,
               "read": false
-            },
-            "format": "hostname"
+            }
           },
           "date_added": {
             "type": "string",
@@ -102856,7 +102772,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:32.052379+00:00"
+                "validatedAt": "2026-07-20T14:36:25.546814+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -102938,7 +102854,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:57:32.052426+00:00"
+                "validatedAt": "2026-07-20T14:36:25.546836+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -103017,7 +102933,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:57:32.052482+00:00"
+                "validatedAt": "2026-07-20T14:36:25.546860+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -103028,7 +102944,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.544065+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.035090+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -103115,7 +103031,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:32.052523+00:00"
+                "validatedAt": "2026-07-20T14:36:25.546879+00:00"
               },
               "deterministic": true
             },
@@ -103127,9 +103043,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.544110+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.035118+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -103160,7 +103075,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:32.052550+00:00"
+                "validatedAt": "2026-07-20T14:36:25.546893+00:00"
               },
               "deterministic": true
             },
@@ -103172,9 +103087,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.544129+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.035130+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -103243,7 +103157,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:32.052606+00:00"
+                "validatedAt": "2026-07-20T14:36:25.546915+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -103255,7 +103169,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.544167+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.035153+00:00"
           },
           "uid": {
             "type": "string",
@@ -103272,7 +103186,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:32.052633+00:00"
+                "validatedAt": "2026-07-20T14:36:25.546926+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -103285,7 +103199,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.544187+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.035166+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of allowed_domain is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -103593,7 +103507,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:36.258838+00:00"
+                "validatedAt": "2026-07-20T14:36:27.254684+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -103685,7 +103599,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:36.258887+00:00"
+                "validatedAt": "2026-07-20T14:36:27.254708+00:00"
               },
               "deterministic": true
             },
@@ -103697,9 +103611,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.633501+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.123607+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -103731,7 +103644,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:36.258933+00:00"
+                "validatedAt": "2026-07-20T14:36:27.254722+00:00"
               },
               "deterministic": true
             },
@@ -103743,9 +103656,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.633521+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.123620+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -103894,7 +103806,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.633583+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.123657+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -103969,7 +103881,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:36.259092+00:00"
+                "validatedAt": "2026-07-20T14:36:27.254768+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -104009,7 +103921,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:36.259209+00:00"
+                "validatedAt": "2026-07-20T14:36:27.254799+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -104091,7 +104003,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:57:36.259259+00:00"
+                "validatedAt": "2026-07-20T14:36:27.254820+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -104170,7 +104082,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:57:36.259315+00:00"
+                "validatedAt": "2026-07-20T14:36:27.254844+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -104181,7 +104093,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.633651+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.123695+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -104268,7 +104180,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:36.259358+00:00"
+                "validatedAt": "2026-07-20T14:36:27.254863+00:00"
               },
               "deterministic": true
             },
@@ -104280,9 +104192,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.633719+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.123723+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -104313,7 +104224,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:36.259386+00:00"
+                "validatedAt": "2026-07-20T14:36:27.254876+00:00"
               },
               "deterministic": true
             },
@@ -104325,9 +104236,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.633738+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.123735+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -104396,7 +104306,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:36.259442+00:00"
+                "validatedAt": "2026-07-20T14:36:27.254898+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -104408,7 +104318,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.633776+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.123759+00:00"
           },
           "uid": {
             "type": "string",
@@ -104426,7 +104336,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:36.259468+00:00"
+                "validatedAt": "2026-07-20T14:36:27.254909+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -104439,7 +104349,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.633795+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.123772+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of protected_domain is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -104748,7 +104658,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:40.176153+00:00"
+                "validatedAt": "2026-07-20T14:36:29.006339+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -104756,8 +104666,7 @@
               "create": true,
               "update": false,
               "read": false
-            },
-            "format": "hostname"
+            }
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -104841,7 +104750,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:40.176221+00:00"
+                "validatedAt": "2026-07-20T14:36:29.006365+00:00"
               },
               "deterministic": true
             },
@@ -104853,9 +104762,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.698757+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.198387+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -104887,7 +104795,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:40.176268+00:00"
+                "validatedAt": "2026-07-20T14:36:29.006381+00:00"
               },
               "deterministic": true
             },
@@ -104899,9 +104807,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.698778+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.198401+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -105050,7 +104957,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.698840+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.198437+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -105126,7 +105033,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:40.176386+00:00"
+                "validatedAt": "2026-07-20T14:36:29.006427+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -105167,7 +105074,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:40.176452+00:00"
+                "validatedAt": "2026-07-20T14:36:29.006460+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -105175,8 +105082,7 @@
               "create": true,
               "update": false,
               "read": false
-            },
-            "format": "hostname"
+            }
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -105250,7 +105156,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:57:40.176500+00:00"
+                "validatedAt": "2026-07-20T14:36:29.006484+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -105329,7 +105235,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:57:40.176555+00:00"
+                "validatedAt": "2026-07-20T14:36:29.006511+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -105340,7 +105246,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.698906+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.198477+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -105427,7 +105333,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:40.176597+00:00"
+                "validatedAt": "2026-07-20T14:36:29.006531+00:00"
               },
               "deterministic": true
             },
@@ -105439,9 +105345,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.698952+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.198505+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -105472,7 +105377,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:40.176625+00:00"
+                "validatedAt": "2026-07-20T14:36:29.006546+00:00"
               },
               "deterministic": true
             },
@@ -105484,9 +105389,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.698971+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.198517+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -105555,7 +105459,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:40.176688+00:00"
+                "validatedAt": "2026-07-20T14:36:29.006569+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -105567,7 +105471,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.699009+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.198541+00:00"
           },
           "uid": {
             "type": "string",
@@ -105585,7 +105489,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:40.176715+00:00"
+                "validatedAt": "2026-07-20T14:36:29.006581+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -105598,7 +105502,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.699029+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.198554+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of mitigated_domain is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -105749,7 +105653,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:42.590866+00:00"
+                "validatedAt": "2026-07-20T14:36:30.098296+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -105775,7 +105679,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:42.590903+00:00"
+                "validatedAt": "2026-07-20T14:36:30.098311+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -105801,7 +105705,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:42.590940+00:00"
+                "validatedAt": "2026-07-20T14:36:30.098326+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -105840,7 +105744,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:42.590971+00:00"
+                "validatedAt": "2026-07-20T14:36:30.098341+00:00"
               },
               "deterministic": true
             },
@@ -105852,9 +105756,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.737255+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.227174+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "page_number": {
             "type": "integer",
@@ -105903,7 +105806,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:42.591033+00:00"
+                "validatedAt": "2026-07-20T14:36:30.098367+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -105935,7 +105838,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:42.591067+00:00"
+                "validatedAt": "2026-07-20T14:36:30.098381+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -105961,7 +105864,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:42.591105+00:00"
+                "validatedAt": "2026-07-20T14:36:30.098398+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -106092,7 +105995,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:42.591172+00:00"
+                "validatedAt": "2026-07-20T14:36:30.098425+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -106487,7 +106390,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:21.043738+00:00"
+                "validatedAt": "2026-07-20T14:37:33.515263+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -106671,7 +106574,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:21.043835+00:00"
+                "validatedAt": "2026-07-20T14:37:33.515333+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -107014,7 +106917,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:21.043933+00:00"
+                "validatedAt": "2026-07-20T14:37:33.515411+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -107221,7 +107124,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T13:00:21.043991+00:00"
+                "validatedAt": "2026-07-20T14:37:33.515456+00:00"
               },
               "deterministic": true
             },
@@ -107273,7 +107176,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:21.044027+00:00"
+                "validatedAt": "2026-07-20T14:37:33.515485+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -107389,7 +107292,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:21.044067+00:00"
+                "validatedAt": "2026-07-20T14:37:33.515517+00:00"
               },
               "deterministic": true
             },
@@ -107401,9 +107304,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.481016+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.023647+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -107435,7 +107337,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:21.044096+00:00"
+                "validatedAt": "2026-07-20T14:37:33.515543+00:00"
               },
               "deterministic": true
             },
@@ -107447,9 +107349,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.481035+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.023660+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -107536,7 +107437,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:21.044172+00:00"
+                "validatedAt": "2026-07-20T14:37:33.515609+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -107747,7 +107648,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.481129+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.023717+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -107876,7 +107777,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:21.044317+00:00"
+                "validatedAt": "2026-07-20T14:37:33.515721+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -107910,7 +107811,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:21.044359+00:00"
+                "validatedAt": "2026-07-20T14:37:33.515754+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -107937,7 +107838,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:21.044404+00:00"
+                "validatedAt": "2026-07-20T14:37:33.515788+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -108006,7 +107907,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:21.044448+00:00"
+                "validatedAt": "2026-07-20T14:37:33.515821+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -108040,7 +107941,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:21.044491+00:00"
+                "validatedAt": "2026-07-20T14:37:33.515854+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -108263,7 +108164,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:21.044562+00:00"
+                "validatedAt": "2026-07-20T14:37:33.515916+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -108370,7 +108271,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:21.044626+00:00"
+                "validatedAt": "2026-07-20T14:37:33.515971+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -108455,7 +108356,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:00:21.044688+00:00"
+                "validatedAt": "2026-07-20T14:37:33.516011+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -108535,7 +108436,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:00:21.044745+00:00"
+                "validatedAt": "2026-07-20T14:37:33.516056+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -108546,7 +108447,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.481319+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.023835+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -108633,7 +108534,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:21.044787+00:00"
+                "validatedAt": "2026-07-20T14:37:33.516095+00:00"
               },
               "deterministic": true
             },
@@ -108645,9 +108546,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.481365+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.023864+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -108678,7 +108578,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:21.044816+00:00"
+                "validatedAt": "2026-07-20T14:37:33.516124+00:00"
               },
               "deterministic": true
             },
@@ -108690,9 +108590,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.481383+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.023876+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -108761,7 +108660,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:21.044868+00:00"
+                "validatedAt": "2026-07-20T14:37:33.516164+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -108773,7 +108672,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.481421+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.023900+00:00"
           },
           "uid": {
             "type": "string",
@@ -108790,7 +108689,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:21.044894+00:00"
+                "validatedAt": "2026-07-20T14:37:33.516186+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -108803,7 +108702,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.481441+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.023913+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of receiver is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -109022,7 +108921,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:21.044968+00:00"
+                "validatedAt": "2026-07-20T14:37:33.516301+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -109207,7 +109106,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:21.045022+00:00"
+                "validatedAt": "2026-07-20T14:37:33.516360+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -109262,7 +109161,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:21.045094+00:00"
+                "validatedAt": "2026-07-20T14:37:33.516404+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -109382,7 +109281,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T13:00:21.045139+00:00"
+                "validatedAt": "2026-07-20T14:37:33.516428+00:00"
               },
               "deterministic": true
             },
@@ -109601,7 +109500,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:21.045251+00:00"
+                "validatedAt": "2026-07-20T14:37:33.516493+00:00"
               },
               "deterministic": true
             },
@@ -109814,7 +109713,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:21.045339+00:00"
+                "validatedAt": "2026-07-20T14:37:33.516536+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -109891,7 +109790,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:21.045381+00:00"
+                "validatedAt": "2026-07-20T14:37:33.516555+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -109932,7 +109831,7 @@
                 "confidence": 1.0,
                 "category": "content",
                 "note": "Blindfold envelope encryption (AES-256-GCM + RSA-OAEP) of an RSA-2048 TLS private key produces ~3700 char string:/// URL. 128KB max secret size = ~175KB base64. Discovery reported 1024 which is incorrect.",
-                "validatedAt": "2026-07-20T13:00:21.045416+00:00"
+                "validatedAt": "2026-07-20T14:37:33.516577+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -109943,7 +109842,7 @@
             },
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.481698+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.024060+00:00"
           },
           "store_provider": {
             "type": "string",
@@ -109962,7 +109861,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:21.045460+00:00"
+                "validatedAt": "2026-07-20T14:37:33.516611+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -110029,7 +109928,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:21.045496+00:00"
+                "validatedAt": "2026-07-20T14:37:33.516633+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -110040,7 +109939,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.481725+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.024077+00:00"
           },
           "url": {
             "type": "string",
@@ -110078,7 +109977,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:21.045550+00:00"
+                "validatedAt": "2026-07-20T14:37:33.516672+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -110262,7 +110161,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T13:00:25.093812+00:00"
+                "validatedAt": "2026-07-20T14:37:35.104672+00:00"
               },
               "deterministic": true
             },
@@ -110288,7 +110187,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.586770+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.140680+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -110346,7 +110245,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:00:25.093918+00:00"
+                "validatedAt": "2026-07-20T14:37:35.104703+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -110357,7 +110256,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.586795+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.140695+00:00"
           },
           "id": {
             "type": "string",
@@ -110376,7 +110275,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:25.093963+00:00"
+                "validatedAt": "2026-07-20T14:37:35.104714+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -110415,7 +110314,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:25.094003+00:00"
+                "validatedAt": "2026-07-20T14:37:35.104729+00:00"
               },
               "deterministic": true
             },
@@ -110427,9 +110326,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.586823+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.140712+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "status": {
             "type": "string",
@@ -110447,7 +110345,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:25.094037+00:00"
+                "validatedAt": "2026-07-20T14:37:35.104743+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -110458,7 +110356,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.586842+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.140725+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -110516,7 +110414,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:25.094076+00:00"
+                "validatedAt": "2026-07-20T14:37:35.104758+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -110569,7 +110467,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:25.094139+00:00"
+                "validatedAt": "2026-07-20T14:37:35.104782+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -110580,7 +110478,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.586883+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.140749+00:00"
           }
         },
         "x-f5xc-description-short": "Message object representing events reason.",
@@ -110639,7 +110537,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:25.094180+00:00"
+                "validatedAt": "2026-07-20T14:37:35.104798+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -110666,7 +110564,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:00:25.094227+00:00"
+                "validatedAt": "2026-07-20T14:37:35.104818+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -110677,7 +110575,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.586911+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.140767+00:00"
           },
           "feature_name": {
             "type": "string",
@@ -110693,7 +110591,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:25.094269+00:00"
+                "validatedAt": "2026-07-20T14:37:35.104835+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -110731,7 +110629,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:25.094305+00:00"
+                "validatedAt": "2026-07-20T14:37:35.104849+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -110814,7 +110712,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:25.094346+00:00"
+                "validatedAt": "2026-07-20T14:37:35.104865+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -110837,7 +110735,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:25.094381+00:00"
+                "validatedAt": "2026-07-20T14:37:35.104879+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -111012,7 +110910,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:25.094453+00:00"
+                "validatedAt": "2026-07-20T14:37:35.104907+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -111228,7 +111126,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:25.094558+00:00"
+                "validatedAt": "2026-07-20T14:37:35.104948+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -111268,7 +111166,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:25.094589+00:00"
+                "validatedAt": "2026-07-20T14:37:35.104962+00:00"
               },
               "deterministic": true
             },
@@ -111280,9 +111178,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.587038+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.140855+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "platform": {
             "type": "string",
@@ -111300,7 +111197,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:25.094625+00:00"
+                "validatedAt": "2026-07-20T14:37:35.104976+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -111325,7 +111222,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:25.094672+00:00"
+                "validatedAt": "2026-07-20T14:37:35.104991+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -111357,7 +111254,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T13:00:25.094716+00:00"
+                "validatedAt": "2026-07-20T14:37:35.105009+00:00"
               },
               "deterministic": true
             },
@@ -111544,7 +111441,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:25.094777+00:00"
+                "validatedAt": "2026-07-20T14:37:35.105034+00:00"
               },
               "deterministic": true
             },
@@ -111556,9 +111453,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.587105+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.140895+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -111806,7 +111702,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:25.094952+00:00"
+                "validatedAt": "2026-07-20T14:37:35.105100+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -111853,7 +111749,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:25.094985+00:00"
+                "validatedAt": "2026-07-20T14:37:35.105117+00:00"
               },
               "deterministic": true
             },
@@ -111865,9 +111761,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.587198+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.140951+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Request to test receiver & destination sink.",
@@ -111925,7 +111820,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:25.095021+00:00"
+                "validatedAt": "2026-07-20T14:37:35.105132+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -111951,7 +111846,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.587226+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.140969+00:00"
           }
         },
         "x-f5xc-description-short": "Response for the Receiver test request; empty because the only returned information is error message.",
@@ -112058,7 +111953,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:25.095053+00:00"
+                "validatedAt": "2026-07-20T14:37:35.105145+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -112098,7 +111993,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:25.095082+00:00"
+                "validatedAt": "2026-07-20T14:37:35.105159+00:00"
               },
               "deterministic": true
             },
@@ -112110,9 +112005,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.587255+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.140986+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "type": {
             "allOf": [
@@ -112184,7 +112078,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:25.095111+00:00"
+                "validatedAt": "2026-07-20T14:37:35.105172+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -112210,7 +112104,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:25.095151+00:00"
+                "validatedAt": "2026-07-20T14:37:35.105188+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -112236,7 +112130,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:25.095184+00:00"
+                "validatedAt": "2026-07-20T14:37:35.105201+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -112247,7 +112141,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.587295+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.141010+00:00"
           }
         },
         "x-f5xc-description-short": "Payload about status of receiver status result.",
@@ -112313,7 +112207,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:25.095250+00:00"
+                "validatedAt": "2026-07-20T14:37:35.105232+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -112347,7 +112241,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:25.095311+00:00"
+                "validatedAt": "2026-07-20T14:37:35.105260+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -112387,7 +112281,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:25.095341+00:00"
+                "validatedAt": "2026-07-20T14:37:35.105273+00:00"
               },
               "deterministic": true
             },
@@ -112399,9 +112293,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.587328+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.141032+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "request_body": {
             "allOf": [
@@ -112473,7 +112366,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:00:25.095378+00:00"
+                "validatedAt": "2026-07-20T14:37:35.105290+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -112538,7 +112431,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:00:25.095423+00:00"
+                "validatedAt": "2026-07-20T14:37:35.105309+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -112549,7 +112442,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.587364+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.141054+00:00"
           },
           "ref_value": {
             "allOf": [
@@ -112591,7 +112484,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:25.095463+00:00"
+                "validatedAt": "2026-07-20T14:37:35.105325+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -112620,7 +112513,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:25.095497+00:00"
+                "validatedAt": "2026-07-20T14:37:35.105339+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -112631,7 +112524,7 @@
             },
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.587396+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.141074+00:00"
           },
           "value": {
             "type": "string",
@@ -112647,7 +112540,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:25.095530+00:00"
+                "validatedAt": "2026-07-20T14:37:35.105351+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -112658,7 +112551,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.587416+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.141086+00:00"
           }
         },
         "x-f5xc-description-short": "Tuple with a suggested value and it's description.",
@@ -112850,7 +112743,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:24.550209+00:00"
+                "validatedAt": "2026-07-20T14:39:09.196506+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -112880,7 +112773,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:24.550290+00:00"
+                "validatedAt": "2026-07-20T14:39:09.196530+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -112943,7 +112836,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:24.550400+00:00"
+                "validatedAt": "2026-07-20T14:39:09.196563+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -113085,7 +112978,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:24.550471+00:00"
+                "validatedAt": "2026-07-20T14:39:09.196585+00:00"
               },
               "deterministic": true
             },
@@ -113097,9 +112990,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.326548+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.116673+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "no_attributes": {
             "allOf": [
@@ -113135,7 +113027,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:24.550518+00:00"
+                "validatedAt": "2026-07-20T14:39:09.196600+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -113147,7 +113039,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.326576+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.116690+00:00"
           },
           "versions": {
             "type": "array",
@@ -113242,7 +113134,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:04:24.550575+00:00"
+                "validatedAt": "2026-07-20T14:39:09.196623+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -113327,7 +113219,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:24.550644+00:00"
+                "validatedAt": "2026-07-20T14:39:09.196653+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -113414,7 +113306,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:24.550722+00:00"
+                "validatedAt": "2026-07-20T14:39:09.196681+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -113492,7 +113384,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:24.550768+00:00"
+                "validatedAt": "2026-07-20T14:39:09.196699+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -113672,7 +113564,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T13:04:24.550812+00:00"
+                "validatedAt": "2026-07-20T14:39:09.196717+00:00"
               },
               "deterministic": true
             },
@@ -113746,7 +113638,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:24.550859+00:00"
+                "validatedAt": "2026-07-20T14:39:09.196753+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -113781,7 +113673,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:24.550930+00:00"
+                "validatedAt": "2026-07-20T14:39:09.196799+00:00"
               },
               "deterministic": true
             },
@@ -113793,7 +113685,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.326695+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.116753+00:00"
           },
           "mobile_app_shield": {
             "allOf": [
@@ -113888,7 +113780,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:24.550970+00:00"
+                "validatedAt": "2026-07-20T14:39:09.196819+00:00"
               },
               "deterministic": true
             },
@@ -113900,9 +113792,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.326734+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.116777+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -113940,7 +113831,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:24.551003+00:00"
+                "validatedAt": "2026-07-20T14:39:09.196834+00:00"
               },
               "deterministic": true
             },
@@ -113952,9 +113843,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.326753+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.116789+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "no_attributes": {
             "allOf": [
@@ -114003,7 +113893,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T13:04:24.551037+00:00"
+                "validatedAt": "2026-07-20T14:39:09.196851+00:00"
               },
               "deterministic": true
             },
@@ -114036,7 +113926,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:24.551074+00:00"
+                "validatedAt": "2026-07-20T14:39:09.196866+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -114047,7 +113937,7 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.326784+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.116809+00:00"
           },
           "mobile_sdk_self_serve": {
             "allOf": [
@@ -114133,7 +114023,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:24.551121+00:00"
+                "validatedAt": "2026-07-20T14:39:09.196885+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -114168,7 +114058,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:24.551191+00:00"
+                "validatedAt": "2026-07-20T14:39:09.196919+00:00"
               },
               "deterministic": true
             },
@@ -114180,7 +114070,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.326811+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.116825+00:00"
           },
           "latest_version": {
             "type": "boolean",
@@ -114224,7 +114114,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T13:04:24.551224+00:00"
+                "validatedAt": "2026-07-20T14:39:09.196935+00:00"
               },
               "deterministic": true
             },
@@ -114249,7 +114139,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:24.551257+00:00"
+                "validatedAt": "2026-07-20T14:39:09.196949+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -114260,7 +114150,7 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.326843+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.116845+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -114480,7 +114370,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:28.866857+00:00"
+                "validatedAt": "2026-07-20T14:39:10.877907+00:00"
               },
               "deterministic": true
             },
@@ -114491,8 +114381,7 @@
               "read": false
             },
             "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "minLength": 1,
-            "format": "hostname"
+            "minLength": 1
           },
           "os": {
             "allOf": [
@@ -114593,7 +114482,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:28.866927+00:00"
+                "validatedAt": "2026-07-20T14:39:10.877930+00:00"
               },
               "deterministic": true
             },
@@ -114605,9 +114494,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.409402+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.186893+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -114639,7 +114527,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:28.866973+00:00"
+                "validatedAt": "2026-07-20T14:39:10.877944+00:00"
               },
               "deterministic": true
             },
@@ -114651,9 +114539,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.409422+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.186906+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -114888,7 +114775,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:28.867094+00:00"
+                "validatedAt": "2026-07-20T14:39:10.877998+00:00"
               },
               "deterministic": true
             },
@@ -114899,8 +114786,7 @@
               "read": false
             },
             "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "minLength": 1,
-            "format": "hostname"
+            "minLength": 1
           },
           "os": {
             "allOf": [
@@ -114930,7 +114816,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:28.867142+00:00"
+                "validatedAt": "2026-07-20T14:39:10.878018+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -115015,7 +114901,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:04:28.867189+00:00"
+                "validatedAt": "2026-07-20T14:39:10.878041+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -115096,7 +114982,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:04:28.867242+00:00"
+                "validatedAt": "2026-07-20T14:39:10.878066+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -115107,7 +114993,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.409541+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.186975+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -115194,7 +115080,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:28.867283+00:00"
+                "validatedAt": "2026-07-20T14:39:10.878085+00:00"
               },
               "deterministic": true
             },
@@ -115206,9 +115092,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.409586+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.187003+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -115239,7 +115124,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:28.867312+00:00"
+                "validatedAt": "2026-07-20T14:39:10.878099+00:00"
               },
               "deterministic": true
             },
@@ -115251,9 +115136,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.409605+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.187015+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -115306,7 +115190,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:28.867353+00:00"
+                "validatedAt": "2026-07-20T14:39:10.878117+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -115318,7 +115202,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.409636+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.187034+00:00"
           },
           "uid": {
             "type": "string",
@@ -115336,7 +115220,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:28.867380+00:00"
+                "validatedAt": "2026-07-20T14:39:10.878128+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -115349,7 +115233,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.409663+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.187047+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of mobile_base_config is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -115415,7 +115299,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:28.867416+00:00"
+                "validatedAt": "2026-07-20T14:39:10.878143+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -115454,7 +115338,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:28.867445+00:00"
+                "validatedAt": "2026-07-20T14:39:10.878158+00:00"
               },
               "deterministic": true
             },
@@ -115466,9 +115350,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.409692+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.187064+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Mobile base configuration file response.",
@@ -115680,7 +115563,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:28.867506+00:00"
+                "validatedAt": "2026-07-20T14:39:10.878189+00:00"
               },
               "deterministic": true
             },
@@ -115691,8 +115574,7 @@
               "read": false
             },
             "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "minLength": 1,
-            "format": "hostname"
+            "minLength": 1
           },
           "os": {
             "allOf": [
@@ -116002,7 +115884,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:11.478545+00:00"
+                "validatedAt": "2026-07-20T14:39:51.040480+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -116182,7 +116064,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:11.478680+00:00"
+                "validatedAt": "2026-07-20T14:39:51.040514+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -116229,7 +116111,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:11.478744+00:00"
+                "validatedAt": "2026-07-20T14:39:51.040530+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -116240,7 +116122,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.966553+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.682147+00:00"
           },
           "xc_mesh": {
             "allOf": [
@@ -116606,7 +116488,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:11.478902+00:00"
+                "validatedAt": "2026-07-20T14:39:51.040583+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -116752,7 +116634,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:11.478979+00:00"
+                "validatedAt": "2026-07-20T14:39:51.040618+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -116788,7 +116670,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T13:06:11.479025+00:00"
+                "validatedAt": "2026-07-20T14:39:51.040638+00:00"
               },
               "deterministic": true
             },
@@ -116826,7 +116708,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:11.479072+00:00"
+                "validatedAt": "2026-07-20T14:39:51.040662+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -116929,7 +116811,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:11.479166+00:00"
+                "validatedAt": "2026-07-20T14:39:51.040708+00:00"
               },
               "byteLength": {
                 "max": 256,
@@ -117051,7 +116933,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:11.479241+00:00"
+                "validatedAt": "2026-07-20T14:39:51.040742+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -117240,7 +117122,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:11.479327+00:00"
+                "validatedAt": "2026-07-20T14:39:51.040782+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -117276,7 +117158,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T13:06:11.479359+00:00"
+                "validatedAt": "2026-07-20T14:39:51.040797+00:00"
               },
               "deterministic": true
             },
@@ -117314,7 +117196,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:11.479403+00:00"
+                "validatedAt": "2026-07-20T14:39:51.040820+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -117420,7 +117302,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:11.479447+00:00"
+                "validatedAt": "2026-07-20T14:39:51.040842+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -117572,7 +117454,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:11.479686+00:00"
+                "validatedAt": "2026-07-20T14:39:51.040947+00:00"
               },
               "deterministic": true
             },
@@ -117612,7 +117494,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:11.479739+00:00"
+                "validatedAt": "2026-07-20T14:39:51.040974+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -117653,7 +117535,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:11.479808+00:00"
+                "validatedAt": "2026-07-20T14:39:51.041007+00:00"
               },
               "byteLength": {
                 "max": 256,
@@ -117723,7 +117605,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:11.479855+00:00"
+                "validatedAt": "2026-07-20T14:39:51.041025+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -117754,7 +117636,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T13:06:11.479888+00:00"
+                "validatedAt": "2026-07-20T14:39:51.041040+00:00"
               },
               "deterministic": true
             },
@@ -117820,7 +117702,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:11.479929+00:00"
+                "validatedAt": "2026-07-20T14:39:51.041058+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -117921,7 +117803,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:11.479968+00:00"
+                "validatedAt": "2026-07-20T14:39:51.041075+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -117959,7 +117841,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:11.479999+00:00"
+                "validatedAt": "2026-07-20T14:39:51.041090+00:00"
               },
               "deterministic": true
             },
@@ -117971,9 +117853,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.966997+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.682401+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -118197,7 +118078,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:11.480050+00:00"
+                "validatedAt": "2026-07-20T14:39:51.041111+00:00"
               },
               "deterministic": true
             },
@@ -118209,9 +118090,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.967059+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.682437+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -118243,7 +118123,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:11.480078+00:00"
+                "validatedAt": "2026-07-20T14:39:51.041125+00:00"
               },
               "deterministic": true
             },
@@ -118255,9 +118135,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.967077+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.682449+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -118420,7 +118299,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.967144+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.682490+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -118515,7 +118394,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:06:11.480194+00:00"
+                "validatedAt": "2026-07-20T14:39:51.041171+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -118594,7 +118473,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:06:11.480247+00:00"
+                "validatedAt": "2026-07-20T14:39:51.041193+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -118605,7 +118484,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.967194+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.682520+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -118692,7 +118571,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:11.480288+00:00"
+                "validatedAt": "2026-07-20T14:39:51.041212+00:00"
               },
               "deterministic": true
             },
@@ -118704,9 +118583,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.967240+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.682548+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -118737,7 +118615,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:11.480317+00:00"
+                "validatedAt": "2026-07-20T14:39:51.041225+00:00"
               },
               "deterministic": true
             },
@@ -118749,9 +118627,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.967258+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.682560+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -118820,7 +118697,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:11.480372+00:00"
+                "validatedAt": "2026-07-20T14:39:51.041246+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -118832,7 +118709,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.967296+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.682583+00:00"
           },
           "uid": {
             "type": "string",
@@ -118850,7 +118727,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:11.480400+00:00"
+                "validatedAt": "2026-07-20T14:39:51.041257+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -118863,7 +118740,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.967315+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.682596+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of protected_application is returned in 'List'.",
@@ -119254,7 +119131,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:11.480495+00:00"
+                "validatedAt": "2026-07-20T14:39:51.041294+00:00"
               },
               "deterministic": true
             },
@@ -119266,9 +119143,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.967400+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.682645+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "template": {
             "type": "string",
@@ -119283,7 +119159,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:11.480530+00:00"
+                "validatedAt": "2026-07-20T14:39:51.041308+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -119412,7 +119288,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:11.480593+00:00"
+                "validatedAt": "2026-07-20T14:39:51.041337+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -119445,7 +119321,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:11.480662+00:00"
+                "validatedAt": "2026-07-20T14:39:51.041364+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -119471,7 +119347,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.967448+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.682674+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -119533,7 +119409,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:11.480721+00:00"
+                "validatedAt": "2026-07-20T14:39:51.041392+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -119566,7 +119442,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:11.480780+00:00"
+                "validatedAt": "2026-07-20T14:39:51.041419+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -119592,7 +119468,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.967481+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.682695+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -119675,7 +119551,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:11.480846+00:00"
+                "validatedAt": "2026-07-20T14:39:51.041449+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -119840,7 +119716,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:11.480914+00:00"
+                "validatedAt": "2026-07-20T14:39:51.041481+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -119896,7 +119772,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:11.480971+00:00"
+                "validatedAt": "2026-07-20T14:39:51.041509+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -119910,8 +119786,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "regex": {
             "type": "string",
@@ -119938,7 +119813,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:11.481034+00:00"
+                "validatedAt": "2026-07-20T14:39:51.041540+00:00"
               },
               "byteLength": {
                 "max": 256
@@ -120024,7 +119899,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:11.481089+00:00"
+                "validatedAt": "2026-07-20T14:39:51.041568+00:00"
               },
               "deterministic": true
             },
@@ -120106,7 +119981,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.967575+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:19.682749+00:00",
             "x-f5xc-conflicts-with": [
               "any_domain"
             ]
@@ -120202,7 +120077,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:11.481148+00:00"
+                "validatedAt": "2026-07-20T14:39:51.041592+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -120275,7 +120150,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:11.481192+00:00"
+                "validatedAt": "2026-07-20T14:39:51.041615+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -120321,7 +120196,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:11.481239+00:00"
+                "validatedAt": "2026-07-20T14:39:51.041635+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -120365,7 +120240,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:11.481296+00:00"
+                "validatedAt": "2026-07-20T14:39:51.041663+00:00"
               },
               "deterministic": true
             },
@@ -120452,7 +120327,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.967650+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:19.682794+00:00",
             "x-f5xc-conflicts-with": [
               "any_domain"
             ]
@@ -120482,7 +120357,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:11.481359+00:00"
+                "validatedAt": "2026-07-20T14:39:51.041693+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -120531,7 +120406,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:11.481425+00:00"
+                "validatedAt": "2026-07-20T14:39:51.041727+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -120584,7 +120459,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:11.481480+00:00"
+                "validatedAt": "2026-07-20T14:39:51.041754+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -120756,7 +120631,7 @@
             "maxLength": 0,
             "minLength": 0,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.967718+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:19.682827+00:00",
             "x-f5xc-conflicts-with": [
               "block"
             ]
@@ -120875,7 +120750,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:11.481551+00:00"
+                "validatedAt": "2026-07-20T14:39:51.041787+00:00"
               },
               "deterministic": true
             },
@@ -120959,7 +120834,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.967763+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:19.682853+00:00",
             "x-f5xc-conflicts-with": [
               "any_domain"
             ]
@@ -121001,7 +120876,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:11.481605+00:00"
+                "validatedAt": "2026-07-20T14:39:51.041813+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -121082,7 +120957,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:11.481688+00:00"
+                "validatedAt": "2026-07-20T14:39:51.041850+00:00"
               },
               "byteLength": {
                 "max": 256
@@ -121208,7 +121083,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:11.481755+00:00"
+                "validatedAt": "2026-07-20T14:39:51.041880+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -121219,7 +121094,7 @@
             },
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.967828+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.682891+00:00"
           },
           "status": {
             "allOf": [
@@ -121237,7 +121112,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.967846+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.682903+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -121310,7 +121185,7 @@
             "maxLength": 0,
             "minLength": 0,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.967873+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:19.682920+00:00",
             "x-f5xc-conflicts-with": [
               "block",
               "redirect"
@@ -121524,7 +121399,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:11.481839+00:00"
+                "validatedAt": "2026-07-20T14:39:51.041917+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -121557,7 +121432,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:11.481896+00:00"
+                "validatedAt": "2026-07-20T14:39:51.041945+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -121583,7 +121458,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.967945+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.682962+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -121645,7 +121520,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:11.481953+00:00"
+                "validatedAt": "2026-07-20T14:39:51.041971+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -121678,7 +121553,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:11.482012+00:00"
+                "validatedAt": "2026-07-20T14:39:51.041999+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -121704,7 +121579,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.967978+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.682983+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -121787,7 +121662,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:11.482076+00:00"
+                "validatedAt": "2026-07-20T14:39:51.042029+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -121952,7 +121827,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:11.482143+00:00"
+                "validatedAt": "2026-07-20T14:39:51.042061+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -122008,7 +121883,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:11.482197+00:00"
+                "validatedAt": "2026-07-20T14:39:51.042089+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -122022,8 +121897,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "regex": {
             "type": "string",
@@ -122050,7 +121924,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:11.482259+00:00"
+                "validatedAt": "2026-07-20T14:39:51.042120+00:00"
               },
               "byteLength": {
                 "max": 256
@@ -122136,7 +122010,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:11.482311+00:00"
+                "validatedAt": "2026-07-20T14:39:51.042147+00:00"
               },
               "deterministic": true
             },
@@ -122218,7 +122092,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.968071+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:19.683037+00:00",
             "x-f5xc-conflicts-with": [
               "any_domain"
             ]
@@ -122327,7 +122201,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:11.482374+00:00"
+                "validatedAt": "2026-07-20T14:39:51.042172+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -122401,7 +122275,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:11.482418+00:00"
+                "validatedAt": "2026-07-20T14:39:51.042196+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -122460,7 +122334,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:11.482467+00:00"
+                "validatedAt": "2026-07-20T14:39:51.042216+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -122504,7 +122378,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:11.482517+00:00"
+                "validatedAt": "2026-07-20T14:39:51.042243+00:00"
               },
               "deterministic": true
             },
@@ -122592,7 +122466,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.968160+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:19.683090+00:00",
             "x-f5xc-conflicts-with": [
               "any_domain"
             ]
@@ -122622,7 +122496,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:11.482579+00:00"
+                "validatedAt": "2026-07-20T14:39:51.042273+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -122671,7 +122545,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:11.482642+00:00"
+                "validatedAt": "2026-07-20T14:39:51.042307+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -122724,7 +122598,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:11.482709+00:00"
+                "validatedAt": "2026-07-20T14:39:51.042334+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -122936,7 +122810,7 @@
             "maxLength": 0,
             "minLength": 0,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.968214+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:19.683122+00:00",
             "x-f5xc-conflicts-with": [
               "block"
             ]
@@ -123055,7 +122929,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:11.482778+00:00"
+                "validatedAt": "2026-07-20T14:39:51.042368+00:00"
               },
               "deterministic": true
             },
@@ -123140,7 +123014,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.968259+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:19.683148+00:00",
             "x-f5xc-conflicts-with": [
               "any_domain"
             ]
@@ -123198,7 +123072,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:11.482836+00:00"
+                "validatedAt": "2026-07-20T14:39:51.042396+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -123272,7 +123146,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:11.482916+00:00"
+                "validatedAt": "2026-07-20T14:39:51.042438+00:00"
               },
               "byteLength": {
                 "max": 256,
@@ -123312,7 +123186,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:11.482976+00:00"
+                "validatedAt": "2026-07-20T14:39:51.042468+00:00"
               },
               "byteLength": {
                 "max": 256
@@ -123456,7 +123330,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:11.483041+00:00"
+                "validatedAt": "2026-07-20T14:39:51.042499+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -123467,7 +123341,7 @@
             },
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.968337+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.683194+00:00"
           },
           "status": {
             "allOf": [
@@ -123485,7 +123359,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.968355+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.683206+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -123558,7 +123432,7 @@
             "maxLength": 0,
             "minLength": 0,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.968382+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:19.683223+00:00",
             "x-f5xc-conflicts-with": [
               "block",
               "redirect"
@@ -124984,7 +124858,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:11.483332+00:00"
+                "validatedAt": "2026-07-20T14:39:51.042620+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -124999,9 +124873,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.968726+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.683419+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "regex_values": {
             "type": "array",
@@ -125039,7 +124912,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:11.483374+00:00"
+                "validatedAt": "2026-07-20T14:39:51.042642+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -125065,7 +124938,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.968753+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.683435+00:00"
           }
         },
         "x-f5xc-description-short": "Bot Defense Transaction Result Condition.",
@@ -125135,7 +125008,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:11.483422+00:00"
+                "validatedAt": "2026-07-20T14:39:51.042667+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -125171,7 +125044,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:11.483467+00:00"
+                "validatedAt": "2026-07-20T14:39:51.042690+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -125297,7 +125170,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:11.483765+00:00"
+                "validatedAt": "2026-07-20T14:39:51.042812+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -125309,8 +125182,7 @@
             "x-f5xc-conflicts-with": [
               "regex_value",
               "suffix_value"
-            ],
-            "format": "hostname"
+            ]
           },
           "regex_value": {
             "type": "string",
@@ -125341,7 +125213,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:11.483826+00:00"
+                "validatedAt": "2026-07-20T14:39:51.042840+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -125386,7 +125258,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:11.483889+00:00"
+                "validatedAt": "2026-07-20T14:39:51.042871+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -125398,8 +125270,7 @@
             "x-f5xc-conflicts-with": [
               "exact_value",
               "regex_value"
-            ],
-            "format": "hostname"
+            ]
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -125469,7 +125340,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:04.451688+00:00"
+                "validatedAt": "2026-07-20T14:40:34.342663+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -125559,7 +125430,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:04.451787+00:00"
+                "validatedAt": "2026-07-20T14:40:34.342704+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -125650,7 +125521,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:04.451865+00:00"
+                "validatedAt": "2026-07-20T14:40:34.342741+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -125852,7 +125723,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:04.451918+00:00"
+                "validatedAt": "2026-07-20T14:40:34.342767+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -126002,7 +125873,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:04.451975+00:00"
+                "validatedAt": "2026-07-20T14:40:34.342790+00:00"
               },
               "deterministic": true
             },
@@ -126014,9 +125885,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.978314+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.482485+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "resource_id": {
             "type": "string",
@@ -126036,7 +125906,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:08:04.452018+00:00"
+                "validatedAt": "2026-07-20T14:40:34.342809+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -126070,7 +125940,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.452060+00:00"
+                "validatedAt": "2026-07-20T14:40:34.342826+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -126207,7 +126077,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.452110+00:00"
+                "validatedAt": "2026-07-20T14:40:34.342844+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -126234,7 +126104,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.452143+00:00"
+                "validatedAt": "2026-07-20T14:40:34.342857+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -126298,7 +126168,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.452184+00:00"
+                "validatedAt": "2026-07-20T14:40:34.342873+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -126325,7 +126195,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.452225+00:00"
+                "validatedAt": "2026-07-20T14:40:34.342888+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -126353,7 +126223,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.452266+00:00"
+                "validatedAt": "2026-07-20T14:40:34.342904+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -126379,7 +126249,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.452302+00:00"
+                "validatedAt": "2026-07-20T14:40:34.342918+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -126477,7 +126347,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:04.452365+00:00"
+                "validatedAt": "2026-07-20T14:40:34.342946+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -126571,7 +126441,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:04.452414+00:00"
+                "validatedAt": "2026-07-20T14:40:34.342969+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -126665,7 +126535,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:04.452462+00:00"
+                "validatedAt": "2026-07-20T14:40:34.342992+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -126744,7 +126614,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.452498+00:00"
+                "validatedAt": "2026-07-20T14:40:34.343006+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -126783,7 +126653,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:04.452529+00:00"
+                "validatedAt": "2026-07-20T14:40:34.343020+00:00"
               },
               "deterministic": true
             },
@@ -126795,9 +126665,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.978465+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.482573+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "percentage": {
             "type": "number",
@@ -126906,7 +126775,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:04.452604+00:00"
+                "validatedAt": "2026-07-20T14:40:34.343051+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -127041,7 +126910,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.452667+00:00"
+                "validatedAt": "2026-07-20T14:40:34.343070+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -127080,7 +126949,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:04.452696+00:00"
+                "validatedAt": "2026-07-20T14:40:34.343083+00:00"
               },
               "deterministic": true
             },
@@ -127092,9 +126961,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.978528+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.482610+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "percentage": {
             "type": "number",
@@ -127167,7 +127035,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.452746+00:00"
+                "validatedAt": "2026-07-20T14:40:34.343102+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -127198,7 +127066,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T13:08:04.452778+00:00"
+                "validatedAt": "2026-07-20T14:40:34.343115+00:00"
               },
               "deterministic": true
             },
@@ -127209,8 +127077,7 @@
               "read": false
             },
             "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "minLength": 1,
-            "format": "fqdn"
+            "minLength": 1
           },
           "human_request_count": {
             "type": "string",
@@ -127230,7 +127097,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.452824+00:00"
+                "validatedAt": "2026-07-20T14:40:34.343132+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -127258,7 +127125,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.452870+00:00"
+                "validatedAt": "2026-07-20T14:40:34.343150+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -127299,7 +127166,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.452921+00:00"
+                "validatedAt": "2026-07-20T14:40:34.343169+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -127339,7 +127206,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.452960+00:00"
+                "validatedAt": "2026-07-20T14:40:34.343184+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -127428,7 +127295,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.453022+00:00"
+                "validatedAt": "2026-07-20T14:40:34.343207+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -127472,7 +127339,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.453077+00:00"
+                "validatedAt": "2026-07-20T14:40:34.343228+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -127497,7 +127364,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.453103+00:00"
+                "validatedAt": "2026-07-20T14:40:34.343238+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -127564,7 +127431,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.453138+00:00"
+                "validatedAt": "2026-07-20T14:40:34.343252+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -127605,7 +127472,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.453190+00:00"
+                "validatedAt": "2026-07-20T14:40:34.343272+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -127633,7 +127500,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.453235+00:00"
+                "validatedAt": "2026-07-20T14:40:34.343289+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -127677,7 +127544,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.453291+00:00"
+                "validatedAt": "2026-07-20T14:40:34.343310+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -127702,7 +127569,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.453317+00:00"
+                "validatedAt": "2026-07-20T14:40:34.343320+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -127788,7 +127655,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.453370+00:00"
+                "validatedAt": "2026-07-20T14:40:34.343340+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -127816,7 +127683,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.453410+00:00"
+                "validatedAt": "2026-07-20T14:40:34.343355+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -127842,7 +127709,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.453445+00:00"
+                "validatedAt": "2026-07-20T14:40:34.343368+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -127925,7 +127792,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.453498+00:00"
+                "validatedAt": "2026-07-20T14:40:34.343388+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -127952,7 +127819,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.453542+00:00"
+                "validatedAt": "2026-07-20T14:40:34.343405+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -127980,7 +127847,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.453581+00:00"
+                "validatedAt": "2026-07-20T14:40:34.343420+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -128020,7 +127887,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.453636+00:00"
+                "validatedAt": "2026-07-20T14:40:34.343442+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -128118,7 +127985,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:04.453705+00:00"
+                "validatedAt": "2026-07-20T14:40:34.343469+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -128212,7 +128079,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:04.453753+00:00"
+                "validatedAt": "2026-07-20T14:40:34.343491+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -128289,7 +128156,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.453793+00:00"
+                "validatedAt": "2026-07-20T14:40:34.343507+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -128331,7 +128198,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.453841+00:00"
+                "validatedAt": "2026-07-20T14:40:34.343525+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -128453,7 +128320,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.453893+00:00"
+                "validatedAt": "2026-07-20T14:40:34.343544+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -128492,7 +128359,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:04.453923+00:00"
+                "validatedAt": "2026-07-20T14:40:34.343557+00:00"
               },
               "deterministic": true
             },
@@ -128504,9 +128371,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.978844+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.482788+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "time_series": {
             "type": "array",
@@ -128581,7 +128447,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.453963+00:00"
+                "validatedAt": "2026-07-20T14:40:34.343572+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -128607,7 +128473,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.453988+00:00"
+                "validatedAt": "2026-07-20T14:40:34.343582+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -128636,7 +128502,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.454020+00:00"
+                "validatedAt": "2026-07-20T14:40:34.343594+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -128666,7 +128532,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.454060+00:00"
+                "validatedAt": "2026-07-20T14:40:34.343610+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -128801,7 +128667,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:04.454118+00:00"
+                "validatedAt": "2026-07-20T14:40:34.343636+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -128881,7 +128747,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.454164+00:00"
+                "validatedAt": "2026-07-20T14:40:34.343653+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -129030,7 +128896,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.454264+00:00"
+                "validatedAt": "2026-07-20T14:40:34.343690+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -129069,7 +128935,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:04.454292+00:00"
+                "validatedAt": "2026-07-20T14:40:34.343702+00:00"
               },
               "deterministic": true
             },
@@ -129081,9 +128947,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.978968+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.482864+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "percentage": {
             "type": "number",
@@ -129167,7 +129032,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.454359+00:00"
+                "validatedAt": "2026-07-20T14:40:34.343727+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -129194,7 +129059,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.454397+00:00"
+                "validatedAt": "2026-07-20T14:40:34.343742+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -129221,7 +129086,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.454435+00:00"
+                "validatedAt": "2026-07-20T14:40:34.343756+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -129352,7 +129217,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.454530+00:00"
+                "validatedAt": "2026-07-20T14:40:34.343791+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -129379,7 +129244,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.454568+00:00"
+                "validatedAt": "2026-07-20T14:40:34.343806+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -129444,7 +129309,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.454608+00:00"
+                "validatedAt": "2026-07-20T14:40:34.343822+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -129471,7 +129336,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.454643+00:00"
+                "validatedAt": "2026-07-20T14:40:34.343835+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -129534,7 +129399,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.454691+00:00"
+                "validatedAt": "2026-07-20T14:40:34.343850+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -129558,7 +129423,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.454727+00:00"
+                "validatedAt": "2026-07-20T14:40:34.343863+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -129585,7 +129450,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.454761+00:00"
+                "validatedAt": "2026-07-20T14:40:34.343878+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -129625,7 +129490,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.454809+00:00"
+                "validatedAt": "2026-07-20T14:40:34.343896+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -129637,7 +129502,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.979104+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.482946+00:00"
           },
           "endpoint": {
             "type": "string",
@@ -129657,7 +129522,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T13:08:04.454844+00:00"
+                "validatedAt": "2026-07-20T14:40:34.343910+00:00"
               },
               "deterministic": true
             },
@@ -129684,7 +129549,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.454873+00:00"
+                "validatedAt": "2026-07-20T14:40:34.343923+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -129757,7 +129622,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:08:04.454911+00:00"
+                "validatedAt": "2026-07-20T14:40:34.343939+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -129822,7 +129687,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.454953+00:00"
+                "validatedAt": "2026-07-20T14:40:34.343955+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -129848,7 +129713,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.454998+00:00"
+                "validatedAt": "2026-07-20T14:40:34.343972+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -129915,7 +129780,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.455040+00:00"
+                "validatedAt": "2026-07-20T14:40:34.343988+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -129941,7 +129806,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.455084+00:00"
+                "validatedAt": "2026-07-20T14:40:34.344004+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -129967,7 +129832,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.455130+00:00"
+                "validatedAt": "2026-07-20T14:40:34.344022+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -130470,7 +130335,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.455219+00:00"
+                "validatedAt": "2026-07-20T14:40:34.344053+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -130521,7 +130386,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.455273+00:00"
+                "validatedAt": "2026-07-20T14:40:34.344073+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -130532,7 +130397,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.979399+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.483069+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -130618,7 +130483,7 @@
             "maxLength": 16,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.979435+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.483091+00:00"
           },
           "mode": {
             "allOf": [
@@ -130712,7 +130577,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.455343+00:00"
+                "validatedAt": "2026-07-20T14:40:34.344099+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -130742,7 +130607,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.455379+00:00"
+                "validatedAt": "2026-07-20T14:40:34.344113+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -130807,7 +130672,7 @@
             "maxLength": 16,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.979484+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.483121+00:00"
           },
           "limit": {
             "type": "integer",
@@ -130836,7 +130701,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:08:04.455420+00:00"
+                "validatedAt": "2026-07-20T14:40:34.344131+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -130931,7 +130796,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.455462+00:00"
+                "validatedAt": "2026-07-20T14:40:34.344147+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -131015,7 +130880,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:04.455511+00:00"
+                "validatedAt": "2026-07-20T14:40:34.344168+00:00"
               },
               "deterministic": true
             },
@@ -131027,9 +130892,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.979544+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.483157+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "start_time": {
             "type": "string",
@@ -131048,7 +130912,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.455547+00:00"
+                "validatedAt": "2026-07-20T14:40:34.344181+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -131225,7 +131089,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.455591+00:00"
+                "validatedAt": "2026-07-20T14:40:34.344198+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -131236,7 +131100,7 @@
             },
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.979579+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.483179+00:00"
           },
           "order": {
             "allOf": [
@@ -131310,7 +131174,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.455629+00:00"
+                "validatedAt": "2026-07-20T14:40:34.344213+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -131321,7 +131185,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.979606+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.483196+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -131377,7 +131241,7 @@
             "maxLength": 16,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.979627+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.483209+00:00"
           },
           "op": {
             "allOf": [
@@ -131431,7 +131295,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:04.455690+00:00"
+                "validatedAt": "2026-07-20T14:40:34.344237+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -131587,7 +131451,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:04.455754+00:00"
+                "validatedAt": "2026-07-20T14:40:34.344266+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -131664,7 +131528,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.455792+00:00"
+                "validatedAt": "2026-07-20T14:40:34.344281+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -131691,7 +131555,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.455825+00:00"
+                "validatedAt": "2026-07-20T14:40:34.344294+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -131757,7 +131621,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.455857+00:00"
+                "validatedAt": "2026-07-20T14:40:34.344307+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -131782,7 +131646,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.455890+00:00"
+                "validatedAt": "2026-07-20T14:40:34.344321+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -131848,7 +131712,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.455923+00:00"
+                "validatedAt": "2026-07-20T14:40:34.344338+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -131889,7 +131753,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.455975+00:00"
+                "validatedAt": "2026-07-20T14:40:34.344358+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -131914,7 +131778,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.456014+00:00"
+                "validatedAt": "2026-07-20T14:40:34.344374+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -131982,7 +131846,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.456047+00:00"
+                "validatedAt": "2026-07-20T14:40:34.344387+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -132007,7 +131871,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.456082+00:00"
+                "validatedAt": "2026-07-20T14:40:34.344400+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -132088,7 +131952,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:04.456136+00:00"
+                "validatedAt": "2026-07-20T14:40:34.344427+00:00"
               },
               "deterministic": true
             },
@@ -132182,7 +132046,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:04.456184+00:00"
+                "validatedAt": "2026-07-20T14:40:34.344449+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -132348,7 +132212,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.456260+00:00"
+                "validatedAt": "2026-07-20T14:40:34.344477+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -132375,7 +132239,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.456293+00:00"
+                "validatedAt": "2026-07-20T14:40:34.344489+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -132453,7 +132317,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T13:08:04.456334+00:00"
+                "validatedAt": "2026-07-20T14:40:34.344508+00:00"
               },
               "deterministic": true
             },
@@ -132500,7 +132364,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:04.456367+00:00"
+                "validatedAt": "2026-07-20T14:40:34.344523+00:00"
               },
               "deterministic": true
             },
@@ -132512,9 +132376,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.979843+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.483329+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "region": {
             "type": "string",
@@ -132538,7 +132401,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.456405+00:00"
+                "validatedAt": "2026-07-20T14:40:34.344538+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -132635,7 +132498,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.456474+00:00"
+                "validatedAt": "2026-07-20T14:40:34.344564+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -132717,7 +132580,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.456523+00:00"
+                "validatedAt": "2026-07-20T14:40:34.344583+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -132742,7 +132605,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.456558+00:00"
+                "validatedAt": "2026-07-20T14:40:34.344597+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -132770,7 +132633,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.456598+00:00"
+                "validatedAt": "2026-07-20T14:40:34.344612+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -132798,7 +132661,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.456640+00:00"
+                "validatedAt": "2026-07-20T14:40:34.344628+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -132826,7 +132689,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.456692+00:00"
+                "validatedAt": "2026-07-20T14:40:34.344645+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -132942,7 +132805,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.456772+00:00"
+                "validatedAt": "2026-07-20T14:40:34.344674+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -132967,7 +132830,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.456807+00:00"
+                "validatedAt": "2026-07-20T14:40:34.344687+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -132995,7 +132858,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.456848+00:00"
+                "validatedAt": "2026-07-20T14:40:34.344703+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -133023,7 +132886,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.456892+00:00"
+                "validatedAt": "2026-07-20T14:40:34.344720+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -133125,7 +132988,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.456962+00:00"
+                "validatedAt": "2026-07-20T14:40:34.344746+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -133150,7 +133013,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.456999+00:00"
+                "validatedAt": "2026-07-20T14:40:34.344760+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -133178,7 +133041,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.457043+00:00"
+                "validatedAt": "2026-07-20T14:40:34.344777+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -133275,7 +133138,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.457108+00:00"
+                "validatedAt": "2026-07-20T14:40:34.344801+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -133303,7 +133166,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.457148+00:00"
+                "validatedAt": "2026-07-20T14:40:34.344817+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -133396,7 +133259,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.457212+00:00"
+                "validatedAt": "2026-07-20T14:40:34.344840+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -133424,7 +133287,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.457251+00:00"
+                "validatedAt": "2026-07-20T14:40:34.344855+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -133465,7 +133328,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.457299+00:00"
+                "validatedAt": "2026-07-20T14:40:34.344873+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -133490,7 +133353,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.457323+00:00"
+                "validatedAt": "2026-07-20T14:40:34.344883+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -133576,7 +133439,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.457377+00:00"
+                "validatedAt": "2026-07-20T14:40:34.344904+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -133617,7 +133480,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.457424+00:00"
+                "validatedAt": "2026-07-20T14:40:34.344922+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -133658,7 +133521,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.457461+00:00"
+                "validatedAt": "2026-07-20T14:40:34.344937+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -133725,7 +133588,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.457497+00:00"
+                "validatedAt": "2026-07-20T14:40:34.344950+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -133750,7 +133613,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.457531+00:00"
+                "validatedAt": "2026-07-20T14:40:34.344963+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -133778,7 +133641,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.457572+00:00"
+                "validatedAt": "2026-07-20T14:40:34.344979+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -133803,7 +133666,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.457596+00:00"
+                "validatedAt": "2026-07-20T14:40:34.344988+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -133831,7 +133694,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.457642+00:00"
+                "validatedAt": "2026-07-20T14:40:34.345006+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -133947,7 +133810,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.457726+00:00"
+                "validatedAt": "2026-07-20T14:40:34.345033+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -133972,7 +133835,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.457760+00:00"
+                "validatedAt": "2026-07-20T14:40:34.345047+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -133997,7 +133860,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.457784+00:00"
+                "validatedAt": "2026-07-20T14:40:34.345057+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -134025,7 +133888,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.457828+00:00"
+                "validatedAt": "2026-07-20T14:40:34.345073+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -134126,7 +133989,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.457892+00:00"
+                "validatedAt": "2026-07-20T14:40:34.345098+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -134154,7 +134017,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.457934+00:00"
+                "validatedAt": "2026-07-20T14:40:34.345114+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -134182,7 +134045,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.457978+00:00"
+                "validatedAt": "2026-07-20T14:40:34.345130+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -134238,7 +134101,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.458031+00:00"
+                "validatedAt": "2026-07-20T14:40:34.345150+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -134322,7 +134185,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.458078+00:00"
+                "validatedAt": "2026-07-20T14:40:34.345168+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -134350,7 +134213,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.458124+00:00"
+                "validatedAt": "2026-07-20T14:40:34.345185+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -134406,7 +134269,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.458178+00:00"
+                "validatedAt": "2026-07-20T14:40:34.345205+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -134477,7 +134340,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.458212+00:00"
+                "validatedAt": "2026-07-20T14:40:34.345219+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -134516,7 +134379,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:04.458241+00:00"
+                "validatedAt": "2026-07-20T14:40:34.345232+00:00"
               },
               "deterministic": true
             },
@@ -134528,9 +134391,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.980304+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.483603+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "percentage": {
             "type": "number",
@@ -134594,7 +134456,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.458313+00:00"
+                "validatedAt": "2026-07-20T14:40:34.345258+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -134663,7 +134525,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.458346+00:00"
+                "validatedAt": "2026-07-20T14:40:34.345271+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -134718,7 +134580,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.458408+00:00"
+                "validatedAt": "2026-07-20T14:40:34.345294+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -134839,7 +134701,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.458460+00:00"
+                "validatedAt": "2026-07-20T14:40:34.345314+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -134864,7 +134726,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.458500+00:00"
+                "validatedAt": "2026-07-20T14:40:34.345329+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -134891,7 +134753,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.458538+00:00"
+                "validatedAt": "2026-07-20T14:40:34.345344+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -134918,7 +134780,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.458571+00:00"
+                "validatedAt": "2026-07-20T14:40:34.345357+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -134943,7 +134805,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.458604+00:00"
+                "validatedAt": "2026-07-20T14:40:34.345370+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -134982,7 +134844,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:04.458630+00:00"
+                "validatedAt": "2026-07-20T14:40:34.345383+00:00"
               },
               "deterministic": true
             },
@@ -134994,9 +134856,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.980418+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.483671+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "parent": {
             "type": "string",
@@ -135013,7 +134874,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.458670+00:00"
+                "validatedAt": "2026-07-20T14:40:34.345396+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -135170,7 +135031,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.458744+00:00"
+                "validatedAt": "2026-07-20T14:40:34.345423+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -135197,7 +135058,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.458769+00:00"
+                "validatedAt": "2026-07-20T14:40:34.345434+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -135224,7 +135085,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.458795+00:00"
+                "validatedAt": "2026-07-20T14:40:34.345444+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -135251,7 +135112,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.458819+00:00"
+                "validatedAt": "2026-07-20T14:40:34.345454+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -135278,7 +135139,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.458845+00:00"
+                "validatedAt": "2026-07-20T14:40:34.345465+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -135320,7 +135181,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.458892+00:00"
+                "validatedAt": "2026-07-20T14:40:34.345483+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -135359,7 +135220,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:04.458918+00:00"
+                "validatedAt": "2026-07-20T14:40:34.345496+00:00"
               },
               "deterministic": true
             },
@@ -135371,9 +135232,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.980510+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.483726+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "reason_code_distribution": {
             "type": "array",
@@ -135407,7 +135267,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.458970+00:00"
+                "validatedAt": "2026-07-20T14:40:34.345515+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -135535,7 +135395,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.459026+00:00"
+                "validatedAt": "2026-07-20T14:40:34.345536+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -135578,7 +135438,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.459081+00:00"
+                "validatedAt": "2026-07-20T14:40:34.345557+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -135604,7 +135464,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.459121+00:00"
+                "validatedAt": "2026-07-20T14:40:34.345572+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -135646,7 +135506,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.459174+00:00"
+                "validatedAt": "2026-07-20T14:40:34.345592+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -135689,7 +135549,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.459228+00:00"
+                "validatedAt": "2026-07-20T14:40:34.345612+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -135715,7 +135575,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.459269+00:00"
+                "validatedAt": "2026-07-20T14:40:34.345628+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -135757,7 +135617,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.459315+00:00"
+                "validatedAt": "2026-07-20T14:40:34.345645+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -135784,7 +135644,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.459354+00:00"
+                "validatedAt": "2026-07-20T14:40:34.345660+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -135931,7 +135791,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.459409+00:00"
+                "validatedAt": "2026-07-20T14:40:34.345681+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -135958,7 +135818,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.459436+00:00"
+                "validatedAt": "2026-07-20T14:40:34.345691+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -135985,7 +135845,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.459462+00:00"
+                "validatedAt": "2026-07-20T14:40:34.345702+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -136012,7 +135872,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.459486+00:00"
+                "validatedAt": "2026-07-20T14:40:34.345712+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -136039,7 +135899,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.459514+00:00"
+                "validatedAt": "2026-07-20T14:40:34.345723+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -136066,7 +135926,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.459552+00:00"
+                "validatedAt": "2026-07-20T14:40:34.345738+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -136137,7 +135997,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.459592+00:00"
+                "validatedAt": "2026-07-20T14:40:34.345753+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -136180,7 +136040,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.459646+00:00"
+                "validatedAt": "2026-07-20T14:40:34.345773+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -136238,7 +136098,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.459721+00:00"
+                "validatedAt": "2026-07-20T14:40:34.345797+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -136394,7 +136254,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:04.459799+00:00"
+                "validatedAt": "2026-07-20T14:40:34.345829+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -136472,7 +136332,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:04.459830+00:00"
+                "validatedAt": "2026-07-20T14:40:34.345844+00:00"
               },
               "deterministic": true
             },
@@ -136484,9 +136344,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.980754+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.483866+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "time_series": {
             "type": "array",
@@ -136579,7 +136438,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:04.459891+00:00"
+                "validatedAt": "2026-07-20T14:40:34.345871+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -136655,7 +136514,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.459922+00:00"
+                "validatedAt": "2026-07-20T14:40:34.345883+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -136682,7 +136541,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.459946+00:00"
+                "validatedAt": "2026-07-20T14:40:34.345893+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -136710,7 +136569,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.459987+00:00"
+                "validatedAt": "2026-07-20T14:40:34.345907+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -136735,7 +136594,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.460019+00:00"
+                "validatedAt": "2026-07-20T14:40:34.345919+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -136830,7 +136689,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:04.460070+00:00"
+                "validatedAt": "2026-07-20T14:40:34.345943+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -136990,7 +136849,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:04.460135+00:00"
+                "validatedAt": "2026-07-20T14:40:34.345969+00:00"
               },
               "deterministic": true
             },
@@ -137002,9 +136861,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.980854+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.483924+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "peer_count": {
             "type": "string",
@@ -137023,7 +136881,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.460171+00:00"
+                "validatedAt": "2026-07-20T14:40:34.345983+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -137065,7 +136923,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.460223+00:00"
+                "validatedAt": "2026-07-20T14:40:34.346003+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -137155,7 +137013,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.460277+00:00"
+                "validatedAt": "2026-07-20T14:40:34.346024+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -137184,7 +137042,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:08:04.460310+00:00"
+                "validatedAt": "2026-07-20T14:40:34.346040+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -137218,7 +137076,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.460348+00:00"
+                "validatedAt": "2026-07-20T14:40:34.346054+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -137251,7 +137109,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.460390+00:00"
+                "validatedAt": "2026-07-20T14:40:34.346071+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -137404,7 +137262,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.460471+00:00"
+                "validatedAt": "2026-07-20T14:40:34.346100+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -137446,7 +137304,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.460522+00:00"
+                "validatedAt": "2026-07-20T14:40:34.346119+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -137628,7 +137486,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:04.460581+00:00"
+                "validatedAt": "2026-07-20T14:40:34.346146+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -137694,7 +137552,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.460623+00:00"
+                "validatedAt": "2026-07-20T14:40:34.346162+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -137734,7 +137592,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.460681+00:00"
+                "validatedAt": "2026-07-20T14:40:34.346181+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -137759,7 +137617,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.460721+00:00"
+                "validatedAt": "2026-07-20T14:40:34.346196+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -137786,7 +137644,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.460755+00:00"
+                "validatedAt": "2026-07-20T14:40:34.346209+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -137813,7 +137671,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.460796+00:00"
+                "validatedAt": "2026-07-20T14:40:34.346224+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -137855,7 +137713,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.460851+00:00"
+                "validatedAt": "2026-07-20T14:40:34.346244+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -137895,7 +137753,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.460899+00:00"
+                "validatedAt": "2026-07-20T14:40:34.346261+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -137922,7 +137780,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.460939+00:00"
+                "validatedAt": "2026-07-20T14:40:34.346276+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -137979,7 +137837,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.461007+00:00"
+                "validatedAt": "2026-07-20T14:40:34.346301+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -138126,7 +137984,7 @@
             "maxLength": 16,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.981098+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.484068+00:00"
           },
           "order": {
             "allOf": [
@@ -138196,7 +138054,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.461077+00:00"
+                "validatedAt": "2026-07-20T14:40:34.346327+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -138304,7 +138162,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:04.461131+00:00"
+                "validatedAt": "2026-07-20T14:40:34.346349+00:00"
               },
               "deterministic": true
             },
@@ -138316,9 +138174,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.981145+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.484097+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "time_series_data": {
             "type": "array",
@@ -138404,7 +138261,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:04.461173+00:00"
+                "validatedAt": "2026-07-20T14:40:34.346366+00:00"
               },
               "deterministic": true
             },
@@ -138416,9 +138273,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.981171+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.484114+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "time_series": {
             "type": "array",
@@ -138492,7 +138348,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.461219+00:00"
+                "validatedAt": "2026-07-20T14:40:34.346384+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -138588,7 +138444,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.461269+00:00"
+                "validatedAt": "2026-07-20T14:40:34.346403+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -138621,7 +138477,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.461302+00:00"
+                "validatedAt": "2026-07-20T14:40:34.346416+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -138661,7 +138517,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.461351+00:00"
+                "validatedAt": "2026-07-20T14:40:34.346434+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -138700,7 +138556,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.461391+00:00"
+                "validatedAt": "2026-07-20T14:40:34.346449+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -138787,7 +138643,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.461437+00:00"
+                "validatedAt": "2026-07-20T14:40:34.346468+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -139144,7 +139000,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.461562+00:00"
+                "validatedAt": "2026-07-20T14:40:34.346513+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -139225,7 +139081,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.461616+00:00"
+                "validatedAt": "2026-07-20T14:40:34.346534+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -139303,7 +139159,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:04.461643+00:00"
+                "validatedAt": "2026-07-20T14:40:34.346546+00:00"
               },
               "deterministic": true
             },
@@ -139315,9 +139171,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.981342+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.484214+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "traffic_usage_count": {
             "type": "string",
@@ -139336,7 +139191,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.461692+00:00"
+                "validatedAt": "2026-07-20T14:40:34.346562+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -139376,7 +139231,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.461738+00:00"
+                "validatedAt": "2026-07-20T14:40:34.346580+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -139527,7 +139382,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.461822+00:00"
+                "validatedAt": "2026-07-20T14:40:34.346611+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -139811,7 +139666,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.461922+00:00"
+                "validatedAt": "2026-07-20T14:40:34.346647+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -139838,7 +139693,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.461956+00:00"
+                "validatedAt": "2026-07-20T14:40:34.346660+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -139865,7 +139720,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.461991+00:00"
+                "validatedAt": "2026-07-20T14:40:34.346674+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -139890,7 +139745,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.462027+00:00"
+                "validatedAt": "2026-07-20T14:40:34.346688+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -139915,7 +139770,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.462060+00:00"
+                "validatedAt": "2026-07-20T14:40:34.346701+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -139926,7 +139781,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.981466+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.484289+00:00"
           },
           "trend": {
             "type": "number",
@@ -140056,7 +139911,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.462127+00:00"
+                "validatedAt": "2026-07-20T14:40:34.346725+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -140083,7 +139938,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.462162+00:00"
+                "validatedAt": "2026-07-20T14:40:34.346739+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -140110,7 +139965,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.462192+00:00"
+                "validatedAt": "2026-07-20T14:40:34.346750+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -140137,7 +139992,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.462218+00:00"
+                "validatedAt": "2026-07-20T14:40:34.346760+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -140164,7 +140019,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.462259+00:00"
+                "validatedAt": "2026-07-20T14:40:34.346776+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -140189,7 +140044,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.462295+00:00"
+                "validatedAt": "2026-07-20T14:40:34.346790+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -140569,7 +140424,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.462437+00:00"
+                "validatedAt": "2026-07-20T14:40:34.346841+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -140859,7 +140714,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.462535+00:00"
+                "validatedAt": "2026-07-20T14:40:34.346876+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -140886,7 +140741,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.462571+00:00"
+                "validatedAt": "2026-07-20T14:40:34.346891+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -140936,7 +140791,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:08:04.462610+00:00"
+                "validatedAt": "2026-07-20T14:40:34.346907+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -140984,7 +140839,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:04.462643+00:00"
+                "validatedAt": "2026-07-20T14:40:34.346920+00:00"
               },
               "deterministic": true
             },
@@ -140996,9 +140851,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.981664+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.484402+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "start_time": {
             "type": "string",
@@ -141017,7 +140871,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.462698+00:00"
+                "validatedAt": "2026-07-20T14:40:34.346935+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -141050,7 +140904,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.462748+00:00"
+                "validatedAt": "2026-07-20T14:40:34.346951+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -141121,7 +140975,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.462793+00:00"
+                "validatedAt": "2026-07-20T14:40:34.346966+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -141148,7 +141002,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.462837+00:00"
+                "validatedAt": "2026-07-20T14:40:34.346979+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -141198,7 +141052,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:08:04.462877+00:00"
+                "validatedAt": "2026-07-20T14:40:34.346996+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -141246,7 +141100,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:04.462909+00:00"
+                "validatedAt": "2026-07-20T14:40:34.347010+00:00"
               },
               "deterministic": true
             },
@@ -141258,9 +141112,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.981725+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.484439+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "start_time": {
             "type": "string",
@@ -141279,7 +141132,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.462950+00:00"
+                "validatedAt": "2026-07-20T14:40:34.347024+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -141312,7 +141165,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.462994+00:00"
+                "validatedAt": "2026-07-20T14:40:34.347039+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -141385,7 +141238,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.463042+00:00"
+                "validatedAt": "2026-07-20T14:40:34.347057+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -141442,7 +141295,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.463113+00:00"
+                "validatedAt": "2026-07-20T14:40:34.347083+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -141467,7 +141320,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.463156+00:00"
+                "validatedAt": "2026-07-20T14:40:34.347098+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -141553,7 +141406,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.463221+00:00"
+                "validatedAt": "2026-07-20T14:40:34.347120+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -141621,7 +141474,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.463264+00:00"
+                "validatedAt": "2026-07-20T14:40:34.347135+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -141681,7 +141534,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T13:08:04.463331+00:00"
+                "validatedAt": "2026-07-20T14:40:34.347159+00:00"
               },
               "deterministic": true
             },
@@ -141704,7 +141557,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.463376+00:00"
+                "validatedAt": "2026-07-20T14:40:34.347174+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -141732,7 +141585,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.463414+00:00"
+                "validatedAt": "2026-07-20T14:40:34.347188+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -141776,7 +141629,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.463465+00:00"
+                "validatedAt": "2026-07-20T14:40:34.347205+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -141820,7 +141673,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.463525+00:00"
+                "validatedAt": "2026-07-20T14:40:34.347225+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -141864,7 +141717,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.463578+00:00"
+                "validatedAt": "2026-07-20T14:40:34.347243+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -141908,7 +141761,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.463631+00:00"
+                "validatedAt": "2026-07-20T14:40:34.347261+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -141950,7 +141803,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.463698+00:00"
+                "validatedAt": "2026-07-20T14:40:34.347282+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -141978,7 +141831,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.463729+00:00"
+                "validatedAt": "2026-07-20T14:40:34.347293+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -142077,7 +141930,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.463794+00:00"
+                "validatedAt": "2026-07-20T14:40:34.347315+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -142105,7 +141958,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.463838+00:00"
+                "validatedAt": "2026-07-20T14:40:34.347330+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -142130,7 +141983,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.463883+00:00"
+                "validatedAt": "2026-07-20T14:40:34.347348+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -142155,7 +142008,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.463927+00:00"
+                "validatedAt": "2026-07-20T14:40:34.347363+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -142238,7 +142091,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.463980+00:00"
+                "validatedAt": "2026-07-20T14:40:34.347381+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -142286,7 +142139,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:08:04.464021+00:00"
+                "validatedAt": "2026-07-20T14:40:34.347398+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -142334,7 +142187,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:04.464055+00:00"
+                "validatedAt": "2026-07-20T14:40:34.347413+00:00"
               },
               "deterministic": true
             },
@@ -142346,9 +142199,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.981977+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.484590+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "start_time": {
             "type": "string",
@@ -142367,7 +142219,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.464096+00:00"
+                "validatedAt": "2026-07-20T14:40:34.347428+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -142400,7 +142252,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.464142+00:00"
+                "validatedAt": "2026-07-20T14:40:34.347445+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -142470,7 +142322,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.464189+00:00"
+                "validatedAt": "2026-07-20T14:40:34.347462+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -142552,7 +142404,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.464245+00:00"
+                "validatedAt": "2026-07-20T14:40:34.347482+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -142613,7 +142465,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:04.464282+00:00"
+                "validatedAt": "2026-07-20T14:40:34.347499+00:00"
               },
               "deterministic": true
             },
@@ -142625,9 +142477,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.982037+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.484627+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "pagination": {
             "allOf": [
@@ -142673,7 +142524,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.464330+00:00"
+                "validatedAt": "2026-07-20T14:40:34.347516+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -142743,7 +142594,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.464377+00:00"
+                "validatedAt": "2026-07-20T14:40:34.347533+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -142823,7 +142674,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.464432+00:00"
+                "validatedAt": "2026-07-20T14:40:34.347553+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -142850,7 +142701,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.464471+00:00"
+                "validatedAt": "2026-07-20T14:40:34.347567+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -142911,7 +142762,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:04.464506+00:00"
+                "validatedAt": "2026-07-20T14:40:34.347582+00:00"
               },
               "deterministic": true
             },
@@ -142923,9 +142774,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.982111+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.484672+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "start_time": {
             "type": "string",
@@ -142944,7 +142794,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.464548+00:00"
+                "validatedAt": "2026-07-20T14:40:34.347597+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -142993,7 +142843,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.464597+00:00"
+                "validatedAt": "2026-07-20T14:40:34.347615+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -143066,7 +142916,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.464634+00:00"
+                "validatedAt": "2026-07-20T14:40:34.347629+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -143094,7 +142944,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.464686+00:00"
+                "validatedAt": "2026-07-20T14:40:34.347645+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -143122,7 +142972,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.464724+00:00"
+                "validatedAt": "2026-07-20T14:40:34.347659+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -143299,7 +143149,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.464795+00:00"
+                "validatedAt": "2026-07-20T14:40:34.347684+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -143327,7 +143177,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.464832+00:00"
+                "validatedAt": "2026-07-20T14:40:34.347698+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -143355,7 +143205,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.464878+00:00"
+                "validatedAt": "2026-07-20T14:40:34.347713+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -143383,7 +143233,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.464917+00:00"
+                "validatedAt": "2026-07-20T14:40:34.347728+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -143524,7 +143374,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.464985+00:00"
+                "validatedAt": "2026-07-20T14:40:34.347752+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -143552,7 +143402,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.465029+00:00"
+                "validatedAt": "2026-07-20T14:40:34.347768+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -143641,7 +143491,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:04.465109+00:00"
+                "validatedAt": "2026-07-20T14:40:34.347800+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -143668,7 +143518,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.465150+00:00"
+                "validatedAt": "2026-07-20T14:40:34.347816+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -143729,7 +143579,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:04.465189+00:00"
+                "validatedAt": "2026-07-20T14:40:34.347832+00:00"
               },
               "deterministic": true
             },
@@ -143741,9 +143591,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.982266+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.484767+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "start_time": {
             "type": "string",
@@ -143762,7 +143611,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.465231+00:00"
+                "validatedAt": "2026-07-20T14:40:34.347847+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -143863,7 +143712,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.465290+00:00"
+                "validatedAt": "2026-07-20T14:40:34.347868+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -143907,7 +143756,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.465354+00:00"
+                "validatedAt": "2026-07-20T14:40:34.347890+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -143933,7 +143782,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.465402+00:00"
+                "validatedAt": "2026-07-20T14:40:34.347906+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -143976,7 +143825,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.465454+00:00"
+                "validatedAt": "2026-07-20T14:40:34.347924+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -144020,7 +143869,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.465515+00:00"
+                "validatedAt": "2026-07-20T14:40:34.347945+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -144046,7 +143895,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.465561+00:00"
+                "validatedAt": "2026-07-20T14:40:34.347961+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -144089,7 +143938,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.465619+00:00"
+                "validatedAt": "2026-07-20T14:40:34.347981+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -144134,7 +143983,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.465702+00:00"
+                "validatedAt": "2026-07-20T14:40:34.348003+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -144160,7 +144009,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.465753+00:00"
+                "validatedAt": "2026-07-20T14:40:34.348022+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -144188,7 +144037,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.465791+00:00"
+                "validatedAt": "2026-07-20T14:40:34.348036+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -144232,7 +144081,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.465848+00:00"
+                "validatedAt": "2026-07-20T14:40:34.348057+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -144275,7 +144124,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.465896+00:00"
+                "validatedAt": "2026-07-20T14:40:34.348075+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -144303,7 +144152,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.465939+00:00"
+                "validatedAt": "2026-07-20T14:40:34.348091+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -144328,7 +144177,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.465982+00:00"
+                "validatedAt": "2026-07-20T14:40:34.348108+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -144513,7 +144362,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:04.466065+00:00"
+                "validatedAt": "2026-07-20T14:40:34.348143+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -144578,7 +144427,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.466108+00:00"
+                "validatedAt": "2026-07-20T14:40:34.348159+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -144603,7 +144452,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.466144+00:00"
+                "validatedAt": "2026-07-20T14:40:34.348173+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -144628,7 +144477,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.466180+00:00"
+                "validatedAt": "2026-07-20T14:40:34.348187+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -144668,7 +144517,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.466229+00:00"
+                "validatedAt": "2026-07-20T14:40:34.348206+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -144692,7 +144541,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.466272+00:00"
+                "validatedAt": "2026-07-20T14:40:34.348224+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -144717,7 +144566,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.466308+00:00"
+                "validatedAt": "2026-07-20T14:40:34.348239+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -144748,7 +144597,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T13:08:04.466342+00:00"
+                "validatedAt": "2026-07-20T14:40:34.348254+00:00"
               },
               "deterministic": true
             },
@@ -144759,8 +144608,7 @@
               "read": false
             },
             "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "minLength": 1,
-            "format": "fqdn"
+            "minLength": 1
           },
           "inference": {
             "type": "string",
@@ -144777,7 +144625,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.466379+00:00"
+                "validatedAt": "2026-07-20T14:40:34.348268+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -144802,7 +144650,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.466422+00:00"
+                "validatedAt": "2026-07-20T14:40:34.348285+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -144827,7 +144675,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.466449+00:00"
+                "validatedAt": "2026-07-20T14:40:34.348295+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -144852,7 +144700,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.466484+00:00"
+                "validatedAt": "2026-07-20T14:40:34.348309+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -144877,7 +144725,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.466520+00:00"
+                "validatedAt": "2026-07-20T14:40:34.348322+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -144911,7 +144759,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T13:08:04.466562+00:00"
+                "validatedAt": "2026-07-20T14:40:34.348364+00:00"
               },
               "deterministic": true
             },
@@ -144937,7 +144785,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.466588+00:00"
+                "validatedAt": "2026-07-20T14:40:34.348380+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -144962,7 +144810,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.466616+00:00"
+                "validatedAt": "2026-07-20T14:40:34.348392+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -145038,7 +144886,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.466659+00:00"
+                "validatedAt": "2026-07-20T14:40:34.348408+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -145076,7 +144924,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:04.466694+00:00"
+                "validatedAt": "2026-07-20T14:40:34.348424+00:00"
               },
               "deterministic": true
             },
@@ -145088,9 +144936,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.982578+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.484956+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "value": {
             "type": "string",
@@ -145105,7 +144952,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:04.466727+00:00"
+                "validatedAt": "2026-07-20T14:40:34.348438+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -145116,7 +144963,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.982598+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.484969+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -145309,7 +145156,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:04.466807+00:00"
+                "validatedAt": "2026-07-20T14:40:34.348477+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -145403,7 +145250,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:04.466857+00:00"
+                "validatedAt": "2026-07-20T14:40:34.348502+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -145503,7 +145350,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:13.096421+00:00"
+                "validatedAt": "2026-07-20T14:40:37.881794+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -145531,7 +145378,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:08:13.096483+00:00"
+                "validatedAt": "2026-07-20T14:40:37.881825+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -145625,7 +145472,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:13.096558+00:00"
+                "validatedAt": "2026-07-20T14:40:37.881858+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -145812,7 +145659,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:13.096683+00:00"
+                "validatedAt": "2026-07-20T14:40:37.881895+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -145837,7 +145684,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:13.096742+00:00"
+                "validatedAt": "2026-07-20T14:40:37.881912+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -145872,7 +145719,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:13.096799+00:00"
+                "validatedAt": "2026-07-20T14:40:37.881932+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -145937,7 +145784,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:13.096839+00:00"
+                "validatedAt": "2026-07-20T14:40:37.881950+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -145978,7 +145825,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:13.096866+00:00"
+                "validatedAt": "2026-07-20T14:40:37.881963+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -146071,7 +145918,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:13.096931+00:00"
+                "validatedAt": "2026-07-20T14:40:37.881992+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -146100,7 +145947,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:08:13.096964+00:00"
+                "validatedAt": "2026-07-20T14:40:37.882010+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -146126,7 +145973,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:13.096995+00:00"
+                "validatedAt": "2026-07-20T14:40:37.882024+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -146137,7 +145984,7 @@
             },
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.296666+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.745666+00:00"
           },
           "projectionAnnualConversion": {
             "type": "number",
@@ -146275,7 +146122,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:13.097104+00:00"
+                "validatedAt": "2026-07-20T14:40:37.882071+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -146302,7 +146149,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:08:13.097140+00:00"
+                "validatedAt": "2026-07-20T14:40:37.882090+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -146391,7 +146238,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:13.097186+00:00"
+                "validatedAt": "2026-07-20T14:40:37.882111+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -146426,7 +146273,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:13.097225+00:00"
+                "validatedAt": "2026-07-20T14:40:37.882129+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -146451,7 +146298,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:13.097260+00:00"
+                "validatedAt": "2026-07-20T14:40:37.882145+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -146486,7 +146333,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:13.097299+00:00"
+                "validatedAt": "2026-07-20T14:40:37.882163+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -146518,7 +146365,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:13.097337+00:00"
+                "validatedAt": "2026-07-20T14:40:37.882181+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -146530,7 +146377,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.296771+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.745728+00:00"
           }
         },
         "x-f5xc-description-short": "Since and to times to generate the Conversion request.",
@@ -146589,7 +146436,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:13.097378+00:00"
+                "validatedAt": "2026-07-20T14:40:37.882200+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -146630,7 +146477,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:13.097405+00:00"
+                "validatedAt": "2026-07-20T14:40:37.882213+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -146693,7 +146540,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:13.097440+00:00"
+                "validatedAt": "2026-07-20T14:40:37.882230+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -146721,7 +146568,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:08:13.097470+00:00"
+                "validatedAt": "2026-07-20T14:40:37.882246+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -146815,7 +146662,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:13.097536+00:00"
+                "validatedAt": "2026-07-20T14:40:37.882274+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -147003,7 +146850,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:13.097615+00:00"
+                "validatedAt": "2026-07-20T14:40:37.882309+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -147028,7 +146875,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:13.097650+00:00"
+                "validatedAt": "2026-07-20T14:40:37.882324+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -147063,7 +146910,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:13.097707+00:00"
+                "validatedAt": "2026-07-20T14:40:37.882343+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -147128,7 +146975,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:13.097747+00:00"
+                "validatedAt": "2026-07-20T14:40:37.882360+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -147169,7 +147016,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:13.097773+00:00"
+                "validatedAt": "2026-07-20T14:40:37.882373+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -147258,7 +147105,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:13.097836+00:00"
+                "validatedAt": "2026-07-20T14:40:37.882401+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -147472,7 +147319,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:13.097966+00:00"
+                "validatedAt": "2026-07-20T14:40:37.882457+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -147497,7 +147344,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:13.098000+00:00"
+                "validatedAt": "2026-07-20T14:40:37.882473+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -147532,7 +147379,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:13.098038+00:00"
+                "validatedAt": "2026-07-20T14:40:37.882490+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -147597,7 +147444,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:13.098077+00:00"
+                "validatedAt": "2026-07-20T14:40:37.882508+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -147638,7 +147485,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:13.098106+00:00"
+                "validatedAt": "2026-07-20T14:40:37.882522+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -147702,7 +147549,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:13.098141+00:00"
+                "validatedAt": "2026-07-20T14:40:37.882538+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -147730,7 +147577,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:08:13.098172+00:00"
+                "validatedAt": "2026-07-20T14:40:37.882554+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -147824,7 +147671,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:13.098237+00:00"
+                "validatedAt": "2026-07-20T14:40:37.882583+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -148011,7 +147858,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:13.098375+00:00"
+                "validatedAt": "2026-07-20T14:40:37.882641+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -148036,7 +147883,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:13.098410+00:00"
+                "validatedAt": "2026-07-20T14:40:37.882657+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -148071,7 +147918,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:13.098448+00:00"
+                "validatedAt": "2026-07-20T14:40:37.882675+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -148136,7 +147983,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:13.098488+00:00"
+                "validatedAt": "2026-07-20T14:40:37.882692+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -148177,7 +148024,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:13.098515+00:00"
+                "validatedAt": "2026-07-20T14:40:37.882705+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -148255,7 +148102,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:13.098560+00:00"
+                "validatedAt": "2026-07-20T14:40:37.882725+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -148266,7 +148113,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.297174+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.745970+00:00"
           }
         },
         "x-f5xc-description-short": "Provision struct response GetStatusProvisionResponse.",
@@ -148322,7 +148169,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:13.098598+00:00"
+                "validatedAt": "2026-07-20T14:40:37.882742+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -148347,7 +148194,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:13.098623+00:00"
+                "validatedAt": "2026-07-20T14:40:37.882754+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -148387,7 +148234,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:13.098650+00:00"
+                "validatedAt": "2026-07-20T14:40:37.882767+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -148411,7 +148258,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:13.098685+00:00"
+                "validatedAt": "2026-07-20T14:40:37.882778+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -148437,7 +148284,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:13.098710+00:00"
+                "validatedAt": "2026-07-20T14:40:37.882790+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -148504,7 +148351,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:13.098746+00:00"
+                "validatedAt": "2026-07-20T14:40:37.882806+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -148660,7 +148507,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:13.098832+00:00"
+                "validatedAt": "2026-07-20T14:40:37.882844+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -148688,7 +148535,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:08:13.098862+00:00"
+                "validatedAt": "2026-07-20T14:40:37.882859+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -148784,7 +148631,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:13.098927+00:00"
+                "validatedAt": "2026-07-20T14:40:37.882888+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -148901,7 +148748,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:13.098979+00:00"
+                "validatedAt": "2026-07-20T14:40:37.882911+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -148926,7 +148773,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:13.099015+00:00"
+                "validatedAt": "2026-07-20T14:40:37.882927+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -148961,7 +148808,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:13.099054+00:00"
+                "validatedAt": "2026-07-20T14:40:37.882944+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -149026,7 +148873,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:13.099091+00:00"
+                "validatedAt": "2026-07-20T14:40:37.882962+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -149067,7 +148914,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:13.099117+00:00"
+                "validatedAt": "2026-07-20T14:40:37.882974+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -149162,7 +149009,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:13.099185+00:00"
+                "validatedAt": "2026-07-20T14:40:37.883004+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -149189,7 +149036,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:13.099225+00:00"
+                "validatedAt": "2026-07-20T14:40:37.883022+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -149243,7 +149090,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:13.099282+00:00"
+                "validatedAt": "2026-07-20T14:40:37.883048+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -149272,7 +149119,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:08:13.099309+00:00"
+                "validatedAt": "2026-07-20T14:40:37.883062+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -149298,7 +149145,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:13.099338+00:00"
+                "validatedAt": "2026-07-20T14:40:37.883075+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -149309,7 +149156,7 @@
             },
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.297414+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.746118+00:00"
           },
           "noBenefit": {
             "type": "number",
@@ -149436,7 +149283,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:13.099431+00:00"
+                "validatedAt": "2026-07-20T14:40:37.883115+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -149477,7 +149324,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.297474+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.746156+00:00"
           }
         },
         "x-f5xc-description-short": "Conversion Item that represent the data to chart.",
@@ -149546,7 +149393,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:13.099492+00:00"
+                "validatedAt": "2026-07-20T14:40:37.883142+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -149571,7 +149418,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:13.099526+00:00"
+                "validatedAt": "2026-07-20T14:40:37.883158+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -149606,7 +149453,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:13.099566+00:00"
+                "validatedAt": "2026-07-20T14:40:37.883176+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -149671,7 +149518,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:13.099605+00:00"
+                "validatedAt": "2026-07-20T14:40:37.883193+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -149712,7 +149559,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:13.099631+00:00"
+                "validatedAt": "2026-07-20T14:40:37.883205+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -149778,7 +149625,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:13.099683+00:00"
+                "validatedAt": "2026-07-20T14:40:37.883225+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -149804,7 +149651,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:13.099733+00:00"
+                "validatedAt": "2026-07-20T14:40:37.883247+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -149829,7 +149676,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:13.099774+00:00"
+                "validatedAt": "2026-07-20T14:40:37.883265+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -149854,7 +149701,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:13.099821+00:00"
+                "validatedAt": "2026-07-20T14:40:37.883287+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -149894,7 +149741,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:13.099870+00:00"
+                "validatedAt": "2026-07-20T14:40:37.883308+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -149991,7 +149838,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:13.099935+00:00"
+                "validatedAt": "2026-07-20T14:40:37.883337+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -150032,7 +149879,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:13.099961+00:00"
+                "validatedAt": "2026-07-20T14:40:37.883350+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -150293,7 +150140,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:13.100050+00:00"
+                "validatedAt": "2026-07-20T14:40:37.883388+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -150328,7 +150175,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:13.100088+00:00"
+                "validatedAt": "2026-07-20T14:40:37.883405+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -150398,7 +150245,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:13.100157+00:00"
+                "validatedAt": "2026-07-20T14:40:37.883441+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -150446,7 +150293,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:13.100205+00:00"
+                "validatedAt": "2026-07-20T14:40:37.883467+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -150593,7 +150440,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:13.100252+00:00"
+                "validatedAt": "2026-07-20T14:40:37.883494+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -150636,7 +150483,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:13.100307+00:00"
+                "validatedAt": "2026-07-20T14:40:37.883526+00:00"
               },
               "deterministic": true
             },
@@ -150717,7 +150564,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:13.100346+00:00"
+                "validatedAt": "2026-07-20T14:40:37.883544+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -150782,7 +150629,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:17.266886+00:00"
+                "validatedAt": "2026-07-20T14:40:39.776600+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -150806,7 +150653,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:17.266962+00:00"
+                "validatedAt": "2026-07-20T14:40:39.776627+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -150830,7 +150677,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:17.267022+00:00"
+                "validatedAt": "2026-07-20T14:40:39.776646+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -150895,7 +150742,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:17.267085+00:00"
+                "validatedAt": "2026-07-20T14:40:39.776664+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -150958,7 +150805,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:17.267146+00:00"
+                "validatedAt": "2026-07-20T14:40:39.776682+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -150985,7 +150832,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:08:17.267196+00:00"
+                "validatedAt": "2026-07-20T14:40:39.776708+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -151048,7 +150895,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:17.267233+00:00"
+                "validatedAt": "2026-07-20T14:40:39.776726+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -151111,7 +150958,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:17.267271+00:00"
+                "validatedAt": "2026-07-20T14:40:39.776744+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -151135,7 +150982,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:17.267306+00:00"
+                "validatedAt": "2026-07-20T14:40:39.776761+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -151159,7 +151006,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:17.267345+00:00"
+                "validatedAt": "2026-07-20T14:40:39.776780+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -151224,7 +151071,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:17.267382+00:00"
+                "validatedAt": "2026-07-20T14:40:39.776797+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -151287,7 +151134,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:17.267419+00:00"
+                "validatedAt": "2026-07-20T14:40:39.776815+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -151311,7 +151158,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:17.267454+00:00"
+                "validatedAt": "2026-07-20T14:40:39.776832+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -151335,7 +151182,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:17.267491+00:00"
+                "validatedAt": "2026-07-20T14:40:39.776849+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -151400,7 +151247,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:17.267533+00:00"
+                "validatedAt": "2026-07-20T14:40:39.776867+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -151463,7 +151310,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:17.267571+00:00"
+                "validatedAt": "2026-07-20T14:40:39.776884+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -151487,7 +151334,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:17.267607+00:00"
+                "validatedAt": "2026-07-20T14:40:39.776900+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -151511,7 +151358,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:17.267645+00:00"
+                "validatedAt": "2026-07-20T14:40:39.776919+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -151576,7 +151423,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:17.267692+00:00"
+                "validatedAt": "2026-07-20T14:40:39.776936+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -151639,7 +151486,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:17.267731+00:00"
+                "validatedAt": "2026-07-20T14:40:39.776954+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -151663,7 +151510,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:17.267766+00:00"
+                "validatedAt": "2026-07-20T14:40:39.776970+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -151687,7 +151534,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:17.267803+00:00"
+                "validatedAt": "2026-07-20T14:40:39.776988+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -151752,7 +151599,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:17.267841+00:00"
+                "validatedAt": "2026-07-20T14:40:39.777005+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -151815,7 +151662,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:17.267878+00:00"
+                "validatedAt": "2026-07-20T14:40:39.777022+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -151839,7 +151686,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:17.267914+00:00"
+                "validatedAt": "2026-07-20T14:40:39.777039+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -151863,7 +151710,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:17.267952+00:00"
+                "validatedAt": "2026-07-20T14:40:39.777057+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -151928,7 +151775,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:17.267990+00:00"
+                "validatedAt": "2026-07-20T14:40:39.777074+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -151989,7 +151836,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:17.268027+00:00"
+                "validatedAt": "2026-07-20T14:40:39.777091+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -152195,7 +152042,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:21.208606+00:00"
+                "validatedAt": "2026-07-20T14:40:41.504499+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -152262,7 +152109,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:21.208684+00:00"
+                "validatedAt": "2026-07-20T14:40:41.504522+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -152329,7 +152176,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:21.208738+00:00"
+                "validatedAt": "2026-07-20T14:40:41.504538+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -152396,7 +152243,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:21.208784+00:00"
+                "validatedAt": "2026-07-20T14:40:41.504553+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -152463,7 +152310,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:21.208834+00:00"
+                "validatedAt": "2026-07-20T14:40:41.504567+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -152530,7 +152377,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:21.208889+00:00"
+                "validatedAt": "2026-07-20T14:40:41.504583+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -152596,7 +152443,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:21.208935+00:00"
+                "validatedAt": "2026-07-20T14:40:41.504597+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -152663,7 +152510,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:21.208968+00:00"
+                "validatedAt": "2026-07-20T14:40:41.504611+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -152736,7 +152583,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:21.209054+00:00"
+                "validatedAt": "2026-07-20T14:40:41.504659+00:00"
               },
               "deterministic": true
             },
@@ -152769,7 +152616,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:21.209115+00:00"
+                "validatedAt": "2026-07-20T14:40:41.504690+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -152816,7 +152663,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:21.209150+00:00"
+                "validatedAt": "2026-07-20T14:40:41.504709+00:00"
               },
               "deterministic": true
             },
@@ -152828,9 +152675,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.440614+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.951030+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "transaction_id": {
             "type": "string",
@@ -152854,7 +152700,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:21.209211+00:00"
+                "validatedAt": "2026-07-20T14:40:41.504740+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -152887,7 +152733,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:21.209321+00:00"
+                "validatedAt": "2026-07-20T14:40:41.504768+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -152898,7 +152744,7 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.440642+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.951047+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -152959,7 +152805,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:21.209377+00:00"
+                "validatedAt": "2026-07-20T14:40:41.504783+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -153033,7 +152879,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:21.209431+00:00"
+                "validatedAt": "2026-07-20T14:40:41.504810+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -153080,7 +152926,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:21.209468+00:00"
+                "validatedAt": "2026-07-20T14:40:41.504827+00:00"
               },
               "deterministic": true
             },
@@ -153092,9 +152938,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.440686+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.951069+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "version": {
             "type": "string",
@@ -153118,7 +152963,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:21.209522+00:00"
+                "validatedAt": "2026-07-20T14:40:41.504855+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -153129,7 +152974,7 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.440705+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.951081+00:00"
           }
         },
         "x-f5xc-description-short": "Any payload to be passed on the Safe SAS Transactions CSV API.",
@@ -153190,7 +153035,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:21.209556+00:00"
+                "validatedAt": "2026-07-20T14:40:41.504869+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -153257,7 +153102,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:21.209588+00:00"
+                "validatedAt": "2026-07-20T14:40:41.504883+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -153304,7 +153149,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:21.209642+00:00"
+                "validatedAt": "2026-07-20T14:40:41.504900+00:00"
               },
               "deterministic": true
             },
@@ -153316,9 +153161,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.440740+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.951102+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "version": {
             "type": "string",
@@ -153342,7 +153186,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:21.209753+00:00"
+                "validatedAt": "2026-07-20T14:40:41.504928+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -153353,7 +153197,7 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.440758+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.951113+00:00"
           }
         },
         "x-f5xc-description-short": "Any payload to be passed on the Safe Block Feedback POST API.",
@@ -153414,7 +153258,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:21.209807+00:00"
+                "validatedAt": "2026-07-20T14:40:41.504942+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -153480,7 +153324,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:21.209859+00:00"
+                "validatedAt": "2026-07-20T14:40:41.504956+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -153527,7 +153371,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:21.209914+00:00"
+                "validatedAt": "2026-07-20T14:40:41.504972+00:00"
               },
               "deterministic": true
             },
@@ -153539,9 +153383,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.440793+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.951134+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "version": {
             "type": "string",
@@ -153565,7 +153408,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:21.210011+00:00"
+                "validatedAt": "2026-07-20T14:40:41.505000+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -153576,7 +153419,7 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.440811+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.951146+00:00"
           }
         },
         "x-f5xc-description-short": "Any payload to be passed on the Safe Block Rule POST API.",
@@ -153637,7 +153480,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:21.210070+00:00"
+                "validatedAt": "2026-07-20T14:40:41.505015+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -153703,7 +153546,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:21.210134+00:00"
+                "validatedAt": "2026-07-20T14:40:41.505028+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -153748,7 +153591,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:21.210187+00:00"
+                "validatedAt": "2026-07-20T14:40:41.505057+00:00"
               },
               "deterministic": true
             },
@@ -153760,9 +153603,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.440846+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.951167+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -153801,7 +153643,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:21.210219+00:00"
+                "validatedAt": "2026-07-20T14:40:41.505071+00:00"
               },
               "deterministic": true
             },
@@ -153813,9 +153655,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.440865+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.951178+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "version": {
             "type": "string",
@@ -153839,7 +153680,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:21.210274+00:00"
+                "validatedAt": "2026-07-20T14:40:41.505099+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -153850,7 +153691,7 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.440883+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.951190+00:00"
           }
         },
         "x-f5xc-description-short": "Any payload to be passed on the Safe Ep POST API.",
@@ -153912,7 +153753,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:21.210306+00:00"
+                "validatedAt": "2026-07-20T14:40:41.505113+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -153978,7 +153819,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:21.210336+00:00"
+                "validatedAt": "2026-07-20T14:40:41.505127+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -154025,7 +153866,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:21.210368+00:00"
+                "validatedAt": "2026-07-20T14:40:41.505143+00:00"
               },
               "deterministic": true
             },
@@ -154037,9 +153878,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.440918+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.951211+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "version": {
             "type": "string",
@@ -154063,7 +153903,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:21.210425+00:00"
+                "validatedAt": "2026-07-20T14:40:41.505171+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -154074,7 +153914,7 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.440936+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.951223+00:00"
           }
         },
         "x-f5xc-description-short": "Any payload to be passed on the Safe Dashboard Transaction Breakdown POST API.",
@@ -154135,7 +153975,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:21.210456+00:00"
+                "validatedAt": "2026-07-20T14:40:41.505185+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -154201,7 +154041,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:21.210487+00:00"
+                "validatedAt": "2026-07-20T14:40:41.505198+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -154248,7 +154088,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:21.210517+00:00"
+                "validatedAt": "2026-07-20T14:40:41.505214+00:00"
               },
               "deterministic": true
             },
@@ -154260,9 +154100,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.440971+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.951243+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "version": {
             "type": "string",
@@ -154286,7 +154125,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:21.210570+00:00"
+                "validatedAt": "2026-07-20T14:40:41.505241+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -154297,7 +154136,7 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.440990+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.951255+00:00"
           }
         },
         "x-f5xc-description-short": "Any payload to be passed on the Safe Provision POST API.",
@@ -154358,7 +154197,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:21.210601+00:00"
+                "validatedAt": "2026-07-20T14:40:41.505256+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -154424,7 +154263,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:21.210632+00:00"
+                "validatedAt": "2026-07-20T14:40:41.505269+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -154471,7 +154310,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:21.210680+00:00"
+                "validatedAt": "2026-07-20T14:40:41.505287+00:00"
               },
               "deterministic": true
             },
@@ -154483,9 +154322,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.441025+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.951276+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "version": {
             "type": "string",
@@ -154509,7 +154347,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:21.210737+00:00"
+                "validatedAt": "2026-07-20T14:40:41.505317+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -154520,7 +154358,7 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.441043+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.951287+00:00"
           }
         },
         "x-f5xc-description-short": "Any payload to be passed on the Safe Dashboard Transaction Breakdown POST API.",
@@ -154581,7 +154419,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:21.210769+00:00"
+                "validatedAt": "2026-07-20T14:40:41.505331+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -154628,7 +154466,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:21.210823+00:00"
+                "validatedAt": "2026-07-20T14:40:41.505347+00:00"
               },
               "deterministic": true
             },
@@ -154640,9 +154478,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.441070+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.951304+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "version": {
             "type": "string",
@@ -154666,7 +154503,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:21.210891+00:00"
+                "validatedAt": "2026-07-20T14:40:41.505375+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -154677,7 +154514,7 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.441088+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.951315+00:00"
           }
         },
         "x-f5xc-description-short": "Any payload to be passed on the Safe Transactions Details POST API.",
@@ -154738,7 +154575,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:21.210925+00:00"
+                "validatedAt": "2026-07-20T14:40:41.505388+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -154804,7 +154641,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:21.210957+00:00"
+                "validatedAt": "2026-07-20T14:40:41.505402+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -154851,7 +154688,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:21.210989+00:00"
+                "validatedAt": "2026-07-20T14:40:41.505418+00:00"
               },
               "deterministic": true
             },
@@ -154863,9 +154700,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.441123+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.951336+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "version": {
             "type": "string",
@@ -154889,7 +154725,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:21.211043+00:00"
+                "validatedAt": "2026-07-20T14:40:41.505445+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -154900,7 +154736,7 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.441140+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.951348+00:00"
           }
         },
         "x-f5xc-description-short": "Any payload to be passed on the Safe Transactions Device Hisotry POST API.",
@@ -154961,7 +154797,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:21.211075+00:00"
+                "validatedAt": "2026-07-20T14:40:41.505459+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -155027,7 +154863,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:21.211106+00:00"
+                "validatedAt": "2026-07-20T14:40:41.505473+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -155074,7 +154910,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:21.211138+00:00"
+                "validatedAt": "2026-07-20T14:40:41.505489+00:00"
               },
               "deterministic": true
             },
@@ -155086,9 +154922,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.441174+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.951369+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "version": {
             "type": "string",
@@ -155112,7 +154947,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:21.211191+00:00"
+                "validatedAt": "2026-07-20T14:40:41.505517+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -155123,7 +154958,7 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.441192+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.951381+00:00"
           }
         },
         "x-f5xc-description-short": "Any payload to be passed on the Safe Transactions Location POST API.",
@@ -155184,7 +155019,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:21.211225+00:00"
+                "validatedAt": "2026-07-20T14:40:41.505532+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -155250,7 +155085,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:21.211256+00:00"
+                "validatedAt": "2026-07-20T14:40:41.505546+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -155297,7 +155132,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:21.211286+00:00"
+                "validatedAt": "2026-07-20T14:40:41.505562+00:00"
               },
               "deterministic": true
             },
@@ -155309,9 +155144,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.441227+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.951401+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "version": {
             "type": "string",
@@ -155335,7 +155169,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:21.211339+00:00"
+                "validatedAt": "2026-07-20T14:40:41.505592+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -155346,7 +155180,7 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.441245+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.951413+00:00"
           }
         },
         "x-f5xc-description-short": "Any payload to be passed on the Safe Transactions Related Sesions POST API.",
@@ -155407,7 +155241,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:21.211372+00:00"
+                "validatedAt": "2026-07-20T14:40:41.505606+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -155473,7 +155307,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:21.211404+00:00"
+                "validatedAt": "2026-07-20T14:40:41.505620+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -155520,7 +155354,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:21.211435+00:00"
+                "validatedAt": "2026-07-20T14:40:41.505637+00:00"
               },
               "deterministic": true
             },
@@ -155532,9 +155366,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.441279+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.951434+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "version": {
             "type": "string",
@@ -155558,7 +155391,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:21.211521+00:00"
+                "validatedAt": "2026-07-20T14:40:41.505665+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -155569,7 +155402,7 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.441297+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.951445+00:00"
           }
         },
         "x-f5xc-description-short": "Any payload to be passed on the Safe Transactions Timeline POST API.",
@@ -155630,7 +155463,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:21.211578+00:00"
+                "validatedAt": "2026-07-20T14:40:41.505679+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -155696,7 +155529,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:21.211652+00:00"
+                "validatedAt": "2026-07-20T14:40:41.505693+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -155743,7 +155576,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:21.211712+00:00"
+                "validatedAt": "2026-07-20T14:40:41.505709+00:00"
               },
               "deterministic": true
             },
@@ -155755,9 +155588,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.441332+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.951466+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "version": {
             "type": "string",
@@ -155781,7 +155613,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:21.211794+00:00"
+                "validatedAt": "2026-07-20T14:40:41.505737+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -155792,7 +155624,7 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.441350+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.951478+00:00"
           }
         },
         "x-f5xc-description-short": "Any payload to be passed on the Safe SAS Transactions CSV API.",
@@ -155853,7 +155685,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:21.211842+00:00"
+                "validatedAt": "2026-07-20T14:40:41.505752+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -155920,7 +155752,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:21.211875+00:00"
+                "validatedAt": "2026-07-20T14:40:41.505766+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -155967,7 +155799,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:21.211907+00:00"
+                "validatedAt": "2026-07-20T14:40:41.505783+00:00"
               },
               "deterministic": true
             },
@@ -155979,9 +155811,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.441384+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.951499+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "version": {
             "type": "string",
@@ -156005,7 +155836,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:21.211962+00:00"
+                "validatedAt": "2026-07-20T14:40:41.505810+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -156016,7 +155847,7 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.441403+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.951511+00:00"
           }
         },
         "x-f5xc-description-short": "Any payload to be passed on the Safe Dashboard Transaction Over Time POST API.",
@@ -156077,7 +155908,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:21.211993+00:00"
+                "validatedAt": "2026-07-20T14:40:41.505824+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -156143,7 +155974,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:21.212024+00:00"
+                "validatedAt": "2026-07-20T14:40:41.505838+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -156190,7 +156021,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:21.212072+00:00"
+                "validatedAt": "2026-07-20T14:40:41.505854+00:00"
               },
               "deterministic": true
             },
@@ -156202,9 +156033,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.441438+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.951532+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "version": {
             "type": "string",
@@ -156228,7 +156058,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:21.212127+00:00"
+                "validatedAt": "2026-07-20T14:40:41.505882+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -156239,7 +156069,7 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.441456+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.951543+00:00"
           }
         },
         "x-f5xc-description-short": "Any payload to be passed on the Safe SAS Transactions API.",
@@ -156300,7 +156130,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:21.212160+00:00"
+                "validatedAt": "2026-07-20T14:40:41.505896+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -156369,7 +156199,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:29.075120+00:00"
+                "validatedAt": "2026-07-20T14:40:45.024740+00:00"
               }
             },
             "x-f5xc-required-for": {

--- a/docs/specifications/api/sites.json
+++ b/docs/specifications/api/sites.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Sites",
     "description": "Multi-cloud node provisioning spanning major public cloud environments including TGW, VNet, and VPC architectures. VPN tunnel configuration handles secure connectivity while IP prefix management controls address allocation. Customer edge deployments support external container orchestration platforms. Geographic distribution with resource sharing enables consistent policy enforcement across deployment points.",
-    "version": "2.1.182",
+    "version": "2.1.181",
     "contact": {
       "name": "F5 Distributed Cloud",
       "url": "https://docs.cloud.f5.com"
@@ -33389,7 +33389,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.388111+00:00"
+                "validatedAt": "2026-07-20T14:36:44.026411+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33431,7 +33431,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.388172+00:00"
+                "validatedAt": "2026-07-20T14:36:44.026436+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33493,7 +33493,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.388272+00:00"
+                "validatedAt": "2026-07-20T14:36:44.026490+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33531,7 +33531,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.388337+00:00"
+                "validatedAt": "2026-07-20T14:36:44.026525+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33557,7 +33557,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.388375+00:00"
+                "validatedAt": "2026-07-20T14:36:44.026540+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33638,7 +33638,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.388422+00:00"
+                "validatedAt": "2026-07-20T14:36:44.026561+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33662,7 +33662,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.388463+00:00"
+                "validatedAt": "2026-07-20T14:36:44.026579+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33685,7 +33685,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.388504+00:00"
+                "validatedAt": "2026-07-20T14:36:44.026597+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33710,7 +33710,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.388546+00:00"
+                "validatedAt": "2026-07-20T14:36:44.026615+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33733,7 +33733,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.388587+00:00"
+                "validatedAt": "2026-07-20T14:36:44.026633+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33773,7 +33773,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.388643+00:00"
+                "validatedAt": "2026-07-20T14:36:44.026657+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33796,7 +33796,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.388713+00:00"
+                "validatedAt": "2026-07-20T14:36:44.026676+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33820,7 +33820,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.388757+00:00"
+                "validatedAt": "2026-07-20T14:36:44.026695+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33844,7 +33844,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.388792+00:00"
+                "validatedAt": "2026-07-20T14:36:44.026709+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33855,7 +33855,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.368927+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.970432+00:00"
           },
           "tags": {
             "type": "object",
@@ -33930,7 +33930,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.388838+00:00"
+                "validatedAt": "2026-07-20T14:36:44.026728+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33968,7 +33968,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.388884+00:00"
+                "validatedAt": "2026-07-20T14:36:44.026747+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33991,7 +33991,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.388919+00:00"
+                "validatedAt": "2026-07-20T14:36:44.026761+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34030,7 +34030,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.388975+00:00"
+                "validatedAt": "2026-07-20T14:36:44.026786+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34053,7 +34053,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.389009+00:00"
+                "validatedAt": "2026-07-20T14:36:44.026801+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34077,7 +34077,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.389051+00:00"
+                "validatedAt": "2026-07-20T14:36:44.026818+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34100,7 +34100,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.389090+00:00"
+                "validatedAt": "2026-07-20T14:36:44.026835+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34123,7 +34123,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.389127+00:00"
+                "validatedAt": "2026-07-20T14:36:44.026850+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34363,7 +34363,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.389186+00:00"
+                "validatedAt": "2026-07-20T14:36:44.026879+00:00"
               },
               "deterministic": true
             },
@@ -34375,9 +34375,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.369074+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.970516+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -34409,7 +34408,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.389216+00:00"
+                "validatedAt": "2026-07-20T14:36:44.026894+00:00"
               },
               "deterministic": true
             },
@@ -34421,9 +34420,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.369094+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.970529+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -34586,7 +34584,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.369164+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.970571+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -34681,7 +34679,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:58:18.389329+00:00"
+                "validatedAt": "2026-07-20T14:36:44.026941+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34760,7 +34758,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:58:18.389382+00:00"
+                "validatedAt": "2026-07-20T14:36:44.026965+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34771,7 +34769,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.369217+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.970602+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -34858,7 +34856,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.389422+00:00"
+                "validatedAt": "2026-07-20T14:36:44.026984+00:00"
               },
               "deterministic": true
             },
@@ -34870,9 +34868,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.369264+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.970630+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -34903,7 +34900,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.389449+00:00"
+                "validatedAt": "2026-07-20T14:36:44.026997+00:00"
               },
               "deterministic": true
             },
@@ -34915,9 +34912,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.369283+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.970642+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -34986,7 +34982,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.389500+00:00"
+                "validatedAt": "2026-07-20T14:36:44.027018+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34998,7 +34994,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.369322+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.970667+00:00"
           },
           "uid": {
             "type": "string",
@@ -35015,7 +35011,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.389525+00:00"
+                "validatedAt": "2026-07-20T14:36:44.027029+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35028,7 +35024,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.369342+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.970680+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of aws_tgw_site is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -35437,7 +35433,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.389606+00:00"
+                "validatedAt": "2026-07-20T14:36:44.027060+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35594,7 +35590,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.389727+00:00"
+                "validatedAt": "2026-07-20T14:36:44.027109+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35712,7 +35708,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.389811+00:00"
+                "validatedAt": "2026-07-20T14:36:44.027146+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35777,7 +35773,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.389894+00:00"
+                "validatedAt": "2026-07-20T14:36:44.027185+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35911,7 +35907,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.389944+00:00"
+                "validatedAt": "2026-07-20T14:36:44.027205+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36075,7 +36071,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.390049+00:00"
+                "validatedAt": "2026-07-20T14:36:44.027249+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36210,7 +36206,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.390132+00:00"
+                "validatedAt": "2026-07-20T14:36:44.027285+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36291,7 +36287,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.390213+00:00"
+                "validatedAt": "2026-07-20T14:36:44.027325+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36439,7 +36435,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.390248+00:00"
+                "validatedAt": "2026-07-20T14:36:44.027341+00:00"
               },
               "deterministic": true
             },
@@ -36451,9 +36447,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.369701+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.970887+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -36485,7 +36480,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.390274+00:00"
+                "validatedAt": "2026-07-20T14:36:44.027353+00:00"
               },
               "deterministic": true
             },
@@ -36497,9 +36492,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.369720+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.970899+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tgw_info": {
             "allOf": [
@@ -36614,7 +36608,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.390305+00:00"
+                "validatedAt": "2026-07-20T14:36:44.027368+00:00"
               },
               "deterministic": true
             },
@@ -36626,9 +36620,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.369747+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.970917+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -36660,7 +36653,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.390332+00:00"
+                "validatedAt": "2026-07-20T14:36:44.027382+00:00"
               },
               "deterministic": true
             },
@@ -36672,9 +36665,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.369765+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.970929+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "vip_params_per_az": {
             "type": "array",
@@ -36798,7 +36790,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.390376+00:00"
+                "validatedAt": "2026-07-20T14:36:44.027402+00:00"
               },
               "deterministic": true
             },
@@ -36810,9 +36802,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.369793+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.970946+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -36844,7 +36835,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.390402+00:00"
+                "validatedAt": "2026-07-20T14:36:44.027415+00:00"
               },
               "deterministic": true
             },
@@ -36856,9 +36847,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.369811+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.970958+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "vpc_ip_prefixes": {
             "type": "object",
@@ -36972,7 +36962,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.390434+00:00"
+                "validatedAt": "2026-07-20T14:36:44.027431+00:00"
               },
               "deterministic": true
             },
@@ -36984,9 +36974,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.369840+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.970976+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -37018,7 +37007,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.390460+00:00"
+                "validatedAt": "2026-07-20T14:36:44.027444+00:00"
               },
               "deterministic": true
             },
@@ -37030,9 +37019,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.369858+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.970988+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -37307,7 +37295,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.390547+00:00"
+                "validatedAt": "2026-07-20T14:36:44.027480+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37395,7 +37383,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.390616+00:00"
+                "validatedAt": "2026-07-20T14:36:44.027514+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37806,7 +37794,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.390724+00:00"
+                "validatedAt": "2026-07-20T14:36:44.027556+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37840,7 +37828,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.390767+00:00"
+                "validatedAt": "2026-07-20T14:36:44.027577+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37901,7 +37889,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.390813+00:00"
+                "validatedAt": "2026-07-20T14:36:44.027612+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37926,7 +37914,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.390855+00:00"
+                "validatedAt": "2026-07-20T14:36:44.027635+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37951,7 +37939,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.390894+00:00"
+                "validatedAt": "2026-07-20T14:36:44.027652+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37976,7 +37964,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.390937+00:00"
+                "validatedAt": "2026-07-20T14:36:44.027670+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38052,7 +38040,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.390998+00:00"
+                "validatedAt": "2026-07-20T14:36:44.027697+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38077,7 +38065,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.391041+00:00"
+                "validatedAt": "2026-07-20T14:36:44.027715+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38100,7 +38088,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.391076+00:00"
+                "validatedAt": "2026-07-20T14:36:44.027729+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38137,7 +38125,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.391114+00:00"
+                "validatedAt": "2026-07-20T14:36:44.027745+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38162,7 +38150,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.391150+00:00"
+                "validatedAt": "2026-07-20T14:36:44.027760+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38185,7 +38173,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.391188+00:00"
+                "validatedAt": "2026-07-20T14:36:44.027776+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38258,7 +38246,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.391236+00:00"
+                "validatedAt": "2026-07-20T14:36:44.027797+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38283,7 +38271,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.391279+00:00"
+                "validatedAt": "2026-07-20T14:36:44.027813+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38322,7 +38310,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.391323+00:00"
+                "validatedAt": "2026-07-20T14:36:44.027831+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38360,7 +38348,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.391369+00:00"
+                "validatedAt": "2026-07-20T14:36:44.027849+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38406,7 +38394,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.391418+00:00"
+                "validatedAt": "2026-07-20T14:36:44.027869+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38429,7 +38417,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.391465+00:00"
+                "validatedAt": "2026-07-20T14:36:44.027890+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38454,7 +38442,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.391513+00:00"
+                "validatedAt": "2026-07-20T14:36:44.027909+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38477,7 +38465,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.391555+00:00"
+                "validatedAt": "2026-07-20T14:36:44.027926+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38501,7 +38489,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.391599+00:00"
+                "validatedAt": "2026-07-20T14:36:44.027945+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38572,7 +38560,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.391643+00:00"
+                "validatedAt": "2026-07-20T14:36:44.027963+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38610,7 +38598,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.391695+00:00"
+                "validatedAt": "2026-07-20T14:36:44.027981+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38636,7 +38624,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.391737+00:00"
+                "validatedAt": "2026-07-20T14:36:44.027998+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38674,7 +38662,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.391765+00:00"
+                "validatedAt": "2026-07-20T14:36:44.028014+00:00"
               },
               "deterministic": true
             },
@@ -38686,9 +38674,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.370250+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.971224+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tags": {
             "type": "object",
@@ -38726,7 +38713,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:37.884596+00:00"
+                "validatedAt": "2026-07-20T14:36:52.292468+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38749,7 +38736,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:37.884647+00:00"
+                "validatedAt": "2026-07-20T14:36:52.292489+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38833,7 +38820,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.391820+00:00"
+                "validatedAt": "2026-07-20T14:36:44.028044+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38904,7 +38891,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.391893+00:00"
+                "validatedAt": "2026-07-20T14:36:44.028083+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38952,7 +38939,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.391938+00:00"
+                "validatedAt": "2026-07-20T14:36:44.028106+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39012,7 +38999,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.391977+00:00"
+                "validatedAt": "2026-07-20T14:36:44.028123+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39038,7 +39025,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.392020+00:00"
+                "validatedAt": "2026-07-20T14:36:44.028141+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39063,7 +39050,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:58:18.392060+00:00"
+                "validatedAt": "2026-07-20T14:36:44.028160+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39087,7 +39074,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.392100+00:00"
+                "validatedAt": "2026-07-20T14:36:44.028176+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39182,7 +39169,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.392160+00:00"
+                "validatedAt": "2026-07-20T14:36:44.028200+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39257,7 +39244,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.392222+00:00"
+                "validatedAt": "2026-07-20T14:36:44.028224+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39281,7 +39268,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.392270+00:00"
+                "validatedAt": "2026-07-20T14:36:44.028244+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39306,7 +39293,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.392319+00:00"
+                "validatedAt": "2026-07-20T14:36:44.028264+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39416,7 +39403,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.392361+00:00"
+                "validatedAt": "2026-07-20T14:36:44.028281+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39439,7 +39426,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.392401+00:00"
+                "validatedAt": "2026-07-20T14:36:44.028297+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39462,7 +39449,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.392443+00:00"
+                "validatedAt": "2026-07-20T14:36:44.028315+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39486,7 +39473,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.392486+00:00"
+                "validatedAt": "2026-07-20T14:36:44.028332+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39510,7 +39497,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.392520+00:00"
+                "validatedAt": "2026-07-20T14:36:44.028346+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39521,7 +39508,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.370414+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.971323+00:00"
           },
           "subnet_id": {
             "type": "string",
@@ -39536,7 +39523,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.392557+00:00"
+                "validatedAt": "2026-07-20T14:36:44.028361+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39717,7 +39704,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.392613+00:00"
+                "validatedAt": "2026-07-20T14:36:44.028389+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39813,7 +39800,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.392644+00:00"
+                "validatedAt": "2026-07-20T14:36:44.028402+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39825,7 +39812,7 @@
             "readOnly": true,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.370477+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.971361+00:00"
           },
           "name": {
             "type": "string",
@@ -39858,7 +39845,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.392680+00:00"
+                "validatedAt": "2026-07-20T14:36:44.028417+00:00"
               },
               "deterministic": true
             },
@@ -39870,9 +39857,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.370495+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.971373+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -39905,7 +39891,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.392707+00:00"
+                "validatedAt": "2026-07-20T14:36:44.028431+00:00"
               },
               "deterministic": true
             },
@@ -39917,9 +39903,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.370514+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.971386+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -39938,7 +39923,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.392741+00:00"
+                "validatedAt": "2026-07-20T14:36:44.028445+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39951,7 +39936,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.370533+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.971398+00:00"
           },
           "uid": {
             "type": "string",
@@ -39970,7 +39955,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.392764+00:00"
+                "validatedAt": "2026-07-20T14:36:44.028456+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39984,7 +39969,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.370553+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.971411+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -40059,7 +40044,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.392812+00:00"
+                "validatedAt": "2026-07-20T14:36:44.028480+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40115,7 +40100,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.392849+00:00"
+                "validatedAt": "2026-07-20T14:36:44.028495+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40138,7 +40123,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.392881+00:00"
+                "validatedAt": "2026-07-20T14:36:44.028508+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40149,7 +40134,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.370588+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.971433+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -40208,7 +40193,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.392924+00:00"
+                "validatedAt": "2026-07-20T14:36:44.028526+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40249,7 +40234,7 @@
                 "confidence": 1.0,
                 "category": "content",
                 "note": "Blindfold envelope encryption (AES-256-GCM + RSA-OAEP) of an RSA-2048 TLS private key produces ~3700 char string:/// URL. 128KB max secret size = ~175KB base64. Discovery reported 1024 which is incorrect.",
-                "validatedAt": "2026-07-20T12:58:18.392959+00:00"
+                "validatedAt": "2026-07-20T14:36:44.028546+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40260,7 +40245,7 @@
             },
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.370616+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.971451+00:00"
           },
           "store_provider": {
             "type": "string",
@@ -40279,7 +40264,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.393003+00:00"
+                "validatedAt": "2026-07-20T14:36:44.028565+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40347,7 +40332,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.393038+00:00"
+                "validatedAt": "2026-07-20T14:36:44.028580+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40358,7 +40343,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.370643+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.971467+00:00"
           },
           "url": {
             "type": "string",
@@ -40396,7 +40381,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.393093+00:00"
+                "validatedAt": "2026-07-20T14:36:44.028610+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -40470,7 +40455,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T12:58:18.393124+00:00"
+                "validatedAt": "2026-07-20T14:36:44.028625+00:00"
               },
               "deterministic": true
             },
@@ -40481,8 +40466,7 @@
               "read": false
             },
             "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "minLength": 1,
-            "format": "fqdn"
+            "minLength": 1
           },
           "last_update_time": {
             "type": "string",
@@ -40499,7 +40483,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.393164+00:00"
+                "validatedAt": "2026-07-20T14:36:44.028641+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40526,7 +40510,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.393197+00:00"
+                "validatedAt": "2026-07-20T14:36:44.028654+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40537,7 +40521,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.370692+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.971492+00:00"
           },
           "service_name": {
             "type": "string",
@@ -40554,7 +40538,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.393235+00:00"
+                "validatedAt": "2026-07-20T14:36:44.028670+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40587,7 +40571,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.393271+00:00"
+                "validatedAt": "2026-07-20T14:36:44.028684+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40598,7 +40582,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.370717+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.971508+00:00"
           },
           "type": {
             "type": "string",
@@ -40623,7 +40607,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.393304+00:00"
+                "validatedAt": "2026-07-20T14:36:44.028698+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40688,7 +40672,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.393349+00:00"
+                "validatedAt": "2026-07-20T14:36:44.028713+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40712,7 +40696,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.393387+00:00"
+                "validatedAt": "2026-07-20T14:36:44.028728+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40737,7 +40721,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.393426+00:00"
+                "validatedAt": "2026-07-20T14:36:44.028743+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40872,7 +40856,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.393465+00:00"
+                "validatedAt": "2026-07-20T14:36:44.028759+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41038,7 +41022,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.393511+00:00"
+                "validatedAt": "2026-07-20T14:36:44.028780+00:00"
               },
               "deterministic": true
             },
@@ -41050,9 +41034,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.370795+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.971555+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -41335,7 +41318,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.393590+00:00"
+                "validatedAt": "2026-07-20T14:36:44.028815+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41427,7 +41410,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.393664+00:00"
+                "validatedAt": "2026-07-20T14:36:44.028847+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41499,7 +41482,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.393715+00:00"
+                "validatedAt": "2026-07-20T14:36:44.028872+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41593,7 +41576,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.393781+00:00"
+                "validatedAt": "2026-07-20T14:36:44.028904+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41665,7 +41648,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.393823+00:00"
+                "validatedAt": "2026-07-20T14:36:44.028926+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41832,7 +41815,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.393902+00:00"
+                "validatedAt": "2026-07-20T14:36:44.028963+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -41847,7 +41830,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.370933+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.971637+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -41917,7 +41900,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.393939+00:00"
+                "validatedAt": "2026-07-20T14:36:44.028980+00:00"
               },
               "deterministic": true
             },
@@ -41929,9 +41912,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.370966+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.971657+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -41964,7 +41946,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.393965+00:00"
+                "validatedAt": "2026-07-20T14:36:44.028993+00:00"
               },
               "deterministic": true
             },
@@ -41976,9 +41958,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.370984+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.971670+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -42076,7 +42057,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.394036+00:00"
+                "validatedAt": "2026-07-20T14:36:44.029027+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -42091,7 +42072,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.371012+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.971687+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -42163,7 +42144,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.394073+00:00"
+                "validatedAt": "2026-07-20T14:36:44.029045+00:00"
               },
               "deterministic": true
             },
@@ -42175,9 +42156,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.371045+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.971708+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -42210,7 +42190,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.394100+00:00"
+                "validatedAt": "2026-07-20T14:36:44.029057+00:00"
               },
               "deterministic": true
             },
@@ -42222,9 +42202,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.371063+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.971720+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -42322,7 +42301,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.394169+00:00"
+                "validatedAt": "2026-07-20T14:36:44.029092+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -42337,7 +42316,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.371091+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.971737+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -42407,7 +42386,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.394206+00:00"
+                "validatedAt": "2026-07-20T14:36:44.029110+00:00"
               },
               "deterministic": true
             },
@@ -42419,9 +42398,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.371123+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.971758+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -42454,7 +42432,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.394232+00:00"
+                "validatedAt": "2026-07-20T14:36:44.029123+00:00"
               },
               "deterministic": true
             },
@@ -42466,9 +42444,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.371142+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.971770+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -42739,7 +42716,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.394280+00:00"
+                "validatedAt": "2026-07-20T14:36:44.029147+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42803,7 +42780,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.394326+00:00"
+                "validatedAt": "2026-07-20T14:36:44.029171+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42870,7 +42847,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.394369+00:00"
+                "validatedAt": "2026-07-20T14:36:44.029188+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42898,7 +42875,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.394408+00:00"
+                "validatedAt": "2026-07-20T14:36:44.029204+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42926,7 +42903,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.394444+00:00"
+                "validatedAt": "2026-07-20T14:36:44.029218+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42965,7 +42942,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.394483+00:00"
+                "validatedAt": "2026-07-20T14:36:44.029234+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42992,7 +42969,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.394508+00:00"
+                "validatedAt": "2026-07-20T14:36:44.029245+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43005,7 +42982,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.371241+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.971829+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -43021,7 +42998,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.394541+00:00"
+                "validatedAt": "2026-07-20T14:36:44.029260+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43162,7 +43139,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.394588+00:00"
+                "validatedAt": "2026-07-20T14:36:44.029279+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43173,7 +43150,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.371281+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.971854+00:00"
           },
           "status": {
             "type": "string",
@@ -43191,7 +43168,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.394620+00:00"
+                "validatedAt": "2026-07-20T14:36:44.029292+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43202,7 +43179,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.371299+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.971867+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -43260,7 +43237,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.394670+00:00"
+                "validatedAt": "2026-07-20T14:36:44.029310+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43287,7 +43264,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.394709+00:00"
+                "validatedAt": "2026-07-20T14:36:44.029325+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43314,7 +43291,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.394746+00:00"
+                "validatedAt": "2026-07-20T14:36:44.029340+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43342,7 +43319,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.394787+00:00"
+                "validatedAt": "2026-07-20T14:36:44.029357+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43418,7 +43395,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.394850+00:00"
+                "validatedAt": "2026-07-20T14:36:44.029382+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43486,7 +43463,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.394900+00:00"
+                "validatedAt": "2026-07-20T14:36:44.029401+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43498,7 +43475,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.371385+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.971920+00:00"
           },
           "uid": {
             "type": "string",
@@ -43517,7 +43494,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.394925+00:00"
+                "validatedAt": "2026-07-20T14:36:44.029411+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43530,7 +43507,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.371403+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.971933+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -43594,7 +43571,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.394966+00:00"
+                "validatedAt": "2026-07-20T14:36:44.029428+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43636,7 +43613,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:58:18.395015+00:00"
+                "validatedAt": "2026-07-20T14:36:44.029451+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43647,7 +43624,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.371437+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.971955+00:00"
           },
           "disable_ocsp_stapling": {
             "allOf": [
@@ -43919,7 +43896,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.395103+00:00"
+                "validatedAt": "2026-07-20T14:36:44.029483+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44014,7 +43991,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.395151+00:00"
+                "validatedAt": "2026-07-20T14:36:44.029500+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44025,7 +44002,7 @@
             },
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.371543+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.972021+00:00"
           },
           "name": {
             "type": "string",
@@ -44058,7 +44035,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.395178+00:00"
+                "validatedAt": "2026-07-20T14:36:44.029514+00:00"
               },
               "deterministic": true
             },
@@ -44070,9 +44047,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.371561+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.972033+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -44105,7 +44081,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.395206+00:00"
+                "validatedAt": "2026-07-20T14:36:44.029527+00:00"
               },
               "deterministic": true
             },
@@ -44117,9 +44093,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.371580+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.972046+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "uid": {
             "type": "string",
@@ -44136,7 +44111,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.395235+00:00"
+                "validatedAt": "2026-07-20T14:36:44.029537+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44149,7 +44124,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.371599+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.972058+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -44273,7 +44248,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.395287+00:00"
+                "validatedAt": "2026-07-20T14:36:44.029564+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44352,7 +44327,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.395336+00:00"
+                "validatedAt": "2026-07-20T14:36:44.029589+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44442,7 +44417,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.395391+00:00"
+                "validatedAt": "2026-07-20T14:36:44.029618+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -44456,8 +44431,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -44496,7 +44470,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.395438+00:00"
+                "validatedAt": "2026-07-20T14:36:44.029643+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -44511,9 +44485,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.371645+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.972087+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -44542,7 +44515,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.395493+00:00"
+                "validatedAt": "2026-07-20T14:36:44.029668+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44555,7 +44528,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.371672+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.972099+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a direct reference from one object(the referrer) to another(the referred).",
@@ -44704,7 +44677,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.395599+00:00"
+                "validatedAt": "2026-07-20T14:36:44.029713+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44745,7 +44718,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.395646+00:00"
+                "validatedAt": "2026-07-20T14:36:44.029735+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44779,7 +44752,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.395721+00:00"
+                "validatedAt": "2026-07-20T14:36:44.029764+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44821,7 +44794,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.395769+00:00"
+                "validatedAt": "2026-07-20T14:36:44.029785+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44869,7 +44842,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.395816+00:00"
+                "validatedAt": "2026-07-20T14:36:44.029807+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44902,7 +44875,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.395881+00:00"
+                "validatedAt": "2026-07-20T14:36:44.029835+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44944,7 +44917,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.395926+00:00"
+                "validatedAt": "2026-07-20T14:36:44.029857+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45129,7 +45102,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.395977+00:00"
+                "validatedAt": "2026-07-20T14:36:44.029876+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45172,7 +45145,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.396026+00:00"
+                "validatedAt": "2026-07-20T14:36:44.029893+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45217,7 +45190,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.396076+00:00"
+                "validatedAt": "2026-07-20T14:36:44.029912+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45243,7 +45216,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.396120+00:00"
+                "validatedAt": "2026-07-20T14:36:44.029928+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45269,7 +45242,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.396161+00:00"
+                "validatedAt": "2026-07-20T14:36:44.029943+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45292,7 +45265,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.396201+00:00"
+                "validatedAt": "2026-07-20T14:36:44.029957+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45369,7 +45342,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.396256+00:00"
+                "validatedAt": "2026-07-20T14:36:44.029978+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45561,7 +45534,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.396307+00:00"
+                "validatedAt": "2026-07-20T14:36:44.029996+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45605,7 +45578,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.396358+00:00"
+                "validatedAt": "2026-07-20T14:36:44.030015+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45647,7 +45620,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.396406+00:00"
+                "validatedAt": "2026-07-20T14:36:44.030032+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45673,7 +45646,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.396451+00:00"
+                "validatedAt": "2026-07-20T14:36:44.030049+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45740,7 +45713,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.396490+00:00"
+                "validatedAt": "2026-07-20T14:36:44.030063+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45780,7 +45753,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.396538+00:00"
+                "validatedAt": "2026-07-20T14:36:44.030081+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45821,7 +45794,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.396586+00:00"
+                "validatedAt": "2026-07-20T14:36:44.030099+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45862,7 +45835,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.396635+00:00"
+                "validatedAt": "2026-07-20T14:36:44.030116+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45943,7 +45916,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.396715+00:00"
+                "validatedAt": "2026-07-20T14:36:44.030150+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45980,7 +45953,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.396771+00:00"
+                "validatedAt": "2026-07-20T14:36:44.030179+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46019,7 +45992,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.396818+00:00"
+                "validatedAt": "2026-07-20T14:36:44.030197+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46108,7 +46081,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.396881+00:00"
+                "validatedAt": "2026-07-20T14:36:44.030224+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46151,7 +46124,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.396926+00:00"
+                "validatedAt": "2026-07-20T14:36:44.030241+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46238,7 +46211,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.396972+00:00"
+                "validatedAt": "2026-07-20T14:36:44.030258+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46518,7 +46491,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.397075+00:00"
+                "validatedAt": "2026-07-20T14:36:44.030300+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46594,7 +46567,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.397112+00:00"
+                "validatedAt": "2026-07-20T14:36:44.030314+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46668,7 +46641,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.397188+00:00"
+                "validatedAt": "2026-07-20T14:36:44.030350+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46801,7 +46774,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.397257+00:00"
+                "validatedAt": "2026-07-20T14:36:44.030381+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46835,7 +46808,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.397321+00:00"
+                "validatedAt": "2026-07-20T14:36:44.030410+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46914,7 +46887,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.397387+00:00"
+                "validatedAt": "2026-07-20T14:36:44.030440+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47121,7 +47094,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.397478+00:00"
+                "validatedAt": "2026-07-20T14:36:44.030474+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47159,7 +47132,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.397545+00:00"
+                "validatedAt": "2026-07-20T14:36:44.030507+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47256,7 +47229,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.397628+00:00"
+                "validatedAt": "2026-07-20T14:36:44.030544+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47421,7 +47394,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.397709+00:00"
+                "validatedAt": "2026-07-20T14:36:44.030575+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47599,7 +47572,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.397768+00:00"
+                "validatedAt": "2026-07-20T14:36:44.030602+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48035,7 +48008,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.397909+00:00"
+                "validatedAt": "2026-07-20T14:36:44.030659+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48283,7 +48256,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.398004+00:00"
+                "validatedAt": "2026-07-20T14:36:44.030703+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48321,7 +48294,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.398080+00:00"
+                "validatedAt": "2026-07-20T14:36:44.030740+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48387,7 +48360,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.398124+00:00"
+                "validatedAt": "2026-07-20T14:36:44.030758+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48412,7 +48385,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.398166+00:00"
+                "validatedAt": "2026-07-20T14:36:44.030775+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48489,7 +48462,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.398216+00:00"
+                "validatedAt": "2026-07-20T14:36:44.030799+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48576,7 +48549,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.398267+00:00"
+                "validatedAt": "2026-07-20T14:36:44.030820+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48815,7 +48788,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.398336+00:00"
+                "validatedAt": "2026-07-20T14:36:44.030850+00:00"
               },
               "deterministic": true
             },
@@ -48827,9 +48800,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.372402+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.972539+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -48861,7 +48833,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.398364+00:00"
+                "validatedAt": "2026-07-20T14:36:44.030863+00:00"
               },
               "deterministic": true
             },
@@ -48873,9 +48845,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.372421+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.972551+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Request to validate AWS VPC site configuration.",
@@ -48968,7 +48939,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.398407+00:00"
+                "validatedAt": "2026-07-20T14:36:44.030880+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49024,7 +48995,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.398477+00:00"
+                "validatedAt": "2026-07-20T14:36:44.030914+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49117,7 +49088,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.398547+00:00"
+                "validatedAt": "2026-07-20T14:36:44.030944+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49196,7 +49167,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.398592+00:00"
+                "validatedAt": "2026-07-20T14:36:44.030967+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49793,7 +49764,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.398739+00:00"
+                "validatedAt": "2026-07-20T14:36:44.031016+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49951,7 +49922,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:18.398816+00:00"
+                "validatedAt": "2026-07-20T14:36:44.031044+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50062,7 +50033,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:18.398877+00:00"
+                "validatedAt": "2026-07-20T14:36:44.031072+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51051,7 +51022,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:23.245845+00:00"
+                "validatedAt": "2026-07-20T14:36:46.027676+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51551,7 +51522,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:23.246002+00:00"
+                "validatedAt": "2026-07-20T14:36:46.027742+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51671,7 +51642,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:23.246062+00:00"
+                "validatedAt": "2026-07-20T14:36:46.027770+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51713,7 +51684,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:23.246102+00:00"
+                "validatedAt": "2026-07-20T14:36:46.027790+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51773,7 +51744,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:23.246185+00:00"
+                "validatedAt": "2026-07-20T14:36:46.027830+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51799,7 +51770,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:23.246227+00:00"
+                "validatedAt": "2026-07-20T14:36:46.027847+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52348,7 +52319,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:23.246373+00:00"
+                "validatedAt": "2026-07-20T14:36:46.027911+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52901,7 +52872,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:23.246486+00:00"
+                "validatedAt": "2026-07-20T14:36:46.027961+00:00"
               },
               "deterministic": true
             },
@@ -52913,9 +52884,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.506936+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.112319+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -52947,7 +52917,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:23.246514+00:00"
+                "validatedAt": "2026-07-20T14:36:46.027977+00:00"
               },
               "deterministic": true
             },
@@ -52959,9 +52929,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.506958+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.112332+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -53124,7 +53093,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.507025+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.112374+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -53219,7 +53188,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:58:23.246628+00:00"
+                "validatedAt": "2026-07-20T14:36:46.028026+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53298,7 +53267,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:58:23.246691+00:00"
+                "validatedAt": "2026-07-20T14:36:46.028051+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53309,7 +53278,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.507076+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.112405+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -53396,7 +53365,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:23.246730+00:00"
+                "validatedAt": "2026-07-20T14:36:46.028070+00:00"
               },
               "deterministic": true
             },
@@ -53408,9 +53377,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.507121+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.112434+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -53441,7 +53409,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:23.246755+00:00"
+                "validatedAt": "2026-07-20T14:36:46.028084+00:00"
               },
               "deterministic": true
             },
@@ -53453,9 +53421,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.507139+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.112446+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -53524,7 +53491,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:23.246808+00:00"
+                "validatedAt": "2026-07-20T14:36:46.028104+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53536,7 +53503,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.507177+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.112470+00:00"
           },
           "uid": {
             "type": "string",
@@ -53553,7 +53520,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:23.246833+00:00"
+                "validatedAt": "2026-07-20T14:36:46.028115+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53566,7 +53533,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.507197+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.112483+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of aws_vpc_site is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -53769,7 +53736,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:23.246874+00:00"
+                "validatedAt": "2026-07-20T14:36:46.028135+00:00"
               },
               "deterministic": true
             },
@@ -53781,9 +53748,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.507246+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.112513+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -53815,7 +53781,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:23.246900+00:00"
+                "validatedAt": "2026-07-20T14:36:46.028149+00:00"
               },
               "deterministic": true
             },
@@ -53827,9 +53793,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.507265+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.112525+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Request to configure Cloud Site Information.",
@@ -53933,7 +53898,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:23.246926+00:00"
+                "validatedAt": "2026-07-20T14:36:46.028164+00:00"
               },
               "deterministic": true
             },
@@ -53945,9 +53910,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.507286+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.112538+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -53979,7 +53943,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:23.246951+00:00"
+                "validatedAt": "2026-07-20T14:36:46.028177+00:00"
               },
               "deterministic": true
             },
@@ -53991,9 +53955,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.507304+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.112550+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "vip_params_per_az": {
             "type": "array",
@@ -54117,7 +54080,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:23.246996+00:00"
+                "validatedAt": "2026-07-20T14:36:46.028198+00:00"
               },
               "deterministic": true
             },
@@ -54129,9 +54092,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.507332+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.112568+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -54163,7 +54125,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:23.247022+00:00"
+                "validatedAt": "2026-07-20T14:36:46.028211+00:00"
               },
               "deterministic": true
             },
@@ -54175,9 +54137,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.507351+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.112580+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "node_names": {
             "type": "array",
@@ -54390,7 +54351,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:23.250751+00:00"
+                "validatedAt": "2026-07-20T14:36:46.029912+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54464,7 +54425,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:23.251122+00:00"
+                "validatedAt": "2026-07-20T14:36:46.030082+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54569,7 +54530,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:23.251351+00:00"
+                "validatedAt": "2026-07-20T14:36:46.030184+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54645,7 +54606,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:23.251416+00:00"
+                "validatedAt": "2026-07-20T14:36:46.030218+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54721,7 +54682,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:23.252598+00:00"
+                "validatedAt": "2026-07-20T14:36:46.030761+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54810,7 +54771,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:23.252672+00:00"
+                "validatedAt": "2026-07-20T14:36:46.030791+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54819,8 +54780,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -54891,7 +54851,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:23.252964+00:00"
+                "validatedAt": "2026-07-20T14:36:46.030929+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54960,7 +54920,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:23.253009+00:00"
+                "validatedAt": "2026-07-20T14:36:46.030947+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55301,7 +55261,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:23.253139+00:00"
+                "validatedAt": "2026-07-20T14:36:46.031000+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55505,7 +55465,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:23.253237+00:00"
+                "validatedAt": "2026-07-20T14:36:46.031043+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55760,7 +55720,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:23.253322+00:00"
+                "validatedAt": "2026-07-20T14:36:46.031080+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55829,7 +55789,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:23.253366+00:00"
+                "validatedAt": "2026-07-20T14:36:46.031098+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56118,7 +56078,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:23.253467+00:00"
+                "validatedAt": "2026-07-20T14:36:46.031136+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56221,7 +56181,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:23.253539+00:00"
+                "validatedAt": "2026-07-20T14:36:46.031168+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56442,7 +56402,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:23.253650+00:00"
+                "validatedAt": "2026-07-20T14:36:46.031215+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56466,7 +56426,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:23.253699+00:00"
+                "validatedAt": "2026-07-20T14:36:46.031231+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56719,7 +56679,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:23.253785+00:00"
+                "validatedAt": "2026-07-20T14:36:46.031269+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56774,7 +56734,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:23.253827+00:00"
+                "validatedAt": "2026-07-20T14:36:46.031286+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57098,7 +57058,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:23.253956+00:00"
+                "validatedAt": "2026-07-20T14:36:46.031338+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57272,7 +57232,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:23.254059+00:00"
+                "validatedAt": "2026-07-20T14:36:46.031378+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57552,7 +57512,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.466378+00:00"
+                "validatedAt": "2026-07-20T14:36:48.193298+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57682,7 +57642,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.466473+00:00"
+                "validatedAt": "2026-07-20T14:36:48.193329+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58163,7 +58123,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.466597+00:00"
+                "validatedAt": "2026-07-20T14:36:48.193370+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58343,7 +58303,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:28.466674+00:00"
+                "validatedAt": "2026-07-20T14:36:48.193398+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58488,7 +58448,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.466754+00:00"
+                "validatedAt": "2026-07-20T14:36:48.193433+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58529,7 +58489,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.466815+00:00"
+                "validatedAt": "2026-07-20T14:36:48.193462+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58789,7 +58749,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:28.466896+00:00"
+                "validatedAt": "2026-07-20T14:36:48.193493+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58846,7 +58806,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.466933+00:00"
+                "validatedAt": "2026-07-20T14:36:48.193511+00:00"
               },
               "deterministic": true
             },
@@ -59083,7 +59043,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.467054+00:00"
+                "validatedAt": "2026-07-20T14:36:48.193564+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59243,7 +59203,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.467200+00:00"
+                "validatedAt": "2026-07-20T14:36:48.193632+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59280,7 +59240,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.467260+00:00"
+                "validatedAt": "2026-07-20T14:36:48.193661+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59400,7 +59360,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.467332+00:00"
+                "validatedAt": "2026-07-20T14:36:48.193694+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59411,8 +59371,7 @@
             },
             "x-f5xc-conflicts-with": [
               "mgmt_ip"
-            ],
-            "format": "hostname"
+            ]
           },
           "mgmt_ip": {
             "type": "string",
@@ -59438,7 +59397,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.467386+00:00"
+                "validatedAt": "2026-07-20T14:36:48.193720+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59518,7 +59477,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.467451+00:00"
+                "validatedAt": "2026-07-20T14:36:48.193751+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59553,7 +59512,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:28.467494+00:00"
+                "validatedAt": "2026-07-20T14:36:48.193768+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59592,7 +59551,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.467539+00:00"
+                "validatedAt": "2026-07-20T14:36:48.193791+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59649,7 +59608,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.467588+00:00"
+                "validatedAt": "2026-07-20T14:36:48.193816+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59711,7 +59670,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:28.467641+00:00"
+                "validatedAt": "2026-07-20T14:36:48.193838+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59806,7 +59765,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.467716+00:00"
+                "validatedAt": "2026-07-20T14:36:48.193869+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59817,8 +59776,7 @@
             },
             "x-f5xc-conflicts-with": [
               "mgmt_ip"
-            ],
-            "format": "hostname"
+            ]
           },
           "mgmt_ip": {
             "type": "string",
@@ -59844,7 +59802,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.467769+00:00"
+                "validatedAt": "2026-07-20T14:36:48.193895+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59884,7 +59842,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.467833+00:00"
+                "validatedAt": "2026-07-20T14:36:48.193926+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59895,8 +59853,7 @@
             },
             "x-f5xc-conflicts-with": [
               "nfs_endpoint_ip"
-            ],
-            "format": "hostname"
+            ]
           },
           "nfs_endpoint_ip": {
             "type": "string",
@@ -59922,7 +59879,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.467891+00:00"
+                "validatedAt": "2026-07-20T14:36:48.193954+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60045,7 +60002,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.467962+00:00"
+                "validatedAt": "2026-07-20T14:36:48.193990+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60089,7 +60046,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.468008+00:00"
+                "validatedAt": "2026-07-20T14:36:48.194016+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60195,7 +60152,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.468057+00:00"
+                "validatedAt": "2026-07-20T14:36:48.194041+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60314,7 +60271,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.468143+00:00"
+                "validatedAt": "2026-07-20T14:36:48.194083+00:00"
               },
               "deterministic": true
             },
@@ -60326,9 +60283,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.637839+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.238313+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -60404,7 +60360,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.468187+00:00"
+                "validatedAt": "2026-07-20T14:36:48.194106+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60476,7 +60432,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.468232+00:00"
+                "validatedAt": "2026-07-20T14:36:48.194130+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60623,7 +60579,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.468315+00:00"
+                "validatedAt": "2026-07-20T14:36:48.194170+00:00"
               },
               "deterministic": true
             },
@@ -60635,7 +60591,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.637906+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.238354+00:00"
           },
           "hpe_storage": {
             "allOf": [
@@ -60717,7 +60673,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.468381+00:00"
+                "validatedAt": "2026-07-20T14:36:48.194201+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60755,7 +60711,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.468441+00:00"
+                "validatedAt": "2026-07-20T14:36:48.194230+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60764,8 +60720,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "storage_device": {
             "type": "string",
@@ -60801,7 +60756,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.468504+00:00"
+                "validatedAt": "2026-07-20T14:36:48.194260+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60883,7 +60838,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.468549+00:00"
+                "validatedAt": "2026-07-20T14:36:48.194284+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61061,7 +61016,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.468626+00:00"
+                "validatedAt": "2026-07-20T14:36:48.194318+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61256,7 +61211,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:28.468703+00:00"
+                "validatedAt": "2026-07-20T14:36:48.194339+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61330,7 +61285,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.468783+00:00"
+                "validatedAt": "2026-07-20T14:36:48.194369+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61375,7 +61330,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:28.468826+00:00"
+                "validatedAt": "2026-07-20T14:36:48.194386+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61427,7 +61382,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.468887+00:00"
+                "validatedAt": "2026-07-20T14:36:48.194415+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61456,7 +61411,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:28.468926+00:00"
+                "validatedAt": "2026-07-20T14:36:48.194431+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61495,7 +61450,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:28.468969+00:00"
+                "validatedAt": "2026-07-20T14:36:48.194448+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61521,7 +61476,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:28.469010+00:00"
+                "validatedAt": "2026-07-20T14:36:48.194466+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61553,7 +61508,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:28.469052+00:00"
+                "validatedAt": "2026-07-20T14:36:48.194483+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61595,7 +61550,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:28.469097+00:00"
+                "validatedAt": "2026-07-20T14:36:48.194501+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61759,7 +61714,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:28.469162+00:00"
+                "validatedAt": "2026-07-20T14:36:48.194527+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61871,7 +61826,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.469234+00:00"
+                "validatedAt": "2026-07-20T14:36:48.194561+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61946,7 +61901,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.469300+00:00"
+                "validatedAt": "2026-07-20T14:36:48.194594+00:00"
               },
               "deterministic": true,
               "format": "uri"
@@ -62019,7 +61974,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.469359+00:00"
+                "validatedAt": "2026-07-20T14:36:48.194623+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62051,7 +62006,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.469418+00:00"
+                "validatedAt": "2026-07-20T14:36:48.194651+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62104,7 +62059,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.469487+00:00"
+                "validatedAt": "2026-07-20T14:36:48.194684+00:00"
               },
               "deterministic": true
             },
@@ -62116,7 +62071,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.638211+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.238541+00:00"
           },
           "destroy_on_delete": {
             "type": "boolean",
@@ -62174,7 +62129,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.469544+00:00"
+                "validatedAt": "2026-07-20T14:36:48.194712+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62201,7 +62156,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:28.469583+00:00"
+                "validatedAt": "2026-07-20T14:36:48.194728+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62228,7 +62183,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:28.469618+00:00"
+                "validatedAt": "2026-07-20T14:36:48.194743+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62261,7 +62216,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.469688+00:00"
+                "validatedAt": "2026-07-20T14:36:48.194773+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62294,7 +62249,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.469739+00:00"
+                "validatedAt": "2026-07-20T14:36:48.194798+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62327,7 +62282,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.469799+00:00"
+                "validatedAt": "2026-07-20T14:36:48.194828+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62361,7 +62316,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.469857+00:00"
+                "validatedAt": "2026-07-20T14:36:48.194856+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62394,7 +62349,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.469916+00:00"
+                "validatedAt": "2026-07-20T14:36:48.194883+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62529,7 +62484,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.469989+00:00"
+                "validatedAt": "2026-07-20T14:36:48.194917+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62600,7 +62555,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:28.470026+00:00"
+                "validatedAt": "2026-07-20T14:36:48.194933+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62634,7 +62589,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.470085+00:00"
+                "validatedAt": "2026-07-20T14:36:48.194961+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62766,7 +62721,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.470180+00:00"
+                "validatedAt": "2026-07-20T14:36:48.195004+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62813,7 +62768,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.470248+00:00"
+                "validatedAt": "2026-07-20T14:36:48.195035+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62846,7 +62801,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.470308+00:00"
+                "validatedAt": "2026-07-20T14:36:48.195063+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62854,8 +62809,7 @@
               "create": false,
               "update": false,
               "read": false
-            },
-            "format": "hostname"
+            }
           },
           "username": {
             "type": "string",
@@ -62891,7 +62845,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.470359+00:00"
+                "validatedAt": "2026-07-20T14:36:48.195089+00:00"
               },
               "deterministic": true
             },
@@ -63000,7 +62954,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.470428+00:00"
+                "validatedAt": "2026-07-20T14:36:48.195121+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63033,7 +62987,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.470488+00:00"
+                "validatedAt": "2026-07-20T14:36:48.195149+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63084,7 +63038,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.470554+00:00"
+                "validatedAt": "2026-07-20T14:36:48.195180+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63095,8 +63049,7 @@
             },
             "x-f5xc-conflicts-with": [
               "data_lif_ip"
-            ],
-            "format": "hostname"
+            ]
           },
           "data_lif_ip": {
             "type": "string",
@@ -63123,7 +63076,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.470611+00:00"
+                "validatedAt": "2026-07-20T14:36:48.195207+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63181,7 +63134,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:28.470666+00:00"
+                "validatedAt": "2026-07-20T14:36:48.195227+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63207,7 +63160,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:28.470707+00:00"
+                "validatedAt": "2026-07-20T14:36:48.195243+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63244,7 +63197,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.470772+00:00"
+                "validatedAt": "2026-07-20T14:36:48.195274+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63255,8 +63208,7 @@
             },
             "x-f5xc-conflicts-with": [
               "management_lif_ip"
-            ],
-            "format": "hostname"
+            ]
           },
           "management_lif_ip": {
             "type": "string",
@@ -63283,7 +63235,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.470832+00:00"
+                "validatedAt": "2026-07-20T14:36:48.195302+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63312,7 +63264,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:28.470873+00:00"
+                "validatedAt": "2026-07-20T14:36:48.195319+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63351,7 +63303,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:28.470908+00:00"
+                "validatedAt": "2026-07-20T14:36:48.195333+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63389,7 +63341,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.470951+00:00"
+                "validatedAt": "2026-07-20T14:36:48.195355+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63424,7 +63376,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:28.470997+00:00"
+                "validatedAt": "2026-07-20T14:36:48.195374+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63450,7 +63402,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:28.471038+00:00"
+                "validatedAt": "2026-07-20T14:36:48.195391+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63487,7 +63439,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.471084+00:00"
+                "validatedAt": "2026-07-20T14:36:48.195414+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63521,7 +63473,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.471148+00:00"
+                "validatedAt": "2026-07-20T14:36:48.195443+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63565,7 +63517,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.471197+00:00"
+                "validatedAt": "2026-07-20T14:36:48.195469+00:00"
               },
               "deterministic": true
             },
@@ -63674,7 +63626,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.471260+00:00"
+                "validatedAt": "2026-07-20T14:36:48.195498+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63725,7 +63677,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.471330+00:00"
+                "validatedAt": "2026-07-20T14:36:48.195529+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63736,8 +63688,7 @@
             },
             "x-f5xc-conflicts-with": [
               "data_lif_ip"
-            ],
-            "format": "hostname"
+            ]
           },
           "data_lif_ip": {
             "type": "string",
@@ -63764,7 +63715,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.471388+00:00"
+                "validatedAt": "2026-07-20T14:36:48.195555+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63804,7 +63755,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.471447+00:00"
+                "validatedAt": "2026-07-20T14:36:48.195583+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63910,7 +63861,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.471547+00:00"
+                "validatedAt": "2026-07-20T14:36:48.195627+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63921,8 +63872,7 @@
             },
             "x-f5xc-conflicts-with": [
               "management_lif_ip"
-            ],
-            "format": "hostname"
+            ]
           },
           "management_lif_ip": {
             "type": "string",
@@ -63949,7 +63899,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.471605+00:00"
+                "validatedAt": "2026-07-20T14:36:48.195654+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64007,7 +63957,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:28.471645+00:00"
+                "validatedAt": "2026-07-20T14:36:48.195670+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64045,7 +63995,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.471696+00:00"
+                "validatedAt": "2026-07-20T14:36:48.195692+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64080,7 +64030,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:28.471742+00:00"
+                "validatedAt": "2026-07-20T14:36:48.195711+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64117,7 +64067,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.471803+00:00"
+                "validatedAt": "2026-07-20T14:36:48.195740+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64154,7 +64104,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.471849+00:00"
+                "validatedAt": "2026-07-20T14:36:48.195763+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64188,7 +64138,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.471910+00:00"
+                "validatedAt": "2026-07-20T14:36:48.195792+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64248,7 +64198,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.471963+00:00"
+                "validatedAt": "2026-07-20T14:36:48.195820+00:00"
               },
               "deterministic": true
             },
@@ -64450,7 +64400,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.472051+00:00"
+                "validatedAt": "2026-07-20T14:36:48.195861+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64564,7 +64514,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:28.472105+00:00"
+                "validatedAt": "2026-07-20T14:36:48.195883+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64740,7 +64690,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.472318+00:00"
+                "validatedAt": "2026-07-20T14:36:48.195982+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64819,7 +64769,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.472366+00:00"
+                "validatedAt": "2026-07-20T14:36:48.196005+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64890,7 +64840,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:28.472454+00:00"
+                "validatedAt": "2026-07-20T14:36:48.196047+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64941,7 +64891,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.472509+00:00"
+                "validatedAt": "2026-07-20T14:36:48.196076+00:00"
               },
               "deterministic": true
             },
@@ -65015,7 +64965,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.472560+00:00"
+                "validatedAt": "2026-07-20T14:36:48.196102+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65050,7 +65000,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.472612+00:00"
+                "validatedAt": "2026-07-20T14:36:48.196127+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65168,7 +65118,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.472672+00:00"
+                "validatedAt": "2026-07-20T14:36:48.196153+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65419,7 +65369,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.472753+00:00"
+                "validatedAt": "2026-07-20T14:36:48.196188+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65458,7 +65408,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.472810+00:00"
+                "validatedAt": "2026-07-20T14:36:48.196215+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65527,7 +65477,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:28.472857+00:00"
+                "validatedAt": "2026-07-20T14:36:48.196234+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65578,7 +65528,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.472910+00:00"
+                "validatedAt": "2026-07-20T14:36:48.196262+00:00"
               },
               "deterministic": true
             },
@@ -65736,7 +65686,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.472964+00:00"
+                "validatedAt": "2026-07-20T14:36:48.196288+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65771,7 +65721,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.473016+00:00"
+                "validatedAt": "2026-07-20T14:36:48.196314+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65903,7 +65853,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.473068+00:00"
+                "validatedAt": "2026-07-20T14:36:48.196341+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66047,7 +65997,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.473134+00:00"
+                "validatedAt": "2026-07-20T14:36:48.196372+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66153,7 +66103,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.473207+00:00"
+                "validatedAt": "2026-07-20T14:36:48.196407+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66210,7 +66160,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:58:28.473247+00:00"
+                "validatedAt": "2026-07-20T14:36:48.196425+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66312,7 +66262,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.473307+00:00"
+                "validatedAt": "2026-07-20T14:36:48.196453+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66370,7 +66320,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.473370+00:00"
+                "validatedAt": "2026-07-20T14:36:48.196483+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66476,7 +66426,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.473429+00:00"
+                "validatedAt": "2026-07-20T14:36:48.196512+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66652,7 +66602,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.473514+00:00"
+                "validatedAt": "2026-07-20T14:36:48.196551+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66709,7 +66659,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:58:28.473552+00:00"
+                "validatedAt": "2026-07-20T14:36:48.196569+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66850,7 +66800,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T12:58:28.473604+00:00"
+                "validatedAt": "2026-07-20T14:36:48.196592+00:00"
               },
               "deterministic": true
             },
@@ -66960,7 +66910,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.473686+00:00"
+                "validatedAt": "2026-07-20T14:36:48.196629+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67204,7 +67154,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.473754+00:00"
+                "validatedAt": "2026-07-20T14:36:48.196660+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67275,7 +67225,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.473813+00:00"
+                "validatedAt": "2026-07-20T14:36:48.196688+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67548,7 +67498,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.473890+00:00"
+                "validatedAt": "2026-07-20T14:36:48.196725+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67587,7 +67537,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.473947+00:00"
+                "validatedAt": "2026-07-20T14:36:48.196754+00:00"
               },
               "deterministic": true
             },
@@ -67686,7 +67636,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.474008+00:00"
+                "validatedAt": "2026-07-20T14:36:48.196784+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67723,7 +67673,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:58:28.474043+00:00"
+                "validatedAt": "2026-07-20T14:36:48.196800+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67867,7 +67817,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.474837+00:00"
+                "validatedAt": "2026-07-20T14:36:48.197149+00:00"
               },
               "deterministic": true
             },
@@ -67879,7 +67829,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.639691+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.239427+00:00"
           },
           "name": {
             "type": "string",
@@ -67923,7 +67873,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.474885+00:00"
+                "validatedAt": "2026-07-20T14:36:48.197175+00:00"
               },
               "deterministic": true
             },
@@ -67933,8 +67883,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "MessageMetaType is metadata (common attributes) of a message that only certain messages have.",
@@ -67998,7 +67947,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.474926+00:00"
+                "validatedAt": "2026-07-20T14:36:48.197197+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68023,7 +67972,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:28.474955+00:00"
+                "validatedAt": "2026-07-20T14:36:48.197210+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68096,7 +68045,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.474995+00:00"
+                "validatedAt": "2026-07-20T14:36:48.197231+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68213,7 +68162,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.476398+00:00"
+                "validatedAt": "2026-07-20T14:36:48.197834+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68369,7 +68318,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.476850+00:00"
+                "validatedAt": "2026-07-20T14:36:48.198026+00:00"
               },
               "deterministic": true
             },
@@ -68381,9 +68330,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.640559+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.239967+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "public_ip": {
             "type": "string",
@@ -68409,7 +68357,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.476909+00:00"
+                "validatedAt": "2026-07-20T14:36:48.198053+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68488,7 +68436,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.477036+00:00"
+                "validatedAt": "2026-07-20T14:36:48.198111+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68569,7 +68517,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.477165+00:00"
+                "validatedAt": "2026-07-20T14:36:48.198170+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68987,7 +68935,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.477284+00:00"
+                "validatedAt": "2026-07-20T14:36:48.198219+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69165,7 +69113,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.477380+00:00"
+                "validatedAt": "2026-07-20T14:36:48.198259+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69174,8 +69122,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "worker_nodes": {
             "type": "array",
@@ -69204,7 +69151,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.477424+00:00"
+                "validatedAt": "2026-07-20T14:36:48.198282+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69324,7 +69271,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.477484+00:00"
+                "validatedAt": "2026-07-20T14:36:48.198310+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69742,7 +69689,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.477601+00:00"
+                "validatedAt": "2026-07-20T14:36:48.198357+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69839,7 +69786,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.477686+00:00"
+                "validatedAt": "2026-07-20T14:36:48.198390+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69939,7 +69886,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.477764+00:00"
+                "validatedAt": "2026-07-20T14:36:48.198423+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69948,8 +69895,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "volterra_software_version": {
             "type": "string",
@@ -69973,7 +69919,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.477831+00:00"
+                "validatedAt": "2026-07-20T14:36:48.198453+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -70010,7 +69956,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.477874+00:00"
+                "validatedAt": "2026-07-20T14:36:48.198475+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -70124,7 +70070,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.477932+00:00"
+                "validatedAt": "2026-07-20T14:36:48.198501+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -70542,7 +70488,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.478050+00:00"
+                "validatedAt": "2026-07-20T14:36:48.198549+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -70720,7 +70666,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.478143+00:00"
+                "validatedAt": "2026-07-20T14:36:48.198588+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -70729,8 +70675,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "worker_nodes": {
             "type": "array",
@@ -70759,7 +70704,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.478185+00:00"
+                "validatedAt": "2026-07-20T14:36:48.198609+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -70867,7 +70812,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.478226+00:00"
+                "validatedAt": "2026-07-20T14:36:48.198631+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -70921,7 +70866,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.478284+00:00"
+                "validatedAt": "2026-07-20T14:36:48.198659+00:00"
               },
               "deterministic": true
             },
@@ -70974,7 +70919,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.478330+00:00"
+                "validatedAt": "2026-07-20T14:36:48.198682+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71071,7 +71016,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.478375+00:00"
+                "validatedAt": "2026-07-20T14:36:48.198704+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71125,7 +71070,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.478431+00:00"
+                "validatedAt": "2026-07-20T14:36:48.198732+00:00"
               },
               "deterministic": true
             },
@@ -71178,7 +71123,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.478477+00:00"
+                "validatedAt": "2026-07-20T14:36:48.198754+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71282,7 +71227,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.478526+00:00"
+                "validatedAt": "2026-07-20T14:36:48.198779+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71513,7 +71458,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.478579+00:00"
+                "validatedAt": "2026-07-20T14:36:48.198801+00:00"
               },
               "deterministic": true
             },
@@ -71525,9 +71470,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.641413+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.240474+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -71559,7 +71503,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.478606+00:00"
+                "validatedAt": "2026-07-20T14:36:48.198814+00:00"
               },
               "deterministic": true
             },
@@ -71571,9 +71515,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.641432+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.240486+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -71736,7 +71679,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.641498+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.240526+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -71895,7 +71838,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.478776+00:00"
+                "validatedAt": "2026-07-20T14:36:48.198876+00:00"
               },
               "deterministic": true
             },
@@ -71907,7 +71850,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.641549+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.240558+00:00"
           },
           "ethernet_interface": {
             "allOf": [
@@ -72039,7 +71982,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.478835+00:00"
+                "validatedAt": "2026-07-20T14:36:48.198903+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -72121,7 +72064,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:58:28.478878+00:00"
+                "validatedAt": "2026-07-20T14:36:48.198921+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -72200,7 +72143,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:58:28.478930+00:00"
+                "validatedAt": "2026-07-20T14:36:48.198943+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -72211,7 +72154,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.641621+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.240601+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -72298,7 +72241,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.478972+00:00"
+                "validatedAt": "2026-07-20T14:36:48.198963+00:00"
               },
               "deterministic": true
             },
@@ -72310,9 +72253,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.641675+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.240629+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -72343,7 +72285,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.478999+00:00"
+                "validatedAt": "2026-07-20T14:36:48.198977+00:00"
               },
               "deterministic": true
             },
@@ -72355,9 +72297,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.641694+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.240641+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -72426,7 +72367,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:28.479053+00:00"
+                "validatedAt": "2026-07-20T14:36:48.198997+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -72438,7 +72379,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.641732+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.240665+00:00"
           },
           "uid": {
             "type": "string",
@@ -72456,7 +72397,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:28.479079+00:00"
+                "validatedAt": "2026-07-20T14:36:48.199008+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -72469,7 +72410,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.641751+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.240677+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of customer_edge_site is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -72758,7 +72699,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.479152+00:00"
+                "validatedAt": "2026-07-20T14:36:48.199042+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -72923,7 +72864,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.479231+00:00"
+                "validatedAt": "2026-07-20T14:36:48.199077+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -72995,7 +72936,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.479301+00:00"
+                "validatedAt": "2026-07-20T14:36:48.199109+00:00"
               },
               "deterministic": true
             },
@@ -73007,7 +72948,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.641849+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.240736+00:00"
           },
           "labels": {
             "type": "object",
@@ -73335,7 +73276,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.479405+00:00"
+                "validatedAt": "2026-07-20T14:36:48.199154+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -73370,7 +73311,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.479467+00:00"
+                "validatedAt": "2026-07-20T14:36:48.199182+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -73556,7 +73497,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.479561+00:00"
+                "validatedAt": "2026-07-20T14:36:48.199223+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -73590,7 +73531,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.479622+00:00"
+                "validatedAt": "2026-07-20T14:36:48.199251+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -73623,7 +73564,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:28.479696+00:00"
+                "validatedAt": "2026-07-20T14:36:48.199281+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74037,7 +73978,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:33.196284+00:00"
+                "validatedAt": "2026-07-20T14:36:50.282781+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74630,7 +74571,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:33.196457+00:00"
+                "validatedAt": "2026-07-20T14:36:50.282852+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75603,7 +75544,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:33.196693+00:00"
+                "validatedAt": "2026-07-20T14:36:50.282945+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -76073,7 +76014,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:33.196817+00:00"
+                "validatedAt": "2026-07-20T14:36:50.282998+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -76279,7 +76220,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:33.196921+00:00"
+                "validatedAt": "2026-07-20T14:36:50.283044+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -76406,7 +76347,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:33.196985+00:00"
+                "validatedAt": "2026-07-20T14:36:50.283074+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -76448,7 +76389,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:33.197023+00:00"
+                "validatedAt": "2026-07-20T14:36:50.283096+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -76481,7 +76422,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:33.197068+00:00"
+                "validatedAt": "2026-07-20T14:36:50.283120+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -77019,7 +76960,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:33.197199+00:00"
+                "validatedAt": "2026-07-20T14:36:50.283177+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -77886,7 +77827,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:33.197401+00:00"
+                "validatedAt": "2026-07-20T14:36:50.283260+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78437,7 +78378,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:33.197505+00:00"
+                "validatedAt": "2026-07-20T14:36:50.283307+00:00"
               },
               "deterministic": true
             },
@@ -78449,9 +78390,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.771539+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.340123+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -78483,7 +78423,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:33.197537+00:00"
+                "validatedAt": "2026-07-20T14:36:50.283323+00:00"
               },
               "deterministic": true
             },
@@ -78495,9 +78435,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.771562+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.340137+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -78605,7 +78544,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:33.197593+00:00"
+                "validatedAt": "2026-07-20T14:36:50.283351+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78870,7 +78809,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:33.197710+00:00"
+                "validatedAt": "2026-07-20T14:36:50.283399+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78932,7 +78871,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:58:33.197754+00:00"
+                "validatedAt": "2026-07-20T14:36:50.283420+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -79086,7 +79025,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:33.197848+00:00"
+                "validatedAt": "2026-07-20T14:36:50.283495+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -79258,7 +79197,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.771777+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.340263+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -79353,7 +79292,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:58:33.197962+00:00"
+                "validatedAt": "2026-07-20T14:36:50.283547+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -79432,7 +79371,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:58:33.198018+00:00"
+                "validatedAt": "2026-07-20T14:36:50.283575+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -79443,7 +79382,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.771829+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.340295+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -79530,7 +79469,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:33.198060+00:00"
+                "validatedAt": "2026-07-20T14:36:50.283596+00:00"
               },
               "deterministic": true
             },
@@ -79542,9 +79481,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.771875+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.340324+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -79575,7 +79513,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:33.198088+00:00"
+                "validatedAt": "2026-07-20T14:36:50.283611+00:00"
               },
               "deterministic": true
             },
@@ -79587,9 +79525,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.771894+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.340336+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -79658,7 +79595,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:33.198141+00:00"
+                "validatedAt": "2026-07-20T14:36:50.283633+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -79670,7 +79607,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.771931+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.340361+00:00"
           },
           "uid": {
             "type": "string",
@@ -79687,7 +79624,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:33.198167+00:00"
+                "validatedAt": "2026-07-20T14:36:50.283645+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -79700,7 +79637,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.771951+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.340374+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of azure_vnet_site is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -79781,7 +79718,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:33.198228+00:00"
+                "validatedAt": "2026-07-20T14:36:50.283677+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -79818,7 +79755,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:33.198293+00:00"
+                "validatedAt": "2026-07-20T14:36:50.283709+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -80025,7 +79962,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:33.198335+00:00"
+                "validatedAt": "2026-07-20T14:36:50.283730+00:00"
               },
               "deterministic": true
             },
@@ -80037,9 +79974,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.772009+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.340409+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -80071,7 +80007,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:33.198364+00:00"
+                "validatedAt": "2026-07-20T14:36:50.283745+00:00"
               },
               "deterministic": true
             },
@@ -80083,9 +80019,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.772028+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.340421+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Request to configure Cloud Site Information.",
@@ -80188,7 +80123,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:33.198392+00:00"
+                "validatedAt": "2026-07-20T14:36:50.283759+00:00"
               },
               "deterministic": true
             },
@@ -80200,9 +80135,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.772048+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.340435+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -80234,7 +80168,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:33.198418+00:00"
+                "validatedAt": "2026-07-20T14:36:50.283774+00:00"
               },
               "deterministic": true
             },
@@ -80246,9 +80180,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.772066+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.340447+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "vip_params_per_az": {
             "type": "array",
@@ -80475,7 +80408,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:58:33.198512+00:00"
+                "validatedAt": "2026-07-20T14:36:50.283813+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -80501,7 +80434,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:33.198550+00:00"
+                "validatedAt": "2026-07-20T14:36:50.283829+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -80586,7 +80519,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:33.198598+00:00"
+                "validatedAt": "2026-07-20T14:36:50.283854+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -80814,7 +80747,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:33.198686+00:00"
+                "validatedAt": "2026-07-20T14:36:50.283886+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -80837,7 +80770,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:33.198732+00:00"
+                "validatedAt": "2026-07-20T14:36:50.283906+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -80861,7 +80794,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:33.198775+00:00"
+                "validatedAt": "2026-07-20T14:36:50.283924+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -80884,7 +80817,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:33.198820+00:00"
+                "validatedAt": "2026-07-20T14:36:50.283943+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -80921,7 +80854,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:33.198867+00:00"
+                "validatedAt": "2026-07-20T14:36:50.283962+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -80944,7 +80877,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:33.198910+00:00"
+                "validatedAt": "2026-07-20T14:36:50.283980+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -80967,7 +80900,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:33.198953+00:00"
+                "validatedAt": "2026-07-20T14:36:50.283998+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -80990,7 +80923,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:33.198997+00:00"
+                "validatedAt": "2026-07-20T14:36:50.284016+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81014,7 +80947,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:33.199038+00:00"
+                "validatedAt": "2026-07-20T14:36:50.284033+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81077,7 +81010,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:33.199099+00:00"
+                "validatedAt": "2026-07-20T14:36:50.284058+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81101,7 +81034,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:33.199138+00:00"
+                "validatedAt": "2026-07-20T14:36:50.284075+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81186,7 +81119,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:33.199219+00:00"
+                "validatedAt": "2026-07-20T14:36:50.284116+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81234,7 +81167,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:33.199267+00:00"
+                "validatedAt": "2026-07-20T14:36:50.284142+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81315,7 +81248,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:33.199313+00:00"
+                "validatedAt": "2026-07-20T14:36:50.284166+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81457,7 +81390,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:33.203441+00:00"
+                "validatedAt": "2026-07-20T14:36:50.286032+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81719,7 +81652,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:33.203523+00:00"
+                "validatedAt": "2026-07-20T14:36:50.286073+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81750,7 +81683,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:33.203584+00:00"
+                "validatedAt": "2026-07-20T14:36:50.286105+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -82045,7 +81978,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:33.203696+00:00"
+                "validatedAt": "2026-07-20T14:36:50.286150+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -82164,7 +82097,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:33.203758+00:00"
+                "validatedAt": "2026-07-20T14:36:50.286186+00:00"
               },
               "deterministic": true
             },
@@ -82175,12 +82108,11 @@
               "read": false
             },
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.982832+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:13.526989+00:00",
             "x-f5xc-conflicts-with": [
               "autogenerate"
             ],
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "primary_ipv4": {
             "type": "string",
@@ -82211,7 +82143,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:33.203801+00:00"
+                "validatedAt": "2026-07-20T14:36:50.286205+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -82431,7 +82363,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:33.203894+00:00"
+                "validatedAt": "2026-07-20T14:36:50.286244+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -82573,7 +82505,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:33.203972+00:00"
+                "validatedAt": "2026-07-20T14:36:50.286282+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -82612,7 +82544,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:33.204029+00:00"
+                "validatedAt": "2026-07-20T14:36:50.286311+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -82691,7 +82623,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:33.204953+00:00"
+                "validatedAt": "2026-07-20T14:36:50.286766+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -82737,7 +82669,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:33.205021+00:00"
+                "validatedAt": "2026-07-20T14:36:50.286796+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -82796,7 +82728,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:33.205086+00:00"
+                "validatedAt": "2026-07-20T14:36:50.286825+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83107,7 +83039,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:33.205205+00:00"
+                "validatedAt": "2026-07-20T14:36:50.286875+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83222,7 +83154,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:33.205296+00:00"
+                "validatedAt": "2026-07-20T14:36:50.286915+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83261,7 +83193,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:33.205355+00:00"
+                "validatedAt": "2026-07-20T14:36:50.287015+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83549,7 +83481,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:33.205446+00:00"
+                "validatedAt": "2026-07-20T14:36:50.287069+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83595,7 +83527,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:33.205509+00:00"
+                "validatedAt": "2026-07-20T14:36:50.287102+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83654,7 +83586,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:33.205570+00:00"
+                "validatedAt": "2026-07-20T14:36:50.287133+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83800,7 +83732,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:33.205649+00:00"
+                "validatedAt": "2026-07-20T14:36:50.287166+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -84002,7 +83934,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:33.205742+00:00"
+                "validatedAt": "2026-07-20T14:36:50.287206+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -84104,7 +84036,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:33.205834+00:00"
+                "validatedAt": "2026-07-20T14:36:50.287247+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -84173,7 +84105,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:33.205914+00:00"
+                "validatedAt": "2026-07-20T14:36:50.287285+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -84197,7 +84129,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:33.205958+00:00"
+                "validatedAt": "2026-07-20T14:36:50.287303+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -84439,7 +84371,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:33.206057+00:00"
+                "validatedAt": "2026-07-20T14:36:50.287350+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -84471,7 +84403,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:33.206120+00:00"
+                "validatedAt": "2026-07-20T14:36:50.287380+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -84530,7 +84462,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:33.206186+00:00"
+                "validatedAt": "2026-07-20T14:36:50.287410+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -84841,7 +84773,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:33.206304+00:00"
+                "validatedAt": "2026-07-20T14:36:50.287460+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -84943,7 +84875,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:33.206393+00:00"
+                "validatedAt": "2026-07-20T14:36:50.287501+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -84982,7 +84914,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:33.206450+00:00"
+                "validatedAt": "2026-07-20T14:36:50.287529+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -85176,7 +85108,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:37.889012+00:00"
+                "validatedAt": "2026-07-20T14:36:52.294496+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -85322,7 +85254,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:37.891209+00:00"
+                "validatedAt": "2026-07-20T14:36:52.295432+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -85345,7 +85277,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:37.891252+00:00"
+                "validatedAt": "2026-07-20T14:36:52.295450+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -85385,7 +85317,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:37.891314+00:00"
+                "validatedAt": "2026-07-20T14:36:52.295473+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -85409,7 +85341,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:37.891359+00:00"
+                "validatedAt": "2026-07-20T14:36:52.295490+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -85433,7 +85365,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:37.891395+00:00"
+                "validatedAt": "2026-07-20T14:36:52.295504+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -85444,7 +85376,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.898526+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.476625+00:00"
           },
           "tags": {
             "type": "object",
@@ -85515,7 +85447,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:37.891442+00:00"
+                "validatedAt": "2026-07-20T14:36:52.295522+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -85553,7 +85485,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:37.891491+00:00"
+                "validatedAt": "2026-07-20T14:36:52.295540+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -85576,7 +85508,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:37.891528+00:00"
+                "validatedAt": "2026-07-20T14:36:52.295555+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -85613,7 +85545,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:37.891579+00:00"
+                "validatedAt": "2026-07-20T14:36:52.295574+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -85637,7 +85569,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:37.891624+00:00"
+                "validatedAt": "2026-07-20T14:36:52.295592+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -85660,7 +85592,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:37.891673+00:00"
+                "validatedAt": "2026-07-20T14:36:52.295607+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -85683,7 +85615,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:37.891714+00:00"
+                "validatedAt": "2026-07-20T14:36:52.295623+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -85756,7 +85688,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:45.703743+00:00"
+                "validatedAt": "2026-07-20T14:36:55.549264+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -85788,7 +85720,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:45.703820+00:00"
+                "validatedAt": "2026-07-20T14:36:55.549297+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -85912,7 +85844,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:45.704479+00:00"
+                "validatedAt": "2026-07-20T14:36:55.549577+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -86143,7 +86075,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:50.211972+00:00"
+                "validatedAt": "2026-07-20T14:36:57.335795+00:00"
               },
               "deterministic": true
             },
@@ -86155,9 +86087,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.240694+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.763413+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -86189,7 +86120,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:50.212015+00:00"
+                "validatedAt": "2026-07-20T14:36:57.335810+00:00"
               },
               "deterministic": true
             },
@@ -86201,9 +86132,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.240716+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.763430+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -86416,7 +86346,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:50.212116+00:00"
+                "validatedAt": "2026-07-20T14:36:57.335844+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -86929,7 +86859,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:50.212320+00:00"
+                "validatedAt": "2026-07-20T14:36:57.335912+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -86975,7 +86905,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:50.212367+00:00"
+                "validatedAt": "2026-07-20T14:36:57.335935+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -87360,7 +87290,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:50.212476+00:00"
+                "validatedAt": "2026-07-20T14:36:57.335981+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -87502,7 +87432,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:50.212562+00:00"
+                "validatedAt": "2026-07-20T14:36:57.336018+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -87548,7 +87478,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:50.212605+00:00"
+                "validatedAt": "2026-07-20T14:36:57.336040+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -87695,7 +87625,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:50.212692+00:00"
+                "validatedAt": "2026-07-20T14:36:57.336071+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -87737,7 +87667,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:50.212744+00:00"
+                "validatedAt": "2026-07-20T14:36:57.336090+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -87927,7 +87857,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:50.212806+00:00"
+                "validatedAt": "2026-07-20T14:36:57.336119+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -88391,7 +88321,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:50.212941+00:00"
+                "validatedAt": "2026-07-20T14:36:57.336175+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -88437,7 +88367,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:50.212985+00:00"
+                "validatedAt": "2026-07-20T14:36:57.336197+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -88890,7 +88820,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.241463+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.763950+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -88985,7 +88915,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:58:50.213152+00:00"
+                "validatedAt": "2026-07-20T14:36:57.336263+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89064,7 +88994,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:58:50.213206+00:00"
+                "validatedAt": "2026-07-20T14:36:57.336286+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89075,7 +89005,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.241514+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.763985+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -89162,7 +89092,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:50.213248+00:00"
+                "validatedAt": "2026-07-20T14:36:57.336305+00:00"
               },
               "deterministic": true
             },
@@ -89174,9 +89104,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.241561+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.764014+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -89207,7 +89136,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:50.213278+00:00"
+                "validatedAt": "2026-07-20T14:36:57.336319+00:00"
               },
               "deterministic": true
             },
@@ -89219,9 +89148,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.241579+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.764027+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -89290,7 +89218,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:50.213331+00:00"
+                "validatedAt": "2026-07-20T14:36:57.336339+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89302,7 +89230,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.241616+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.764052+00:00"
           },
           "uid": {
             "type": "string",
@@ -89319,7 +89247,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:50.213356+00:00"
+                "validatedAt": "2026-07-20T14:36:57.336350+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89332,7 +89260,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.241637+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.764066+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of gcp_vpc_site is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -89521,7 +89449,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:50.213395+00:00"
+                "validatedAt": "2026-07-20T14:36:57.336368+00:00"
               },
               "deterministic": true
             },
@@ -89533,9 +89461,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.241692+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.764092+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -89567,7 +89494,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:50.213421+00:00"
+                "validatedAt": "2026-07-20T14:36:57.336381+00:00"
               },
               "deterministic": true
             },
@@ -89579,9 +89506,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.241712+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.764105+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Request to configure Cloud Site Information.",
@@ -89783,7 +89709,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:50.217003+00:00"
+                "validatedAt": "2026-07-20T14:36:57.337987+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89816,7 +89742,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:50.217061+00:00"
+                "validatedAt": "2026-07-20T14:36:57.338017+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89893,7 +89819,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:50.217123+00:00"
+                "validatedAt": "2026-07-20T14:36:57.338048+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -90110,7 +90036,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:50.217187+00:00"
+                "validatedAt": "2026-07-20T14:36:57.338087+00:00"
               },
               "deterministic": true
             },
@@ -90120,8 +90046,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Parameters to create a new GCP VPC Network.",
@@ -90203,7 +90128,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:50.217235+00:00"
+                "validatedAt": "2026-07-20T14:36:57.338115+00:00"
               },
               "deterministic": true
             },
@@ -90213,8 +90138,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -90351,7 +90275,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:50.217929+00:00"
+                "validatedAt": "2026-07-20T14:36:57.338460+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -90551,7 +90475,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:50.218028+00:00"
+                "validatedAt": "2026-07-20T14:36:57.338503+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -90621,7 +90545,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:50.218091+00:00"
+                "validatedAt": "2026-07-20T14:36:57.338533+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -90778,7 +90702,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:50.218169+00:00"
+                "validatedAt": "2026-07-20T14:36:57.338569+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -90948,7 +90872,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:50.218228+00:00"
+                "validatedAt": "2026-07-20T14:36:57.338598+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -91126,7 +91050,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:50.218307+00:00"
+                "validatedAt": "2026-07-20T14:36:57.338628+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -91185,7 +91109,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:50.218368+00:00"
+                "validatedAt": "2026-07-20T14:36:57.338657+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -91255,7 +91179,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:50.218429+00:00"
+                "validatedAt": "2026-07-20T14:36:57.338685+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -91429,7 +91353,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:50.218519+00:00"
+                "validatedAt": "2026-07-20T14:36:57.338724+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -91453,7 +91377,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:50.218558+00:00"
+                "validatedAt": "2026-07-20T14:36:57.338740+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -91621,7 +91545,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:50.218618+00:00"
+                "validatedAt": "2026-07-20T14:36:57.338770+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -91782,7 +91706,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:50.218720+00:00"
+                "validatedAt": "2026-07-20T14:36:57.338811+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -91852,7 +91776,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:50.218783+00:00"
+                "validatedAt": "2026-07-20T14:36:57.338841+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -91996,7 +91920,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:50.218857+00:00"
+                "validatedAt": "2026-07-20T14:36:57.338875+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -92101,7 +92025,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:52.945549+00:00"
+                "validatedAt": "2026-07-20T14:36:58.523935+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -92140,7 +92064,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:52.945641+00:00"
+                "validatedAt": "2026-07-20T14:36:58.523975+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -92200,7 +92124,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:10.693588+00:00"
+                "validatedAt": "2026-07-20T14:37:05.682029+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -92211,7 +92135,7 @@
             },
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.867049+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:13.373731+00:00"
           },
           "location": {
             "type": "string",
@@ -92227,7 +92151,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:10.693625+00:00"
+                "validatedAt": "2026-07-20T14:37:05.682043+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -92238,7 +92162,7 @@
             },
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.867069+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:13.373742+00:00"
           },
           "provider": {
             "type": "string",
@@ -92255,7 +92179,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:10.693670+00:00"
+                "validatedAt": "2026-07-20T14:37:05.682056+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -92266,7 +92190,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.867087+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:13.373753+00:00"
           },
           "secret_encoding": {
             "allOf": [
@@ -92298,7 +92222,7 @@
             "maxLength": 1,
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.867112+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:13.373768+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Vault Secret\" VaultSecretInfoType specifies information about the Secret managed by Hashicorp Vault.",
@@ -92368,7 +92292,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:10.693834+00:00"
+                "validatedAt": "2026-07-20T14:37:05.682124+00:00"
               },
               "deterministic": true
             },
@@ -92380,9 +92304,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.867210+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:13.373850+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Wingman Secret\" WingmanSecretInfoType specifies the handle to the wingman secret.",
@@ -92606,7 +92529,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:10.694042+00:00"
+                "validatedAt": "2026-07-20T14:37:05.682221+00:00"
               },
               "deterministic": true
             },
@@ -92618,9 +92541,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.867318+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:13.374034+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -92652,7 +92574,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:10.694068+00:00"
+                "validatedAt": "2026-07-20T14:37:05.682234+00:00"
               },
               "deterministic": true
             },
@@ -92664,9 +92586,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.867336+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:13.374052+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -92829,7 +92750,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.867401+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:13.374090+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -92986,7 +92907,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:10.694219+00:00"
+                "validatedAt": "2026-07-20T14:37:05.682295+00:00"
               },
               "deterministic": true
             },
@@ -92998,7 +92919,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.867453+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:13.374119+00:00"
           },
           "ethernet_interface": {
             "allOf": [
@@ -93123,7 +93044,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:10.694272+00:00"
+                "validatedAt": "2026-07-20T14:37:05.682320+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -93205,7 +93126,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:59:10.694315+00:00"
+                "validatedAt": "2026-07-20T14:37:05.682339+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -93284,7 +93205,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:59:10.694366+00:00"
+                "validatedAt": "2026-07-20T14:37:05.682361+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -93295,7 +93216,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.867519+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:13.374155+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -93382,7 +93303,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:10.694406+00:00"
+                "validatedAt": "2026-07-20T14:37:05.682379+00:00"
               },
               "deterministic": true
             },
@@ -93394,9 +93315,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.867564+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:13.374180+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -93427,7 +93347,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:10.694433+00:00"
+                "validatedAt": "2026-07-20T14:37:05.682392+00:00"
               },
               "deterministic": true
             },
@@ -93439,9 +93359,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.867582+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:13.374191+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -93510,7 +93429,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:10.694486+00:00"
+                "validatedAt": "2026-07-20T14:37:05.682412+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -93522,7 +93441,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.867620+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:13.374212+00:00"
           },
           "uid": {
             "type": "string",
@@ -93539,7 +93458,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:10.694511+00:00"
+                "validatedAt": "2026-07-20T14:37:05.682423+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -93552,7 +93471,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.867639+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:13.374223+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of securemesh_site is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -94097,7 +94016,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:10.694642+00:00"
+                "validatedAt": "2026-07-20T14:37:05.682476+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -94312,7 +94231,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:10.694753+00:00"
+                "validatedAt": "2026-07-20T14:37:05.682517+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -94431,7 +94350,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:10.694821+00:00"
+                "validatedAt": "2026-07-20T14:37:05.682547+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -94511,7 +94430,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:10.695293+00:00"
+                "validatedAt": "2026-07-20T14:37:05.682746+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -94703,7 +94622,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:10.695369+00:00"
+                "validatedAt": "2026-07-20T14:37:05.682777+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -94815,7 +94734,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:10.695452+00:00"
+                "validatedAt": "2026-07-20T14:37:05.682812+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -94824,8 +94743,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "worker_nodes": {
             "type": "array",
@@ -94854,7 +94772,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:10.695496+00:00"
+                "validatedAt": "2026-07-20T14:37:05.682834+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -94951,7 +94869,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:10.695553+00:00"
+                "validatedAt": "2026-07-20T14:37:05.682859+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -95143,7 +95061,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:10.695628+00:00"
+                "validatedAt": "2026-07-20T14:37:05.682890+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -95206,7 +95124,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:10.695707+00:00"
+                "validatedAt": "2026-07-20T14:37:05.682923+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -95274,7 +95192,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:10.695778+00:00"
+                "validatedAt": "2026-07-20T14:37:05.682953+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -95283,8 +95201,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "volterra_software_version": {
             "type": "string",
@@ -95308,7 +95225,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:10.695841+00:00"
+                "validatedAt": "2026-07-20T14:37:05.682982+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -95345,7 +95262,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:10.695884+00:00"
+                "validatedAt": "2026-07-20T14:37:05.683003+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -95436,7 +95353,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:10.695940+00:00"
+                "validatedAt": "2026-07-20T14:37:05.683029+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -95628,7 +95545,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:10.696013+00:00"
+                "validatedAt": "2026-07-20T14:37:05.683060+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -95740,7 +95657,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:10.696091+00:00"
+                "validatedAt": "2026-07-20T14:37:05.683094+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -95749,8 +95666,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "worker_nodes": {
             "type": "array",
@@ -95779,7 +95695,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:10.696134+00:00"
+                "validatedAt": "2026-07-20T14:37:05.683115+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -95897,7 +95813,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:15.382752+00:00"
+                "validatedAt": "2026-07-20T14:37:07.530236+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -95921,7 +95837,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:15.382781+00:00"
+                "validatedAt": "2026-07-20T14:37:07.530248+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -95997,7 +95913,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:15.382970+00:00"
+                "validatedAt": "2026-07-20T14:37:07.530340+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -96021,7 +95937,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:15.382999+00:00"
+                "validatedAt": "2026-07-20T14:37:07.530353+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -96059,7 +95975,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:15.383025+00:00"
+                "validatedAt": "2026-07-20T14:37:07.530369+00:00"
               },
               "deterministic": true
             },
@@ -96071,9 +95987,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.981393+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:13.526137+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"New Cloud Subnet Parameters\" Parameters for creating a new cloud subnet.",
@@ -96128,7 +96043,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:15.383065+00:00"
+                "validatedAt": "2026-07-20T14:37:07.530386+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -96158,7 +96073,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T12:59:15.383095+00:00"
+                "validatedAt": "2026-07-20T14:37:07.530400+00:00"
               },
               "deterministic": true
             },
@@ -96169,8 +96084,7 @@
               "read": false
             },
             "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "minLength": 1,
-            "format": "fqdn"
+            "minLength": 1
           },
           "interface_list": {
             "type": "array",
@@ -96201,7 +96115,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:15.383139+00:00"
+                "validatedAt": "2026-07-20T14:37:07.530418+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -96473,7 +96387,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:15.383224+00:00"
+                "validatedAt": "2026-07-20T14:37:07.530451+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -96549,7 +96463,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:15.383263+00:00"
+                "validatedAt": "2026-07-20T14:37:07.530466+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -96579,7 +96493,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T12:59:15.383292+00:00"
+                "validatedAt": "2026-07-20T14:37:07.530481+00:00"
               },
               "deterministic": true
             },
@@ -96590,8 +96504,7 @@
               "read": false
             },
             "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "minLength": 1,
-            "format": "fqdn"
+            "minLength": 1
           },
           "interface_list": {
             "type": "array",
@@ -96622,7 +96535,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:15.383334+00:00"
+                "validatedAt": "2026-07-20T14:37:07.530497+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -97306,7 +97219,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:15.383451+00:00"
+                "validatedAt": "2026-07-20T14:37:07.530546+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -97378,7 +97291,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:15.383496+00:00"
+                "validatedAt": "2026-07-20T14:37:07.530567+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -97500,7 +97413,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:15.383567+00:00"
+                "validatedAt": "2026-07-20T14:37:07.530598+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -97558,7 +97471,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:15.383611+00:00"
+                "validatedAt": "2026-07-20T14:37:07.530617+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -97640,7 +97553,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:15.383662+00:00"
+                "validatedAt": "2026-07-20T14:37:07.530638+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -97837,7 +97750,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:15.383709+00:00"
+                "validatedAt": "2026-07-20T14:37:07.530658+00:00"
               },
               "deterministic": true
             },
@@ -97849,9 +97762,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.981747+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:13.526342+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -97883,7 +97795,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:15.383737+00:00"
+                "validatedAt": "2026-07-20T14:37:07.530671+00:00"
               },
               "deterministic": true
             },
@@ -97895,9 +97807,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.981767+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:13.526354+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -98017,7 +97928,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:15.383776+00:00"
+                "validatedAt": "2026-07-20T14:37:07.530686+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -98055,7 +97966,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:15.383802+00:00"
+                "validatedAt": "2026-07-20T14:37:07.530699+00:00"
               },
               "deterministic": true
             },
@@ -98067,9 +97978,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.981809+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:13.526381+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"New Cloud Subnet Parameters\" Parameters for creating a new cloud subnet.",
@@ -98136,7 +98046,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:15.383841+00:00"
+                "validatedAt": "2026-07-20T14:37:07.530714+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -98197,7 +98107,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:15.383881+00:00"
+                "validatedAt": "2026-07-20T14:37:07.530730+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -98227,7 +98137,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T12:59:15.383910+00:00"
+                "validatedAt": "2026-07-20T14:37:07.530744+00:00"
               },
               "deterministic": true
             },
@@ -98238,8 +98148,7 @@
               "read": false
             },
             "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "minLength": 1,
-            "format": "fqdn"
+            "minLength": 1
           },
           "interface_list": {
             "type": "array",
@@ -98629,7 +98538,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:15.384019+00:00"
+                "validatedAt": "2026-07-20T14:37:07.530784+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -98704,7 +98613,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:15.384063+00:00"
+                "validatedAt": "2026-07-20T14:37:07.530801+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -98889,7 +98798,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.982010+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:13.526507+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -98997,7 +98906,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:15.384204+00:00"
+                "validatedAt": "2026-07-20T14:37:07.530861+00:00"
               },
               "deterministic": true
             },
@@ -99009,7 +98918,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.982043+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:13.526528+00:00"
           },
           "dhcp_client": {
             "allOf": [
@@ -99183,7 +99092,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:15.384280+00:00"
+                "validatedAt": "2026-07-20T14:37:07.530895+00:00"
               },
               "deterministic": true
             },
@@ -99195,9 +99104,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.982109+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:13.526568+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "network_option": {
             "allOf": [
@@ -99274,7 +99182,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:59:15.384322+00:00"
+                "validatedAt": "2026-07-20T14:37:07.530914+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -99508,7 +99416,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:59:15.384381+00:00"
+                "validatedAt": "2026-07-20T14:37:07.530939+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -99587,7 +99495,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:59:15.384429+00:00"
+                "validatedAt": "2026-07-20T14:37:07.530966+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -99598,7 +99506,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.982219+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:13.526635+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -99685,7 +99593,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:15.384467+00:00"
+                "validatedAt": "2026-07-20T14:37:07.530984+00:00"
               },
               "deterministic": true
             },
@@ -99697,9 +99605,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.982265+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:13.526664+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -99730,7 +99637,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:15.384493+00:00"
+                "validatedAt": "2026-07-20T14:37:07.530997+00:00"
               },
               "deterministic": true
             },
@@ -99742,9 +99649,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.982283+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:13.526683+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -99813,7 +99719,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:15.384546+00:00"
+                "validatedAt": "2026-07-20T14:37:07.531017+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -99825,7 +99731,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.982321+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:13.526713+00:00"
           },
           "uid": {
             "type": "string",
@@ -99843,7 +99749,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:15.384572+00:00"
+                "validatedAt": "2026-07-20T14:37:07.531027+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -99856,7 +99762,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.982341+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:13.526727+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of securemesh_site_v2 is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -100141,7 +100047,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:15.384639+00:00"
+                "validatedAt": "2026-07-20T14:37:07.531058+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -100554,7 +100460,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:15.384706+00:00"
+                "validatedAt": "2026-07-20T14:37:07.531081+00:00"
               },
               "format": "ipv4",
               "deterministic": true
@@ -100588,7 +100494,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:15.384746+00:00"
+                "validatedAt": "2026-07-20T14:37:07.531097+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -100690,7 +100596,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:43.663110+00:00"
+                "validatedAt": "2026-07-20T14:37:18.674091+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -101010,7 +100916,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:15.384834+00:00"
+                "validatedAt": "2026-07-20T14:37:07.531134+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -101390,7 +101296,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:15.384950+00:00"
+                "validatedAt": "2026-07-20T14:37:07.531185+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -101492,7 +101398,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:15.385009+00:00"
+                "validatedAt": "2026-07-20T14:37:07.531212+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -101526,7 +101432,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:43.663361+00:00"
+                "validatedAt": "2026-07-20T14:37:18.674208+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -101607,7 +101513,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:15.385067+00:00"
+                "validatedAt": "2026-07-20T14:37:07.531245+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -101643,7 +101549,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T12:59:15.385097+00:00"
+                "validatedAt": "2026-07-20T14:37:07.531261+00:00"
               },
               "deterministic": true
             },
@@ -101730,7 +101636,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:15.385322+00:00"
+                "validatedAt": "2026-07-20T14:37:07.531356+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -101950,7 +101856,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:15.386043+00:00"
+                "validatedAt": "2026-07-20T14:37:07.531608+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -101974,7 +101880,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:43.663864+00:00"
+                "validatedAt": "2026-07-20T14:37:18.674417+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -102098,7 +102004,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:15.386247+00:00"
+                "validatedAt": "2026-07-20T14:37:07.531675+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -102188,7 +102094,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:15.386286+00:00"
+                "validatedAt": "2026-07-20T14:37:07.531690+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -102226,7 +102132,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:15.386314+00:00"
+                "validatedAt": "2026-07-20T14:37:07.531703+00:00"
               },
               "deterministic": true
             },
@@ -102238,9 +102144,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.983179+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:13.527196+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"New Cloud Subnet Parameters\" Parameters for creating a new cloud subnet.",
@@ -103163,7 +103068,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:43.664163+00:00"
+                "validatedAt": "2026-07-20T14:37:18.674540+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -103357,7 +103262,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:15.386525+00:00"
+                "validatedAt": "2026-07-20T14:37:07.531786+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -103390,7 +103295,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:15.386569+00:00"
+                "validatedAt": "2026-07-20T14:37:07.531808+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -104124,7 +104029,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:15.386757+00:00"
+                "validatedAt": "2026-07-20T14:37:07.531873+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -104320,7 +104225,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:15.386891+00:00"
+                "validatedAt": "2026-07-20T14:37:07.531927+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -104415,7 +104320,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:43.664527+00:00"
+                "validatedAt": "2026-07-20T14:37:18.674693+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -104606,7 +104511,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:15.386946+00:00"
+                "validatedAt": "2026-07-20T14:37:07.531953+00:00"
               },
               "deterministic": true
             },
@@ -104617,8 +104522,7 @@
               "read": false
             },
             "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "minLength": 1,
-            "format": "fqdn"
+            "minLength": 1
           },
           "interface_list": {
             "type": "array",
@@ -104647,7 +104551,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:15.386990+00:00"
+                "validatedAt": "2026-07-20T14:37:07.531973+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -104679,7 +104583,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:15.387047+00:00"
+                "validatedAt": "2026-07-20T14:37:07.531999+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -104711,7 +104615,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:15.387082+00:00"
+                "validatedAt": "2026-07-20T14:37:07.532012+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -105608,7 +105512,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:43.664991+00:00"
+                "validatedAt": "2026-07-20T14:37:18.674893+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -105792,7 +105696,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:17.869009+00:00"
+                "validatedAt": "2026-07-20T14:37:08.529450+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -105824,7 +105728,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:17.869053+00:00"
+                "validatedAt": "2026-07-20T14:37:08.529467+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -106256,7 +106160,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:28.578041+00:00"
+                "validatedAt": "2026-07-20T14:38:48.140492+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -106338,7 +106242,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:28.578090+00:00"
+                "validatedAt": "2026-07-20T14:38:48.140516+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -106417,7 +106321,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:28.578137+00:00"
+                "validatedAt": "2026-07-20T14:38:48.140538+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -107172,7 +107076,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:28.578263+00:00"
+                "validatedAt": "2026-07-20T14:38:48.140584+00:00"
               },
               "deterministic": true
             },
@@ -107184,9 +107088,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.504192+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.292269+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -107218,7 +107121,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:28.578293+00:00"
+                "validatedAt": "2026-07-20T14:38:48.140598+00:00"
               },
               "deterministic": true
             },
@@ -107230,9 +107133,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.504211+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.292282+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -107395,7 +107297,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.504276+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.292324+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -107907,7 +107809,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:28.578472+00:00"
+                "validatedAt": "2026-07-20T14:38:48.140665+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -107988,7 +107890,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:03:28.578516+00:00"
+                "validatedAt": "2026-07-20T14:38:48.140684+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -108067,7 +107969,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:03:28.578572+00:00"
+                "validatedAt": "2026-07-20T14:38:48.140707+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -108078,7 +107980,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.504460+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.292438+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -108165,7 +108067,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:28.578613+00:00"
+                "validatedAt": "2026-07-20T14:38:48.140725+00:00"
               },
               "deterministic": true
             },
@@ -108177,9 +108079,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.504505+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.292467+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -108210,7 +108111,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:28.578640+00:00"
+                "validatedAt": "2026-07-20T14:38:48.140738+00:00"
               },
               "deterministic": true
             },
@@ -108222,9 +108123,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.504524+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.292479+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -108293,7 +108193,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:28.578704+00:00"
+                "validatedAt": "2026-07-20T14:38:48.140760+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -108305,7 +108205,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.504562+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.292504+00:00"
           },
           "uid": {
             "type": "string",
@@ -108322,7 +108222,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:28.578731+00:00"
+                "validatedAt": "2026-07-20T14:38:48.140770+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -108335,7 +108235,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.504582+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.292517+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of k8s_cluster is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -108437,7 +108337,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:28.578809+00:00"
+                "validatedAt": "2026-07-20T14:38:48.140805+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -108445,8 +108345,7 @@
               "create": true,
               "update": false,
               "read": false
-            },
-            "format": "hostname"
+            }
           },
           "password": {
             "allOf": [
@@ -108489,7 +108388,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:28.578850+00:00"
+                "validatedAt": "2026-07-20T14:38:48.140823+00:00"
               },
               "deterministic": true
             },
@@ -108593,7 +108492,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:28.578919+00:00"
+                "validatedAt": "2026-07-20T14:38:48.140893+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -108601,8 +108500,7 @@
               "create": true,
               "update": false,
               "read": false
-            },
-            "format": "hostname"
+            }
           },
           "port": {
             "type": "integer",
@@ -108631,7 +108529,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:28.578949+00:00"
+                "validatedAt": "2026-07-20T14:38:48.140917+00:00"
               },
               "deterministic": true
             },
@@ -108718,7 +108616,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:28.578997+00:00"
+                "validatedAt": "2026-07-20T14:38:48.140946+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -109691,7 +109589,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.658425+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540229+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -109731,7 +109629,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:06.658485+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540255+00:00"
               },
               "deterministic": true
             },
@@ -109743,9 +109641,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.048895+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.842295+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query": {
             "type": "string",
@@ -109765,7 +109662,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.658548+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540274+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -109798,7 +109695,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.658604+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540291+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -109886,7 +109783,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.658682+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540309+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -109915,7 +109812,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.658740+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540326+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -109955,7 +109852,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:06.658785+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540340+00:00"
               },
               "deterministic": true
             },
@@ -109967,9 +109864,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.048953+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.842329+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query": {
             "type": "string",
@@ -109989,7 +109885,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.658839+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540357+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -110053,7 +109949,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.658886+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540375+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -110174,7 +110070,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.658931+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540393+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -110214,7 +110110,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:06.658959+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540406+00:00"
               },
               "deterministic": true
             },
@@ -110226,9 +110122,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.049015+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.842365+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query": {
             "type": "string",
@@ -110248,7 +110143,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.658998+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540423+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -110281,7 +110176,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.659037+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540439+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -110369,7 +110264,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.659080+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540455+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -110398,7 +110293,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.659110+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540469+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -110437,7 +110332,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:06.659138+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540482+00:00"
               },
               "deterministic": true
             },
@@ -110449,9 +110344,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.049068+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.842398+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query": {
             "type": "string",
@@ -110471,7 +110365,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.659176+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540499+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -110535,7 +110429,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.659224+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540518+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -110631,7 +110525,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.049115+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.842426+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Avg Aggregation Data\" Average Aggregation data.",
@@ -110683,7 +110577,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.659270+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540536+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -110759,7 +110653,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.659308+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540551+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -110798,7 +110692,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T13:04:06.659351+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540569+00:00"
               },
               "deterministic": true
             },
@@ -110892,7 +110786,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.659401+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540588+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -110963,7 +110857,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.659441+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540604+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -110989,7 +110883,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.659484+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540620+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -111027,7 +110921,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:06.659536+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540644+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -111062,7 +110956,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.659573+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540661+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -111102,7 +110996,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:06.659601+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540674+00:00"
               },
               "deterministic": true
             },
@@ -111114,9 +111008,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.049223+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.842489+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "site": {
             "type": "string",
@@ -111133,7 +111026,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.659631+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540686+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -111166,7 +111059,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.659682+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540702+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -111232,7 +111125,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.659719+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540715+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -111255,7 +111148,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.659745+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540725+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -111266,7 +111159,7 @@
             },
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.049264+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.842515+00:00"
           },
           "order_by": {
             "allOf": [
@@ -111412,7 +111305,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.659804+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540748+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -111436,7 +111329,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.659830+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540759+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -111447,7 +111340,7 @@
             },
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.049319+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.842549+00:00"
           },
           "order_by": {
             "allOf": [
@@ -111515,7 +111408,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.659868+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540774+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -111539,7 +111432,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.659894+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540784+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -111550,7 +111443,7 @@
             },
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.049353+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.842570+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Field Sub Field Aggregation Bucket\" Field sub aggregation bucket containing field values and the number of logs.",
@@ -111604,7 +111497,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.659928+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540797+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -111677,7 +111570,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.659965+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540813+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -111701,7 +111594,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.659991+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540824+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -111712,7 +111605,7 @@
             },
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.049397+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.842595+00:00"
           },
           "sub_aggs": {
             "type": "object",
@@ -111803,7 +111696,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.660039+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540843+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -111843,7 +111736,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:06.660068+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540856+00:00"
               },
               "deterministic": true
             },
@@ -111855,9 +111748,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.049439+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.842620+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query": {
             "type": "string",
@@ -111877,7 +111769,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.660107+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540873+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -111910,7 +111802,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.660147+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540889+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -111998,7 +111890,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.660190+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540906+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -112027,7 +111919,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.660221+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540920+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -112067,7 +111959,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:06.660248+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540932+00:00"
               },
               "deterministic": true
             },
@@ -112079,9 +111971,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.049492+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.842651+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query": {
             "type": "string",
@@ -112101,7 +111992,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.660286+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540949+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -112165,7 +112056,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.660331+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540967+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -112286,7 +112177,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.660374+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540983+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -112326,7 +112217,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:06.660401+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540996+00:00"
               },
               "deterministic": true
             },
@@ -112338,9 +112229,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.049553+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.842687+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query": {
             "type": "string",
@@ -112360,7 +112250,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.660440+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541012+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -112385,7 +112275,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.660468+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541024+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -112418,7 +112308,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.660507+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541039+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -112507,7 +112397,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.660550+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541056+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -112536,7 +112426,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.660580+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541070+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -112576,7 +112466,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:06.660607+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541083+00:00"
               },
               "deterministic": true
             },
@@ -112588,9 +112478,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.049613+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.842723+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query": {
             "type": "string",
@@ -112610,7 +112499,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.660644+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541100+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -112652,7 +112541,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.660685+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541112+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -112699,7 +112588,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.660729+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541129+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -112821,7 +112710,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.660772+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541145+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -112861,7 +112750,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:06.660800+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541158+00:00"
               },
               "deterministic": true
             },
@@ -112873,9 +112762,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.049688+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.842762+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query": {
             "type": "string",
@@ -112895,7 +112783,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.660839+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541175+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -112920,7 +112808,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.660868+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541187+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -112953,7 +112841,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.660907+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541202+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -113042,7 +112930,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.660950+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541219+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -113071,7 +112959,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.660981+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541232+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -113111,7 +112999,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:06.661008+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541246+00:00"
               },
               "deterministic": true
             },
@@ -113123,9 +113011,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.049749+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.842797+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query": {
             "type": "string",
@@ -113145,7 +113032,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.661046+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541264+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -113187,7 +113074,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.661078+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541277+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -113234,7 +113121,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.661120+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541293+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -113370,7 +113257,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:06.661183+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541321+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -113381,7 +113268,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.049815+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.842835+00:00"
           }
         },
         "x-f5xc-description-short": "Label Filter is used to filter th that match the logs specified label key/value and the operator.",
@@ -113454,7 +113341,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.661227+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541339+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -113552,7 +113439,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.661277+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541359+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -113581,7 +113468,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.661315+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541373+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -113675,7 +113562,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:06.661345+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541387+00:00"
               },
               "deterministic": true
             },
@@ -113687,9 +113574,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.049880+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.842873+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "scroll_id": {
             "type": "string",
@@ -113707,7 +113593,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.661380+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541401+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -113769,7 +113655,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.049907+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.842889+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Max Aggregation Data\" Max Aggregation data.",
@@ -113868,7 +113754,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.049936+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.842906+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Min Aggregation Data\" Min Aggregation data.",
@@ -113920,7 +113806,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.661443+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541426+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -114073,7 +113959,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.661502+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541448+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -114182,7 +114068,7 @@
             "maxLength": 16,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.050010+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.842950+00:00"
           },
           "value": {
             "type": "number",
@@ -114198,7 +114084,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.050028+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.842961+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Percentile Aggregation Data\" Percentile Aggregation data.",
@@ -114275,7 +114161,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.661573+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541475+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -114315,7 +114201,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:06.661601+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541488+00:00"
               },
               "deterministic": true
             },
@@ -114327,9 +114213,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.050062+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.842983+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query": {
             "type": "string",
@@ -114349,7 +114234,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.661640+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541505+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -114382,7 +114267,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.661688+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541521+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -114470,7 +114355,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.661732+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541538+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -114514,7 +114399,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.661766+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541553+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -114553,7 +114438,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:06.661793+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541566+00:00"
               },
               "deterministic": true
             },
@@ -114565,9 +114450,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.050123+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.843018+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query": {
             "type": "string",
@@ -114587,7 +114471,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.661831+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541583+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -114651,7 +114535,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.661876+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541600+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -114749,7 +114633,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.661909+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541613+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -114849,7 +114733,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.661964+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541635+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -114889,7 +114773,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:06.661990+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541648+00:00"
               },
               "deterministic": true
             },
@@ -114901,9 +114785,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.050196+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.843065+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query": {
             "type": "string",
@@ -114923,7 +114806,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.662029+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541666+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -114956,7 +114839,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.662068+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541681+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -115044,7 +114927,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.662111+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541697+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -115073,7 +114956,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.662140+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541711+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -115113,7 +114996,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:06.662168+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541725+00:00"
               },
               "deterministic": true
             },
@@ -115125,9 +115008,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.050249+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.843098+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query": {
             "type": "string",
@@ -115147,7 +115029,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.662206+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541742+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -115211,7 +115093,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.662250+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541759+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -115333,7 +115215,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.662292+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541776+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -115373,7 +115255,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:06.662318+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541789+00:00"
               },
               "deterministic": true
             },
@@ -115385,9 +115267,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.050309+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.843133+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query": {
             "type": "string",
@@ -115407,7 +115288,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.662356+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541806+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -115440,7 +115321,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.662393+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541821+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -115528,7 +115409,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.662435+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541838+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -115557,7 +115438,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.662463+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541851+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -115597,7 +115478,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:06.662490+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541865+00:00"
               },
               "deterministic": true
             },
@@ -115609,9 +115490,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.050362+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.843165+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query": {
             "type": "string",
@@ -115631,7 +115511,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.662527+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541882+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -115695,7 +115575,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.662575+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541899+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -115841,7 +115721,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.662611+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541914+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -116057,7 +115937,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.662671+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541934+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -116278,7 +116158,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.662723+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541953+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -116456,7 +116336,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.662773+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541973+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -116516,7 +116396,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.662805+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541986+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -116680,7 +116560,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.662851+00:00"
+                "validatedAt": "2026-07-20T14:39:02.542003+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -116840,7 +116720,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.662897+00:00"
+                "validatedAt": "2026-07-20T14:39:02.542021+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -116900,7 +116780,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.662927+00:00"
+                "validatedAt": "2026-07-20T14:39:02.542033+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -117184,7 +117064,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:04:06.662992+00:00"
+                "validatedAt": "2026-07-20T14:39:02.542058+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -117195,7 +117075,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.050605+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:17.843301+00:00",
             "x-displayname": "Description.",
             "x-ves-example": "Trend was calculated by comparing the avg of window size intervals of end-start Time and last window time interval."
           },
@@ -117212,7 +117092,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.663031+00:00"
+                "validatedAt": "2026-07-20T14:39:02.542074+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -117251,7 +117131,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.663066+00:00"
+                "validatedAt": "2026-07-20T14:39:02.542089+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -117262,7 +117142,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.050636+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:17.843320+00:00",
             "x-displayname": "Value",
             "x-ves-example": "-15"
           }
@@ -117365,7 +117245,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:26.939672+00:00"
+                "validatedAt": "2026-07-20T14:39:10.147887+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -117439,7 +117319,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.237888+00:00"
+                "validatedAt": "2026-07-20T14:40:46.877207+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -117464,7 +117344,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.237956+00:00"
+                "validatedAt": "2026-07-20T14:40:46.877229+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -117654,7 +117534,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.820364+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.257876+00:00"
           }
         },
         "x-f5xc-description-short": "Node is a worker node in Kubernetes. Each node will have a unique identifier in the cache (i.e.",
@@ -117716,7 +117596,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.238079+00:00"
+                "validatedAt": "2026-07-20T14:40:46.877259+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -117739,7 +117619,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.238130+00:00"
+                "validatedAt": "2026-07-20T14:40:46.877272+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -117796,7 +117676,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.238404+00:00"
+                "validatedAt": "2026-07-20T14:40:46.877387+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -117989,7 +117869,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.239193+00:00"
+                "validatedAt": "2026-07-20T14:40:46.877719+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -118000,7 +117880,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.820811+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.258117+00:00"
           }
         },
         "x-f5xc-description-short": "Metric data contains timestamp and the value.",
@@ -118091,7 +117971,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.239541+00:00"
+                "validatedAt": "2026-07-20T14:40:46.877886+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -118336,7 +118216,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.240510+00:00"
+                "validatedAt": "2026-07-20T14:40:46.878301+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -118384,7 +118264,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.240586+00:00"
+                "validatedAt": "2026-07-20T14:40:46.878331+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -118418,7 +118298,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.240645+00:00"
+                "validatedAt": "2026-07-20T14:40:46.878360+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -118541,7 +118421,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.240769+00:00"
+                "validatedAt": "2026-07-20T14:40:46.878402+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -118585,7 +118465,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.240835+00:00"
+                "validatedAt": "2026-07-20T14:40:46.878432+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -118619,7 +118499,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.240923+00:00"
+                "validatedAt": "2026-07-20T14:40:46.878458+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -118735,7 +118615,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.241072+00:00"
+                "validatedAt": "2026-07-20T14:40:46.878493+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -118768,7 +118648,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.241178+00:00"
+                "validatedAt": "2026-07-20T14:40:46.878521+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -118802,7 +118682,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.241279+00:00"
+                "validatedAt": "2026-07-20T14:40:46.878548+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -118854,7 +118734,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.241350+00:00"
+                "validatedAt": "2026-07-20T14:40:46.878565+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -118927,7 +118807,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.241423+00:00"
+                "validatedAt": "2026-07-20T14:40:46.878598+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -119064,7 +118944,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.241519+00:00"
+                "validatedAt": "2026-07-20T14:40:46.878635+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -119175,7 +119055,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.241550+00:00"
+                "validatedAt": "2026-07-20T14:40:46.878650+00:00"
               },
               "deterministic": true
             },
@@ -119187,9 +119067,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.821624+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:22.259019+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "sli_address": {
             "type": "string",
@@ -119204,7 +119083,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.241588+00:00"
+                "validatedAt": "2026-07-20T14:40:46.878665+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -119227,7 +119106,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.241628+00:00"
+                "validatedAt": "2026-07-20T14:40:46.878681+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -119299,7 +119178,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.241721+00:00"
+                "validatedAt": "2026-07-20T14:40:46.878709+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -119333,7 +119212,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.241780+00:00"
+                "validatedAt": "2026-07-20T14:40:46.878736+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -119367,7 +119246,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.241839+00:00"
+                "validatedAt": "2026-07-20T14:40:46.878764+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -119432,7 +119311,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.241894+00:00"
+                "validatedAt": "2026-07-20T14:40:46.878790+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -119465,7 +119344,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.241955+00:00"
+                "validatedAt": "2026-07-20T14:40:46.878819+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -119499,7 +119378,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.242011+00:00"
+                "validatedAt": "2026-07-20T14:40:46.878846+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -119538,7 +119417,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.242059+00:00"
+                "validatedAt": "2026-07-20T14:40:46.878866+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -119571,7 +119450,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.242184+00:00"
+                "validatedAt": "2026-07-20T14:40:46.878895+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -119605,7 +119484,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.242243+00:00"
+                "validatedAt": "2026-07-20T14:40:46.878920+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -119630,7 +119509,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.242280+00:00"
+                "validatedAt": "2026-07-20T14:40:46.878935+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -119677,7 +119556,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.242345+00:00"
+                "validatedAt": "2026-07-20T14:40:46.878965+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -119766,7 +119645,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.242417+00:00"
+                "validatedAt": "2026-07-20T14:40:46.878993+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -119946,7 +119825,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T13:08:33.242454+00:00"
+                "validatedAt": "2026-07-20T14:40:46.879010+00:00"
               },
               "deterministic": true
             },
@@ -120004,7 +119883,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.242500+00:00"
+                "validatedAt": "2026-07-20T14:40:46.879029+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -120029,7 +119908,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.242545+00:00"
+                "validatedAt": "2026-07-20T14:40:46.879047+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -120052,7 +119931,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.242590+00:00"
+                "validatedAt": "2026-07-20T14:40:46.879066+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -120076,7 +119955,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.242694+00:00"
+                "validatedAt": "2026-07-20T14:40:46.879086+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -120099,7 +119978,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.242779+00:00"
+                "validatedAt": "2026-07-20T14:40:46.879105+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -120327,7 +120206,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.242942+00:00"
+                "validatedAt": "2026-07-20T14:40:46.879146+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -120398,7 +120277,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.243009+00:00"
+                "validatedAt": "2026-07-20T14:40:46.879165+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -120421,7 +120300,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.243051+00:00"
+                "validatedAt": "2026-07-20T14:40:46.879183+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -120444,7 +120323,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.243096+00:00"
+                "validatedAt": "2026-07-20T14:40:46.879201+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -120467,7 +120346,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.243137+00:00"
+                "validatedAt": "2026-07-20T14:40:46.879218+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -120540,7 +120419,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T13:08:33.243196+00:00"
+                "validatedAt": "2026-07-20T14:40:46.879236+00:00"
               },
               "deterministic": true
             },
@@ -120567,7 +120446,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.243230+00:00"
+                "validatedAt": "2026-07-20T14:40:46.879249+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -120593,7 +120472,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.243265+00:00"
+                "validatedAt": "2026-07-20T14:40:46.879263+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -120604,7 +120483,7 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.821947+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.259347+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -120660,7 +120539,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.243303+00:00"
+                "validatedAt": "2026-07-20T14:40:46.879278+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -120700,7 +120579,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.243333+00:00"
+                "validatedAt": "2026-07-20T14:40:46.879291+00:00"
               },
               "deterministic": true
             },
@@ -120712,9 +120591,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.821974+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:22.259380+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "serial": {
             "type": "string",
@@ -120732,7 +120610,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.243366+00:00"
+                "validatedAt": "2026-07-20T14:40:46.879305+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -120758,7 +120636,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.243400+00:00"
+                "validatedAt": "2026-07-20T14:40:46.879318+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -120784,7 +120662,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.243433+00:00"
+                "validatedAt": "2026-07-20T14:40:46.879332+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -120795,7 +120673,7 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.822005+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.259413+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -120892,7 +120770,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.243480+00:00"
+                "validatedAt": "2026-07-20T14:40:46.879353+00:00"
               },
               "deterministic": true
             },
@@ -120904,9 +120782,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.822039+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:22.259452+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "BondMembersType represents the bond interface members along with the corresponding link state.",
@@ -121005,7 +120882,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.243519+00:00"
+                "validatedAt": "2026-07-20T14:40:46.879368+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -121031,7 +120908,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.243551+00:00"
+                "validatedAt": "2026-07-20T14:40:46.879381+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -121073,7 +120950,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.243593+00:00"
+                "validatedAt": "2026-07-20T14:40:46.879398+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -121099,7 +120976,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.243627+00:00"
+                "validatedAt": "2026-07-20T14:40:46.879411+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -121110,7 +120987,7 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.822086+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.259502+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -121175,7 +121052,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.243697+00:00"
+                "validatedAt": "2026-07-20T14:40:46.879427+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -121221,7 +121098,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.243731+00:00"
+                "validatedAt": "2026-07-20T14:40:46.879443+00:00"
               },
               "deterministic": true
             },
@@ -121233,9 +121110,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.822113+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:22.259532+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "start_time": {
             "type": "string",
@@ -121260,7 +121136,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.243772+00:00"
+                "validatedAt": "2026-07-20T14:40:46.879459+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -121324,7 +121200,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.822140+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.259562+00:00"
           }
         },
         "x-f5xc-description-short": "Response for the Check Site Exist Request.",
@@ -121423,7 +121299,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.243872+00:00"
+                "validatedAt": "2026-07-20T14:40:46.879497+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -121478,7 +121354,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.243926+00:00"
+                "validatedAt": "2026-07-20T14:40:46.879518+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -121556,7 +121432,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.243971+00:00"
+                "validatedAt": "2026-07-20T14:40:46.879537+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -121600,7 +121476,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.244031+00:00"
+                "validatedAt": "2026-07-20T14:40:46.879564+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -121688,7 +121564,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.244084+00:00"
+                "validatedAt": "2026-07-20T14:40:46.879590+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -121702,8 +121578,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -121746,7 +121621,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.244134+00:00"
+                "validatedAt": "2026-07-20T14:40:46.879617+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -121760,8 +121635,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -121886,7 +121760,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.244176+00:00"
+                "validatedAt": "2026-07-20T14:40:46.879634+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -121913,7 +121787,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.244216+00:00"
+                "validatedAt": "2026-07-20T14:40:46.879651+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -121952,7 +121826,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.244253+00:00"
+                "validatedAt": "2026-07-20T14:40:46.879666+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -121976,7 +121850,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.244288+00:00"
+                "validatedAt": "2026-07-20T14:40:46.879680+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -121987,7 +121861,7 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.822296+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.259723+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -122039,7 +121913,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.244329+00:00"
+                "validatedAt": "2026-07-20T14:40:46.879696+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -122062,7 +121936,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.244369+00:00"
+                "validatedAt": "2026-07-20T14:40:46.879713+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -122098,7 +121972,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.244418+00:00"
+                "validatedAt": "2026-07-20T14:40:46.879732+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -122122,7 +121996,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.244458+00:00"
+                "validatedAt": "2026-07-20T14:40:46.879749+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -122145,7 +122019,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.244497+00:00"
+                "validatedAt": "2026-07-20T14:40:46.879764+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -122168,7 +122042,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.244538+00:00"
+                "validatedAt": "2026-07-20T14:40:46.879782+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -122230,7 +122104,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.244584+00:00"
+                "validatedAt": "2026-07-20T14:40:46.879801+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -122254,7 +122128,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.244630+00:00"
+                "validatedAt": "2026-07-20T14:40:46.879820+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -122278,7 +122152,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.244696+00:00"
+                "validatedAt": "2026-07-20T14:40:46.879840+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -122317,7 +122191,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.244751+00:00"
+                "validatedAt": "2026-07-20T14:40:46.879861+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -122341,7 +122215,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.244789+00:00"
+                "validatedAt": "2026-07-20T14:40:46.879877+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -122418,7 +122292,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.244845+00:00"
+                "validatedAt": "2026-07-20T14:40:46.879899+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -122456,7 +122330,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.244893+00:00"
+                "validatedAt": "2026-07-20T14:40:46.879918+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -122480,7 +122354,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.244931+00:00"
+                "validatedAt": "2026-07-20T14:40:46.879933+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -122539,7 +122413,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.244971+00:00"
+                "validatedAt": "2026-07-20T14:40:46.879949+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -122562,7 +122436,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.245009+00:00"
+                "validatedAt": "2026-07-20T14:40:46.879964+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -122585,7 +122459,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.245051+00:00"
+                "validatedAt": "2026-07-20T14:40:46.879981+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -122608,7 +122482,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.245093+00:00"
+                "validatedAt": "2026-07-20T14:40:46.879998+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -122632,7 +122506,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.245126+00:00"
+                "validatedAt": "2026-07-20T14:40:46.880012+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -122693,7 +122567,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.245163+00:00"
+                "validatedAt": "2026-07-20T14:40:46.880026+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -122718,7 +122592,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.245203+00:00"
+                "validatedAt": "2026-07-20T14:40:46.880041+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -122756,7 +122630,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.245232+00:00"
+                "validatedAt": "2026-07-20T14:40:46.880054+00:00"
               },
               "deterministic": true
             },
@@ -122768,9 +122642,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.822482+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:22.259916+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "result": {
             "type": "string",
@@ -122785,7 +122658,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.245266+00:00"
+                "validatedAt": "2026-07-20T14:40:46.880069+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -122863,7 +122736,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.245311+00:00"
+                "validatedAt": "2026-07-20T14:40:46.880089+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -122890,7 +122763,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.245356+00:00"
+                "validatedAt": "2026-07-20T14:40:46.880106+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -122915,7 +122788,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.245390+00:00"
+                "validatedAt": "2026-07-20T14:40:46.880121+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -123029,7 +122902,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.245435+00:00"
+                "validatedAt": "2026-07-20T14:40:46.880139+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -123054,7 +122927,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.245476+00:00"
+                "validatedAt": "2026-07-20T14:40:46.880156+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -123133,7 +123006,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.245518+00:00"
+                "validatedAt": "2026-07-20T14:40:46.880172+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -123158,7 +123031,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.245555+00:00"
+                "validatedAt": "2026-07-20T14:40:46.880187+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -123183,7 +123056,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.245595+00:00"
+                "validatedAt": "2026-07-20T14:40:46.880203+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -123340,7 +123213,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.822624+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.260067+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -123417,7 +123290,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:08:33.245748+00:00"
+                "validatedAt": "2026-07-20T14:40:46.880249+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -123428,7 +123301,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.822651+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.260097+00:00"
           },
           "ref": {
             "type": "array",
@@ -123503,7 +123376,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:08:33.245791+00:00"
+                "validatedAt": "2026-07-20T14:40:46.880268+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -123689,7 +123562,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.245856+00:00"
+                "validatedAt": "2026-07-20T14:40:46.880293+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -123727,7 +123600,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.245886+00:00"
+                "validatedAt": "2026-07-20T14:40:46.880307+00:00"
               },
               "deterministic": true
             },
@@ -123739,9 +123612,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.822758+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:22.260199+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "network_name": {
             "type": "string",
@@ -123758,7 +123630,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.245925+00:00"
+                "validatedAt": "2026-07-20T14:40:46.880323+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -123844,7 +123716,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.245968+00:00"
+                "validatedAt": "2026-07-20T14:40:46.880341+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -123869,7 +123741,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.246003+00:00"
+                "validatedAt": "2026-07-20T14:40:46.880355+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -123894,7 +123766,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.246038+00:00"
+                "validatedAt": "2026-07-20T14:40:46.880368+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -123905,7 +123777,7 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.822804+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.260255+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -123962,7 +123834,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.822825+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.260317+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -124103,7 +123975,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:08:33.246073+00:00"
+                "validatedAt": "2026-07-20T14:40:46.880385+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -124164,7 +124036,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.246115+00:00"
+                "validatedAt": "2026-07-20T14:40:46.880401+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -124189,7 +124061,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.246155+00:00"
+                "validatedAt": "2026-07-20T14:40:46.880417+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -124237,7 +124109,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.246210+00:00"
+                "validatedAt": "2026-07-20T14:40:46.880446+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -124251,8 +124123,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "uid": {
             "type": "string",
@@ -124269,7 +124140,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.246238+00:00"
+                "validatedAt": "2026-07-20T14:40:46.880457+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -124282,7 +124153,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.822877+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.260377+00:00"
           },
           "user_email": {
             "type": "string",
@@ -124300,7 +124171,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.246273+00:00"
+                "validatedAt": "2026-07-20T14:40:46.880472+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -124385,7 +124256,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:08:33.246314+00:00"
+                "validatedAt": "2026-07-20T14:40:46.880490+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -124463,7 +124334,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:08:33.246365+00:00"
+                "validatedAt": "2026-07-20T14:40:46.880512+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -124474,7 +124345,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.822928+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.260432+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -124560,7 +124431,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.246407+00:00"
+                "validatedAt": "2026-07-20T14:40:46.880531+00:00"
               },
               "deterministic": true
             },
@@ -124572,9 +124443,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.822972+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:22.260481+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -124605,7 +124475,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.246435+00:00"
+                "validatedAt": "2026-07-20T14:40:46.880544+00:00"
               },
               "deterministic": true
             },
@@ -124617,9 +124487,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.822991+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:22.260502+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -124688,7 +124557,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.246489+00:00"
+                "validatedAt": "2026-07-20T14:40:46.880565+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -124700,7 +124569,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.823028+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.260541+00:00"
           },
           "uid": {
             "type": "string",
@@ -124717,7 +124586,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.246515+00:00"
+                "validatedAt": "2026-07-20T14:40:46.880576+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -124730,7 +124599,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.823047+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.260563+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of site is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -124827,7 +124696,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.246568+00:00"
+                "validatedAt": "2026-07-20T14:40:46.880597+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -124890,7 +124759,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.246604+00:00"
+                "validatedAt": "2026-07-20T14:40:46.880612+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -124963,7 +124832,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T13:08:33.246687+00:00"
+                "validatedAt": "2026-07-20T14:40:46.880635+00:00"
               },
               "deterministic": true
             },
@@ -125003,7 +124872,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.246715+00:00"
+                "validatedAt": "2026-07-20T14:40:46.880648+00:00"
               },
               "deterministic": true
             },
@@ -125015,9 +124884,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.823120+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:22.260639+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "port": {
             "type": "string",
@@ -125036,7 +124904,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.246745+00:00"
+                "validatedAt": "2026-07-20T14:40:46.880660+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -125121,7 +124989,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T13:08:33.246789+00:00"
+                "validatedAt": "2026-07-20T14:40:46.880679+00:00"
               },
               "deterministic": true
             },
@@ -125132,8 +125000,7 @@
               "read": false
             },
             "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "minLength": 1,
-            "format": "fqdn"
+            "minLength": 1
           },
           "role": {
             "type": "array",
@@ -125206,7 +125073,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.246838+00:00"
+                "validatedAt": "2026-07-20T14:40:46.880698+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -125245,7 +125112,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.246865+00:00"
+                "validatedAt": "2026-07-20T14:40:46.880711+00:00"
               },
               "deterministic": true
             },
@@ -125257,9 +125124,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.823174+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:22.260697+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "release": {
             "type": "string",
@@ -125276,7 +125142,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.246900+00:00"
+                "validatedAt": "2026-07-20T14:40:46.880725+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -125301,7 +125167,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.246933+00:00"
+                "validatedAt": "2026-07-20T14:40:46.880739+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -125326,7 +125192,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.246968+00:00"
+                "validatedAt": "2026-07-20T14:40:46.880753+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -125337,7 +125203,7 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.823205+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.260731+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -125433,7 +125299,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.247004+00:00"
+                "validatedAt": "2026-07-20T14:40:46.880769+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -125509,7 +125375,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.247051+00:00"
+                "validatedAt": "2026-07-20T14:40:46.880788+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -125555,7 +125421,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.247121+00:00"
+                "validatedAt": "2026-07-20T14:40:46.880818+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -125713,7 +125579,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:08:33.247176+00:00"
+                "validatedAt": "2026-07-20T14:40:46.880842+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -125746,7 +125612,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.247220+00:00"
+                "validatedAt": "2026-07-20T14:40:46.880863+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -126114,7 +125980,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.247320+00:00"
+                "validatedAt": "2026-07-20T14:40:46.880903+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -126140,7 +126006,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.247356+00:00"
+                "validatedAt": "2026-07-20T14:40:46.880918+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -126195,7 +126061,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.247413+00:00"
+                "validatedAt": "2026-07-20T14:40:46.880946+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -126235,7 +126101,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.247443+00:00"
+                "validatedAt": "2026-07-20T14:40:46.880960+00:00"
               },
               "deterministic": true
             },
@@ -126247,9 +126113,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.823409+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:22.260940+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "site": {
             "type": "string",
@@ -126266,7 +126131,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.247472+00:00"
+                "validatedAt": "2026-07-20T14:40:46.880972+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -126298,7 +126163,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.247511+00:00"
+                "validatedAt": "2026-07-20T14:40:46.880989+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -126432,7 +126297,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.247552+00:00"
+                "validatedAt": "2026-07-20T14:40:46.881008+00:00"
               },
               "deterministic": true
             },
@@ -126444,9 +126309,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.823450+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:22.261045+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "serial": {
             "type": "string",
@@ -126465,7 +126329,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.247585+00:00"
+                "validatedAt": "2026-07-20T14:40:46.881021+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -126490,7 +126354,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.247618+00:00"
+                "validatedAt": "2026-07-20T14:40:46.881035+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -126516,7 +126380,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.247652+00:00"
+                "validatedAt": "2026-07-20T14:40:46.881048+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -126527,7 +126391,7 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.823481+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.261102+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -126704,7 +126568,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.248108+00:00"
+                "validatedAt": "2026-07-20T14:40:46.881262+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -126718,8 +126582,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Revoke kubeconfig object with a given name.",
@@ -126768,7 +126631,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.248143+00:00"
+                "validatedAt": "2026-07-20T14:40:46.881276+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -126791,7 +126654,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.248177+00:00"
+                "validatedAt": "2026-07-20T14:40:46.881291+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -126814,7 +126677,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.248228+00:00"
+                "validatedAt": "2026-07-20T14:40:46.881308+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -126888,7 +126751,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.248293+00:00"
+                "validatedAt": "2026-07-20T14:40:46.881330+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -126990,7 +126853,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.248335+00:00"
+                "validatedAt": "2026-07-20T14:40:46.881344+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -127098,7 +126961,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:08:33.248431+00:00"
+                "validatedAt": "2026-07-20T14:40:46.881377+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -127109,7 +126972,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.823639+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.261271+00:00"
           },
           "ref": {
             "type": "array",
@@ -127182,7 +127045,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:08:33.248474+00:00"
+                "validatedAt": "2026-07-20T14:40:46.881394+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -127264,7 +127127,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.248506+00:00"
+                "validatedAt": "2026-07-20T14:40:46.881409+00:00"
               },
               "deterministic": true
             },
@@ -127276,9 +127139,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.823682+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:22.261553+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -127316,7 +127178,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.248537+00:00"
+                "validatedAt": "2026-07-20T14:40:46.881424+00:00"
               },
               "deterministic": true
             },
@@ -127328,9 +127190,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.823701+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:22.261575+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "state": {
             "allOf": [
@@ -127433,7 +127294,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.248588+00:00"
+                "validatedAt": "2026-07-20T14:40:46.881442+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -127457,7 +127318,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.248628+00:00"
+                "validatedAt": "2026-07-20T14:40:46.881457+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -127747,7 +127608,7 @@
             "maxLength": 16,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.823778+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.261654+00:00"
           },
           "value": {
             "type": "array",
@@ -127766,7 +127627,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.823799+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.261678+00:00"
           }
         },
         "x-f5xc-description-short": "Site Status Field Data contains key/value pair for a field.",
@@ -127829,7 +127690,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.248741+00:00"
+                "validatedAt": "2026-07-20T14:40:46.881487+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -127899,7 +127760,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.248792+00:00"
+                "validatedAt": "2026-07-20T14:40:46.881508+00:00"
               },
               "deterministic": true
             },
@@ -127911,9 +127772,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.823833+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:22.261714+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "site": {
             "type": "string",
@@ -127937,7 +127797,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.248828+00:00"
+                "validatedAt": "2026-07-20T14:40:46.881521+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -127970,7 +127830,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.248872+00:00"
+                "validatedAt": "2026-07-20T14:40:46.881538+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -128003,7 +127863,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.248908+00:00"
+                "validatedAt": "2026-07-20T14:40:46.881552+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -128095,7 +127955,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.248956+00:00"
+                "validatedAt": "2026-07-20T14:40:46.881570+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -128283,7 +128143,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.249003+00:00"
+                "validatedAt": "2026-07-20T14:40:46.881588+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -128396,7 +128256,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T13:08:33.249066+00:00"
+                "validatedAt": "2026-07-20T14:40:46.881612+00:00"
               },
               "deterministic": true
             },
@@ -128407,8 +128267,7 @@
               "read": false
             },
             "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "minLength": 1,
-            "format": "fqdn"
+            "minLength": 1
           },
           "hw_info": {
             "allOf": [
@@ -128672,7 +128531,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.249170+00:00"
+                "validatedAt": "2026-07-20T14:40:46.881649+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -128697,7 +128556,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.249203+00:00"
+                "validatedAt": "2026-07-20T14:40:46.881663+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -128736,7 +128595,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.249231+00:00"
+                "validatedAt": "2026-07-20T14:40:46.881676+00:00"
               },
               "deterministic": true
             },
@@ -128748,9 +128607,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.824045+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:22.261929+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "serial": {
             "type": "string",
@@ -128767,7 +128625,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.249263+00:00"
+                "validatedAt": "2026-07-20T14:40:46.881690+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -128807,7 +128665,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.249317+00:00"
+                "validatedAt": "2026-07-20T14:40:46.881708+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -128882,7 +128740,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.249364+00:00"
+                "validatedAt": "2026-07-20T14:40:46.881729+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -128973,7 +128831,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.249427+00:00"
+                "validatedAt": "2026-07-20T14:40:46.881751+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -129048,7 +128906,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.249487+00:00"
+                "validatedAt": "2026-07-20T14:40:46.881776+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -129071,7 +128929,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.249532+00:00"
+                "validatedAt": "2026-07-20T14:40:46.881794+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -129103,7 +128961,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T13:08:33.249564+00:00"
+                "validatedAt": "2026-07-20T14:40:46.881808+00:00"
               },
               "deterministic": true
             },
@@ -129128,7 +128986,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.249603+00:00"
+                "validatedAt": "2026-07-20T14:40:46.881823+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -129152,7 +129010,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.249645+00:00"
+                "validatedAt": "2026-07-20T14:40:46.881839+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -129223,7 +129081,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.249723+00:00"
+                "validatedAt": "2026-07-20T14:40:46.881856+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -129251,7 +129109,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T13:08:33.249766+00:00"
+                "validatedAt": "2026-07-20T14:40:46.881873+00:00"
               },
               "deterministic": true
             },
@@ -129411,7 +129269,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.249824+00:00"
+                "validatedAt": "2026-07-20T14:40:46.881894+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -129437,7 +129295,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.249870+00:00"
+                "validatedAt": "2026-07-20T14:40:46.881911+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -129463,7 +129321,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.249915+00:00"
+                "validatedAt": "2026-07-20T14:40:46.881928+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -129503,7 +129361,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.249972+00:00"
+                "validatedAt": "2026-07-20T14:40:46.881948+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -129528,7 +129386,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.250009+00:00"
+                "validatedAt": "2026-07-20T14:40:46.881963+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -129573,7 +129431,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:08:33.250066+00:00"
+                "validatedAt": "2026-07-20T14:40:46.881986+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -129584,7 +129442,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.824248+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.262255+00:00"
           },
           "i_manufacturer": {
             "type": "string",
@@ -129601,7 +129459,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.250108+00:00"
+                "validatedAt": "2026-07-20T14:40:46.882002+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -129626,7 +129484,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.250147+00:00"
+                "validatedAt": "2026-07-20T14:40:46.882016+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -129652,7 +129510,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.250184+00:00"
+                "validatedAt": "2026-07-20T14:40:46.882031+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -129678,7 +129536,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.250225+00:00"
+                "validatedAt": "2026-07-20T14:40:46.882046+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -129703,7 +129561,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.250264+00:00"
+                "validatedAt": "2026-07-20T14:40:46.882061+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -129733,7 +129591,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.250294+00:00"
+                "validatedAt": "2026-07-20T14:40:46.882076+00:00"
               },
               "deterministic": true
             },
@@ -129760,7 +129618,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.250336+00:00"
+                "validatedAt": "2026-07-20T14:40:46.882092+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -129786,7 +129644,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.250371+00:00"
+                "validatedAt": "2026-07-20T14:40:46.882106+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -129825,7 +129683,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.250416+00:00"
+                "validatedAt": "2026-07-20T14:40:46.882124+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -129948,7 +129806,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.250451+00:00"
+                "validatedAt": "2026-07-20T14:40:46.882141+00:00"
               },
               "deterministic": true
             },
@@ -129960,9 +129818,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.824339+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:22.262355+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -130000,7 +129857,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.250483+00:00"
+                "validatedAt": "2026-07-20T14:40:46.882157+00:00"
               },
               "deterministic": true
             },
@@ -130012,9 +129869,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.824357+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:22.262376+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "version": {
             "type": "string",
@@ -130038,7 +129894,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.250523+00:00"
+                "validatedAt": "2026-07-20T14:40:46.882172+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -130049,7 +129905,7 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.824376+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.262397+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -130183,7 +130039,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.250561+00:00"
+                "validatedAt": "2026-07-20T14:40:46.882190+00:00"
               },
               "deterministic": true
             },
@@ -130195,9 +130051,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.824403+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:22.262428+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -130235,7 +130090,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.250593+00:00"
+                "validatedAt": "2026-07-20T14:40:46.882206+00:00"
               },
               "deterministic": true
             },
@@ -130247,9 +130102,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.824422+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:22.262449+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "version": {
             "type": "string",
@@ -130273,7 +130127,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.250634+00:00"
+                "validatedAt": "2026-07-20T14:40:46.882223+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -130284,7 +130138,7 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.824440+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.262470+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -130501,7 +130355,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:08:33.250711+00:00"
+                "validatedAt": "2026-07-20T14:40:46.882245+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -130512,7 +130366,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.824463+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.262560+00:00"
           },
           "state": {
             "allOf": [
@@ -130581,7 +130435,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.250762+00:00"
+                "validatedAt": "2026-07-20T14:40:46.882264+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -130604,7 +130458,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.250801+00:00"
+                "validatedAt": "2026-07-20T14:40:46.882279+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -130629,7 +130483,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.250841+00:00"
+                "validatedAt": "2026-07-20T14:40:46.882295+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -130785,7 +130639,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.250967+00:00"
+                "validatedAt": "2026-07-20T14:40:46.882339+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -131052,7 +130906,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.251050+00:00"
+                "validatedAt": "2026-07-20T14:40:46.882369+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -131088,7 +130942,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.251098+00:00"
+                "validatedAt": "2026-07-20T14:40:46.882392+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -131128,7 +130982,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.251129+00:00"
+                "validatedAt": "2026-07-20T14:40:46.882407+00:00"
               },
               "deterministic": true
             },
@@ -131140,9 +130994,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.824606+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:22.262718+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "site": {
             "type": "string",
@@ -131159,7 +131012,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.251163+00:00"
+                "validatedAt": "2026-07-20T14:40:46.882420+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -131191,7 +131044,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.251209+00:00"
+                "validatedAt": "2026-07-20T14:40:46.882437+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -131322,7 +131175,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.251277+00:00"
+                "validatedAt": "2026-07-20T14:40:46.882464+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -131347,7 +131200,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.251316+00:00"
+                "validatedAt": "2026-07-20T14:40:46.882480+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -131370,7 +131223,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.251356+00:00"
+                "validatedAt": "2026-07-20T14:40:46.882495+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -131433,7 +131286,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.251404+00:00"
+                "validatedAt": "2026-07-20T14:40:46.882513+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -131472,7 +131325,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.251456+00:00"
+                "validatedAt": "2026-07-20T14:40:46.882533+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -131504,7 +131357,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.251526+00:00"
+                "validatedAt": "2026-07-20T14:40:46.882564+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -131530,7 +131383,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.251577+00:00"
+                "validatedAt": "2026-07-20T14:40:46.882583+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -131590,7 +131443,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.252210+00:00"
+                "validatedAt": "2026-07-20T14:40:46.882802+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -131636,7 +131489,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.252266+00:00"
+                "validatedAt": "2026-07-20T14:40:46.882823+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -131774,7 +131627,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.252317+00:00"
+                "validatedAt": "2026-07-20T14:40:46.882843+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -131811,7 +131664,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.252348+00:00"
+                "validatedAt": "2026-07-20T14:40:46.882857+00:00"
               },
               "deterministic": true
             },
@@ -131823,9 +131676,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.824894+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:22.263007+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -131874,7 +131726,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.252389+00:00"
+                "validatedAt": "2026-07-20T14:40:46.882874+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -131896,7 +131748,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.252427+00:00"
+                "validatedAt": "2026-07-20T14:40:46.882889+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -131918,7 +131770,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.252463+00:00"
+                "validatedAt": "2026-07-20T14:40:46.882904+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -131940,7 +131792,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.252498+00:00"
+                "validatedAt": "2026-07-20T14:40:46.882919+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -131962,7 +131814,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.252530+00:00"
+                "validatedAt": "2026-07-20T14:40:46.882932+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -131973,7 +131825,7 @@
             },
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.824940+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.263055+00:00"
           },
           "readOnly": {
             "type": "boolean",
@@ -132050,7 +131902,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.252578+00:00"
+                "validatedAt": "2026-07-20T14:40:46.882951+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -132072,7 +131924,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.252619+00:00"
+                "validatedAt": "2026-07-20T14:40:46.882968+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -132094,7 +131946,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.252685+00:00"
+                "validatedAt": "2026-07-20T14:40:46.882983+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -132165,7 +132017,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.252729+00:00"
+                "validatedAt": "2026-07-20T14:40:46.883001+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -132187,7 +132039,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.252767+00:00"
+                "validatedAt": "2026-07-20T14:40:46.883016+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -132271,7 +132123,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.252810+00:00"
+                "validatedAt": "2026-07-20T14:40:46.883034+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -132293,7 +132145,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.252845+00:00"
+                "validatedAt": "2026-07-20T14:40:46.883048+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -132366,7 +132218,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.252900+00:00"
+                "validatedAt": "2026-07-20T14:40:46.883070+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -132430,7 +132282,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.252937+00:00"
+                "validatedAt": "2026-07-20T14:40:46.883085+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -132452,7 +132304,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.252973+00:00"
+                "validatedAt": "2026-07-20T14:40:46.883100+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -132628,7 +132480,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:08:33.253060+00:00"
+                "validatedAt": "2026-07-20T14:40:46.883135+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -132662,7 +132514,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.253103+00:00"
+                "validatedAt": "2026-07-20T14:40:46.883152+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -132703,7 +132555,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.253138+00:00"
+                "validatedAt": "2026-07-20T14:40:46.883169+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -132782,7 +132634,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:08:33.253191+00:00"
+                "validatedAt": "2026-07-20T14:40:46.883192+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -132816,7 +132668,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.253234+00:00"
+                "validatedAt": "2026-07-20T14:40:46.883211+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -132857,7 +132709,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.253267+00:00"
+                "validatedAt": "2026-07-20T14:40:46.883227+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -132919,7 +132771,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.253303+00:00"
+                "validatedAt": "2026-07-20T14:40:46.883242+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -132966,7 +132818,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.253348+00:00"
+                "validatedAt": "2026-07-20T14:40:46.883259+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -133026,7 +132878,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.253385+00:00"
+                "validatedAt": "2026-07-20T14:40:46.883275+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -133073,7 +132925,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.253429+00:00"
+                "validatedAt": "2026-07-20T14:40:46.883293+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -133315,7 +133167,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.253493+00:00"
+                "validatedAt": "2026-07-20T14:40:46.883319+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -133326,7 +133178,7 @@
             },
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.825299+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.263418+00:00"
           },
           "localObjectReference": {
             "allOf": [
@@ -133406,7 +133258,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:08:33.253531+00:00"
+                "validatedAt": "2026-07-20T14:40:46.883336+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -133478,7 +133330,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.253576+00:00"
+                "validatedAt": "2026-07-20T14:40:46.883355+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -133515,7 +133367,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.253606+00:00"
+                "validatedAt": "2026-07-20T14:40:46.883370+00:00"
               },
               "deterministic": true
             },
@@ -133527,9 +133379,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.825355+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:22.263476+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -133559,7 +133410,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.253635+00:00"
+                "validatedAt": "2026-07-20T14:40:46.883384+00:00"
               },
               "deterministic": true
             },
@@ -133571,9 +133422,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.825373+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:22.263498+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "resourceVersion": {
             "type": "string",
@@ -133587,7 +133437,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.253694+00:00"
+                "validatedAt": "2026-07-20T14:40:46.883401+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -133598,7 +133448,7 @@
             },
             "minLength": 0,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.825391+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.263539+00:00"
           },
           "uid": {
             "type": "string",
@@ -133612,7 +133462,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.253723+00:00"
+                "validatedAt": "2026-07-20T14:40:46.883413+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -133625,7 +133475,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.825412+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.263563+00:00"
           }
         },
         "x-f5xc-description-short": "ConfigMapNodeConfigSource contains the information to reference a ConfigMap as a config source for the Node.",
@@ -133683,7 +133533,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:08:33.253753+00:00"
+                "validatedAt": "2026-07-20T14:40:46.883427+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -133787,7 +133637,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:08:33.253803+00:00"
+                "validatedAt": "2026-07-20T14:40:46.883450+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -133929,7 +133779,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.253888+00:00"
+                "validatedAt": "2026-07-20T14:40:46.883482+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -133952,7 +133802,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.253930+00:00"
+                "validatedAt": "2026-07-20T14:40:46.883499+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -134017,7 +133867,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.253967+00:00"
+                "validatedAt": "2026-07-20T14:40:46.883516+00:00"
               },
               "deterministic": true
             },
@@ -134029,9 +133879,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.825531+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:22.263688+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "ports": {
             "type": "array",
@@ -134137,7 +133986,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.254039+00:00"
+                "validatedAt": "2026-07-20T14:40:46.883544+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -134160,7 +134009,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.254084+00:00"
+                "validatedAt": "2026-07-20T14:40:46.883563+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -134224,7 +134073,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.254155+00:00"
+                "validatedAt": "2026-07-20T14:40:46.883590+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -134318,7 +134167,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.254205+00:00"
+                "validatedAt": "2026-07-20T14:40:46.883610+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -134386,7 +134235,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.254256+00:00"
+                "validatedAt": "2026-07-20T14:40:46.883630+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -134435,7 +134284,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.254297+00:00"
+                "validatedAt": "2026-07-20T14:40:46.883649+00:00"
               },
               "deterministic": true
             },
@@ -134447,9 +134296,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.825674+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:22.263830+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "protocol": {
             "type": "string",
@@ -134463,7 +134311,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.254334+00:00"
+                "validatedAt": "2026-07-20T14:40:46.883665+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -134646,7 +134494,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.254389+00:00"
+                "validatedAt": "2026-07-20T14:40:46.883688+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -134693,7 +134541,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.254442+00:00"
+                "validatedAt": "2026-07-20T14:40:46.883709+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -134715,7 +134563,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.254479+00:00"
+                "validatedAt": "2026-07-20T14:40:46.883724+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -134726,7 +134574,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.825755+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.263913+00:00"
           },
           "signal": {
             "type": "integer",
@@ -134805,7 +134653,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.254532+00:00"
+                "validatedAt": "2026-07-20T14:40:46.883745+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -134827,7 +134675,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.254568+00:00"
+                "validatedAt": "2026-07-20T14:40:46.883760+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -134838,7 +134686,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.825799+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.263956+00:00"
           }
         },
         "x-f5xc-description-short": "ContainerStateWaiting is a waiting state of a container.",
@@ -134887,7 +134735,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.254610+00:00"
+                "validatedAt": "2026-07-20T14:40:46.883777+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -134909,7 +134757,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.254644+00:00"
+                "validatedAt": "2026-07-20T14:40:46.883791+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -134930,7 +134778,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.254705+00:00"
+                "validatedAt": "2026-07-20T14:40:46.883806+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -134980,7 +134828,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.254740+00:00"
+                "validatedAt": "2026-07-20T14:40:46.883821+00:00"
               },
               "deterministic": true
             },
@@ -134992,9 +134840,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.825847+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:22.264028+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "ready": {
             "type": "boolean",
@@ -135103,7 +134950,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.254792+00:00"
+                "validatedAt": "2026-07-20T14:40:46.883843+00:00"
               },
               "deterministic": true
             },
@@ -135192,7 +135039,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.825914+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.264105+00:00"
           }
         },
         "x-f5xc-description-short": "DaemonSet represents the configuration of a daemon set.",
@@ -135256,7 +135103,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.254842+00:00"
+                "validatedAt": "2026-07-20T14:40:46.883863+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -135278,7 +135125,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.254878+00:00"
+                "validatedAt": "2026-07-20T14:40:46.883878+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -135289,7 +135136,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.825946+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.264146+00:00"
           },
           "status": {
             "type": "string",
@@ -135304,7 +135151,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.254913+00:00"
+                "validatedAt": "2026-07-20T14:40:46.883892+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -135315,7 +135162,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.825966+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.264171+00:00"
           },
           "type": {
             "type": "string",
@@ -135328,7 +135175,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.254947+00:00"
+                "validatedAt": "2026-07-20T14:40:46.883906+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -135392,7 +135239,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:08:33.254978+00:00"
+                "validatedAt": "2026-07-20T14:40:46.883921+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -135672,7 +135519,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.255164+00:00"
+                "validatedAt": "2026-07-20T14:40:46.883996+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -135764,7 +135611,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.255214+00:00"
+                "validatedAt": "2026-07-20T14:40:46.884017+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -135853,7 +135700,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.826129+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.264345+00:00"
           }
         },
         "x-f5xc-description-short": "Deployment enables declarative updates for Pods and ReplicaSets.",
@@ -135931,7 +135778,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.255270+00:00"
+                "validatedAt": "2026-07-20T14:40:46.884040+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -135953,7 +135800,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.255306+00:00"
+                "validatedAt": "2026-07-20T14:40:46.884055+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -135964,7 +135811,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.826168+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.264389+00:00"
           },
           "status": {
             "type": "string",
@@ -135979,7 +135826,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.255340+00:00"
+                "validatedAt": "2026-07-20T14:40:46.884070+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -135990,7 +135837,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.826187+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.264414+00:00"
           },
           "type": {
             "type": "string",
@@ -136003,7 +135850,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.255374+00:00"
+                "validatedAt": "2026-07-20T14:40:46.884084+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -136068,7 +135915,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:08:33.255403+00:00"
+                "validatedAt": "2026-07-20T14:40:46.884098+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -136322,7 +136169,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.255553+00:00"
+                "validatedAt": "2026-07-20T14:40:46.884156+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -136450,7 +136297,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.255640+00:00"
+                "validatedAt": "2026-07-20T14:40:46.884190+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -136512,7 +136359,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:08:33.255686+00:00"
+                "validatedAt": "2026-07-20T14:40:46.884205+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -136597,7 +136444,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:08:33.255742+00:00"
+                "validatedAt": "2026-07-20T14:40:46.884230+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -136687,7 +136534,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:08:33.255788+00:00"
+                "validatedAt": "2026-07-20T14:40:46.884250+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -136745,7 +136592,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.255825+00:00"
+                "validatedAt": "2026-07-20T14:40:46.884266+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -136823,7 +136670,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T13:08:33.255860+00:00"
+                "validatedAt": "2026-07-20T14:40:46.884283+00:00"
               },
               "deterministic": true
             },
@@ -136834,8 +136681,7 @@
               "read": false
             },
             "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "minLength": 1,
-            "format": "fqdn"
+            "minLength": 1
           },
           "ip": {
             "type": "string",
@@ -136851,7 +136697,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.255887+00:00"
+                "validatedAt": "2026-07-20T14:40:46.884295+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -136873,7 +136719,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.255923+00:00"
+                "validatedAt": "2026-07-20T14:40:46.884311+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -136960,7 +136806,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.255957+00:00"
+                "validatedAt": "2026-07-20T14:40:46.884326+00:00"
               },
               "deterministic": true
             },
@@ -136972,9 +136818,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.826436+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:22.264699+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "port": {
             "type": "integer",
@@ -136992,7 +136837,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.255984+00:00"
+                "validatedAt": "2026-07-20T14:40:46.884341+00:00"
               },
               "deterministic": true
             },
@@ -137015,7 +136860,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.256019+00:00"
+                "validatedAt": "2026-07-20T14:40:46.884356+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -137216,7 +137061,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:08:33.256101+00:00"
+                "validatedAt": "2026-07-20T14:40:46.884391+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -137300,7 +137145,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.256143+00:00"
+                "validatedAt": "2026-07-20T14:40:46.884408+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -137385,7 +137230,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.256176+00:00"
+                "validatedAt": "2026-07-20T14:40:46.884424+00:00"
               },
               "deterministic": true
             },
@@ -137397,9 +137242,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.826540+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:22.264814+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "value": {
             "type": "string",
@@ -137413,7 +137257,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.256210+00:00"
+                "validatedAt": "2026-07-20T14:40:46.884438+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -137424,7 +137268,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.826557+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.264835+00:00"
           },
           "valueFrom": {
             "allOf": [
@@ -137592,7 +137436,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.256272+00:00"
+                "validatedAt": "2026-07-20T14:40:46.884464+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -137706,7 +137550,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.256350+00:00"
+                "validatedAt": "2026-07-20T14:40:46.884494+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -137729,7 +137573,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.256391+00:00"
+                "validatedAt": "2026-07-20T14:40:46.884511+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -137794,7 +137638,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.256428+00:00"
+                "validatedAt": "2026-07-20T14:40:46.884528+00:00"
               },
               "deterministic": true
             },
@@ -137806,9 +137650,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.826685+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:22.264960+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "ports": {
             "type": "array",
@@ -137914,7 +137757,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.256500+00:00"
+                "validatedAt": "2026-07-20T14:40:46.884557+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -137937,7 +137780,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.256544+00:00"
+                "validatedAt": "2026-07-20T14:40:46.884575+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -138001,7 +137844,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.256611+00:00"
+                "validatedAt": "2026-07-20T14:40:46.884603+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -138127,7 +137970,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.256683+00:00"
+                "validatedAt": "2026-07-20T14:40:46.884624+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -138242,7 +138085,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.256748+00:00"
+                "validatedAt": "2026-07-20T14:40:46.884650+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -138299,7 +138142,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.256784+00:00"
+                "validatedAt": "2026-07-20T14:40:46.884666+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -138321,7 +138164,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.256819+00:00"
+                "validatedAt": "2026-07-20T14:40:46.884681+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -138418,7 +138261,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.256867+00:00"
+                "validatedAt": "2026-07-20T14:40:46.884701+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -138440,7 +138283,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.256902+00:00"
+                "validatedAt": "2026-07-20T14:40:46.884716+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -138538,7 +138381,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.256954+00:00"
+                "validatedAt": "2026-07-20T14:40:46.884736+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -138561,7 +138404,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.256995+00:00"
+                "validatedAt": "2026-07-20T14:40:46.884753+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -138619,7 +138462,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.257032+00:00"
+                "validatedAt": "2026-07-20T14:40:46.884769+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -138653,7 +138496,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.257079+00:00"
+                "validatedAt": "2026-07-20T14:40:46.884789+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -138725,7 +138568,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.257122+00:00"
+                "validatedAt": "2026-07-20T14:40:46.884806+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -138747,7 +138590,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.257160+00:00"
+                "validatedAt": "2026-07-20T14:40:46.884822+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -138769,7 +138612,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.257197+00:00"
+                "validatedAt": "2026-07-20T14:40:46.884837+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -138829,7 +138672,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.257235+00:00"
+                "validatedAt": "2026-07-20T14:40:46.884853+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -138852,7 +138695,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.257279+00:00"
+                "validatedAt": "2026-07-20T14:40:46.884871+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -138877,7 +138720,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:08:33.257319+00:00"
+                "validatedAt": "2026-07-20T14:40:46.884891+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -138950,7 +138793,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.257364+00:00"
+                "validatedAt": "2026-07-20T14:40:46.884909+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -138975,7 +138818,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:08:33.257405+00:00"
+                "validatedAt": "2026-07-20T14:40:46.884928+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -139048,7 +138891,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.257442+00:00"
+                "validatedAt": "2026-07-20T14:40:46.884945+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -139088,7 +138931,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:08:33.257494+00:00"
+                "validatedAt": "2026-07-20T14:40:46.884968+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -139124,7 +138967,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.257536+00:00"
+                "validatedAt": "2026-07-20T14:40:46.884985+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -139199,7 +139042,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.257566+00:00"
+                "validatedAt": "2026-07-20T14:40:46.885000+00:00"
               },
               "deterministic": true
             },
@@ -139211,9 +139054,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.827050+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:22.265314+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "value": {
             "type": "string",
@@ -139227,7 +139069,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.257600+00:00"
+                "validatedAt": "2026-07-20T14:40:46.885015+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -139238,7 +139080,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.827068+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.265335+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -139376,7 +139218,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.257649+00:00"
+                "validatedAt": "2026-07-20T14:40:46.885035+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -139437,7 +139279,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:08:33.257709+00:00"
+                "validatedAt": "2026-07-20T14:40:46.885053+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -139459,7 +139301,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.257743+00:00"
+                "validatedAt": "2026-07-20T14:40:46.885067+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -139543,7 +139385,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.257789+00:00"
+                "validatedAt": "2026-07-20T14:40:46.885085+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -139565,7 +139407,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.257830+00:00"
+                "validatedAt": "2026-07-20T14:40:46.885103+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -139586,7 +139428,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.257857+00:00"
+                "validatedAt": "2026-07-20T14:40:46.885115+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -139609,7 +139451,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.257900+00:00"
+                "validatedAt": "2026-07-20T14:40:46.885132+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -139682,7 +139524,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.257969+00:00"
+                "validatedAt": "2026-07-20T14:40:46.885159+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -139775,7 +139617,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.258013+00:00"
+                "validatedAt": "2026-07-20T14:40:46.885177+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -139797,7 +139639,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.258053+00:00"
+                "validatedAt": "2026-07-20T14:40:46.885194+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -139818,7 +139660,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.258081+00:00"
+                "validatedAt": "2026-07-20T14:40:46.885205+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -139841,7 +139683,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.258120+00:00"
+                "validatedAt": "2026-07-20T14:40:46.885221+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -139914,7 +139756,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.258188+00:00"
+                "validatedAt": "2026-07-20T14:40:46.885248+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -140013,7 +139855,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.827293+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.265556+00:00"
           }
         },
         "x-f5xc-description-short": "Job represents the configuration of a single job.",
@@ -140091,7 +139933,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.258242+00:00"
+                "validatedAt": "2026-07-20T14:40:46.885269+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -140113,7 +139955,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.258277+00:00"
+                "validatedAt": "2026-07-20T14:40:46.885284+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -140124,7 +139966,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.827331+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.265599+00:00"
           },
           "status": {
             "type": "string",
@@ -140139,7 +139981,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.258312+00:00"
+                "validatedAt": "2026-07-20T14:40:46.885299+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -140150,7 +139992,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.827351+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.265621+00:00"
           },
           "type": {
             "type": "string",
@@ -140164,7 +140006,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.258344+00:00"
+                "validatedAt": "2026-07-20T14:40:46.885312+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -140229,7 +140071,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:08:33.258375+00:00"
+                "validatedAt": "2026-07-20T14:40:46.885327+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -140301,7 +140143,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.258427+00:00"
+                "validatedAt": "2026-07-20T14:40:46.885346+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -140571,7 +140413,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.258570+00:00"
+                "validatedAt": "2026-07-20T14:40:46.885401+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -140582,7 +140424,7 @@
             },
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.827484+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.265753+00:00"
           },
           "mode": {
             "type": "integer",
@@ -140612,7 +140454,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:08:33.258620+00:00"
+                "validatedAt": "2026-07-20T14:40:46.885422+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -140733,7 +140575,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.258694+00:00"
+                "validatedAt": "2026-07-20T14:40:46.885441+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -140744,7 +140586,7 @@
             },
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.827534+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.265806+00:00"
           },
           "operator": {
             "type": "string",
@@ -140759,7 +140601,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.258732+00:00"
+                "validatedAt": "2026-07-20T14:40:46.885457+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -140895,7 +140737,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.258789+00:00"
+                "validatedAt": "2026-07-20T14:40:46.885480+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -140906,7 +140748,7 @@
             },
             "minLength": 0,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.827580+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.265857+00:00"
           },
           "remainingItemCount": {
             "type": "string",
@@ -140922,7 +140764,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.258833+00:00"
+                "validatedAt": "2026-07-20T14:40:46.885498+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -140944,7 +140786,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.258874+00:00"
+                "validatedAt": "2026-07-20T14:40:46.885516+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -140955,7 +140797,7 @@
             },
             "minLength": 0,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.827605+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.265884+00:00"
           },
           "selfLink": {
             "type": "string",
@@ -140970,7 +140812,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.258910+00:00"
+                "validatedAt": "2026-07-20T14:40:46.885531+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -140981,7 +140823,7 @@
             },
             "minLength": 0,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.827628+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.265906+00:00"
           }
         },
         "x-f5xc-description-short": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects.",
@@ -141040,7 +140882,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T13:08:33.258945+00:00"
+                "validatedAt": "2026-07-20T14:40:46.885548+00:00"
               },
               "deterministic": true
             },
@@ -141051,8 +140893,7 @@
               "read": false
             },
             "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "minLength": 1,
-            "format": "fqdn"
+            "minLength": 1
           },
           "ip": {
             "type": "string",
@@ -141068,7 +140909,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.258972+00:00"
+                "validatedAt": "2026-07-20T14:40:46.885560+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -141189,7 +141030,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.259014+00:00"
+                "validatedAt": "2026-07-20T14:40:46.885579+00:00"
               },
               "deterministic": true
             },
@@ -141201,9 +141042,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.827681+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:22.265951+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
@@ -141252,7 +141092,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.259050+00:00"
+                "validatedAt": "2026-07-20T14:40:46.885595+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -141278,7 +141118,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:08:33.259089+00:00"
+                "validatedAt": "2026-07-20T14:40:46.885613+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -141335,7 +141175,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.259128+00:00"
+                "validatedAt": "2026-07-20T14:40:46.885629+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -141357,7 +141197,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.259166+00:00"
+                "validatedAt": "2026-07-20T14:40:46.885645+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -141392,7 +141232,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.259205+00:00"
+                "validatedAt": "2026-07-20T14:40:46.885661+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -141415,7 +141255,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.259243+00:00"
+                "validatedAt": "2026-07-20T14:40:46.885676+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -141493,7 +141333,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:08:33.259287+00:00"
+                "validatedAt": "2026-07-20T14:40:46.885696+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -141527,7 +141367,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.259327+00:00"
+                "validatedAt": "2026-07-20T14:40:46.885713+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -141618,7 +141458,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.827790+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.266061+00:00"
           }
         },
         "x-f5xc-description-short": "Namespace provides a scope for Names. Use of multiple namespaces is optional.",
@@ -141682,7 +141522,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.259377+00:00"
+                "validatedAt": "2026-07-20T14:40:46.885732+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -141704,7 +141544,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.259413+00:00"
+                "validatedAt": "2026-07-20T14:40:46.885746+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -141715,7 +141555,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.827823+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.266098+00:00"
           },
           "status": {
             "type": "string",
@@ -141730,7 +141570,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.259448+00:00"
+                "validatedAt": "2026-07-20T14:40:46.885761+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -141741,7 +141581,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.827842+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.266120+00:00"
           },
           "type": {
             "type": "string",
@@ -141754,7 +141594,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.259480+00:00"
+                "validatedAt": "2026-07-20T14:40:46.885775+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -141819,7 +141659,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:08:33.259510+00:00"
+                "validatedAt": "2026-07-20T14:40:46.885789+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -141952,7 +141792,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.259575+00:00"
+                "validatedAt": "2026-07-20T14:40:46.885814+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -142008,7 +141848,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.259612+00:00"
+                "validatedAt": "2026-07-20T14:40:46.885830+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -142030,7 +141870,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.259643+00:00"
+                "validatedAt": "2026-07-20T14:40:46.885843+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -142177,7 +142017,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.259719+00:00"
+                "validatedAt": "2026-07-20T14:40:46.885869+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -142199,7 +142039,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.259756+00:00"
+                "validatedAt": "2026-07-20T14:40:46.885884+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -142210,7 +142050,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.827953+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.266229+00:00"
           },
           "status": {
             "type": "string",
@@ -142225,7 +142065,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.259791+00:00"
+                "validatedAt": "2026-07-20T14:40:46.885899+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -142236,7 +142076,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.827973+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.266251+00:00"
           },
           "type": {
             "type": "string",
@@ -142249,7 +142089,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.259823+00:00"
+                "validatedAt": "2026-07-20T14:40:46.885914+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -142385,7 +142225,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.259868+00:00"
+                "validatedAt": "2026-07-20T14:40:46.885933+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -142510,7 +142350,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:08:33.259906+00:00"
+                "validatedAt": "2026-07-20T14:40:46.885951+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -142631,7 +142471,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.259954+00:00"
+                "validatedAt": "2026-07-20T14:40:46.885971+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -142642,7 +142482,7 @@
             },
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.828064+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.266342+00:00"
           },
           "operator": {
             "type": "string",
@@ -142657,7 +142497,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.259993+00:00"
+                "validatedAt": "2026-07-20T14:40:46.885989+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -142810,7 +142650,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.260075+00:00"
+                "validatedAt": "2026-07-20T14:40:46.886022+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -142832,7 +142672,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.260110+00:00"
+                "validatedAt": "2026-07-20T14:40:46.886037+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -142868,7 +142708,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.260160+00:00"
+                "validatedAt": "2026-07-20T14:40:46.886058+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -143063,7 +142903,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.260260+00:00"
+                "validatedAt": "2026-07-20T14:40:46.886098+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -143160,7 +143000,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.260327+00:00"
+                "validatedAt": "2026-07-20T14:40:46.886127+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -143181,7 +143021,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.260363+00:00"
+                "validatedAt": "2026-07-20T14:40:46.886143+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -143203,7 +143043,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.260407+00:00"
+                "validatedAt": "2026-07-20T14:40:46.886161+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -143225,7 +143065,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.260446+00:00"
+                "validatedAt": "2026-07-20T14:40:46.886178+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -143246,7 +143086,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.260487+00:00"
+                "validatedAt": "2026-07-20T14:40:46.886196+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -143267,7 +143107,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.260527+00:00"
+                "validatedAt": "2026-07-20T14:40:46.886213+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -143289,7 +143129,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.260565+00:00"
+                "validatedAt": "2026-07-20T14:40:46.886229+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -143312,7 +143152,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.260605+00:00"
+                "validatedAt": "2026-07-20T14:40:46.886246+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -143334,7 +143174,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.260642+00:00"
+                "validatedAt": "2026-07-20T14:40:46.886262+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -143356,7 +143196,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.260702+00:00"
+                "validatedAt": "2026-07-20T14:40:46.886278+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -143421,7 +143261,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.260744+00:00"
+                "validatedAt": "2026-07-20T14:40:46.886294+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -143443,7 +143283,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.260785+00:00"
+                "validatedAt": "2026-07-20T14:40:46.886311+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -143513,7 +143353,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.260834+00:00"
+                "validatedAt": "2026-07-20T14:40:46.886329+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -143551,7 +143391,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.260889+00:00"
+                "validatedAt": "2026-07-20T14:40:46.886350+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -143602,7 +143442,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.260950+00:00"
+                "validatedAt": "2026-07-20T14:40:46.886373+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -143626,7 +143466,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.260994+00:00"
+                "validatedAt": "2026-07-20T14:40:46.886390+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -143691,7 +143531,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.261045+00:00"
+                "validatedAt": "2026-07-20T14:40:46.886411+00:00"
               },
               "deterministic": true
             },
@@ -143703,9 +143543,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.828375+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:22.266694+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -143735,7 +143574,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.261078+00:00"
+                "validatedAt": "2026-07-20T14:40:46.886426+00:00"
               },
               "deterministic": true
             },
@@ -143747,9 +143586,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.828394+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:22.266726+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "ownerReferences": {
             "type": "array",
@@ -143778,7 +143616,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.261134+00:00"
+                "validatedAt": "2026-07-20T14:40:46.886449+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -143789,7 +143627,7 @@
             },
             "minLength": 0,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.828421+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.266755+00:00"
           },
           "selfLink": {
             "type": "string",
@@ -143804,7 +143642,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.261174+00:00"
+                "validatedAt": "2026-07-20T14:40:46.886464+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -143815,7 +143653,7 @@
             },
             "minLength": 0,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.828441+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.266776+00:00"
           },
           "uid": {
             "type": "string",
@@ -143830,7 +143668,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.261203+00:00"
+                "validatedAt": "2026-07-20T14:40:46.886476+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -143843,7 +143681,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.828461+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.266798+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectMeta is metadata that all persisted resources must have, which includes all objects users must create.",
@@ -143907,7 +143745,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.261245+00:00"
+                "validatedAt": "2026-07-20T14:40:46.886493+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -143929,7 +143767,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.261283+00:00"
+                "validatedAt": "2026-07-20T14:40:46.886508+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -143951,7 +143789,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.261316+00:00"
+                "validatedAt": "2026-07-20T14:40:46.886522+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -143962,7 +143800,7 @@
             },
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.828494+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.266834+00:00"
           },
           "name": {
             "type": "string",
@@ -143991,7 +143829,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.261347+00:00"
+                "validatedAt": "2026-07-20T14:40:46.886536+00:00"
               },
               "deterministic": true
             },
@@ -144003,9 +143841,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.828513+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:22.266857+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -144034,7 +143871,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.261378+00:00"
+                "validatedAt": "2026-07-20T14:40:46.886550+00:00"
               },
               "deterministic": true
             },
@@ -144046,9 +143883,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.828532+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:22.266877+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "resourceVersion": {
             "type": "string",
@@ -144062,7 +143898,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.261421+00:00"
+                "validatedAt": "2026-07-20T14:40:46.886568+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -144073,7 +143909,7 @@
             },
             "minLength": 0,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.828550+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.266897+00:00"
           },
           "uid": {
             "type": "string",
@@ -144087,7 +143923,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.261450+00:00"
+                "validatedAt": "2026-07-20T14:40:46.886580+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -144100,7 +143936,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.828571+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.266921+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -144152,7 +143988,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.261492+00:00"
+                "validatedAt": "2026-07-20T14:40:46.886597+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -144199,7 +144035,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.261534+00:00"
+                "validatedAt": "2026-07-20T14:40:46.886613+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -144210,7 +144046,7 @@
             },
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.828610+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.266961+00:00"
           },
           "name": {
             "type": "string",
@@ -144239,7 +144075,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.261564+00:00"
+                "validatedAt": "2026-07-20T14:40:46.886627+00:00"
               },
               "deterministic": true
             },
@@ -144251,9 +144087,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.828630+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:22.266983+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "uid": {
             "type": "string",
@@ -144267,7 +144102,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.261593+00:00"
+                "validatedAt": "2026-07-20T14:40:46.886639+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -144280,7 +144115,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.828649+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.267004+00:00"
           }
         },
         "x-f5xc-description-short": "OwnerReference contains enough information to let you identify an owning object.",
@@ -144366,7 +144201,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.828692+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.267039+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -144447,7 +144282,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.828725+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.267073+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -144524,7 +144359,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.261670+00:00"
+                "validatedAt": "2026-07-20T14:40:46.886664+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -144546,7 +144381,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.261710+00:00"
+                "validatedAt": "2026-07-20T14:40:46.886679+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -144557,7 +144392,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.828764+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.267113+00:00"
           },
           "status": {
             "type": "string",
@@ -144571,7 +144406,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.261748+00:00"
+                "validatedAt": "2026-07-20T14:40:46.886694+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -144582,7 +144417,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.828784+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.267134+00:00"
           },
           "type": {
             "type": "string",
@@ -144595,7 +144430,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.261802+00:00"
+                "validatedAt": "2026-07-20T14:40:46.886708+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -144660,7 +144495,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:08:33.261837+00:00"
+                "validatedAt": "2026-07-20T14:40:46.886723+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -144786,7 +144621,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.261907+00:00"
+                "validatedAt": "2026-07-20T14:40:46.886750+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -144808,7 +144643,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.261946+00:00"
+                "validatedAt": "2026-07-20T14:40:46.886766+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -144830,7 +144665,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.261984+00:00"
+                "validatedAt": "2026-07-20T14:40:46.886781+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -144932,7 +144767,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.262051+00:00"
+                "validatedAt": "2026-07-20T14:40:46.886807+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -144991,7 +144826,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.262091+00:00"
+                "validatedAt": "2026-07-20T14:40:46.886824+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -145066,7 +144901,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:08:33.262127+00:00"
+                "validatedAt": "2026-07-20T14:40:46.886839+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -145551,7 +145386,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.262283+00:00"
+                "validatedAt": "2026-07-20T14:40:46.886897+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -145587,7 +145422,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.262328+00:00"
+                "validatedAt": "2026-07-20T14:40:46.886916+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -145609,7 +145444,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.262367+00:00"
+                "validatedAt": "2026-07-20T14:40:46.886931+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -145673,7 +145508,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.262404+00:00"
+                "validatedAt": "2026-07-20T14:40:46.886946+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -145696,7 +145531,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.262439+00:00"
+                "validatedAt": "2026-07-20T14:40:46.886960+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -145718,7 +145553,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.262478+00:00"
+                "validatedAt": "2026-07-20T14:40:46.886975+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -145729,7 +145564,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.829140+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.267476+00:00"
           }
         },
         "x-f5xc-description-short": "PersistentVolumeStatus is the current status of a persistent volume.",
@@ -145780,7 +145615,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.262516+00:00"
+                "validatedAt": "2026-07-20T14:40:46.886990+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -145802,7 +145637,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.262549+00:00"
+                "validatedAt": "2026-07-20T14:40:46.887004+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -145891,7 +145726,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.829188+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.267526+00:00"
           }
         },
         "x-f5xc-description-short": "Pod is a collection of containers that can run on a host. This resource is created by clients and scheduled onto hosts.",
@@ -146034,7 +145869,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.262663+00:00"
+                "validatedAt": "2026-07-20T14:40:46.887043+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -146182,7 +146017,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.262743+00:00"
+                "validatedAt": "2026-07-20T14:40:46.887073+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -146204,7 +146039,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.262780+00:00"
+                "validatedAt": "2026-07-20T14:40:46.887088+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -146215,7 +146050,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.829276+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.267614+00:00"
           },
           "status": {
             "type": "string",
@@ -146230,7 +146065,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.262816+00:00"
+                "validatedAt": "2026-07-20T14:40:46.887103+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -146241,7 +146076,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.829296+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.267636+00:00"
           },
           "type": {
             "type": "string",
@@ -146255,7 +146090,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.262850+00:00"
+                "validatedAt": "2026-07-20T14:40:46.887116+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -146409,7 +146244,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.262922+00:00"
+                "validatedAt": "2026-07-20T14:40:46.887145+00:00"
               },
               "deterministic": true
             },
@@ -146421,9 +146256,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.829342+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:22.267683+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "value": {
             "type": "string",
@@ -146437,7 +146271,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.262956+00:00"
+                "validatedAt": "2026-07-20T14:40:46.887159+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -146448,7 +146282,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.829361+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.267704+00:00"
           }
         },
         "x-f5xc-description-short": "PodDNSConfigOption defines DNS resolver OPTIONS of a pod.",
@@ -146499,7 +146333,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.262983+00:00"
+                "validatedAt": "2026-07-20T14:40:46.887170+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -146561,7 +146395,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:08:33.263017+00:00"
+                "validatedAt": "2026-07-20T14:40:46.887185+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -146631,7 +146465,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.263063+00:00"
+                "validatedAt": "2026-07-20T14:40:46.887203+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -146690,7 +146524,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.263100+00:00"
+                "validatedAt": "2026-07-20T14:40:46.887218+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -146714,7 +146548,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.263139+00:00"
+                "validatedAt": "2026-07-20T14:40:46.887235+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -146751,7 +146585,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.263182+00:00"
+                "validatedAt": "2026-07-20T14:40:46.887253+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -146875,7 +146709,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.263259+00:00"
+                "validatedAt": "2026-07-20T14:40:46.887283+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -146950,7 +146784,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.263321+00:00"
+                "validatedAt": "2026-07-20T14:40:46.887308+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -147057,7 +146891,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T13:08:33.263394+00:00"
+                "validatedAt": "2026-07-20T14:40:46.887338+00:00"
               },
               "deterministic": true
             },
@@ -147068,8 +146902,7 @@
               "read": false
             },
             "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "minLength": 1,
-            "format": "fqdn"
+            "minLength": 1
           },
           "imagePullSecrets": {
             "type": "array",
@@ -147112,7 +146945,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.263458+00:00"
+                "validatedAt": "2026-07-20T14:40:46.887364+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -147158,7 +146991,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.263508+00:00"
+                "validatedAt": "2026-07-20T14:40:46.887383+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -147183,7 +147016,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:08:33.263544+00:00"
+                "validatedAt": "2026-07-20T14:40:46.887399+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -147205,7 +147038,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.263587+00:00"
+                "validatedAt": "2026-07-20T14:40:46.887417+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -147243,7 +147076,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.263642+00:00"
+                "validatedAt": "2026-07-20T14:40:46.887438+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -147265,7 +147098,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.263692+00:00"
+                "validatedAt": "2026-07-20T14:40:46.887455+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -147287,7 +147120,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.263733+00:00"
+                "validatedAt": "2026-07-20T14:40:46.887471+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -147322,7 +147155,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.263781+00:00"
+                "validatedAt": "2026-07-20T14:40:46.887489+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -147344,7 +147177,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.263825+00:00"
+                "validatedAt": "2026-07-20T14:40:46.887506+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -147378,7 +147211,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.263870+00:00"
+                "validatedAt": "2026-07-20T14:40:46.887522+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -147402,7 +147235,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.263919+00:00"
+                "validatedAt": "2026-07-20T14:40:46.887541+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -147576,7 +147409,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.264042+00:00"
+                "validatedAt": "2026-07-20T14:40:46.887585+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -147612,7 +147445,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.264095+00:00"
+                "validatedAt": "2026-07-20T14:40:46.887605+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -147634,7 +147467,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.264138+00:00"
+                "validatedAt": "2026-07-20T14:40:46.887622+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -147659,7 +147492,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.264173+00:00"
+                "validatedAt": "2026-07-20T14:40:46.887636+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -147681,7 +147514,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.264208+00:00"
+                "validatedAt": "2026-07-20T14:40:46.887650+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -147717,7 +147550,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.264258+00:00"
+                "validatedAt": "2026-07-20T14:40:46.887669+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -147739,7 +147572,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.264296+00:00"
+                "validatedAt": "2026-07-20T14:40:46.887684+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -147750,7 +147583,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.829767+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.268090+00:00"
           },
           "startTime": {
             "allOf": [
@@ -147887,7 +147720,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.264345+00:00"
+                "validatedAt": "2026-07-20T14:40:46.887703+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -147921,7 +147754,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.264389+00:00"
+                "validatedAt": "2026-07-20T14:40:46.887719+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -147995,7 +147828,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:08:33.264427+00:00"
+                "validatedAt": "2026-07-20T14:40:46.887737+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -148229,7 +148062,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.264568+00:00"
+                "validatedAt": "2026-07-20T14:40:46.887788+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -148263,7 +148096,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.264610+00:00"
+                "validatedAt": "2026-07-20T14:40:46.887805+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -148286,7 +148119,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.264647+00:00"
+                "validatedAt": "2026-07-20T14:40:46.887820+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -148298,7 +148131,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.829918+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.268238+00:00"
           },
           "user": {
             "type": "string",
@@ -148318,7 +148151,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.264688+00:00"
+                "validatedAt": "2026-07-20T14:40:46.887834+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -148340,7 +148173,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.264723+00:00"
+                "validatedAt": "2026-07-20T14:40:46.887849+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -148402,7 +148235,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.264761+00:00"
+                "validatedAt": "2026-07-20T14:40:46.887864+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -148424,7 +148257,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.264796+00:00"
+                "validatedAt": "2026-07-20T14:40:46.887878+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -148446,7 +148279,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.264834+00:00"
+                "validatedAt": "2026-07-20T14:40:46.887893+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -148482,7 +148315,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.264880+00:00"
+                "validatedAt": "2026-07-20T14:40:46.887910+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -148535,7 +148368,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.264917+00:00"
+                "validatedAt": "2026-07-20T14:40:46.887927+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -148599,7 +148432,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.264953+00:00"
+                "validatedAt": "2026-07-20T14:40:46.887942+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -148621,7 +148454,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.264988+00:00"
+                "validatedAt": "2026-07-20T14:40:46.887956+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -148643,7 +148476,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.265026+00:00"
+                "validatedAt": "2026-07-20T14:40:46.887971+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -148679,7 +148512,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.265071+00:00"
+                "validatedAt": "2026-07-20T14:40:46.887989+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -148732,7 +148565,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.265107+00:00"
+                "validatedAt": "2026-07-20T14:40:46.888004+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -148828,7 +148661,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.830068+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.268386+00:00"
           }
         },
         "x-f5xc-description-short": "ReplicaSet ensures that a specified number of pod replicas are running at any given time.",
@@ -148892,7 +148725,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.265157+00:00"
+                "validatedAt": "2026-07-20T14:40:46.888025+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -148914,7 +148747,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.265194+00:00"
+                "validatedAt": "2026-07-20T14:40:46.888040+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -148925,7 +148758,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.830100+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.268419+00:00"
           },
           "status": {
             "type": "string",
@@ -148940,7 +148773,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.265232+00:00"
+                "validatedAt": "2026-07-20T14:40:46.888055+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -148951,7 +148784,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.830122+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.268442+00:00"
           },
           "type": {
             "type": "string",
@@ -148964,7 +148797,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.265265+00:00"
+                "validatedAt": "2026-07-20T14:40:46.888068+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -149029,7 +148862,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:08:33.265296+00:00"
+                "validatedAt": "2026-07-20T14:40:46.888082+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -149229,7 +149062,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.265422+00:00"
+                "validatedAt": "2026-07-20T14:40:46.888129+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -149315,7 +149148,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.265495+00:00"
+                "validatedAt": "2026-07-20T14:40:46.888155+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -149350,7 +149183,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.265538+00:00"
+                "validatedAt": "2026-07-20T14:40:46.888171+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -149621,7 +149454,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.265612+00:00"
+                "validatedAt": "2026-07-20T14:40:46.888199+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -149643,7 +149476,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.265646+00:00"
+                "validatedAt": "2026-07-20T14:40:46.888213+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -149665,7 +149498,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.265689+00:00"
+                "validatedAt": "2026-07-20T14:40:46.888226+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -149693,7 +149526,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.265720+00:00"
+                "validatedAt": "2026-07-20T14:40:46.888240+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -149751,7 +149584,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.265757+00:00"
+                "validatedAt": "2026-07-20T14:40:46.888255+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -149774,7 +149607,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.265796+00:00"
+                "validatedAt": "2026-07-20T14:40:46.888271+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -149797,7 +149630,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.265842+00:00"
+                "validatedAt": "2026-07-20T14:40:46.888289+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -149857,7 +149690,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.265897+00:00"
+                "validatedAt": "2026-07-20T14:40:46.888310+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -149880,7 +149713,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.265940+00:00"
+                "validatedAt": "2026-07-20T14:40:46.888327+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -149902,7 +149735,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.265979+00:00"
+                "validatedAt": "2026-07-20T14:40:46.888343+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -149925,7 +149758,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.266020+00:00"
+                "validatedAt": "2026-07-20T14:40:46.888359+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -149989,7 +149822,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.266060+00:00"
+                "validatedAt": "2026-07-20T14:40:46.888375+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -150012,7 +149845,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.266098+00:00"
+                "validatedAt": "2026-07-20T14:40:46.888390+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -150035,7 +149868,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.266143+00:00"
+                "validatedAt": "2026-07-20T14:40:46.888408+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -150095,7 +149928,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.266197+00:00"
+                "validatedAt": "2026-07-20T14:40:46.888428+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -150118,7 +149951,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.266241+00:00"
+                "validatedAt": "2026-07-20T14:40:46.888445+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -150140,7 +149973,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.266279+00:00"
+                "validatedAt": "2026-07-20T14:40:46.888461+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -150163,7 +149996,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.266320+00:00"
+                "validatedAt": "2026-07-20T14:40:46.888477+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -150264,7 +150097,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.266366+00:00"
+                "validatedAt": "2026-07-20T14:40:46.888495+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -150388,7 +150221,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.266403+00:00"
+                "validatedAt": "2026-07-20T14:40:46.888509+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -150399,7 +150232,7 @@
             },
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.830496+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.268808+00:00"
           },
           "localObjectReference": {
             "allOf": [
@@ -150481,7 +150314,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:08:33.266445+00:00"
+                "validatedAt": "2026-07-20T14:40:46.888528+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -150556,7 +150389,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:08:33.266479+00:00"
+                "validatedAt": "2026-07-20T14:40:46.888543+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -150657,7 +150490,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.266518+00:00"
+                "validatedAt": "2026-07-20T14:40:46.888560+00:00"
               },
               "deterministic": true
             },
@@ -150669,9 +150502,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.830566+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:22.268891+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -150700,7 +150532,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.266548+00:00"
+                "validatedAt": "2026-07-20T14:40:46.888574+00:00"
               },
               "deterministic": true
             },
@@ -150712,9 +150544,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.830585+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:22.268913+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -150780,7 +150611,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:08:33.266592+00:00"
+                "validatedAt": "2026-07-20T14:40:46.888593+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -150815,7 +150646,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.266636+00:00"
+                "validatedAt": "2026-07-20T14:40:46.888611+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -150913,7 +150744,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.266696+00:00"
+                "validatedAt": "2026-07-20T14:40:46.888630+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -150950,7 +150781,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.266742+00:00"
+                "validatedAt": "2026-07-20T14:40:46.888647+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -150987,7 +150818,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.266787+00:00"
+                "validatedAt": "2026-07-20T14:40:46.888665+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -151113,7 +150944,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.830718+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.269040+00:00"
           }
         },
         "x-f5xc-description-short": "Service is a named abstraction of software service (for example, example-SQL) consisting of local port (for example 3306) that the proxy listens...",
@@ -151164,7 +150995,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.266843+00:00"
+                "validatedAt": "2026-07-20T14:40:46.888687+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -151188,7 +151019,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.266887+00:00"
+                "validatedAt": "2026-07-20T14:40:46.888704+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -151213,7 +151044,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:08:33.266930+00:00"
+                "validatedAt": "2026-07-20T14:40:46.888723+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -151277,7 +151108,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:08:33.266961+00:00"
+                "validatedAt": "2026-07-20T14:40:46.888738+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -151362,7 +151193,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.266994+00:00"
+                "validatedAt": "2026-07-20T14:40:46.888753+00:00"
               },
               "deterministic": true
             },
@@ -151374,9 +151205,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.830775+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:22.269099+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "nodePort": {
             "type": "integer",
@@ -151407,7 +151237,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.267036+00:00"
+                "validatedAt": "2026-07-20T14:40:46.888771+00:00"
               },
               "deterministic": true
             },
@@ -151430,7 +151260,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.267073+00:00"
+                "validatedAt": "2026-07-20T14:40:46.888786+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -151504,7 +151334,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.267118+00:00"
+                "validatedAt": "2026-07-20T14:40:46.888803+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -151541,7 +151371,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.267175+00:00"
+                "validatedAt": "2026-07-20T14:40:46.888825+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -151564,7 +151394,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.267220+00:00"
+                "validatedAt": "2026-07-20T14:40:46.888843+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -151598,7 +151428,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.267274+00:00"
+                "validatedAt": "2026-07-20T14:40:46.888864+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -151621,7 +151451,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.267316+00:00"
+                "validatedAt": "2026-07-20T14:40:46.888881+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -151695,7 +151525,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.267395+00:00"
+                "validatedAt": "2026-07-20T14:40:46.888910+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -151745,7 +151575,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.267445+00:00"
+                "validatedAt": "2026-07-20T14:40:46.888931+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -151943,7 +151773,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.830947+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.269274+00:00"
           }
         },
         "x-f5xc-description-short": "StatefulSet represents a set of pods with consistent identities.",
@@ -152008,7 +151838,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.267505+00:00"
+                "validatedAt": "2026-07-20T14:40:46.888955+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -152030,7 +151860,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.267542+00:00"
+                "validatedAt": "2026-07-20T14:40:46.888970+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -152041,7 +151871,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.830979+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.269309+00:00"
           },
           "status": {
             "type": "string",
@@ -152056,7 +151886,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.267578+00:00"
+                "validatedAt": "2026-07-20T14:40:46.888984+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -152067,7 +151897,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.830999+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.269383+00:00"
           },
           "type": {
             "type": "string",
@@ -152080,7 +151910,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.267612+00:00"
+                "validatedAt": "2026-07-20T14:40:46.888998+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -152144,7 +151974,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:08:33.267643+00:00"
+                "validatedAt": "2026-07-20T14:40:46.889012+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -152216,7 +152046,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.267698+00:00"
+                "validatedAt": "2026-07-20T14:40:46.889031+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -152277,7 +152107,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.267769+00:00"
+                "validatedAt": "2026-07-20T14:40:46.889058+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -152422,7 +152252,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.267869+00:00"
+                "validatedAt": "2026-07-20T14:40:46.889099+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -152447,7 +152277,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.267911+00:00"
+                "validatedAt": "2026-07-20T14:40:46.889116+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -152495,7 +152325,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.267977+00:00"
+                "validatedAt": "2026-07-20T14:40:46.889144+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -152586,7 +152416,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.268029+00:00"
+                "validatedAt": "2026-07-20T14:40:46.889165+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -152644,7 +152474,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.268065+00:00"
+                "validatedAt": "2026-07-20T14:40:46.889181+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -152692,7 +152522,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.268110+00:00"
+                "validatedAt": "2026-07-20T14:40:46.889200+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -152714,7 +152544,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.268153+00:00"
+                "validatedAt": "2026-07-20T14:40:46.889218+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -152774,7 +152604,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.268189+00:00"
+                "validatedAt": "2026-07-20T14:40:46.889233+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -152822,7 +152652,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.268234+00:00"
+                "validatedAt": "2026-07-20T14:40:46.889251+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -152844,7 +152674,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.268276+00:00"
+                "validatedAt": "2026-07-20T14:40:46.889270+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -152919,7 +152749,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.268306+00:00"
+                "validatedAt": "2026-07-20T14:40:46.889285+00:00"
               },
               "deterministic": true
             },
@@ -152931,9 +152761,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.831230+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:22.269640+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "value": {
             "type": "string",
@@ -152947,7 +152776,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.268340+00:00"
+                "validatedAt": "2026-07-20T14:40:46.889300+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -152958,7 +152787,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.831248+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.269662+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -153008,7 +152837,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.268373+00:00"
+                "validatedAt": "2026-07-20T14:40:46.889314+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -153079,7 +152908,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.268418+00:00"
+                "validatedAt": "2026-07-20T14:40:46.889331+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -153102,7 +152931,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.268448+00:00"
+                "validatedAt": "2026-07-20T14:40:46.889343+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -153113,7 +152942,7 @@
             },
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.831290+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.269727+00:00"
           },
           "timeAdded": {
             "allOf": [
@@ -153140,7 +152969,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.268486+00:00"
+                "validatedAt": "2026-07-20T14:40:46.889359+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -153151,7 +152980,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.831315+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.269774+00:00"
           }
         },
         "x-f5xc-description-short": "The node this Taint is attached to has the \"effect\" on any pod that does not tolerate the Taint.",
@@ -153218,7 +153047,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.268533+00:00"
+                "validatedAt": "2026-07-20T14:40:46.889378+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -153276,7 +153105,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.268570+00:00"
+                "validatedAt": "2026-07-20T14:40:46.889394+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -153299,7 +153128,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.268598+00:00"
+                "validatedAt": "2026-07-20T14:40:46.889405+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -153310,7 +153139,7 @@
             },
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.831358+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.269824+00:00"
           },
           "operator": {
             "type": "string",
@@ -153324,7 +153153,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.268635+00:00"
+                "validatedAt": "2026-07-20T14:40:46.889421+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -153348,7 +153177,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.268685+00:00"
+                "validatedAt": "2026-07-20T14:40:46.889438+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -153370,7 +153199,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.268721+00:00"
+                "validatedAt": "2026-07-20T14:40:46.889453+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -153381,7 +153210,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.831388+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.269859+00:00"
           }
         },
         "x-f5xc-description-short": "The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.",
@@ -153461,7 +153290,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.268777+00:00"
+                "validatedAt": "2026-07-20T14:40:46.889475+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -153484,7 +153313,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.268821+00:00"
+                "validatedAt": "2026-07-20T14:40:46.889493+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -153543,7 +153372,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.268860+00:00"
+                "validatedAt": "2026-07-20T14:40:46.889509+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -153565,7 +153394,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.268892+00:00"
+                "validatedAt": "2026-07-20T14:40:46.889522+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -153576,7 +153405,7 @@
             },
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.831443+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.269918+00:00"
           },
           "name": {
             "type": "string",
@@ -153605,7 +153434,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.268922+00:00"
+                "validatedAt": "2026-07-20T14:40:46.889536+00:00"
               },
               "deterministic": true
             },
@@ -153617,9 +153446,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.831463+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:22.269941+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "TypedLocalObjectReference contains enough information to let you locate the typed referenced object inside the same namespace.",
@@ -153685,7 +153513,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.268953+00:00"
+                "validatedAt": "2026-07-20T14:40:46.889551+00:00"
               },
               "deterministic": true
             },
@@ -153697,9 +153525,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.831484+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:22.269968+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "volumeSource": {
             "allOf": [
@@ -153762,7 +153589,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.268997+00:00"
+                "validatedAt": "2026-07-20T14:40:46.889569+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -153799,7 +153626,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.269026+00:00"
+                "validatedAt": "2026-07-20T14:40:46.889583+00:00"
               },
               "deterministic": true
             },
@@ -153811,9 +153638,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.831518+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:22.270005+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "VolumeDevice describes a mapping of a raw block device within a container.",
@@ -153862,7 +153688,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.269066+00:00"
+                "validatedAt": "2026-07-20T14:40:46.889599+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -153885,7 +153711,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.269107+00:00"
+                "validatedAt": "2026-07-20T14:40:46.889617+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -153921,7 +153747,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.269137+00:00"
+                "validatedAt": "2026-07-20T14:40:46.889632+00:00"
               },
               "deterministic": true
             },
@@ -153933,9 +153759,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.831550+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:22.270041+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "readOnly": {
             "type": "boolean",
@@ -153961,7 +153786,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.269175+00:00"
+                "validatedAt": "2026-07-20T14:40:46.889648+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -153983,7 +153808,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.269216+00:00"
+                "validatedAt": "2026-07-20T14:40:46.889665+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -154612,7 +154437,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.269353+00:00"
+                "validatedAt": "2026-07-20T14:40:46.889715+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -154634,7 +154459,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.269396+00:00"
+                "validatedAt": "2026-07-20T14:40:46.889733+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -154656,7 +154481,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.269439+00:00"
+                "validatedAt": "2026-07-20T14:40:46.889750+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -154678,7 +154503,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.269477+00:00"
+                "validatedAt": "2026-07-20T14:40:46.889766+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -154753,7 +154578,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:08:33.269513+00:00"
+                "validatedAt": "2026-07-20T14:40:46.889783+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -154809,7 +154634,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.269557+00:00"
+                "validatedAt": "2026-07-20T14:40:46.889801+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -154831,7 +154656,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.269600+00:00"
+                "validatedAt": "2026-07-20T14:40:46.889819+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -154853,7 +154678,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.269641+00:00"
+                "validatedAt": "2026-07-20T14:40:46.889836+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -154943,7 +154768,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.831885+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.270441+00:00"
           }
         },
         "x-f5xc-description-short": "CronJob represents the configuration of a single cron job.",
@@ -154997,7 +154822,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:08:33.269691+00:00"
+                "validatedAt": "2026-07-20T14:40:46.889854+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -155069,7 +154894,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.269738+00:00"
+                "validatedAt": "2026-07-20T14:40:46.889872+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -155116,7 +154941,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.269794+00:00"
+                "validatedAt": "2026-07-20T14:40:46.889894+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -155140,7 +154965,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.269838+00:00"
+                "validatedAt": "2026-07-20T14:40:46.889912+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -155355,7 +155180,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:08:33.270124+00:00"
+                "validatedAt": "2026-07-20T14:40:46.890037+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -155383,7 +155208,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.270153+00:00"
+                "validatedAt": "2026-07-20T14:40:46.890052+00:00"
               },
               "deterministic": true
             },
@@ -155407,7 +155232,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.270191+00:00"
+                "validatedAt": "2026-07-20T14:40:46.890067+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -155430,7 +155255,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.270228+00:00"
+                "validatedAt": "2026-07-20T14:40:46.890083+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -155441,7 +155266,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.832057+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.270743+00:00"
           },
           "status": {
             "type": "string",
@@ -155457,7 +155282,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.270265+00:00"
+                "validatedAt": "2026-07-20T14:40:46.890098+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -155468,7 +155293,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.832077+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.270815+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -155525,7 +155350,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:08:33.270300+00:00"
+                "validatedAt": "2026-07-20T14:40:46.890133+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -155563,7 +155388,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.270329+00:00"
+                "validatedAt": "2026-07-20T14:40:46.890156+00:00"
               },
               "deterministic": true
             },
@@ -155575,9 +155400,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.832106+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:22.270849+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "nlb_cname": {
             "type": "string",
@@ -155593,7 +155417,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.270367+00:00"
+                "validatedAt": "2026-07-20T14:40:46.890174+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -155616,7 +155440,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.270405+00:00"
+                "validatedAt": "2026-07-20T14:40:46.890191+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -155639,7 +155463,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.270441+00:00"
+                "validatedAt": "2026-07-20T14:40:46.890206+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -155650,7 +155474,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.832138+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.271013+00:00"
           },
           "target_group_status": {
             "type": "array",
@@ -155720,7 +155544,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:08:33.270492+00:00"
+                "validatedAt": "2026-07-20T14:40:46.890231+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -155773,7 +155597,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.270537+00:00"
+                "validatedAt": "2026-07-20T14:40:46.890251+00:00"
               },
               "deterministic": true
             },
@@ -155785,9 +155609,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.832179+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:22.271557+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "protocol": {
             "type": "string",
@@ -155802,7 +155625,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.270572+00:00"
+                "validatedAt": "2026-07-20T14:40:46.890267+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -155825,7 +155648,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.270607+00:00"
+                "validatedAt": "2026-07-20T14:40:46.890282+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -155836,7 +155659,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.832204+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.271587+00:00"
           },
           "status": {
             "type": "string",
@@ -155852,7 +155675,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.270644+00:00"
+                "validatedAt": "2026-07-20T14:40:46.890297+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -155863,7 +155686,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.832224+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.271611+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -155934,7 +155757,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:33.270755+00:00"
+                "validatedAt": "2026-07-20T14:40:46.890340+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -156012,7 +155835,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:33.270794+00:00"
+                "validatedAt": "2026-07-20T14:40:46.890358+00:00"
               },
               "deterministic": true
             },
@@ -156024,9 +155847,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.832315+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:22.271704+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "state": {
             "allOf": [
@@ -156371,7 +156193,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:35.390215+00:00"
+                "validatedAt": "2026-07-20T14:40:47.732766+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -156382,7 +156204,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.018998+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.400981+00:00"
           },
           "type": {
             "allOf": [
@@ -156414,7 +156236,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.019028+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.400999+00:00"
           }
         },
         "x-f5xc-description-short": "HealthScoreTypeData contains healthscore type and the corresponding value.",
@@ -156496,7 +156318,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.019064+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.401021+00:00"
           }
         },
         "x-f5xc-description-short": "MetricData contains the metric type and the corresponding metric value(s).",
@@ -156767,7 +156589,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:35.390453+00:00"
+                "validatedAt": "2026-07-20T14:40:47.732849+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -156818,7 +156640,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:35.390510+00:00"
+                "validatedAt": "2026-07-20T14:40:47.732876+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -157065,7 +156887,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:35.390712+00:00"
+                "validatedAt": "2026-07-20T14:40:47.732958+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -157076,7 +156898,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.019233+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.401121+00:00"
           }
         },
         "x-f5xc-description-short": "Each metric value consists of a timestamp and a value. Timestamp in the Metric Value is based on the start_time, end_time and step in the request.",
@@ -157367,7 +157189,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:35.390787+00:00"
+                "validatedAt": "2026-07-20T14:40:47.732987+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -157421,7 +157243,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:35.390824+00:00"
+                "validatedAt": "2026-07-20T14:40:47.733005+00:00"
               },
               "deterministic": true
             },
@@ -157433,9 +157255,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.019323+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:22.401174+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "range": {
             "type": "string",
@@ -157460,7 +157281,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:35.390862+00:00"
+                "validatedAt": "2026-07-20T14:40:47.733021+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -157507,7 +157328,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:35.390905+00:00"
+                "validatedAt": "2026-07-20T14:40:47.733039+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -157540,7 +157361,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:35.390938+00:00"
+                "validatedAt": "2026-07-20T14:40:47.733052+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -157632,7 +157453,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:35.390975+00:00"
+                "validatedAt": "2026-07-20T14:40:47.733068+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -157833,7 +157654,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:35.391036+00:00"
+                "validatedAt": "2026-07-20T14:40:47.733092+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -157960,7 +157781,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:35.391076+00:00"
+                "validatedAt": "2026-07-20T14:40:47.733109+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -157971,7 +157792,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.019436+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.401240+00:00"
           }
         },
         "x-f5xc-description-short": "Metrics used to render the site graph are tagged with labels listed in the enum Label.",
@@ -158233,7 +158054,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:35.391137+00:00"
+                "validatedAt": "2026-07-20T14:40:47.733133+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -158301,7 +158122,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:35.391172+00:00"
+                "validatedAt": "2026-07-20T14:40:47.733149+00:00"
               },
               "deterministic": true
             },
@@ -158313,9 +158134,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.019521+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:22.401289+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "range": {
             "type": "string",
@@ -158340,7 +158160,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:35.391207+00:00"
+                "validatedAt": "2026-07-20T14:40:47.733165+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -158373,7 +158193,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:35.391247+00:00"
+                "validatedAt": "2026-07-20T14:40:47.733181+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -158406,7 +158226,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:35.391282+00:00"
+                "validatedAt": "2026-07-20T14:40:47.733195+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -158497,7 +158317,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:35.391320+00:00"
+                "validatedAt": "2026-07-20T14:40:47.733211+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -158569,7 +158389,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:35.391359+00:00"
+                "validatedAt": "2026-07-20T14:40:47.733228+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -158656,7 +158476,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:35.391417+00:00"
+                "validatedAt": "2026-07-20T14:40:47.733254+00:00"
               },
               "deterministic": true
             },
@@ -158668,9 +158488,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.019602+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:22.401337+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "range": {
             "type": "string",
@@ -158695,7 +158514,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:35.391451+00:00"
+                "validatedAt": "2026-07-20T14:40:47.733268+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -158728,7 +158547,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:35.391491+00:00"
+                "validatedAt": "2026-07-20T14:40:47.733285+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -158761,7 +158580,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:35.391525+00:00"
+                "validatedAt": "2026-07-20T14:40:47.733299+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -158852,7 +158671,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:35.391562+00:00"
+                "validatedAt": "2026-07-20T14:40:47.733315+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -159395,7 +159214,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.701721+00:00"
+                "validatedAt": "2026-07-20T14:41:18.280288+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -159729,7 +159548,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:56.701829+00:00"
+                "validatedAt": "2026-07-20T14:41:18.280336+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -159842,7 +159661,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:09:56.701886+00:00"
+                "validatedAt": "2026-07-20T14:41:18.280363+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -160318,7 +160137,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.702328+00:00"
+                "validatedAt": "2026-07-20T14:41:18.280578+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -160342,7 +160161,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.702371+00:00"
+                "validatedAt": "2026-07-20T14:41:18.280596+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -160369,7 +160188,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T13:09:56.702404+00:00"
+                "validatedAt": "2026-07-20T14:41:18.280613+00:00"
               },
               "deterministic": true
             },
@@ -160411,7 +160230,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.702443+00:00"
+                "validatedAt": "2026-07-20T14:41:18.280630+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -160449,7 +160268,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:56.702468+00:00"
+                "validatedAt": "2026-07-20T14:41:18.280643+00:00"
               },
               "deterministic": true
             },
@@ -160461,9 +160280,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.437620+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.010644+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "resource_id": {
             "type": "string",
@@ -160480,7 +160298,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:09:56.702504+00:00"
+                "validatedAt": "2026-07-20T14:41:18.280661+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -160505,7 +160323,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.702545+00:00"
+                "validatedAt": "2026-07-20T14:41:18.280678+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -160528,7 +160346,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.702583+00:00"
+                "validatedAt": "2026-07-20T14:41:18.280694+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -160614,7 +160432,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.702623+00:00"
+                "validatedAt": "2026-07-20T14:41:18.280711+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -160639,7 +160457,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:09:56.702669+00:00"
+                "validatedAt": "2026-07-20T14:41:18.280729+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -160664,7 +160482,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.702710+00:00"
+                "validatedAt": "2026-07-20T14:41:18.280746+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -160687,7 +160505,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.702749+00:00"
+                "validatedAt": "2026-07-20T14:41:18.280763+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -160711,7 +160529,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.702783+00:00"
+                "validatedAt": "2026-07-20T14:41:18.280777+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -160792,7 +160610,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.702837+00:00"
+                "validatedAt": "2026-07-20T14:41:18.280803+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -160852,7 +160670,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.702873+00:00"
+                "validatedAt": "2026-07-20T14:41:18.280818+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -160887,7 +160705,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T13:09:56.702907+00:00"
+                "validatedAt": "2026-07-20T14:41:18.280835+00:00"
               },
               "deterministic": true
             },
@@ -160898,8 +160716,7 @@
               "read": false
             },
             "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "minLength": 1,
-            "format": "fqdn"
+            "minLength": 1
           },
           "primary": {
             "type": "boolean",
@@ -160964,7 +160781,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.702947+00:00"
+                "validatedAt": "2026-07-20T14:41:18.280852+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -160987,7 +160804,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.702991+00:00"
+                "validatedAt": "2026-07-20T14:41:18.280871+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -161192,7 +161009,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.703053+00:00"
+                "validatedAt": "2026-07-20T14:41:18.280896+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -161283,7 +161100,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.703102+00:00"
+                "validatedAt": "2026-07-20T14:41:18.280917+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -161307,7 +161124,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.703139+00:00"
+                "validatedAt": "2026-07-20T14:41:18.280933+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -161334,7 +161151,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.437810+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.010751+00:00"
           }
         },
         "x-f5xc-description-short": "Canonical representation of Edge in the topology graph.",
@@ -161392,7 +161209,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:09:56.703185+00:00"
+                "validatedAt": "2026-07-20T14:41:18.280952+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -161418,7 +161235,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.437839+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.010769+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -161472,7 +161289,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.703228+00:00"
+                "validatedAt": "2026-07-20T14:41:18.280970+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -161498,7 +161315,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:09:56.703260+00:00"
+                "validatedAt": "2026-07-20T14:41:18.280985+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -161523,7 +161340,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.703297+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281001+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -161698,7 +161515,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.703356+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281026+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -161721,7 +161538,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.703399+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281044+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -161758,7 +161575,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.703450+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281065+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -161781,7 +161598,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.703490+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281082+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -161819,7 +161636,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.703539+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281103+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -161842,7 +161659,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.703580+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281121+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -161866,7 +161683,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.703622+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281138+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -161889,7 +161706,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.703670+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281155+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -161913,7 +161730,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.703713+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281173+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -162042,7 +161859,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.703762+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281193+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -162083,7 +161900,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:56.703790+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281207+00:00"
               },
               "deterministic": true
             },
@@ -162095,9 +161912,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.437979+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.010853+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "src_id": {
             "type": "string",
@@ -162115,7 +161931,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.703824+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281221+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -162142,7 +161958,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.438005+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.010870+00:00"
           },
           "type": {
             "allOf": [
@@ -162214,7 +162030,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:09:56.703861+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281240+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -162240,7 +162056,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.438039+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.010891+00:00"
           },
           "type": {
             "allOf": [
@@ -162416,7 +162232,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.703909+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281259+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -162454,7 +162270,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:56.703936+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281272+00:00"
               },
               "deterministic": true
             },
@@ -162466,9 +162282,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.438087+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.010921+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -162540,7 +162355,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.703970+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281288+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -162578,7 +162393,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:56.703997+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281303+00:00"
               },
               "deterministic": true
             },
@@ -162590,9 +162405,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.438121+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.010943+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_id": {
             "type": "string",
@@ -162607,7 +162421,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.704031+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281318+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -162644,7 +162458,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.704070+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281335+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -162668,7 +162482,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.704104+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281350+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -162679,7 +162493,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.438159+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.010967+00:00"
           },
           "tags": {
             "type": "object",
@@ -162843,7 +162657,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:56.704166+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281380+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -162876,7 +162690,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.704205+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281396+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -162909,7 +162723,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:56.704243+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281417+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -162942,7 +162756,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.704282+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281434+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -162975,7 +162789,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.704314+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281449+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -163067,7 +162881,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:56.704346+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281465+00:00"
               },
               "deterministic": true
             },
@@ -163079,9 +162893,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.438248+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.011021+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "private_addresses": {
             "type": "array",
@@ -163142,7 +162955,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.704418+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281496+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -163153,7 +162966,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.438286+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.011045+00:00"
           },
           "subnet": {
             "type": "array",
@@ -163416,7 +163229,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.704513+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281536+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -163494,7 +163307,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.704571+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281561+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -163521,7 +163334,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.704596+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281573+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -163559,7 +163372,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:56.704624+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281587+00:00"
               },
               "deterministic": true
             },
@@ -163571,9 +163384,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.438376+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.011100+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "network_type": {
             "allOf": [
@@ -163845,7 +163657,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.704774+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281646+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -163874,7 +163686,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:09:56.704819+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281667+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -163885,7 +163697,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.438463+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.011153+00:00"
           },
           "level": {
             "type": "integer",
@@ -163932,7 +163744,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:56.704856+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281685+00:00"
               },
               "deterministic": true
             },
@@ -163944,9 +163756,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.438487+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.011169+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_id": {
             "type": "string",
@@ -163963,7 +163774,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.704889+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281700+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -164001,7 +163812,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.704925+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281716+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -164012,7 +163823,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.438520+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.011189+00:00"
           },
           "tags": {
             "type": "object",
@@ -164883,7 +164694,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.705077+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281777+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -164923,7 +164734,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:56.705102+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281790+00:00"
               },
               "deterministic": true
             },
@@ -164935,9 +164746,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.438696+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.011288+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tags": {
             "type": "object",
@@ -165165,7 +164975,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:09:56.705185+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281826+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -165377,7 +165187,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.705279+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281864+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -165429,7 +165239,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.705318+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281881+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -165480,7 +165290,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.705367+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281903+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -165703,7 +165513,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.705468+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281945+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -165979,7 +165789,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.705578+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281990+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -166005,7 +165815,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.705610+00:00"
+                "validatedAt": "2026-07-20T14:41:18.282004+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -166166,7 +165976,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.705689+00:00"
+                "validatedAt": "2026-07-20T14:41:18.282033+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -166205,7 +166015,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:56.705719+00:00"
+                "validatedAt": "2026-07-20T14:41:18.282048+00:00"
               },
               "deterministic": true
             },
@@ -166217,9 +166027,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.439011+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.011473+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -166326,7 +166135,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.705774+00:00"
+                "validatedAt": "2026-07-20T14:41:18.282071+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -166397,7 +166206,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:09:56.705835+00:00"
+                "validatedAt": "2026-07-20T14:41:18.282099+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -166571,7 +166380,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.705917+00:00"
+                "validatedAt": "2026-07-20T14:41:18.282131+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -166680,7 +166489,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:09:56.705971+00:00"
+                "validatedAt": "2026-07-20T14:41:18.282155+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -167086,7 +166895,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:07.134378+00:00"
+                "validatedAt": "2026-07-20T14:41:44.411168+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -167187,7 +166996,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:07.134410+00:00"
+                "validatedAt": "2026-07-20T14:41:44.411183+00:00"
               },
               "deterministic": true
             },
@@ -167199,9 +167008,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.548272+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.441967+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -167233,7 +167041,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:07.134438+00:00"
+                "validatedAt": "2026-07-20T14:41:44.411195+00:00"
               },
               "deterministic": true
             },
@@ -167245,9 +167053,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.548291+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.441977+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -167412,7 +167219,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.548357+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.442013+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -167555,7 +167362,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:07.134561+00:00"
+                "validatedAt": "2026-07-20T14:41:44.411247+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -167642,7 +167449,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:11:07.134604+00:00"
+                "validatedAt": "2026-07-20T14:41:44.411266+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -167723,7 +167530,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:11:07.134661+00:00"
+                "validatedAt": "2026-07-20T14:41:44.411287+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -167734,7 +167541,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.548434+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.442056+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -167821,7 +167628,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:07.134703+00:00"
+                "validatedAt": "2026-07-20T14:41:44.411305+00:00"
               },
               "deterministic": true
             },
@@ -167833,9 +167640,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.548479+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.442080+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -167866,7 +167672,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:07.134730+00:00"
+                "validatedAt": "2026-07-20T14:41:44.411318+00:00"
               },
               "deterministic": true
             },
@@ -167878,9 +167684,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.548497+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.442090+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -167949,7 +167754,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:07.134781+00:00"
+                "validatedAt": "2026-07-20T14:41:44.411339+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -167961,7 +167766,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.548535+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.442111+00:00"
           },
           "uid": {
             "type": "string",
@@ -167978,7 +167783,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:07.134807+00:00"
+                "validatedAt": "2026-07-20T14:41:44.411350+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -167991,7 +167796,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.548554+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.442122+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of virtual_k8s is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -168224,7 +168029,7 @@
             "maxLength": 16,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.548597+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.442145+00:00"
           },
           "value": {
             "type": "array",
@@ -168243,7 +168048,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.548619+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.442159+00:00"
           }
         },
         "x-f5xc-description-short": "PVC Metric Type Data contains key/value pair that uniquely identifies the group_by labels specified in the request.",
@@ -168309,7 +168114,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:07.134879+00:00"
+                "validatedAt": "2026-07-20T14:41:44.411377+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -168354,7 +168159,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:07.134928+00:00"
+                "validatedAt": "2026-07-20T14:41:44.411401+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -168381,7 +168186,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:07.134961+00:00"
+                "validatedAt": "2026-07-20T14:41:44.411414+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -168436,7 +168241,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:07.135000+00:00"
+                "validatedAt": "2026-07-20T14:41:44.411432+00:00"
               },
               "deterministic": true
             },
@@ -168448,9 +168253,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.548679+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.442183+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "range": {
             "type": "string",
@@ -168475,7 +168279,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:07.135034+00:00"
+                "validatedAt": "2026-07-20T14:41:44.411445+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -168508,7 +168312,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:07.135075+00:00"
+                "validatedAt": "2026-07-20T14:41:44.411462+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -168541,7 +168345,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:07.135110+00:00"
+                "validatedAt": "2026-07-20T14:41:44.411475+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -168636,7 +168440,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:07.135154+00:00"
+                "validatedAt": "2026-07-20T14:41:44.411494+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -168864,7 +168668,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:07.135216+00:00"
+                "validatedAt": "2026-07-20T14:41:44.411523+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -169039,7 +168843,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:14.994157+00:00"
+                "validatedAt": "2026-07-20T14:41:47.302812+00:00"
               },
               "source": "minimum_configs",
               "description": "Kubernetes-style label selector expressions. Common patterns:\n- Match by site name: \"ves.io/siteName in (example-ce-site-1, example-ce-site-2)\"\n- Match by label: \"environment=production,tier=frontend\"\n- All CE sites in a region: \"ves.io/region in (us-east-1)\"\n"
@@ -169482,7 +169286,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:14.995369+00:00"
+                "validatedAt": "2026-07-20T14:41:47.303326+00:00"
               },
               "deterministic": true
             },
@@ -169494,9 +169298,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.686117+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.590441+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -169528,7 +169331,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:14.995396+00:00"
+                "validatedAt": "2026-07-20T14:41:47.303339+00:00"
               },
               "deterministic": true
             },
@@ -169540,9 +169343,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.686137+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.590455+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -169707,7 +169509,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.686204+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.590497+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -169804,7 +169606,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:11:14.995510+00:00"
+                "validatedAt": "2026-07-20T14:41:47.303384+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -169885,7 +169687,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:11:14.995562+00:00"
+                "validatedAt": "2026-07-20T14:41:47.303405+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -169896,7 +169698,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.686256+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.590528+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -169983,7 +169785,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:14.995601+00:00"
+                "validatedAt": "2026-07-20T14:41:47.303422+00:00"
               },
               "deterministic": true
             },
@@ -169995,9 +169797,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.686301+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.590557+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -170028,7 +169829,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:14.995628+00:00"
+                "validatedAt": "2026-07-20T14:41:47.303435+00:00"
               },
               "deterministic": true
             },
@@ -170040,9 +169841,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.686320+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.590569+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -170111,7 +169911,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:14.995687+00:00"
+                "validatedAt": "2026-07-20T14:41:47.303455+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -170123,7 +169923,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.686357+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.590594+00:00"
           },
           "uid": {
             "type": "string",
@@ -170140,7 +169940,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:14.995714+00:00"
+                "validatedAt": "2026-07-20T14:41:47.303466+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -170153,7 +169953,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.686376+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.590606+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of virtual_site is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -170322,7 +170122,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:14.995752+00:00"
+                "validatedAt": "2026-07-20T14:41:47.303481+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -170333,7 +170133,7 @@
             },
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.686412+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.590628+00:00"
           },
           "name": {
             "type": "string",
@@ -170364,7 +170164,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:14.995779+00:00"
+                "validatedAt": "2026-07-20T14:41:47.303494+00:00"
               },
               "deterministic": true
             },
@@ -170376,9 +170176,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.686430+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.590641+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -170410,7 +170209,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:14.995805+00:00"
+                "validatedAt": "2026-07-20T14:41:47.303506+00:00"
               },
               "deterministic": true
             },
@@ -170422,9 +170221,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.686448+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.590653+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -170441,7 +170239,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:14.995838+00:00"
+                "validatedAt": "2026-07-20T14:41:47.303519+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -170453,7 +170251,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.686467+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.590665+00:00"
           }
         },
         "x-f5xc-description-short": "Individual object that has been selected by the Virtual Site.",
@@ -170528,7 +170326,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:11:14.995870+00:00"
+                "validatedAt": "2026-07-20T14:41:47.303533+00:00"
               }
             },
             "x-f5xc-required-for": {

--- a/docs/specifications/api/statistics.json
+++ b/docs/specifications/api/statistics.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Statistics",
     "description": "Alert policies with custom matchers, label groupings, and notification parameters. Log receivers for centralized collection with confirmation and verification workflows. Flow analytics, historical trend data, and namespace-scoped dashboards. Topology discovery and site-level health indicators for operational visibility.",
-    "version": "2.1.182",
+    "version": "2.1.181",
     "contact": {
       "name": "F5 Distributed Cloud",
       "url": "https://docs.cloud.f5.com"
@@ -1205,7 +1205,7 @@
           },
           {
             "name": "response_format",
-            "description": "The format in which the configuration object is to be fetched. This could be for example\n - in GetSpec form for the contents of object\n - in CreateRequest form to create a new similar object\n - to ReplaceRequest form to replace changeable values\n\nDefault format of returned resource\nResponse should be in CreateRequest format\nResponse should be in ReplaceRequest format\nResponse should be in StatusObject(s) format\nResponse should be in format of GetSpecType\nResponse should have other objects referring to this object\nResponse should have deleted and disabled objects referred by this object.",
+            "description": "The format in which the configuration object is to be fetched. This could be for example\n - in GetSpec form for the contents of object\n - in CreateRequest form to create a new similar object\n - to ReplaceRequest form to replace changeable values\n\nDefault format of returned resource\nResponse should be in CreateRequest format\nResponse should be in ReplaceRequest format\nResponse should be in StatusObject(s) format\nResponse should be in format of GetSpecType\nResponse should have other objects referring to this object\nResponse should have deleted and disabled objects referrred by this object.",
             "in": "query",
             "required": false,
             "x-displayname": "Broken Referred Objects.",
@@ -2345,7 +2345,7 @@
           },
           {
             "name": "response_format",
-            "description": "The format in which the configuration object is to be fetched. This could be for example\n - in GetSpec form for the contents of object\n - in CreateRequest form to create a new similar object\n - to ReplaceRequest form to replace changeable values\n\nDefault format of returned resource\nResponse should be in CreateRequest format\nResponse should be in ReplaceRequest format\nResponse should be in StatusObject(s) format\nResponse should be in format of GetSpecType\nResponse should have other objects referring to this object\nResponse should have deleted and disabled objects referred by this object.",
+            "description": "The format in which the configuration object is to be fetched. This could be for example\n - in GetSpec form for the contents of object\n - in CreateRequest form to create a new similar object\n - to ReplaceRequest form to replace changeable values\n\nDefault format of returned resource\nResponse should be in CreateRequest format\nResponse should be in ReplaceRequest format\nResponse should be in StatusObject(s) format\nResponse should be in format of GetSpecType\nResponse should have other objects referring to this object\nResponse should have deleted and disabled objects referrred by this object.",
             "in": "query",
             "required": false,
             "x-displayname": "Broken Referred Objects.",
@@ -19796,7 +19796,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:10.854935+00:00"
+                "validatedAt": "2026-07-20T14:35:29.185588+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19921,7 +19921,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:10.855022+00:00"
+                "validatedAt": "2026-07-20T14:35:29.185626+00:00"
               },
               "deterministic": true
             },
@@ -19933,9 +19933,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.874032+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.579122+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Request message for GetAlertPolicyMatch RPC, describing alert to match against alert policies.",
@@ -20258,7 +20257,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:10.855116+00:00"
+                "validatedAt": "2026-07-20T14:35:29.185671+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20295,7 +20294,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:10.855158+00:00"
+                "validatedAt": "2026-07-20T14:35:29.185695+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20381,7 +20380,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:10.855203+00:00"
+                "validatedAt": "2026-07-20T14:35:29.185721+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20581,7 +20580,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:10.855256+00:00"
+                "validatedAt": "2026-07-20T14:35:29.185748+00:00"
               },
               "deterministic": true
             },
@@ -20593,9 +20592,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.874166+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.579205+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -20627,7 +20625,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:10.855283+00:00"
+                "validatedAt": "2026-07-20T14:35:29.185762+00:00"
               },
               "deterministic": true
             },
@@ -20639,9 +20637,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.874185+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.579219+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -20806,7 +20803,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.874252+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.579263+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -20908,7 +20905,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:10.855402+00:00"
+                "validatedAt": "2026-07-20T14:35:29.185819+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20945,7 +20942,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:10.855441+00:00"
+                "validatedAt": "2026-07-20T14:35:29.185841+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21123,7 +21120,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:10.855496+00:00"
+                "validatedAt": "2026-07-20T14:35:29.185866+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21152,7 +21149,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:10.855534+00:00"
+                "validatedAt": "2026-07-20T14:35:29.185883+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21239,7 +21236,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:55:10.855579+00:00"
+                "validatedAt": "2026-07-20T14:35:29.185905+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21320,7 +21317,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:55:10.855638+00:00"
+                "validatedAt": "2026-07-20T14:35:29.185930+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21331,7 +21328,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.874348+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.579322+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -21418,7 +21415,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:10.855691+00:00"
+                "validatedAt": "2026-07-20T14:35:29.185949+00:00"
               },
               "deterministic": true
             },
@@ -21430,9 +21427,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.874394+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.579353+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -21463,7 +21459,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:10.855719+00:00"
+                "validatedAt": "2026-07-20T14:35:29.185964+00:00"
               },
               "deterministic": true
             },
@@ -21475,9 +21471,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.874413+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.579366+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -21546,7 +21541,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:10.855774+00:00"
+                "validatedAt": "2026-07-20T14:35:29.185986+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21558,7 +21553,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.874451+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.579392+00:00"
           },
           "uid": {
             "type": "string",
@@ -21575,7 +21570,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:10.855801+00:00"
+                "validatedAt": "2026-07-20T14:35:29.185998+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21588,7 +21583,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.874470+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.579406+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of alert_policy is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -21707,7 +21702,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:10.855854+00:00"
+                "validatedAt": "2026-07-20T14:35:29.186022+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21744,7 +21739,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:10.855896+00:00"
+                "validatedAt": "2026-07-20T14:35:29.186040+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21799,7 +21794,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:10.855943+00:00"
+                "validatedAt": "2026-07-20T14:35:29.186061+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22012,7 +22007,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:10.856003+00:00"
+                "validatedAt": "2026-07-20T14:35:29.186091+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22049,7 +22044,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:10.856044+00:00"
+                "validatedAt": "2026-07-20T14:35:29.186113+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22138,7 +22133,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:10.856089+00:00"
+                "validatedAt": "2026-07-20T14:35:29.186134+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22553,7 +22548,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:10.856189+00:00"
+                "validatedAt": "2026-07-20T14:35:29.186175+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22576,7 +22571,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:10.856224+00:00"
+                "validatedAt": "2026-07-20T14:35:29.186191+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22587,7 +22582,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.874679+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.579534+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -22651,7 +22646,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T12:55:10.856260+00:00"
+                "validatedAt": "2026-07-20T14:35:29.186209+00:00"
               },
               "deterministic": true
             },
@@ -22662,8 +22657,7 @@
               "read": false
             },
             "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "minLength": 1,
-            "format": "fqdn"
+            "minLength": 1
           },
           "last_update_time": {
             "type": "string",
@@ -22680,7 +22674,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:10.856302+00:00"
+                "validatedAt": "2026-07-20T14:35:29.186227+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22706,7 +22700,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:10.856336+00:00"
+                "validatedAt": "2026-07-20T14:35:29.186242+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22717,7 +22711,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.874715+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.579557+00:00"
           },
           "service_name": {
             "type": "string",
@@ -22734,7 +22728,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:10.856375+00:00"
+                "validatedAt": "2026-07-20T14:35:29.186260+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22746,7 +22740,7 @@
           },
           "status": {
             "type": "string",
-            "description": "Status of the condition\n\"Success\" Validation has succeeded. Requested operation was successful.\n\"Failed\" Validation has failed.\n\"Incomplete\" Validation of configuration has failed due to missing configuration.\n\"Installed\" Validation has passed and configuration has been installed in data path or K8s\n\"Down\" Configuration is operationally down. E.g. Down interface\n\"Disabled\" Configuration is administratively disabled i.e. objectmetatype.disable = true.\n\"NotApplicable\" Configuration is not applicable e.g. Tenant service_policy_set(s) in system namespace are not applicable on REs.",
+            "description": "Status of the condition\n\"Success\" Validtion has succeded. Requested operation was successful.\n\"Failed\" Validation has failed.\n\"Incomplete\" Validation of configuration has failed due to missing configuration.\n\"Installed\" Validation has passed and configuration has been installed in data path or K8s\n\"Down\" Configuration is operationally down. E.g. Down interface\n\"Disabled\" Configuration is administratively disabled i.e. objectmetatype.disable = true.\n\"NotApplicable\" Configuration is not applicable e.g. Tenant service_policy_set(s) in system namespace are not applicable on REs.",
             "title": "status",
             "x-displayname": "Status",
             "x-ves-example": "Failed",
@@ -22757,8 +22751,8 @@
             "x-validation-rules": {
               "ves.io.schema.rules.string.in": "[\\\"Success\\\",\\\"Failed\\\",\\\"Incomplete\\\",\\\"Installed\\\",\\\"Down\\\",\\\"Disabled\\\",\\\"NotApplicable\\\"]"
             },
-            "x-f5xc-description-short": "Status of the condition \"Success\" Validation has succeeded.",
-            "x-f5xc-description-medium": "Status of the condition \"Success\" Validation has succeeded. Requested operation was successful. \"Failed\" Validation has failed. \"Incomplete\" Validation of configuration has failed due to missing configuration. \"Installed\" Validation has passed and configuration has been installed in data path or...",
+            "x-f5xc-description-short": "Status of the condition \"Success\" Validtion has succeded.",
+            "x-f5xc-description-medium": "Status of the condition \"Success\" Validtion has succeded. Requested operation was successful. \"Failed\" Validation has failed. \"Incomplete\" Validation of configuration has failed due to missing configuration. \"Installed\" Validation has passed and configuration has been installed in data path or...",
             "maxLength": 1024,
             "x-f5xc-constraints": {
               "constraintType": "string",
@@ -22767,7 +22761,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:10.856413+00:00"
+                "validatedAt": "2026-07-20T14:35:29.186277+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22778,7 +22772,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.874739+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.579574+00:00"
           },
           "type": {
             "type": "string",
@@ -22803,7 +22797,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:10.856446+00:00"
+                "validatedAt": "2026-07-20T14:35:29.186291+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22947,7 +22941,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:10.856488+00:00"
+                "validatedAt": "2026-07-20T14:35:29.186309+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23027,7 +23021,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:10.856517+00:00"
+                "validatedAt": "2026-07-20T14:35:29.186324+00:00"
               },
               "deterministic": true
             },
@@ -23039,9 +23033,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.874789+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.579606+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -23205,7 +23198,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:10.856611+00:00"
+                "validatedAt": "2026-07-20T14:35:29.186371+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -23220,7 +23213,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.874832+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.579634+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -23290,7 +23283,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:10.856650+00:00"
+                "validatedAt": "2026-07-20T14:35:29.186390+00:00"
               },
               "deterministic": true
             },
@@ -23302,9 +23295,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.874865+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.579655+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -23337,7 +23329,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:10.856686+00:00"
+                "validatedAt": "2026-07-20T14:35:29.186404+00:00"
               },
               "deterministic": true
             },
@@ -23349,9 +23341,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.874883+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.579668+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -23451,7 +23442,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:10.856760+00:00"
+                "validatedAt": "2026-07-20T14:35:29.186442+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -23466,7 +23457,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.874911+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.579687+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -23538,7 +23529,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:10.856797+00:00"
+                "validatedAt": "2026-07-20T14:35:29.186462+00:00"
               },
               "deterministic": true
             },
@@ -23550,9 +23541,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.874944+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.579709+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -23585,7 +23575,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:10.856823+00:00"
+                "validatedAt": "2026-07-20T14:35:29.186475+00:00"
               },
               "deterministic": true
             },
@@ -23597,9 +23587,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.874963+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.579722+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -23662,7 +23651,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:10.856855+00:00"
+                "validatedAt": "2026-07-20T14:35:29.186489+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23674,7 +23663,7 @@
             "readOnly": true,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.874983+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.579735+00:00"
           },
           "name": {
             "type": "string",
@@ -23707,7 +23696,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:10.856881+00:00"
+                "validatedAt": "2026-07-20T14:35:29.186504+00:00"
               },
               "deterministic": true
             },
@@ -23719,9 +23708,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.875001+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.579748+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -23754,7 +23742,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:10.856909+00:00"
+                "validatedAt": "2026-07-20T14:35:29.186519+00:00"
               },
               "deterministic": true
             },
@@ -23766,9 +23754,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.875019+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.579761+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -23787,7 +23774,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:10.856942+00:00"
+                "validatedAt": "2026-07-20T14:35:29.186534+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23800,7 +23787,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.875038+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.579773+00:00"
           },
           "uid": {
             "type": "string",
@@ -23819,7 +23806,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:10.856967+00:00"
+                "validatedAt": "2026-07-20T14:35:29.186547+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23833,7 +23820,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.875057+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.579787+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -23933,7 +23920,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:10.857041+00:00"
+                "validatedAt": "2026-07-20T14:35:29.186585+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -23948,7 +23935,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.875085+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.579805+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -24018,7 +24005,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:10.857080+00:00"
+                "validatedAt": "2026-07-20T14:35:29.186604+00:00"
               },
               "deterministic": true
             },
@@ -24030,9 +24017,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.875118+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.579827+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -24065,7 +24051,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:10.857105+00:00"
+                "validatedAt": "2026-07-20T14:35:29.186619+00:00"
               },
               "deterministic": true
             },
@@ -24077,9 +24063,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.875135+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.579839+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -24142,7 +24127,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:10.857148+00:00"
+                "validatedAt": "2026-07-20T14:35:29.186638+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24170,7 +24155,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:10.857188+00:00"
+                "validatedAt": "2026-07-20T14:35:29.186655+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24198,7 +24183,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:10.857225+00:00"
+                "validatedAt": "2026-07-20T14:35:29.186671+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24237,7 +24222,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:10.857264+00:00"
+                "validatedAt": "2026-07-20T14:35:29.186688+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24264,7 +24249,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:10.857290+00:00"
+                "validatedAt": "2026-07-20T14:35:29.186700+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24277,7 +24262,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.875188+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.579874+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -24293,7 +24278,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:10.857324+00:00"
+                "validatedAt": "2026-07-20T14:35:29.186715+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24438,7 +24423,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:10.857376+00:00"
+                "validatedAt": "2026-07-20T14:35:29.186739+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24449,7 +24434,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.875229+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.579900+00:00"
           },
           "status": {
             "type": "string",
@@ -24467,7 +24452,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:10.857409+00:00"
+                "validatedAt": "2026-07-20T14:35:29.186754+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24478,7 +24463,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.875247+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.579914+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -24538,7 +24523,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:10.857451+00:00"
+                "validatedAt": "2026-07-20T14:35:29.186772+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24565,7 +24550,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:10.857489+00:00"
+                "validatedAt": "2026-07-20T14:35:29.186789+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24592,7 +24577,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:10.857526+00:00"
+                "validatedAt": "2026-07-20T14:35:29.186806+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24620,7 +24605,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:10.857568+00:00"
+                "validatedAt": "2026-07-20T14:35:29.186824+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24696,7 +24681,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:10.857631+00:00"
+                "validatedAt": "2026-07-20T14:35:29.186851+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24764,7 +24749,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:10.857689+00:00"
+                "validatedAt": "2026-07-20T14:35:29.186873+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24776,7 +24761,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.875335+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.579969+00:00"
           },
           "uid": {
             "type": "string",
@@ -24795,7 +24780,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:10.857716+00:00"
+                "validatedAt": "2026-07-20T14:35:29.186884+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24808,7 +24793,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.875353+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.579982+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -24876,7 +24861,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:10.857747+00:00"
+                "validatedAt": "2026-07-20T14:35:29.186898+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24887,7 +24872,7 @@
             },
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.875373+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.579996+00:00"
           },
           "name": {
             "type": "string",
@@ -24920,7 +24905,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:10.857775+00:00"
+                "validatedAt": "2026-07-20T14:35:29.186912+00:00"
               },
               "deterministic": true
             },
@@ -24932,9 +24917,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.875391+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.580009+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -24967,7 +24951,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:10.857802+00:00"
+                "validatedAt": "2026-07-20T14:35:29.186926+00:00"
               },
               "deterministic": true
             },
@@ -24979,9 +24963,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.875409+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.580022+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "uid": {
             "type": "string",
@@ -24998,7 +24981,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:10.857828+00:00"
+                "validatedAt": "2026-07-20T14:35:29.186938+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25011,7 +24994,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.875428+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.580035+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -25130,7 +25113,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:12.864333+00:00"
+                "validatedAt": "2026-07-20T14:35:30.050516+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25201,7 +25184,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:12.864404+00:00"
+                "validatedAt": "2026-07-20T14:35:30.050623+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25278,7 +25261,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:12.864447+00:00"
+                "validatedAt": "2026-07-20T14:35:30.050656+00:00"
               },
               "deterministic": true
             },
@@ -25290,9 +25273,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.910241+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.614588+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -25331,7 +25313,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:12.864487+00:00"
+                "validatedAt": "2026-07-20T14:35:30.050678+00:00"
               },
               "deterministic": true
             },
@@ -25343,9 +25325,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.910262+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.614603+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "verification_code": {
             "type": "string",
@@ -25368,7 +25349,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:12.864538+00:00"
+                "validatedAt": "2026-07-20T14:35:30.050701+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25834,7 +25815,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:12.864614+00:00"
+                "validatedAt": "2026-07-20T14:35:30.050734+00:00"
               },
               "deterministic": true
             },
@@ -25846,9 +25827,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.910372+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.614674+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -25880,7 +25860,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:12.864642+00:00"
+                "validatedAt": "2026-07-20T14:35:30.050747+00:00"
               },
               "deterministic": true
             },
@@ -25892,9 +25872,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.910390+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.614687+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -25965,7 +25944,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:12.864732+00:00"
+                "validatedAt": "2026-07-20T14:35:30.050778+00:00"
               },
               "deterministic": true
             },
@@ -26137,7 +26116,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.910465+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.614737+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -26599,7 +26578,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:12.864913+00:00"
+                "validatedAt": "2026-07-20T14:35:30.050860+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26684,7 +26663,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:55:12.864960+00:00"
+                "validatedAt": "2026-07-20T14:35:30.050886+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26765,7 +26744,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:55:12.865036+00:00"
+                "validatedAt": "2026-07-20T14:35:30.050915+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26776,7 +26755,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.910626+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.614837+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -26863,7 +26842,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:12.865100+00:00"
+                "validatedAt": "2026-07-20T14:35:30.050938+00:00"
               },
               "deterministic": true
             },
@@ -26875,9 +26854,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.910680+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.614867+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -26908,7 +26886,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:12.865143+00:00"
+                "validatedAt": "2026-07-20T14:35:30.050953+00:00"
               },
               "deterministic": true
             },
@@ -26920,9 +26898,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.910700+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.614880+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -26991,7 +26968,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:12.865228+00:00"
+                "validatedAt": "2026-07-20T14:35:30.050979+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27003,7 +26980,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.910737+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.614905+00:00"
           },
           "uid": {
             "type": "string",
@@ -27020,7 +26997,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:12.865270+00:00"
+                "validatedAt": "2026-07-20T14:35:30.050992+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27033,7 +27010,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.910757+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.614919+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of alert_receiver is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -27133,7 +27110,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:12.865360+00:00"
+                "validatedAt": "2026-07-20T14:35:30.051047+00:00"
               },
               "deterministic": true
             },
@@ -27231,7 +27208,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:12.865443+00:00"
+                "validatedAt": "2026-07-20T14:35:30.051096+00:00"
               },
               "deterministic": true
             },
@@ -27591,7 +27568,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:12.865556+00:00"
+                "validatedAt": "2026-07-20T14:35:30.051132+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27666,7 +27643,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:12.865625+00:00"
+                "validatedAt": "2026-07-20T14:35:30.051171+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27884,7 +27861,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:12.865757+00:00"
+                "validatedAt": "2026-07-20T14:35:30.051219+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27895,8 +27872,7 @@
             },
             "x-f5xc-conflicts-with": [
               "disable_sni"
-            ],
-            "format": "hostname"
+            ]
           },
           "use_server_verification": {
             "allOf": [
@@ -28005,7 +27981,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:12.865797+00:00"
+                "validatedAt": "2026-07-20T14:35:30.051239+00:00"
               },
               "deterministic": true
             },
@@ -28017,9 +27993,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.910946+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.615039+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -28058,7 +28033,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:12.865829+00:00"
+                "validatedAt": "2026-07-20T14:35:30.051256+00:00"
               },
               "deterministic": true
             },
@@ -28070,9 +28045,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.910965+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.615052+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -28230,7 +28204,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:12.865865+00:00"
+                "validatedAt": "2026-07-20T14:35:30.051274+00:00"
               },
               "deterministic": true
             },
@@ -28242,9 +28216,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.910994+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.615071+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -28283,7 +28256,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:12.865897+00:00"
+                "validatedAt": "2026-07-20T14:35:30.051291+00:00"
               },
               "deterministic": true
             },
@@ -28295,9 +28268,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.911012+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.615084+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -28458,7 +28430,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:12.866028+00:00"
+                "validatedAt": "2026-07-20T14:35:30.051352+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28499,7 +28471,7 @@
                 "confidence": 1.0,
                 "category": "content",
                 "note": "Blindfold envelope encryption (AES-256-GCM + RSA-OAEP) of an RSA-2048 TLS private key produces ~3700 char string:/// URL. 128KB max secret size = ~175KB base64. Discovery reported 1024 which is incorrect.",
-                "validatedAt": "2026-07-20T12:55:12.866064+00:00"
+                "validatedAt": "2026-07-20T14:35:30.051377+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28510,7 +28482,7 @@
             },
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.911083+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.615131+00:00"
           },
           "store_provider": {
             "type": "string",
@@ -28529,7 +28501,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:12.866110+00:00"
+                "validatedAt": "2026-07-20T14:35:30.051400+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28596,7 +28568,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:12.866148+00:00"
+                "validatedAt": "2026-07-20T14:35:30.051418+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28607,7 +28579,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.911110+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.615149+00:00"
           },
           "url": {
             "type": "string",
@@ -28645,7 +28617,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:12.866207+00:00"
+                "validatedAt": "2026-07-20T14:35:30.051454+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -28851,7 +28823,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:14.598476+00:00"
+                "validatedAt": "2026-07-20T14:35:30.842206+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28877,7 +28849,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:14.598556+00:00"
+                "validatedAt": "2026-07-20T14:35:30.842232+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28918,7 +28890,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:14.598615+00:00"
+                "validatedAt": "2026-07-20T14:35:30.842253+00:00"
               },
               "deterministic": true
             },
@@ -28930,9 +28902,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.946187+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.648591+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "start_time": {
             "type": "string",
@@ -28957,7 +28928,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:14.598700+00:00"
+                "validatedAt": "2026-07-20T14:35:30.842273+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29040,7 +29011,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:14.598748+00:00"
+                "validatedAt": "2026-07-20T14:35:30.842295+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29123,7 +29094,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:14.598803+00:00"
+                "validatedAt": "2026-07-20T14:35:30.842320+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29152,7 +29123,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:14.598841+00:00"
+                "validatedAt": "2026-07-20T14:35:30.842338+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29230,7 +29201,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:14.598874+00:00"
+                "validatedAt": "2026-07-20T14:35:30.842356+00:00"
               },
               "deterministic": true
             },
@@ -29242,9 +29213,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.946259+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.648633+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "scroll_id": {
             "type": "string",
@@ -29262,7 +29232,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:14.598911+00:00"
+                "validatedAt": "2026-07-20T14:35:30.842373+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29327,7 +29297,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:14.598945+00:00"
+                "validatedAt": "2026-07-20T14:35:30.842389+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29392,7 +29362,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:02.918321+00:00"
+                "validatedAt": "2026-07-20T14:36:13.771223+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29422,7 +29392,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:02.918400+00:00"
+                "validatedAt": "2026-07-20T14:36:13.771248+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30051,7 +30021,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:33.050391+00:00"
+                "validatedAt": "2026-07-20T14:37:14.623143+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30104,7 +30074,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:33.050474+00:00"
+                "validatedAt": "2026-07-20T14:37:14.623169+00:00"
               },
               "deterministic": true
             },
@@ -30116,9 +30086,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.526120+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:13.997581+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "range": {
             "type": "string",
@@ -30143,7 +30112,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:33.050530+00:00"
+                "validatedAt": "2026-07-20T14:37:14.623185+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30190,7 +30159,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:33.050602+00:00"
+                "validatedAt": "2026-07-20T14:37:14.623202+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30223,7 +30192,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:33.050641+00:00"
+                "validatedAt": "2026-07-20T14:37:14.623215+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30317,7 +30286,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:33.050693+00:00"
+                "validatedAt": "2026-07-20T14:37:14.623231+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30450,7 +30419,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:33.050733+00:00"
+                "validatedAt": "2026-07-20T14:37:14.623246+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30595,7 +30564,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:33.050777+00:00"
+                "validatedAt": "2026-07-20T14:37:14.623262+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30606,7 +30575,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.526225+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:13.997647+00:00"
           }
         },
         "x-f5xc-description-short": "Metrics used in the connectivity graph are tagged with labels listed in the enum Label.",
@@ -30854,7 +30823,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:33.050856+00:00"
+                "validatedAt": "2026-07-20T14:37:14.623290+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30961,7 +30930,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.526328+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:13.997708+00:00"
           }
         },
         "x-f5xc-description-short": "NodeInstanceMetricData contains the metric type and the corresponding value for a node instance.",
@@ -31074,7 +31043,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:33.050907+00:00"
+                "validatedAt": "2026-07-20T14:37:14.623309+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31115,7 +31084,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:33.050958+00:00"
+                "validatedAt": "2026-07-20T14:37:14.623329+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31141,7 +31110,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:33.050997+00:00"
+                "validatedAt": "2026-07-20T14:37:14.623343+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31235,7 +31204,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.526392+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:13.997747+00:00"
           }
         },
         "x-f5xc-description-short": "NodeInterfaceMetricData contains the metric type and the corresponding value for a node interface.",
@@ -31400,7 +31369,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:33.051049+00:00"
+                "validatedAt": "2026-07-20T14:37:14.623363+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31484,7 +31453,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:33.051101+00:00"
+                "validatedAt": "2026-07-20T14:37:14.623383+00:00"
               },
               "deterministic": true
             },
@@ -31496,9 +31465,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.526440+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:13.997777+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "range": {
             "type": "string",
@@ -31523,7 +31491,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:33.051136+00:00"
+                "validatedAt": "2026-07-20T14:37:14.623398+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31556,7 +31524,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:33.051175+00:00"
+                "validatedAt": "2026-07-20T14:37:14.623413+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31589,7 +31557,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:33.051208+00:00"
+                "validatedAt": "2026-07-20T14:37:14.623426+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31628,7 +31596,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:00.082426+00:00"
+                "validatedAt": "2026-07-20T14:37:25.112625+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31722,7 +31690,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:33.051246+00:00"
+                "validatedAt": "2026-07-20T14:37:14.623441+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31796,7 +31764,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:33.051285+00:00"
+                "validatedAt": "2026-07-20T14:37:14.623456+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31882,7 +31850,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:33.051343+00:00"
+                "validatedAt": "2026-07-20T14:37:14.623480+00:00"
               },
               "deterministic": true
             },
@@ -31894,9 +31862,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.526519+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:13.997827+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "start_time": {
             "type": "string",
@@ -31921,7 +31888,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:33.051382+00:00"
+                "validatedAt": "2026-07-20T14:37:14.623495+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32221,7 +32188,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:33.051461+00:00"
+                "validatedAt": "2026-07-20T14:37:14.623525+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32232,7 +32199,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.526577+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:13.997862+00:00"
           },
           "type": {
             "allOf": [
@@ -32264,7 +32231,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.526603+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:13.997879+00:00"
           }
         },
         "x-f5xc-description-short": "HealthScoreTypeData contains healthscore type and the corresponding value.",
@@ -32528,7 +32495,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.526686+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:13.997924+00:00"
           }
         },
         "x-f5xc-description-short": "EdgeMetricData contains the metric type and the corresponding metric value.",
@@ -32611,7 +32578,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:33.051613+00:00"
+                "validatedAt": "2026-07-20T14:37:14.623586+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32746,7 +32713,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.526736+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:13.997954+00:00"
           }
         },
         "x-f5xc-description-short": "NodeMetricData contains metric type and the corresponding value for a node.",
@@ -32828,7 +32795,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:33.051689+00:00"
+                "validatedAt": "2026-07-20T14:37:14.623615+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32861,7 +32828,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:33.051729+00:00"
+                "validatedAt": "2026-07-20T14:37:14.623635+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32894,7 +32861,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:33.051768+00:00"
+                "validatedAt": "2026-07-20T14:37:14.623654+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33008,7 +32975,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:59:33.051818+00:00"
+                "validatedAt": "2026-07-20T14:37:14.623675+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33019,7 +32986,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.526786+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:13.997985+00:00"
           },
           "previous_value": {
             "type": "string",
@@ -33037,7 +33004,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:33.051858+00:00"
+                "validatedAt": "2026-07-20T14:37:14.623691+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33075,7 +33042,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:33.051894+00:00"
+                "validatedAt": "2026-07-20T14:37:14.623705+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33086,7 +33053,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.526817+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:13.998005+00:00"
           }
         },
         "x-f5xc-description-short": "Trend value contains trend value, trend sentiment and trend calculation description and window size.",
@@ -33240,7 +33207,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:33.051945+00:00"
+                "validatedAt": "2026-07-20T14:37:14.623725+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33251,7 +33218,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.526851+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:13.998026+00:00"
           }
         },
         "x-f5xc-description-short": "Each metric value consists of a timestamp and a value. Timestamp in the Metric Value is based on the start_time, end_time and step in the request.",
@@ -33426,7 +33393,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.110501+00:00"
+                "validatedAt": "2026-07-20T14:37:45.899318+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33460,7 +33427,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.110570+00:00"
+                "validatedAt": "2026-07-20T14:37:45.899345+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33493,7 +33460,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:51.110627+00:00"
+                "validatedAt": "2026-07-20T14:37:45.899381+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33688,7 +33655,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.110691+00:00"
+                "validatedAt": "2026-07-20T14:37:45.899418+00:00"
               },
               "deterministic": true
             },
@@ -33700,9 +33667,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.027441+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.511996+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -33741,7 +33707,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.110725+00:00"
+                "validatedAt": "2026-07-20T14:37:45.899437+00:00"
               },
               "deterministic": true
             },
@@ -33753,9 +33719,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.027462+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.512010+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tcp_lb_request": {
             "allOf": [
@@ -33905,7 +33870,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.110767+00:00"
+                "validatedAt": "2026-07-20T14:37:45.899459+00:00"
               },
               "deterministic": true
             },
@@ -33917,9 +33882,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.027497+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.512032+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -33958,7 +33922,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.110797+00:00"
+                "validatedAt": "2026-07-20T14:37:45.899475+00:00"
               },
               "deterministic": true
             },
@@ -33970,9 +33934,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.027515+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.512045+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Disable visibility on the discovered service.",
@@ -34063,7 +34026,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.027538+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.512060+00:00"
           },
           "virtual_server_pool_members_health": {
             "allOf": [
@@ -34154,7 +34117,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.110847+00:00"
+                "validatedAt": "2026-07-20T14:37:45.899500+00:00"
               },
               "deterministic": true
             },
@@ -34166,9 +34129,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.027565+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.512077+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -34207,7 +34169,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.110875+00:00"
+                "validatedAt": "2026-07-20T14:37:45.899516+00:00"
               },
               "deterministic": true
             },
@@ -34219,9 +34181,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.027584+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.512090+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Enable visibility of the discovered service in all workspaces like WAAP, App Connect, etc.",
@@ -34481,7 +34442,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.110995+00:00"
+                "validatedAt": "2026-07-20T14:37:45.899572+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34491,9 +34452,9 @@
               "read": false
             },
             "minLength": 26,
-            "format": "fqdn",
+            "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.027662+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.512133+00:00"
           },
           "http": {
             "allOf": [
@@ -34585,7 +34546,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.111039+00:00"
+                "validatedAt": "2026-07-20T14:37:45.899595+00:00"
               },
               "deterministic": true
             },
@@ -34597,9 +34558,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.027702+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.512158+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "skip_server_verification": {
             "allOf": [
@@ -34733,7 +34693,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.111091+00:00"
+                "validatedAt": "2026-07-20T14:37:45.899623+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34767,7 +34727,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.111129+00:00"
+                "validatedAt": "2026-07-20T14:37:45.899646+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34800,7 +34760,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:51.111171+00:00"
+                "validatedAt": "2026-07-20T14:37:45.899664+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34884,7 +34844,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:00:51.111216+00:00"
+                "validatedAt": "2026-07-20T14:37:45.899686+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34963,7 +34923,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:00:51.111272+00:00"
+                "validatedAt": "2026-07-20T14:37:45.899713+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34974,7 +34934,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.027790+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.512210+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -35061,7 +35021,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.111313+00:00"
+                "validatedAt": "2026-07-20T14:37:45.899734+00:00"
               },
               "deterministic": true
             },
@@ -35073,9 +35033,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.027836+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.512240+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -35106,7 +35065,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.111341+00:00"
+                "validatedAt": "2026-07-20T14:37:45.899750+00:00"
               },
               "deterministic": true
             },
@@ -35118,9 +35077,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.027854+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.512252+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -35173,7 +35131,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:51.111380+00:00"
+                "validatedAt": "2026-07-20T14:37:45.899766+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35185,7 +35143,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.027885+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.512273+00:00"
           },
           "uid": {
             "type": "string",
@@ -35203,7 +35161,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:51.111406+00:00"
+                "validatedAt": "2026-07-20T14:37:45.899794+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35216,7 +35174,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.027905+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.512286+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of discovered_service is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -35302,7 +35260,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:00:51.111448+00:00"
+                "validatedAt": "2026-07-20T14:37:45.899821+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35382,7 +35340,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:00:51.111499+00:00"
+                "validatedAt": "2026-07-20T14:37:45.899848+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35393,7 +35351,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.027948+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.512313+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -35480,7 +35438,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.111539+00:00"
+                "validatedAt": "2026-07-20T14:37:45.899871+00:00"
               },
               "deterministic": true
             },
@@ -35492,9 +35450,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.027994+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.512341+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -35525,7 +35482,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.111566+00:00"
+                "validatedAt": "2026-07-20T14:37:45.899886+00:00"
               },
               "deterministic": true
             },
@@ -35537,9 +35494,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.028012+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.512353+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -35608,7 +35564,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:51.111619+00:00"
+                "validatedAt": "2026-07-20T14:37:45.899908+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35620,7 +35576,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.028050+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.512378+00:00"
           },
           "uid": {
             "type": "string",
@@ -35638,7 +35594,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:51.111646+00:00"
+                "validatedAt": "2026-07-20T14:37:45.899921+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35651,7 +35607,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.028069+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.512391+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of discovered services is returned in 'List'.",
@@ -35729,7 +35685,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.111711+00:00"
+                "validatedAt": "2026-07-20T14:37:45.899952+00:00"
               },
               "deterministic": true
             },
@@ -35771,7 +35727,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.111776+00:00"
+                "validatedAt": "2026-07-20T14:37:45.899985+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35797,7 +35753,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:51.111819+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900004+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35861,7 +35817,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.111860+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900026+00:00"
               },
               "deterministic": true
             },
@@ -35902,7 +35858,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.111922+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900057+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36087,7 +36043,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.111982+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900088+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36261,7 +36217,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.112065+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900127+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36295,7 +36251,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.112126+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900158+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36335,7 +36291,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.112154+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900173+00:00"
               },
               "deterministic": true
             },
@@ -36347,9 +36303,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.028207+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.512478+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "request_body": {
             "allOf": [
@@ -36466,7 +36421,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.112218+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900205+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36476,9 +36431,9 @@
               "read": false
             },
             "minLength": 26,
-            "format": "fqdn",
+            "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.028247+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.512503+00:00"
           },
           "listen_port": {
             "type": "integer",
@@ -36543,7 +36498,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.112267+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900229+00:00"
               },
               "deterministic": true
             },
@@ -36555,9 +36510,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.028273+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.512520+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "no_sni": {
             "allOf": [
@@ -36607,7 +36561,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.112333+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900262+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36764,7 +36718,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.112401+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900296+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36798,7 +36752,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.112461+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900326+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36873,7 +36827,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.112522+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900359+00:00"
               },
               "deterministic": true
             },
@@ -36908,7 +36862,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.112580+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900389+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36946,7 +36900,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.112609+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900404+00:00"
               },
               "deterministic": true
             },
@@ -36978,7 +36932,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.112675+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900434+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37004,7 +36958,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.028374+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.512582+00:00"
           },
           "sub_path": {
             "type": "string",
@@ -37027,7 +36981,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.112735+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900497+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37152,7 +37106,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.112765+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900515+00:00"
               },
               "deterministic": true
             },
@@ -37164,9 +37118,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.028402+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.512600+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "status": {
             "type": "array",
@@ -37186,7 +37139,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.028422+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.512613+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -37336,7 +37289,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:51.112821+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900540+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37361,7 +37314,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:51.112856+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900556+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37440,7 +37393,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.112886+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900573+00:00"
               },
               "deterministic": true
             },
@@ -37474,7 +37427,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:51.112924+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900590+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37568,7 +37521,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:51.112973+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900611+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37580,7 +37533,7 @@
             "readOnly": true,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.028488+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.512653+00:00"
           },
           "name": {
             "type": "string",
@@ -37613,7 +37566,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.113000+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900626+00:00"
               },
               "deterministic": true
             },
@@ -37625,9 +37578,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.028507+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.512670+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -37660,7 +37612,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.113026+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900640+00:00"
               },
               "deterministic": true
             },
@@ -37672,9 +37624,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.028525+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.512682+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -37693,7 +37644,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:51.113060+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900655+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37706,7 +37657,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.028544+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.512695+00:00"
           },
           "uid": {
             "type": "string",
@@ -37725,7 +37676,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:51.113084+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900666+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37739,7 +37690,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.028564+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.512707+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -37829,7 +37780,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:51.113505+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900855+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37840,7 +37791,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.028756+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.512822+00:00"
           }
         },
         "x-f5xc-description-short": "Metric data contains timestamp and the value.",
@@ -38109,7 +38060,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:00:51.114575+00:00"
+                "validatedAt": "2026-07-20T14:37:45.901336+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38174,7 +38125,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:00:51.114621+00:00"
+                "validatedAt": "2026-07-20T14:37:45.901358+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38185,7 +38136,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.029270+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.513153+00:00"
           },
           "ref_value": {
             "allOf": [
@@ -38227,7 +38178,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:51.114670+00:00"
+                "validatedAt": "2026-07-20T14:37:45.901377+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38305,7 +38256,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.114715+00:00"
+                "validatedAt": "2026-07-20T14:37:45.901400+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38379,7 +38330,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.114758+00:00"
+                "validatedAt": "2026-07-20T14:37:45.901423+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38469,7 +38420,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.114813+00:00"
+                "validatedAt": "2026-07-20T14:37:45.901453+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -38484,9 +38435,8 @@
               "read": false
             },
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.969398+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.775570+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -38525,7 +38475,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.114860+00:00"
+                "validatedAt": "2026-07-20T14:37:45.901481+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -38540,9 +38490,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.029328+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.513188+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -38571,7 +38520,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.114913+00:00"
+                "validatedAt": "2026-07-20T14:37:45.901507+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38584,7 +38533,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.029347+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.513201+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a direct reference from one object(the referrer) to another(the referred).",
@@ -38653,7 +38602,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.114958+00:00"
+                "validatedAt": "2026-07-20T14:37:45.901531+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38853,7 +38802,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.115020+00:00"
+                "validatedAt": "2026-07-20T14:37:45.901563+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39102,7 +39051,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.115058+00:00"
+                "validatedAt": "2026-07-20T14:37:45.901581+00:00"
               },
               "deterministic": true
             },
@@ -39149,7 +39098,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.115121+00:00"
+                "validatedAt": "2026-07-20T14:37:45.901612+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39503,7 +39452,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.115211+00:00"
+                "validatedAt": "2026-07-20T14:37:45.901653+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39538,7 +39487,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.115268+00:00"
+                "validatedAt": "2026-07-20T14:37:45.901682+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39641,7 +39590,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.115313+00:00"
+                "validatedAt": "2026-07-20T14:37:45.901706+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39824,7 +39773,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.915580+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.085447+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -39899,7 +39848,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:46.608785+00:00"
+                "validatedAt": "2026-07-20T14:38:07.274954+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39996,7 +39945,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:01:46.608865+00:00"
+                "validatedAt": "2026-07-20T14:38:07.274986+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40075,7 +40024,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:01:46.608933+00:00"
+                "validatedAt": "2026-07-20T14:38:07.275011+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40086,7 +40035,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.915650+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.085486+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -40173,7 +40122,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:46.608977+00:00"
+                "validatedAt": "2026-07-20T14:38:07.275031+00:00"
               },
               "deterministic": true
             },
@@ -40185,9 +40134,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.915706+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.085513+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -40218,7 +40166,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:46.609006+00:00"
+                "validatedAt": "2026-07-20T14:38:07.275045+00:00"
               },
               "deterministic": true
             },
@@ -40230,9 +40178,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.915725+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.085524+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -40301,7 +40248,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:46.609062+00:00"
+                "validatedAt": "2026-07-20T14:38:07.275067+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40313,7 +40260,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.915764+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.085547+00:00"
           },
           "uid": {
             "type": "string",
@@ -40330,7 +40277,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:46.609088+00:00"
+                "validatedAt": "2026-07-20T14:38:07.275078+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40343,7 +40290,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.915784+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.085559+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of flow_anomaly is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -40526,7 +40473,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:51.679375+00:00"
+                "validatedAt": "2026-07-20T14:38:09.144795+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40554,7 +40501,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:51.679435+00:00"
+                "validatedAt": "2026-07-20T14:38:09.144819+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40613,7 +40560,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:51.679519+00:00"
+                "validatedAt": "2026-07-20T14:38:09.144846+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40673,7 +40620,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:51.679607+00:00"
+                "validatedAt": "2026-07-20T14:38:09.144872+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40757,7 +40704,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:51.679744+00:00"
+                "validatedAt": "2026-07-20T14:38:09.144905+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40884,7 +40831,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:51.679839+00:00"
+                "validatedAt": "2026-07-20T14:38:09.144934+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40955,7 +40902,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:51.679901+00:00"
+                "validatedAt": "2026-07-20T14:38:09.144958+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41057,7 +41004,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:51.679957+00:00"
+                "validatedAt": "2026-07-20T14:38:09.144981+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41126,7 +41073,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:51.680011+00:00"
+                "validatedAt": "2026-07-20T14:38:09.145004+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41172,7 +41119,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:51.680050+00:00"
+                "validatedAt": "2026-07-20T14:38:09.145025+00:00"
               },
               "deterministic": true
             },
@@ -41184,9 +41131,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.962326+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.114565+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "node": {
             "type": "string",
@@ -41215,7 +41161,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:51.680114+00:00"
+                "validatedAt": "2026-07-20T14:38:09.145059+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41242,7 +41188,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:51.680142+00:00"
+                "validatedAt": "2026-07-20T14:38:09.145071+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41312,7 +41258,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:51.680196+00:00"
+                "validatedAt": "2026-07-20T14:38:09.145094+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41337,7 +41283,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:51.680222+00:00"
+                "validatedAt": "2026-07-20T14:38:09.145105+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41385,7 +41331,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:51.680264+00:00"
+                "validatedAt": "2026-07-20T14:38:09.145122+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41624,7 +41570,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:55.466020+00:00"
+                "validatedAt": "2026-07-20T14:38:10.715830+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41651,7 +41597,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:55.466085+00:00"
+                "validatedAt": "2026-07-20T14:38:10.715857+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41707,7 +41653,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:55.466165+00:00"
+                "validatedAt": "2026-07-20T14:38:10.715883+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41734,7 +41680,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:55.466216+00:00"
+                "validatedAt": "2026-07-20T14:38:10.715898+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41775,7 +41721,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:55.466281+00:00"
+                "validatedAt": "2026-07-20T14:38:10.715916+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41800,7 +41746,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:55.466353+00:00"
+                "validatedAt": "2026-07-20T14:38:10.715935+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41924,7 +41870,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.014222+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.145289+00:00"
           }
         },
         "x-f5xc-description-short": "Field Data contains key/value pairs that uniquely identifies the group_by labels specified in the request.",
@@ -42383,7 +42329,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:55.466504+00:00"
+                "validatedAt": "2026-07-20T14:38:10.715982+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42411,7 +42357,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:55.466546+00:00"
+                "validatedAt": "2026-07-20T14:38:10.715999+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42479,7 +42425,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:55.466601+00:00"
+                "validatedAt": "2026-07-20T14:38:10.716022+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42521,7 +42467,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:55.466646+00:00"
+                "validatedAt": "2026-07-20T14:38:10.716040+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42608,7 +42554,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:55.466707+00:00"
+                "validatedAt": "2026-07-20T14:38:10.716061+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42652,7 +42598,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:55.466765+00:00"
+                "validatedAt": "2026-07-20T14:38:10.716091+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42686,7 +42632,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:55.466821+00:00"
+                "validatedAt": "2026-07-20T14:38:10.716118+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42722,7 +42668,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:55.466864+00:00"
+                "validatedAt": "2026-07-20T14:38:10.716140+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42757,7 +42703,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:01:55.466905+00:00"
+                "validatedAt": "2026-07-20T14:38:10.716161+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42807,7 +42753,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:55.466957+00:00"
+                "validatedAt": "2026-07-20T14:38:10.716183+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42936,7 +42882,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:55.467013+00:00"
+                "validatedAt": "2026-07-20T14:38:10.716205+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42980,7 +42926,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:55.467062+00:00"
+                "validatedAt": "2026-07-20T14:38:10.716230+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43007,7 +42953,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:55.467095+00:00"
+                "validatedAt": "2026-07-20T14:38:10.716244+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43058,7 +43004,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:01:55.467141+00:00"
+                "validatedAt": "2026-07-20T14:38:10.716264+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43108,7 +43054,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:55.467193+00:00"
+                "validatedAt": "2026-07-20T14:38:10.716285+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43450,7 +43396,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:13.235612+00:00"
+                "validatedAt": "2026-07-20T14:38:17.679071+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43520,7 +43466,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:13.235759+00:00"
+                "validatedAt": "2026-07-20T14:38:17.679125+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43564,7 +43510,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:13.235834+00:00"
+                "validatedAt": "2026-07-20T14:38:17.679161+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43744,7 +43690,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:13.235923+00:00"
+                "validatedAt": "2026-07-20T14:38:17.679203+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43858,7 +43804,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:13.235998+00:00"
+                "validatedAt": "2026-07-20T14:38:17.679239+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43912,7 +43858,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:13.236068+00:00"
+                "validatedAt": "2026-07-20T14:38:17.679275+00:00"
               },
               "deterministic": true
             },
@@ -43922,8 +43868,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[A-Za-z0-9][A-Za-z0-9-]+[A-Za-z0-9]$",
-            "format": "dns-label"
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9-]+[A-Za-z0-9]$"
           }
         },
         "x-f5xc-description-short": "Azure Event Hubs Configuration for Global Log Receiver.",
@@ -44084,7 +44029,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:13.236161+00:00"
+                "validatedAt": "2026-07-20T14:38:17.679311+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45014,7 +44959,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T13:02:13.236295+00:00"
+                "validatedAt": "2026-07-20T14:38:17.679363+00:00"
               },
               "deterministic": true
             },
@@ -45066,7 +45011,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:13.236332+00:00"
+                "validatedAt": "2026-07-20T14:38:17.679379+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45182,7 +45127,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:13.236374+00:00"
+                "validatedAt": "2026-07-20T14:38:17.679398+00:00"
               },
               "deterministic": true
             },
@@ -45194,9 +45139,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.279325+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.317001+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -45228,7 +45172,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:13.236401+00:00"
+                "validatedAt": "2026-07-20T14:38:17.679411+00:00"
               },
               "deterministic": true
             },
@@ -45240,9 +45184,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.279346+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.317014+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -45310,7 +45253,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:13.236473+00:00"
+                "validatedAt": "2026-07-20T14:38:17.679445+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45446,7 +45389,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:13.236549+00:00"
+                "validatedAt": "2026-07-20T14:38:17.679481+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45672,7 +45615,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.279468+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.317085+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -46348,7 +46291,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:13.236806+00:00"
+                "validatedAt": "2026-07-20T14:38:17.679555+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46399,7 +46342,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:13.236868+00:00"
+                "validatedAt": "2026-07-20T14:38:17.679582+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46446,7 +46389,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:13.236903+00:00"
+                "validatedAt": "2026-07-20T14:38:17.679598+00:00"
               },
               "deterministic": true
             },
@@ -46458,9 +46401,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.279659+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.317192+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "start_time": {
             "type": "string",
@@ -46485,7 +46427,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:13.236942+00:00"
+                "validatedAt": "2026-07-20T14:38:17.679614+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46518,7 +46460,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:13.236976+00:00"
+                "validatedAt": "2026-07-20T14:38:17.679628+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46610,7 +46552,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:13.237025+00:00"
+                "validatedAt": "2026-07-20T14:38:17.679647+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46782,7 +46724,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:13.237091+00:00"
+                "validatedAt": "2026-07-20T14:38:17.679676+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46889,7 +46831,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:13.237156+00:00"
+                "validatedAt": "2026-07-20T14:38:17.679707+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46994,7 +46936,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:13.237209+00:00"
+                "validatedAt": "2026-07-20T14:38:17.679732+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47051,7 +46993,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:13.237283+00:00"
+                "validatedAt": "2026-07-20T14:38:17.679768+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47178,7 +47120,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:13.237329+00:00"
+                "validatedAt": "2026-07-20T14:38:17.679785+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47189,7 +47131,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.279834+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.317287+00:00"
           }
         },
         "x-f5xc-description-short": "Metrics used in the global log receiver are tagged with labels listed in the enum Label.",
@@ -47268,7 +47210,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:02:13.237373+00:00"
+                "validatedAt": "2026-07-20T14:38:17.679805+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47349,7 +47291,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:02:13.237428+00:00"
+                "validatedAt": "2026-07-20T14:38:17.679828+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47360,7 +47302,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.279878+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.317313+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -47447,7 +47389,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:13.237470+00:00"
+                "validatedAt": "2026-07-20T14:38:17.679846+00:00"
               },
               "deterministic": true
             },
@@ -47459,9 +47401,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.279923+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.317340+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -47492,7 +47433,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:13.237498+00:00"
+                "validatedAt": "2026-07-20T14:38:17.679859+00:00"
               },
               "deterministic": true
             },
@@ -47504,9 +47445,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.279941+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.317352+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -47575,7 +47515,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:13.237551+00:00"
+                "validatedAt": "2026-07-20T14:38:17.679879+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47587,7 +47527,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.279979+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.317375+00:00"
           },
           "uid": {
             "type": "string",
@@ -47605,7 +47545,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:13.237577+00:00"
+                "validatedAt": "2026-07-20T14:38:17.679890+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47618,7 +47558,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.279999+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.317388+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of global_log_receiver is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -47701,7 +47641,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:13.237623+00:00"
+                "validatedAt": "2026-07-20T14:38:17.679911+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47907,7 +47847,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:13.237720+00:00"
+                "validatedAt": "2026-07-20T14:38:17.679940+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48671,7 +48611,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:13.237833+00:00"
+                "validatedAt": "2026-07-20T14:38:17.679984+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48726,7 +48666,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:13.237906+00:00"
+                "validatedAt": "2026-07-20T14:38:17.680019+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48863,7 +48803,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:13.237974+00:00"
+                "validatedAt": "2026-07-20T14:38:17.680050+00:00"
               },
               "deterministic": true
             },
@@ -49108,7 +49048,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.280316+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.317569+00:00"
           },
           "timestamp": {
             "type": "number",
@@ -49249,7 +49189,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:13.238112+00:00"
+                "validatedAt": "2026-07-20T14:38:17.680109+00:00"
               },
               "deterministic": true
             },
@@ -49464,7 +49404,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:13.238200+00:00"
+                "validatedAt": "2026-07-20T14:38:17.680147+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49552,7 +49492,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:13.238230+00:00"
+                "validatedAt": "2026-07-20T14:38:17.680163+00:00"
               },
               "deterministic": true
             },
@@ -49564,9 +49504,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.280418+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.317627+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -49605,7 +49544,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:13.238262+00:00"
+                "validatedAt": "2026-07-20T14:38:17.680177+00:00"
               },
               "deterministic": true
             },
@@ -49617,9 +49556,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.280436+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.317639+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -49686,7 +49624,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.631358+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.570510+00:00"
           }
         },
         "x-f5xc-namespace-profile": {
@@ -50131,7 +50069,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:02.088027+00:00"
+                "validatedAt": "2026-07-20T14:39:00.739084+00:00"
               },
               "deterministic": true
             },
@@ -50143,9 +50081,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.968091+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.774784+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -50177,7 +50114,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:02.088055+00:00"
+                "validatedAt": "2026-07-20T14:39:00.739097+00:00"
               },
               "deterministic": true
             },
@@ -50189,9 +50126,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.968109+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.774796+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -50354,7 +50290,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.968176+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.774837+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -50495,7 +50431,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:02.088172+00:00"
+                "validatedAt": "2026-07-20T14:39:00.739145+00:00"
               },
               "deterministic": true
             },
@@ -50520,7 +50456,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:02.088211+00:00"
+                "validatedAt": "2026-07-20T14:39:00.739161+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50584,7 +50520,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T13:04:02.088250+00:00"
+                "validatedAt": "2026-07-20T14:39:00.739180+00:00"
               },
               "deterministic": true
             },
@@ -50613,7 +50549,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:02.088277+00:00"
+                "validatedAt": "2026-07-20T14:39:00.739193+00:00"
               },
               "deterministic": true
             },
@@ -50697,7 +50633,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:04:02.088322+00:00"
+                "validatedAt": "2026-07-20T14:39:00.739213+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50776,7 +50712,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:04:02.088376+00:00"
+                "validatedAt": "2026-07-20T14:39:00.739238+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50787,7 +50723,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.968273+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.774893+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -50874,7 +50810,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:02.088417+00:00"
+                "validatedAt": "2026-07-20T14:39:00.739257+00:00"
               },
               "deterministic": true
             },
@@ -50886,9 +50822,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.968319+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.774921+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -50919,7 +50854,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:02.088443+00:00"
+                "validatedAt": "2026-07-20T14:39:00.739271+00:00"
               },
               "deterministic": true
             },
@@ -50931,9 +50866,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.968338+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.774932+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -51002,7 +50936,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:02.088497+00:00"
+                "validatedAt": "2026-07-20T14:39:00.739291+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51014,7 +50948,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.968376+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.774956+00:00"
           },
           "uid": {
             "type": "string",
@@ -51031,7 +50965,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:02.088523+00:00"
+                "validatedAt": "2026-07-20T14:39:00.739302+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51044,7 +50978,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.968396+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.774968+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of log_receiver is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -51486,7 +51420,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:02.088636+00:00"
+                "validatedAt": "2026-07-20T14:39:00.739347+00:00"
               },
               "deterministic": true
             },
@@ -51525,7 +51459,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:02.088724+00:00"
+                "validatedAt": "2026-07-20T14:39:00.739378+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51605,7 +51539,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:02.088801+00:00"
+                "validatedAt": "2026-07-20T14:39:00.739415+00:00"
               },
               "deterministic": true
             },
@@ -51765,7 +51699,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:02.088846+00:00"
+                "validatedAt": "2026-07-20T14:39:00.739436+00:00"
               },
               "deterministic": true
             },
@@ -51810,7 +51744,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:02.088909+00:00"
+                "validatedAt": "2026-07-20T14:39:00.739465+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51818,8 +51752,7 @@
               "create": true,
               "update": false,
               "read": false
-            },
-            "format": "hostname"
+            }
           },
           "trusted_ca_url": {
             "type": "string",
@@ -51849,7 +51782,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:02.088972+00:00"
+                "validatedAt": "2026-07-20T14:39:00.739494+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51952,7 +51885,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:02.089005+00:00"
+                "validatedAt": "2026-07-20T14:39:00.739510+00:00"
               },
               "deterministic": true
             },
@@ -51964,9 +51897,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.968580+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.775076+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -52005,7 +51937,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:02.089036+00:00"
+                "validatedAt": "2026-07-20T14:39:00.739524+00:00"
               },
               "deterministic": true
             },
@@ -52017,9 +51949,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.968598+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.775088+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -52123,7 +52054,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:02.089068+00:00"
+                "validatedAt": "2026-07-20T14:39:00.739540+00:00"
               },
               "deterministic": true
             },
@@ -52162,7 +52093,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:02.089127+00:00"
+                "validatedAt": "2026-07-20T14:39:00.739568+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52558,7 +52489,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.658425+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540229+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52598,7 +52529,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:06.658485+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540255+00:00"
               },
               "deterministic": true
             },
@@ -52610,9 +52541,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.048895+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.842295+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query": {
             "type": "string",
@@ -52632,7 +52562,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.658548+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540274+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52665,7 +52595,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.658604+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540291+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52755,7 +52685,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.658682+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540309+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52784,7 +52714,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.658740+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540326+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52824,7 +52754,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:06.658785+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540340+00:00"
               },
               "deterministic": true
             },
@@ -52836,9 +52766,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.048953+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.842329+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query": {
             "type": "string",
@@ -52858,7 +52787,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.658839+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540357+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52922,7 +52851,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.658886+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540375+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53045,7 +52974,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.658931+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540393+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53085,7 +53014,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:06.658959+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540406+00:00"
               },
               "deterministic": true
             },
@@ -53097,9 +53026,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.049015+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.842365+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query": {
             "type": "string",
@@ -53119,7 +53047,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.658998+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540423+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53152,7 +53080,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.659037+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540439+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53242,7 +53170,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.659080+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540455+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53271,7 +53199,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.659110+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540469+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53310,7 +53238,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:06.659138+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540482+00:00"
               },
               "deterministic": true
             },
@@ -53322,9 +53250,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.049068+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.842398+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query": {
             "type": "string",
@@ -53344,7 +53271,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.659176+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540499+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53408,7 +53335,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.659224+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540518+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53506,7 +53433,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.049115+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.842426+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Avg Aggregation Data\" Average Aggregation data.",
@@ -53560,7 +53487,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.659270+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540536+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53638,7 +53565,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.659308+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540551+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53677,7 +53604,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T13:04:06.659351+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540569+00:00"
               },
               "deterministic": true
             },
@@ -53773,7 +53700,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.659401+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540588+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53846,7 +53773,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.659441+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540604+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53872,7 +53799,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.659484+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540620+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53910,7 +53837,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:06.659536+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540644+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53945,7 +53872,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.659573+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540661+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53985,7 +53912,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:06.659601+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540674+00:00"
               },
               "deterministic": true
             },
@@ -53997,9 +53924,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.049223+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.842489+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "site": {
             "type": "string",
@@ -54016,7 +53942,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.659631+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540686+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54049,7 +53975,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.659682+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540702+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54117,7 +54043,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.659719+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540715+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54140,7 +54066,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.659745+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540725+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54151,7 +54077,7 @@
             },
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.049264+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.842515+00:00"
           },
           "order_by": {
             "allOf": [
@@ -54301,7 +54227,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.659804+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540748+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54325,7 +54251,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.659830+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540759+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54336,7 +54262,7 @@
             },
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.049319+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.842549+00:00"
           },
           "order_by": {
             "allOf": [
@@ -54406,7 +54332,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.659868+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540774+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54430,7 +54356,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.659894+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540784+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54441,7 +54367,7 @@
             },
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.049353+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.842570+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Field Sub Field Aggregation Bucket\" Field sub aggregation bucket containing field values and the number of logs.",
@@ -54497,7 +54423,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.659928+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540797+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54572,7 +54498,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.659965+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540813+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54596,7 +54522,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.659991+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540824+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54607,7 +54533,7 @@
             },
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.049397+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.842595+00:00"
           },
           "sub_aggs": {
             "type": "object",
@@ -54700,7 +54626,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.660039+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540843+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54740,7 +54666,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:06.660068+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540856+00:00"
               },
               "deterministic": true
             },
@@ -54752,9 +54678,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.049439+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.842620+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query": {
             "type": "string",
@@ -54774,7 +54699,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.660107+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540873+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54807,7 +54732,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.660147+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540889+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54897,7 +54822,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.660190+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540906+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54926,7 +54851,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.660221+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540920+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54966,7 +54891,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:06.660248+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540932+00:00"
               },
               "deterministic": true
             },
@@ -54978,9 +54903,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.049492+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.842651+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query": {
             "type": "string",
@@ -55000,7 +54924,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.660286+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540949+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55064,7 +54988,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.660331+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540967+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55187,7 +55111,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.660374+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540983+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55227,7 +55151,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:06.660401+00:00"
+                "validatedAt": "2026-07-20T14:39:02.540996+00:00"
               },
               "deterministic": true
             },
@@ -55239,9 +55163,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.049553+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.842687+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query": {
             "type": "string",
@@ -55261,7 +55184,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.660440+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541012+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55286,7 +55209,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.660468+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541024+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55319,7 +55242,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.660507+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541039+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55410,7 +55333,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.660550+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541056+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55439,7 +55362,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.660580+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541070+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55479,7 +55402,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:06.660607+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541083+00:00"
               },
               "deterministic": true
             },
@@ -55491,9 +55414,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.049613+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.842723+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query": {
             "type": "string",
@@ -55513,7 +55435,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.660644+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541100+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55555,7 +55477,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.660685+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541112+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55602,7 +55524,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.660729+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541129+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55726,7 +55648,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.660772+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541145+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55766,7 +55688,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:06.660800+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541158+00:00"
               },
               "deterministic": true
             },
@@ -55778,9 +55700,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.049688+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.842762+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query": {
             "type": "string",
@@ -55800,7 +55721,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.660839+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541175+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55825,7 +55746,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.660868+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541187+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55858,7 +55779,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.660907+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541202+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55949,7 +55870,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.660950+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541219+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55978,7 +55899,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.660981+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541232+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56018,7 +55939,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:06.661008+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541246+00:00"
               },
               "deterministic": true
             },
@@ -56030,9 +55951,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.049749+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.842797+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query": {
             "type": "string",
@@ -56052,7 +55972,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.661046+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541264+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56094,7 +56014,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.661078+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541277+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56141,7 +56061,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.661120+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541293+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56279,7 +56199,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:06.661183+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541321+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56290,7 +56210,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.049815+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.842835+00:00"
           }
         },
         "x-f5xc-description-short": "Label Filter is used to filter th that match the logs specified label key/value and the operator.",
@@ -56365,7 +56285,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.661227+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541339+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56465,7 +56385,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.661277+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541359+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56494,7 +56414,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.661315+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541373+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56590,7 +56510,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:06.661345+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541387+00:00"
               },
               "deterministic": true
             },
@@ -56602,9 +56522,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.049880+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.842873+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "scroll_id": {
             "type": "string",
@@ -56622,7 +56541,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.661380+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541401+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56686,7 +56605,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.049907+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.842889+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Max Aggregation Data\" Max Aggregation data.",
@@ -56789,7 +56708,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.049936+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.842906+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Min Aggregation Data\" Min Aggregation data.",
@@ -56843,7 +56762,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.661443+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541426+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57000,7 +56919,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.661502+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541448+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57113,7 +57032,7 @@
             "maxLength": 16,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.050010+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.842950+00:00"
           },
           "value": {
             "type": "number",
@@ -57129,7 +57048,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.050028+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.842961+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Percentile Aggregation Data\" Percentile Aggregation data.",
@@ -57208,7 +57127,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.661573+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541475+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57248,7 +57167,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:06.661601+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541488+00:00"
               },
               "deterministic": true
             },
@@ -57260,9 +57179,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.050062+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.842983+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query": {
             "type": "string",
@@ -57282,7 +57200,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.661640+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541505+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57315,7 +57233,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.661688+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541521+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57405,7 +57323,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.661732+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541538+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57449,7 +57367,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.661766+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541553+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57488,7 +57406,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:06.661793+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541566+00:00"
               },
               "deterministic": true
             },
@@ -57500,9 +57418,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.050123+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.843018+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query": {
             "type": "string",
@@ -57522,7 +57439,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.661831+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541583+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57586,7 +57503,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.661876+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541600+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57686,7 +57603,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.661909+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541613+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57788,7 +57705,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.661964+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541635+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57828,7 +57745,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:06.661990+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541648+00:00"
               },
               "deterministic": true
             },
@@ -57840,9 +57757,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.050196+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.843065+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query": {
             "type": "string",
@@ -57862,7 +57778,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.662029+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541666+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57895,7 +57811,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.662068+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541681+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57985,7 +57901,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.662111+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541697+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58014,7 +57930,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.662140+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541711+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58054,7 +57970,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:06.662168+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541725+00:00"
               },
               "deterministic": true
             },
@@ -58066,9 +57982,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.050249+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.843098+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query": {
             "type": "string",
@@ -58088,7 +58003,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.662206+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541742+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58152,7 +58067,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.662250+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541759+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58276,7 +58191,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.662292+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541776+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58316,7 +58231,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:06.662318+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541789+00:00"
               },
               "deterministic": true
             },
@@ -58328,9 +58243,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.050309+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.843133+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query": {
             "type": "string",
@@ -58350,7 +58264,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.662356+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541806+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58383,7 +58297,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.662393+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541821+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58473,7 +58387,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.662435+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541838+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58502,7 +58416,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.662463+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541851+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58542,7 +58456,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:06.662490+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541865+00:00"
               },
               "deterministic": true
             },
@@ -58554,9 +58468,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.050362+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.843165+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query": {
             "type": "string",
@@ -58576,7 +58489,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:04:06.662527+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541882+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58640,7 +58553,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.662575+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541899+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58790,7 +58703,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.662611+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541914+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59012,7 +58925,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.662671+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541934+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59241,7 +59154,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.662723+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541953+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59425,7 +59338,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.662773+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541973+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59487,7 +59400,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.662805+00:00"
+                "validatedAt": "2026-07-20T14:39:02.541986+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59657,7 +59570,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.662851+00:00"
+                "validatedAt": "2026-07-20T14:39:02.542003+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59823,7 +59736,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.662897+00:00"
+                "validatedAt": "2026-07-20T14:39:02.542021+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59885,7 +59798,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:06.662927+00:00"
+                "validatedAt": "2026-07-20T14:39:02.542033+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60141,7 +60054,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:26.939672+00:00"
+                "validatedAt": "2026-07-20T14:39:10.147887+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60223,7 +60136,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:44.737957+00:00"
+                "validatedAt": "2026-07-20T14:40:03.528806+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60248,7 +60161,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:44.738015+00:00"
+                "validatedAt": "2026-07-20T14:40:03.528821+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60274,7 +60187,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:44.738079+00:00"
+                "validatedAt": "2026-07-20T14:40:03.528836+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60299,7 +60212,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:44.738140+00:00"
+                "validatedAt": "2026-07-20T14:40:03.528850+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60397,7 +60310,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:44.738204+00:00"
+                "validatedAt": "2026-07-20T14:40:03.528874+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60462,7 +60375,7 @@
             "maxLength": 16,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.516694+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.205354+00:00"
           },
           "value": {
             "allOf": [
@@ -60479,7 +60392,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.516715+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.205367+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -60607,7 +60520,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:44.738267+00:00"
+                "validatedAt": "2026-07-20T14:40:03.528897+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60672,7 +60585,7 @@
             "maxLength": 16,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.516752+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.205389+00:00"
           },
           "value": {
             "allOf": [
@@ -60689,7 +60602,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.516771+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.205401+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -60807,7 +60720,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:44.738329+00:00"
+                "validatedAt": "2026-07-20T14:40:03.528921+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60838,7 +60751,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:44.738368+00:00"
+                "validatedAt": "2026-07-20T14:40:03.528937+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61150,7 +61063,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:44.738477+00:00"
+                "validatedAt": "2026-07-20T14:40:03.528976+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61186,7 +61099,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:44.738516+00:00"
+                "validatedAt": "2026-07-20T14:40:03.528992+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61232,7 +61145,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:44.738559+00:00"
+                "validatedAt": "2026-07-20T14:40:03.529008+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61330,7 +61243,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:44.738608+00:00"
+                "validatedAt": "2026-07-20T14:40:03.529027+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61364,7 +61277,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:44.738652+00:00"
+                "validatedAt": "2026-07-20T14:40:03.529044+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61476,7 +61389,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:44.738703+00:00"
+                "validatedAt": "2026-07-20T14:40:03.529061+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61725,7 +61638,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:44.738767+00:00"
+                "validatedAt": "2026-07-20T14:40:03.529087+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61752,7 +61665,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:44.738793+00:00"
+                "validatedAt": "2026-07-20T14:40:03.529097+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61874,7 +61787,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:44.738823+00:00"
+                "validatedAt": "2026-07-20T14:40:03.529110+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61914,7 +61827,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:44.738865+00:00"
+                "validatedAt": "2026-07-20T14:40:03.529126+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61941,7 +61854,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:07.285222+00:00"
+                "validatedAt": "2026-07-20T14:40:12.061637+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62014,7 +61927,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:44.738905+00:00"
+                "validatedAt": "2026-07-20T14:40:03.529142+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62046,7 +61959,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:44.738947+00:00"
+                "validatedAt": "2026-07-20T14:40:03.529158+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62093,7 +62006,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:44.738984+00:00"
+                "validatedAt": "2026-07-20T14:40:03.529175+00:00"
               },
               "deterministic": true
             },
@@ -62105,9 +62018,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.517049+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.205564+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "report_frequency": {
             "allOf": [
@@ -62144,7 +62056,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:44.739031+00:00"
+                "validatedAt": "2026-07-20T14:40:03.529193+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62176,7 +62088,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:44.739071+00:00"
+                "validatedAt": "2026-07-20T14:40:03.529210+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62209,7 +62121,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:44.739114+00:00"
+                "validatedAt": "2026-07-20T14:40:03.529226+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62241,7 +62153,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:44.739154+00:00"
+                "validatedAt": "2026-07-20T14:40:03.529242+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62388,7 +62300,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:44.739206+00:00"
+                "validatedAt": "2026-07-20T14:40:03.529262+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62453,7 +62365,7 @@
             "maxLength": 16,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.517118+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.205606+00:00"
           },
           "value": {
             "allOf": [
@@ -62470,7 +62382,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.517137+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.205618+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -62609,7 +62521,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:44.739264+00:00"
+                "validatedAt": "2026-07-20T14:40:03.529286+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62674,7 +62586,7 @@
             "maxLength": 16,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.517172+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.205640+00:00"
           },
           "value": {
             "allOf": [
@@ -62691,7 +62603,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.517191+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.205652+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -62821,7 +62733,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:44.739338+00:00"
+                "validatedAt": "2026-07-20T14:40:03.529314+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62889,7 +62801,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:44.739401+00:00"
+                "validatedAt": "2026-07-20T14:40:03.529338+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63270,7 +63182,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:06:48.984268+00:00"
+                "validatedAt": "2026-07-20T14:40:05.157099+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63281,7 +63193,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.603699+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.282145+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -63368,7 +63280,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:48.984311+00:00"
+                "validatedAt": "2026-07-20T14:40:05.157117+00:00"
               },
               "deterministic": true
             },
@@ -63380,9 +63292,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.603746+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.282172+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -63413,7 +63324,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:48.984338+00:00"
+                "validatedAt": "2026-07-20T14:40:05.157130+00:00"
               },
               "deterministic": true
             },
@@ -63425,9 +63336,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.603765+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.282186+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "object": {
             "allOf": [
@@ -63493,7 +63403,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:48.984380+00:00"
+                "validatedAt": "2026-07-20T14:40:05.157146+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63505,7 +63415,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.603802+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.282208+00:00"
           },
           "uid": {
             "type": "string",
@@ -63522,7 +63432,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:48.984406+00:00"
+                "validatedAt": "2026-07-20T14:40:05.157157+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63535,7 +63445,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.603822+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.282220+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of report is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -63632,7 +63542,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:48.984437+00:00"
+                "validatedAt": "2026-07-20T14:40:05.157171+00:00"
               },
               "deterministic": true
             },
@@ -63644,9 +63554,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.603848+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.282236+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -63678,7 +63587,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:48.984464+00:00"
+                "validatedAt": "2026-07-20T14:40:05.157185+00:00"
               },
               "deterministic": true
             },
@@ -63690,9 +63599,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.603867+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.282248+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -63771,7 +63679,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:48.984495+00:00"
+                "validatedAt": "2026-07-20T14:40:05.157199+00:00"
               },
               "deterministic": true
             },
@@ -63783,9 +63691,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.603886+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.282261+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -63824,7 +63731,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:48.984524+00:00"
+                "validatedAt": "2026-07-20T14:40:05.157213+00:00"
               },
               "deterministic": true
             },
@@ -63836,9 +63743,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.603905+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.282272+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -64036,7 +63942,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.603972+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.282312+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -64155,7 +64061,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:48.984629+00:00"
+                "validatedAt": "2026-07-20T14:40:05.157254+00:00"
               },
               "deterministic": true
             },
@@ -64167,9 +64073,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.604005+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.282332+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "report_config_names": {
             "allOf": [
@@ -64247,7 +64152,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:06:48.984672+00:00"
+                "validatedAt": "2026-07-20T14:40:05.157270+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64428,7 +64333,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:06:48.984747+00:00"
+                "validatedAt": "2026-07-20T14:40:05.157298+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64509,7 +64414,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:06:48.984796+00:00"
+                "validatedAt": "2026-07-20T14:40:05.157318+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64520,7 +64425,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.604090+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.282380+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -64607,7 +64512,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:48.984834+00:00"
+                "validatedAt": "2026-07-20T14:40:05.157336+00:00"
               },
               "deterministic": true
             },
@@ -64619,9 +64524,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.604135+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.282407+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -64652,7 +64556,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:48.984862+00:00"
+                "validatedAt": "2026-07-20T14:40:05.157349+00:00"
               },
               "deterministic": true
             },
@@ -64664,9 +64568,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.604154+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.282418+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -64735,7 +64638,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:48.984913+00:00"
+                "validatedAt": "2026-07-20T14:40:05.157369+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64747,7 +64650,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.604191+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.282441+00:00"
           },
           "uid": {
             "type": "string",
@@ -64764,7 +64667,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:48.984938+00:00"
+                "validatedAt": "2026-07-20T14:40:05.157380+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64777,7 +64680,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.604211+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.282453+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of report_config is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -64863,7 +64766,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:48.984990+00:00"
+                "validatedAt": "2026-07-20T14:40:05.157405+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65107,7 +65010,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:48.985049+00:00"
+                "validatedAt": "2026-07-20T14:40:05.157432+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65183,7 +65086,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:48.985127+00:00"
+                "validatedAt": "2026-07-20T14:40:05.157471+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65273,7 +65176,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:48.985202+00:00"
+                "validatedAt": "2026-07-20T14:40:05.157507+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65364,7 +65267,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:48.985276+00:00"
+                "validatedAt": "2026-07-20T14:40:05.157546+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65556,7 +65459,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:48.985320+00:00"
+                "validatedAt": "2026-07-20T14:40:05.157568+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65787,7 +65690,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:48.985393+00:00"
+                "validatedAt": "2026-07-20T14:40:05.157601+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65846,7 +65749,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:48.985438+00:00"
+                "validatedAt": "2026-07-20T14:40:05.157623+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65873,7 +65776,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:48.985476+00:00"
+                "validatedAt": "2026-07-20T14:40:05.157638+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65981,7 +65884,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:48.986144+00:00"
+                "validatedAt": "2026-07-20T14:40:05.157923+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -65996,7 +65899,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.604701+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.282731+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -66068,7 +65971,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:48.986180+00:00"
+                "validatedAt": "2026-07-20T14:40:05.157939+00:00"
               },
               "deterministic": true
             },
@@ -66080,9 +65983,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.604734+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.282750+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -66115,7 +66017,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:48.986207+00:00"
+                "validatedAt": "2026-07-20T14:40:05.157951+00:00"
               },
               "deterministic": true
             },
@@ -66127,9 +66029,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.604753+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.282762+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "uid": {
             "type": "string",
@@ -66148,7 +66049,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:48.986232+00:00"
+                "validatedAt": "2026-07-20T14:40:05.157962+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66162,7 +66063,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.604772+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.282774+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectMetaType is metadata(common attributes) of an object that all configuration objects will have.",
@@ -66227,7 +66128,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:48.987017+00:00"
+                "validatedAt": "2026-07-20T14:40:05.158280+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66255,7 +66156,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:48.987055+00:00"
+                "validatedAt": "2026-07-20T14:40:05.158295+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66284,7 +66185,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:48.987093+00:00"
+                "validatedAt": "2026-07-20T14:40:05.158310+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66311,7 +66212,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:48.987129+00:00"
+                "validatedAt": "2026-07-20T14:40:05.158325+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66340,7 +66241,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:48.987171+00:00"
+                "validatedAt": "2026-07-20T14:40:05.158342+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66365,7 +66266,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:48.987211+00:00"
+                "validatedAt": "2026-07-20T14:40:05.158358+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66441,7 +66342,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:48.987272+00:00"
+                "validatedAt": "2026-07-20T14:40:05.158382+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66479,7 +66380,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:48.987317+00:00"
+                "validatedAt": "2026-07-20T14:40:05.158402+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66491,7 +66392,7 @@
             "maxLength": 6,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.605154+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.282999+00:00"
           },
           "object_index": {
             "type": "integer",
@@ -66551,7 +66452,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:48.987367+00:00"
+                "validatedAt": "2026-07-20T14:40:05.158422+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66595,7 +66496,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:48.987403+00:00"
+                "validatedAt": "2026-07-20T14:40:05.158436+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66608,7 +66509,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.605199+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.283025+00:00"
           },
           "trace_info": {
             "type": "string",
@@ -66627,7 +66528,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:48.987439+00:00"
+                "validatedAt": "2026-07-20T14:40:05.158451+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66654,7 +66555,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:48.987463+00:00"
+                "validatedAt": "2026-07-20T14:40:05.158461+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66668,7 +66569,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.605224+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.283040+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -66683,7 +66584,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:48.987497+00:00"
+                "validatedAt": "2026-07-20T14:40:05.158475+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66853,7 +66754,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:48.987797+00:00"
+                "validatedAt": "2026-07-20T14:40:05.158597+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66889,7 +66790,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:48.987838+00:00"
+                "validatedAt": "2026-07-20T14:40:05.158612+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66935,7 +66836,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:48.987880+00:00"
+                "validatedAt": "2026-07-20T14:40:05.158629+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67096,7 +66997,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:48.987939+00:00"
+                "validatedAt": "2026-07-20T14:40:05.158651+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67142,7 +67043,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:48.987983+00:00"
+                "validatedAt": "2026-07-20T14:40:05.158668+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67494,7 +67395,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.868749+00:00"
+                "validatedAt": "2026-07-20T14:40:24.800811+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67561,7 +67462,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.868820+00:00"
+                "validatedAt": "2026-07-20T14:40:24.800839+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67677,7 +67578,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.868948+00:00"
+                "validatedAt": "2026-07-20T14:40:24.800878+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67719,7 +67620,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.869002+00:00"
+                "validatedAt": "2026-07-20T14:40:24.800900+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67765,7 +67666,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.869050+00:00"
+                "validatedAt": "2026-07-20T14:40:24.800921+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67828,7 +67729,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.869117+00:00"
+                "validatedAt": "2026-07-20T14:40:24.800948+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67869,7 +67770,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.869160+00:00"
+                "validatedAt": "2026-07-20T14:40:24.800965+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67909,7 +67810,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.869208+00:00"
+                "validatedAt": "2026-07-20T14:40:24.800984+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68020,7 +67921,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.869297+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801017+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68214,7 +68115,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.869399+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801058+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68755,7 +68656,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.869551+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801115+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68780,7 +68681,7 @@
             "maxLength": 4,
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.522853+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.081468+00:00"
           },
           "type": {
             "allOf": [
@@ -69254,7 +69155,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.523027+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.081574+00:00"
           }
         },
         "x-f5xc-description-short": "MetricData contains the metric type and the corresponding metric value(s).",
@@ -69393,7 +69294,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:39.869901+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801247+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69444,7 +69345,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:39.869956+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801273+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69559,7 +69460,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.869994+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801288+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69584,7 +69485,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.870029+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801303+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69624,7 +69525,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:39.870065+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801319+00:00"
               },
               "deterministic": true
             },
@@ -69636,9 +69537,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.523137+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.081639+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "service": {
             "type": "string",
@@ -69656,7 +69556,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.870101+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801334+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69682,7 +69582,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.870130+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801347+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69707,7 +69607,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.870170+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801363+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69830,7 +69730,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.870215+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801380+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69863,7 +69763,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.870253+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801396+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69896,7 +69796,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.870289+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801411+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69922,7 +69822,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.870320+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801423+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69955,7 +69855,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.870361+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801440+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -70133,7 +70033,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:39.870580+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801531+00:00"
               },
               "deterministic": true
             },
@@ -70145,9 +70045,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.523307+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.081741+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "List of application types for a namespace.",
@@ -70358,7 +70257,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.523363+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.081775+00:00"
           }
         },
         "x-f5xc-description-short": "CdnMetricData contains the metric type and the corresponding metric value(s).",
@@ -70790,7 +70689,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.870721+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801580+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -70843,7 +70742,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:39.870753+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801595+00:00"
               },
               "deterministic": true
             },
@@ -70855,9 +70754,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.523478+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.081843+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "range": {
             "type": "string",
@@ -70882,7 +70780,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.870789+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801609+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -70929,7 +70827,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.870834+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801627+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -70962,7 +70860,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.870867+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801640+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71056,7 +70954,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.870904+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801655+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71264,7 +71162,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.870970+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801681+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71290,7 +71188,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.871009+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801696+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71330,7 +71228,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:39.871037+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801710+00:00"
               },
               "deterministic": true
             },
@@ -71342,9 +71240,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.523579+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.081904+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "service": {
             "type": "string",
@@ -71362,7 +71259,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.871071+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801723+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71388,7 +71285,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.871101+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801737+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71413,7 +71310,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.871135+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801752+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71439,7 +71336,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.871160+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801763+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71464,7 +71361,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.871202+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801779+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71489,7 +71386,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:06.903914+00:00"
+                "validatedAt": "2026-07-20T14:40:35.298807+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71685,7 +71582,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.871248+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801798+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71752,7 +71649,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:39.871282+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801814+00:00"
               },
               "deterministic": true
             },
@@ -71764,9 +71661,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.523673+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.081957+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "range": {
             "type": "string",
@@ -71791,7 +71687,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.871317+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801829+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71824,7 +71720,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.871356+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801845+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71857,7 +71753,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.871389+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801858+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71949,7 +71845,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.871427+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801873+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -72077,7 +71973,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.871480+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801894+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -72164,7 +72060,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:39.871536+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801918+00:00"
               },
               "deterministic": true
             },
@@ -72176,9 +72072,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.523761+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.082011+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "range": {
             "type": "string",
@@ -72203,7 +72098,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.871571+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801932+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -72236,7 +72131,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.871611+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801948+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -72269,7 +72164,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.871643+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801962+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -72362,7 +72257,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.871688+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801977+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -72436,7 +72331,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.871729+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801993+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -72497,7 +72392,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:39.871794+00:00"
+                "validatedAt": "2026-07-20T14:40:24.802023+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -72542,7 +72437,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:39.871845+00:00"
+                "validatedAt": "2026-07-20T14:40:24.802047+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -72582,7 +72477,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:39.871874+00:00"
+                "validatedAt": "2026-07-20T14:40:24.802061+00:00"
               },
               "deterministic": true
             },
@@ -72594,9 +72489,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.523841+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.082060+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "start_time": {
             "type": "string",
@@ -72621,7 +72515,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.871914+00:00"
+                "validatedAt": "2026-07-20T14:40:24.802078+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -72654,7 +72548,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.871947+00:00"
+                "validatedAt": "2026-07-20T14:40:24.802091+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -72748,7 +72642,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.871992+00:00"
+                "validatedAt": "2026-07-20T14:40:24.802110+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -72839,7 +72733,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.872031+00:00"
+                "validatedAt": "2026-07-20T14:40:24.802125+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -72850,7 +72744,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.523900+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.082099+00:00"
           }
         },
         "x-f5xc-description-short": "Metrics used to render the service graph are tagged with labels listed in the enum Label.",
@@ -73120,7 +73014,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.872093+00:00"
+                "validatedAt": "2026-07-20T14:40:24.802148+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -73187,7 +73081,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:39.872126+00:00"
+                "validatedAt": "2026-07-20T14:40:24.802164+00:00"
               },
               "deterministic": true
             },
@@ -73199,9 +73093,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.523982+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.082149+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "range": {
             "type": "string",
@@ -73226,7 +73119,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.872159+00:00"
+                "validatedAt": "2026-07-20T14:40:24.802178+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -73259,7 +73152,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.872197+00:00"
+                "validatedAt": "2026-07-20T14:40:24.802194+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -73292,7 +73185,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.872229+00:00"
+                "validatedAt": "2026-07-20T14:40:24.802207+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -73385,7 +73278,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.872266+00:00"
+                "validatedAt": "2026-07-20T14:40:24.802222+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -73459,7 +73352,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.872305+00:00"
+                "validatedAt": "2026-07-20T14:40:24.802238+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -73562,7 +73455,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:39.872364+00:00"
+                "validatedAt": "2026-07-20T14:40:24.802263+00:00"
               },
               "deterministic": true
             },
@@ -73574,9 +73467,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.524069+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.082203+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "range": {
             "type": "string",
@@ -73601,7 +73493,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.872398+00:00"
+                "validatedAt": "2026-07-20T14:40:24.802277+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -73634,7 +73526,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.872437+00:00"
+                "validatedAt": "2026-07-20T14:40:24.802292+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -73667,7 +73559,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.872469+00:00"
+                "validatedAt": "2026-07-20T14:40:24.802306+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -73761,7 +73653,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.872506+00:00"
+                "validatedAt": "2026-07-20T14:40:24.802320+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -73828,7 +73720,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.872541+00:00"
+                "validatedAt": "2026-07-20T14:40:24.802335+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -73861,7 +73753,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.872580+00:00"
+                "validatedAt": "2026-07-20T14:40:24.802350+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -73888,7 +73780,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.872610+00:00"
+                "validatedAt": "2026-07-20T14:40:24.802363+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -73913,7 +73805,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.872634+00:00"
+                "validatedAt": "2026-07-20T14:40:24.802374+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -73946,7 +73838,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.872683+00:00"
+                "validatedAt": "2026-07-20T14:40:24.802391+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74015,7 +73907,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:06.903172+00:00"
+                "validatedAt": "2026-07-20T14:40:35.298524+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74055,7 +73947,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:06.903202+00:00"
+                "validatedAt": "2026-07-20T14:40:35.298537+00:00"
               },
               "deterministic": true
             },
@@ -74067,9 +73959,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.154128+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.621009+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Represents a category of vulnerability as defined in the OWASP API Top 10.",
@@ -74376,7 +74267,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:56.701247+00:00"
+                "validatedAt": "2026-07-20T14:41:18.280104+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74473,7 +74364,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:56.701372+00:00"
+                "validatedAt": "2026-07-20T14:41:18.280140+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74596,7 +74487,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:56.701579+00:00"
+                "validatedAt": "2026-07-20T14:41:18.280233+00:00"
               },
               "deterministic": true
             },
@@ -74608,9 +74499,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.437108+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.010340+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "sli_address": {
             "type": "string",
@@ -74625,7 +74515,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.701617+00:00"
+                "validatedAt": "2026-07-20T14:41:18.280249+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74648,7 +74538,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.701666+00:00"
+                "validatedAt": "2026-07-20T14:41:18.280266+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74987,7 +74877,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.701721+00:00"
+                "validatedAt": "2026-07-20T14:41:18.280288+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75323,7 +75213,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:56.701829+00:00"
+                "validatedAt": "2026-07-20T14:41:18.280336+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75438,7 +75328,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:09:56.701886+00:00"
+                "validatedAt": "2026-07-20T14:41:18.280363+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75668,7 +75558,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:56.702107+00:00"
+                "validatedAt": "2026-07-20T14:41:18.280481+00:00"
               },
               "deterministic": true
             },
@@ -75680,9 +75570,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.437384+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.010505+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "BondMembersType represents the bond interface members along with the corresponding link state.",
@@ -75863,7 +75752,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.702170+00:00"
+                "validatedAt": "2026-07-20T14:41:18.280507+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75901,7 +75790,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:56.702197+00:00"
+                "validatedAt": "2026-07-20T14:41:18.280522+00:00"
               },
               "deterministic": true
             },
@@ -75913,9 +75802,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.437473+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.010557+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "network_name": {
             "type": "string",
@@ -75932,7 +75820,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.702237+00:00"
+                "validatedAt": "2026-07-20T14:41:18.280540+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -76430,7 +76318,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.702328+00:00"
+                "validatedAt": "2026-07-20T14:41:18.280578+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -76454,7 +76342,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.702371+00:00"
+                "validatedAt": "2026-07-20T14:41:18.280596+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -76481,7 +76369,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T13:09:56.702404+00:00"
+                "validatedAt": "2026-07-20T14:41:18.280613+00:00"
               },
               "deterministic": true
             },
@@ -76523,7 +76411,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.702443+00:00"
+                "validatedAt": "2026-07-20T14:41:18.280630+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -76561,7 +76449,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:56.702468+00:00"
+                "validatedAt": "2026-07-20T14:41:18.280643+00:00"
               },
               "deterministic": true
             },
@@ -76573,9 +76461,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.437620+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.010644+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "resource_id": {
             "type": "string",
@@ -76592,7 +76479,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:09:56.702504+00:00"
+                "validatedAt": "2026-07-20T14:41:18.280661+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -76617,7 +76504,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.702545+00:00"
+                "validatedAt": "2026-07-20T14:41:18.280678+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -76640,7 +76527,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.702583+00:00"
+                "validatedAt": "2026-07-20T14:41:18.280694+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -76728,7 +76615,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.702623+00:00"
+                "validatedAt": "2026-07-20T14:41:18.280711+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -76753,7 +76640,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:09:56.702669+00:00"
+                "validatedAt": "2026-07-20T14:41:18.280729+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -76778,7 +76665,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.702710+00:00"
+                "validatedAt": "2026-07-20T14:41:18.280746+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -76801,7 +76688,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.702749+00:00"
+                "validatedAt": "2026-07-20T14:41:18.280763+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -76825,7 +76712,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.702783+00:00"
+                "validatedAt": "2026-07-20T14:41:18.280777+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -76908,7 +76795,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.702837+00:00"
+                "validatedAt": "2026-07-20T14:41:18.280803+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -76970,7 +76857,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.702873+00:00"
+                "validatedAt": "2026-07-20T14:41:18.280818+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -77005,7 +76892,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T13:09:56.702907+00:00"
+                "validatedAt": "2026-07-20T14:41:18.280835+00:00"
               },
               "deterministic": true
             },
@@ -77016,8 +76903,7 @@
               "read": false
             },
             "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "minLength": 1,
-            "format": "fqdn"
+            "minLength": 1
           },
           "primary": {
             "type": "boolean",
@@ -77084,7 +76970,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.702947+00:00"
+                "validatedAt": "2026-07-20T14:41:18.280852+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -77107,7 +76993,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.702991+00:00"
+                "validatedAt": "2026-07-20T14:41:18.280871+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -77320,7 +77206,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.703053+00:00"
+                "validatedAt": "2026-07-20T14:41:18.280896+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -77413,7 +77299,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.703102+00:00"
+                "validatedAt": "2026-07-20T14:41:18.280917+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -77437,7 +77323,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.703139+00:00"
+                "validatedAt": "2026-07-20T14:41:18.280933+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -77464,7 +77350,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.437810+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.010751+00:00"
           }
         },
         "x-f5xc-description-short": "Canonical representation of Edge in the topology graph.",
@@ -77524,7 +77410,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:09:56.703185+00:00"
+                "validatedAt": "2026-07-20T14:41:18.280952+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -77550,7 +77436,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.437839+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.010769+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -77606,7 +77492,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.703228+00:00"
+                "validatedAt": "2026-07-20T14:41:18.280970+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -77632,7 +77518,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:09:56.703260+00:00"
+                "validatedAt": "2026-07-20T14:41:18.280985+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -77657,7 +77543,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.703297+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281001+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -77838,7 +77724,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.703356+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281026+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -77861,7 +77747,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.703399+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281044+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -77898,7 +77784,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.703450+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281065+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -77921,7 +77807,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.703490+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281082+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -77959,7 +77845,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.703539+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281103+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -77982,7 +77868,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.703580+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281121+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78006,7 +77892,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.703622+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281138+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78029,7 +77915,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.703670+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281155+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78053,7 +77939,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.703713+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281173+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78186,7 +78072,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.703762+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281193+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78227,7 +78113,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:56.703790+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281207+00:00"
               },
               "deterministic": true
             },
@@ -78239,9 +78125,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.437979+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.010853+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "src_id": {
             "type": "string",
@@ -78259,7 +78144,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.703824+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281221+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78286,7 +78171,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.438005+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.010870+00:00"
           },
           "type": {
             "allOf": [
@@ -78360,7 +78245,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:09:56.703861+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281240+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78386,7 +78271,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.438039+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.010891+00:00"
           },
           "type": {
             "allOf": [
@@ -78568,7 +78453,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.703909+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281259+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78606,7 +78491,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:56.703936+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281272+00:00"
               },
               "deterministic": true
             },
@@ -78618,9 +78503,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.438087+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.010921+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -78694,7 +78578,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.703970+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281288+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78732,7 +78616,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:56.703997+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281303+00:00"
               },
               "deterministic": true
             },
@@ -78744,9 +78628,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.438121+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.010943+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_id": {
             "type": "string",
@@ -78761,7 +78644,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.704031+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281318+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78798,7 +78681,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.704070+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281335+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78822,7 +78705,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.704104+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281350+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78833,7 +78716,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.438159+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.010967+00:00"
           },
           "tags": {
             "type": "object",
@@ -79001,7 +78884,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:56.704166+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281380+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -79034,7 +78917,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.704205+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281396+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -79067,7 +78950,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:56.704243+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281417+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -79100,7 +78983,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.704282+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281434+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -79133,7 +79016,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.704314+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281449+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -79227,7 +79110,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:56.704346+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281465+00:00"
               },
               "deterministic": true
             },
@@ -79239,9 +79122,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.438248+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.011021+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "private_addresses": {
             "type": "array",
@@ -79302,7 +79184,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.704418+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281496+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -79313,7 +79195,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.438286+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.011045+00:00"
           },
           "subnet": {
             "type": "array",
@@ -79584,7 +79466,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.704513+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281536+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -79664,7 +79546,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.704571+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281561+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -79691,7 +79573,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.704596+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281573+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -79729,7 +79611,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:56.704624+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281587+00:00"
               },
               "deterministic": true
             },
@@ -79741,9 +79623,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.438376+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.011100+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "network_type": {
             "allOf": [
@@ -80021,7 +79902,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.704774+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281646+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -80050,7 +79931,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:09:56.704819+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281667+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -80061,7 +79942,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.438463+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.011153+00:00"
           },
           "level": {
             "type": "integer",
@@ -80108,7 +79989,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:56.704856+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281685+00:00"
               },
               "deterministic": true
             },
@@ -80120,9 +80001,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.438487+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.011169+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_id": {
             "type": "string",
@@ -80139,7 +80019,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.704889+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281700+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -80177,7 +80057,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.704925+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281716+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -80188,7 +80068,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.438520+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.011189+00:00"
           },
           "tags": {
             "type": "object",
@@ -81087,7 +80967,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.705077+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281777+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81127,7 +81007,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:56.705102+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281790+00:00"
               },
               "deterministic": true
             },
@@ -81139,9 +81019,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.438696+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.011288+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tags": {
             "type": "object",
@@ -81375,7 +81254,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:09:56.705185+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281826+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81591,7 +81470,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.705279+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281864+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81643,7 +81522,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.705318+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281881+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81694,7 +81573,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.705367+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281903+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81923,7 +81802,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.705468+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281945+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -82205,7 +82084,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.705578+00:00"
+                "validatedAt": "2026-07-20T14:41:18.281990+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -82231,7 +82110,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.705610+00:00"
+                "validatedAt": "2026-07-20T14:41:18.282004+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -82396,7 +82275,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.705689+00:00"
+                "validatedAt": "2026-07-20T14:41:18.282033+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -82435,7 +82314,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:56.705719+00:00"
+                "validatedAt": "2026-07-20T14:41:18.282048+00:00"
               },
               "deterministic": true
             },
@@ -82447,9 +82326,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.439011+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.011473+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -82560,7 +82438,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.705774+00:00"
+                "validatedAt": "2026-07-20T14:41:18.282071+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -82631,7 +82509,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:09:56.705835+00:00"
+                "validatedAt": "2026-07-20T14:41:18.282099+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -82809,7 +82687,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:56.705917+00:00"
+                "validatedAt": "2026-07-20T14:41:18.282131+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -82920,7 +82798,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:09:56.705971+00:00"
+                "validatedAt": "2026-07-20T14:41:18.282155+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83122,7 +83000,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:52.321712+00:00"
+                "validatedAt": "2026-07-20T14:42:01.455636+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83162,7 +83040,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:52.321773+00:00"
+                "validatedAt": "2026-07-20T14:42:01.455666+00:00"
               },
               "deterministic": true
             },
@@ -83174,9 +83052,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:26.315753+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:26.360014+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "network_id": {
             "type": "string",
@@ -83193,7 +83070,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:52.321819+00:00"
+                "validatedAt": "2026-07-20T14:42:01.455684+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83223,7 +83100,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:52.321873+00:00"
+                "validatedAt": "2026-07-20T14:42:01.455701+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83378,7 +83255,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:52.321966+00:00"
+                "validatedAt": "2026-07-20T14:42:01.455728+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83403,7 +83280,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:52.322035+00:00"
+                "validatedAt": "2026-07-20T14:42:01.455747+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83444,7 +83321,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:52.322084+00:00"
+                "validatedAt": "2026-07-20T14:42:01.455763+00:00"
               },
               "deterministic": true
             },
@@ -83456,9 +83333,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:26.315827+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:26.360057+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "sort": {
             "allOf": [
@@ -83493,7 +83369,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:52.322143+00:00"
+                "validatedAt": "2026-07-20T14:42:01.455780+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83650,7 +83526,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:52.322213+00:00"
+                "validatedAt": "2026-07-20T14:42:01.455808+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83690,7 +83566,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:52.322245+00:00"
+                "validatedAt": "2026-07-20T14:42:01.455825+00:00"
               },
               "deterministic": true
             },
@@ -83702,9 +83578,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:26.315888+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:26.360094+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "network_id": {
             "type": "string",
@@ -83721,7 +83596,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:52.322283+00:00"
+                "validatedAt": "2026-07-20T14:42:01.455841+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83751,7 +83626,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:52.322322+00:00"
+                "validatedAt": "2026-07-20T14:42:01.455857+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83906,7 +83781,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:52.322381+00:00"
+                "validatedAt": "2026-07-20T14:42:01.455882+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83946,7 +83821,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:52.322412+00:00"
+                "validatedAt": "2026-07-20T14:42:01.455897+00:00"
               },
               "deterministic": true
             },
@@ -83958,9 +83833,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:26.315949+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:26.360130+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "network_id": {
             "type": "string",
@@ -83977,7 +83851,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:52.322448+00:00"
+                "validatedAt": "2026-07-20T14:42:01.455913+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -84021,7 +83895,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:52.322488+00:00"
+                "validatedAt": "2026-07-20T14:42:01.455930+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -84176,7 +84050,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:52.322547+00:00"
+                "validatedAt": "2026-07-20T14:42:01.455955+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -84216,7 +84090,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:52.322578+00:00"
+                "validatedAt": "2026-07-20T14:42:01.455971+00:00"
               },
               "deterministic": true
             },
@@ -84228,9 +84102,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:26.316015+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:26.360169+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "network_id": {
             "type": "string",
@@ -84248,7 +84121,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:52.322614+00:00"
+                "validatedAt": "2026-07-20T14:42:01.455987+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -84278,7 +84151,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:52.322651+00:00"
+                "validatedAt": "2026-07-20T14:42:01.456002+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -84305,7 +84178,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:52.322695+00:00"
+                "validatedAt": "2026-07-20T14:42:01.456016+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -84428,7 +84301,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:52.322745+00:00"
+                "validatedAt": "2026-07-20T14:42:01.456036+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -84453,7 +84326,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:52.322779+00:00"
+                "validatedAt": "2026-07-20T14:42:01.456051+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -84486,7 +84359,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T13:11:52.322824+00:00"
+                "validatedAt": "2026-07-20T14:42:01.456070+00:00"
               },
               "deterministic": true
             },
@@ -84560,7 +84433,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T13:11:52.322867+00:00"
+                "validatedAt": "2026-07-20T14:42:01.456090+00:00"
               },
               "deterministic": true
             },
@@ -84586,7 +84459,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:52.322900+00:00"
+                "validatedAt": "2026-07-20T14:42:01.456104+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -84597,7 +84470,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:26.316091+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:26.360213+00:00"
           }
         },
         "x-f5xc-description-short": "Each metric value consists of a timestamp and a value. Timestamp in the Metric Value is based on the start_time, end_time and step in the request.",
@@ -84667,7 +84540,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:52.322930+00:00"
+                "validatedAt": "2026-07-20T14:42:01.456119+00:00"
               },
               "deterministic": true
             },
@@ -84679,9 +84552,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:26.316113+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:26.360226+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "values": {
             "type": "array",
@@ -84834,7 +84706,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:52.322968+00:00"
+                "validatedAt": "2026-07-20T14:42:01.456135+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -84858,7 +84730,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:52.322994+00:00"
+                "validatedAt": "2026-07-20T14:42:01.456146+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -84883,7 +84755,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:52.323020+00:00"
+                "validatedAt": "2026-07-20T14:42:01.456157+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -84952,7 +84824,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:52.323057+00:00"
+                "validatedAt": "2026-07-20T14:42:01.456172+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -84992,7 +84864,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:52.323087+00:00"
+                "validatedAt": "2026-07-20T14:42:01.456188+00:00"
               },
               "deterministic": true
             },
@@ -85004,9 +84876,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:26.316176+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:26.360260+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "network_id": {
             "type": "string",
@@ -85023,7 +84894,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:52.323124+00:00"
+                "validatedAt": "2026-07-20T14:42:01.456203+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -85053,7 +84924,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:52.323163+00:00"
+                "validatedAt": "2026-07-20T14:42:01.456219+00:00"
               }
             },
             "x-f5xc-required-for": {

--- a/docs/specifications/api/support.json
+++ b/docs/specifications/api/support.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Support",
     "description": "Case management workflows including submission, commentary, and closure paths. Urgency adjustments and routing for time-sensitive incidents. Tax exemption verification requests. Site-level tcpdump operations—initiation, enumeration, and termination—for low-level network troubleshooting and protocol analysis.",
-    "version": "2.1.182",
+    "version": "2.1.181",
     "contact": {
       "name": "F5 Distributed Cloud",
       "url": "https://docs.cloud.f5.com"
@@ -13142,7 +13142,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:59.305566+00:00"
+                "validatedAt": "2026-07-20T14:36:12.441699+00:00"
               },
               "deterministic": true
             },
@@ -13154,12 +13154,11 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.020851+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:10.588625+00:00",
             "x-f5xc-conflicts-with": [
               "uid"
             ],
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -13191,7 +13190,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:56:59.305603+00:00"
+                "validatedAt": "2026-07-20T14:36:12.441717+00:00"
               },
               "deterministic": true
             },
@@ -13203,9 +13202,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.020873+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.588639+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "site": {
             "type": "string",
@@ -13223,7 +13221,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:59.305643+00:00"
+                "validatedAt": "2026-07-20T14:36:12.441732+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13247,7 +13245,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:59.305681+00:00"
+                "validatedAt": "2026-07-20T14:36:12.441743+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13260,7 +13258,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.020901+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:10.588659+00:00",
             "x-f5xc-conflicts-with": [
               "name"
             ]
@@ -13322,7 +13320,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:56:59.305734+00:00"
+                "validatedAt": "2026-07-20T14:36:12.441757+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13333,7 +13331,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.020924+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.588673+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -13392,7 +13390,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:45.818815+00:00"
+                "validatedAt": "2026-07-20T14:37:19.511487+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13418,7 +13416,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:45.818902+00:00"
+                "validatedAt": "2026-07-20T14:37:19.511513+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13444,7 +13442,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:45.818958+00:00"
+                "validatedAt": "2026-07-20T14:37:19.511527+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13470,7 +13468,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:45.819011+00:00"
+                "validatedAt": "2026-07-20T14:37:19.511541+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13552,7 +13550,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:45.819066+00:00"
+                "validatedAt": "2026-07-20T14:37:19.511559+00:00"
               },
               "deterministic": true
             },
@@ -13564,9 +13562,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.794817+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.289908+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -13598,7 +13595,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:45.819121+00:00"
+                "validatedAt": "2026-07-20T14:37:19.511575+00:00"
               },
               "deterministic": true
             },
@@ -13610,15 +13607,14 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.794838+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:14.289921+00:00",
             "x-ves-validation-rules": {
               "ves.io.schema.rules.string.const": "system"
             },
             "x-validation-rules": {
               "ves.io.schema.rules.string.const": "system"
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Closes an open existing customer support ticket.",
@@ -13744,7 +13740,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:59:45.819187+00:00"
+                "validatedAt": "2026-07-20T14:37:19.511603+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13784,7 +13780,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:45.819214+00:00"
+                "validatedAt": "2026-07-20T14:37:19.511616+00:00"
               },
               "deterministic": true
             },
@@ -13796,9 +13792,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.794880+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.289947+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -13830,7 +13825,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:45.819241+00:00"
+                "validatedAt": "2026-07-20T14:37:19.511631+00:00"
               },
               "deterministic": true
             },
@@ -13842,15 +13837,14 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.794899+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:14.289959+00:00",
             "x-ves-validation-rules": {
               "ves.io.schema.rules.string.const": "system"
             },
             "x-validation-rules": {
               "ves.io.schema.rules.string.const": "system"
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Adds a new comment to an existing customer support ticket.",
@@ -13992,7 +13986,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:45.819315+00:00"
+                "validatedAt": "2026-07-20T14:37:19.511660+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14017,7 +14011,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:45.819355+00:00"
+                "validatedAt": "2026-07-20T14:37:19.511675+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14050,7 +14044,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T12:59:45.819399+00:00"
+                "validatedAt": "2026-07-20T14:37:19.511694+00:00"
               },
               "deterministic": true
             },
@@ -14077,7 +14071,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:45.819430+00:00"
+                "validatedAt": "2026-07-20T14:37:19.511707+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14102,7 +14096,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:45.819468+00:00"
+                "validatedAt": "2026-07-20T14:37:19.511722+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14128,7 +14122,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:10.139435+00:00"
+                "validatedAt": "2026-07-20T14:37:29.045252+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14355,7 +14349,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:45.819516+00:00"
+                "validatedAt": "2026-07-20T14:37:19.511742+00:00"
               },
               "deterministic": true
             },
@@ -14367,9 +14361,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.795010+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.290025+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -14401,7 +14394,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:45.819543+00:00"
+                "validatedAt": "2026-07-20T14:37:19.511755+00:00"
               },
               "deterministic": true
             },
@@ -14413,15 +14406,14 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.795028+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:14.290038+00:00",
             "x-ves-validation-rules": {
               "ves.io.schema.rules.string.const": "system"
             },
             "x-validation-rules": {
               "ves.io.schema.rules.string.const": "system"
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Changes priority of an existing customer support ticket.",
@@ -14620,7 +14612,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.795097+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.290080+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -14714,7 +14706,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:59:45.819670+00:00"
+                "validatedAt": "2026-07-20T14:37:19.511804+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14793,7 +14785,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:59:45.819725+00:00"
+                "validatedAt": "2026-07-20T14:37:19.511828+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14804,7 +14796,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.795147+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.290110+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -14891,7 +14883,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:45.819765+00:00"
+                "validatedAt": "2026-07-20T14:37:19.511846+00:00"
               },
               "deterministic": true
             },
@@ -14903,9 +14895,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.795192+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.290138+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -14936,7 +14927,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:45.819792+00:00"
+                "validatedAt": "2026-07-20T14:37:19.511859+00:00"
               },
               "deterministic": true
             },
@@ -14948,9 +14939,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.795211+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.290151+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -15019,7 +15009,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:45.819845+00:00"
+                "validatedAt": "2026-07-20T14:37:19.511880+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15031,7 +15021,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.795249+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.290174+00:00"
           },
           "uid": {
             "type": "string",
@@ -15049,7 +15039,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:45.819870+00:00"
+                "validatedAt": "2026-07-20T14:37:19.511891+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15062,7 +15052,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.795269+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.290187+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of customer_support is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -15149,7 +15139,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:45.819925+00:00"
+                "validatedAt": "2026-07-20T14:37:19.511918+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15194,7 +15184,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:45.819968+00:00"
+                "validatedAt": "2026-07-20T14:37:19.511940+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15206,7 +15196,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.795297+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.290204+00:00"
           }
         },
         "x-f5xc-description-short": "Input message of the 'ListCTSupportTickets' RPC. Fields can be used to control scope and filtering of collection.",
@@ -15282,7 +15272,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:59:45.820011+00:00"
+                "validatedAt": "2026-07-20T14:37:19.511959+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15360,7 +15350,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:45.820041+00:00"
+                "validatedAt": "2026-07-20T14:37:19.511973+00:00"
               },
               "deterministic": true
             },
@@ -15372,9 +15362,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.795331+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.290226+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -15406,7 +15395,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:45.820067+00:00"
+                "validatedAt": "2026-07-20T14:37:19.511987+00:00"
               },
               "deterministic": true
             },
@@ -15418,15 +15407,14 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.795350+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:14.290238+00:00",
             "x-ves-validation-rules": {
               "ves.io.schema.rules.string.const": "system"
             },
             "x-validation-rules": {
               "ves.io.schema.rules.string.const": "system"
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "priority": {
             "allOf": [
@@ -15564,7 +15552,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:45.820131+00:00"
+                "validatedAt": "2026-07-20T14:37:19.512012+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15654,7 +15642,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:45.820163+00:00"
+                "validatedAt": "2026-07-20T14:37:19.512027+00:00"
               },
               "deterministic": true
             },
@@ -15666,9 +15654,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.795406+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.290273+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Any error that may occurred during tax status verification request.",
@@ -15739,7 +15726,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:45.820191+00:00"
+                "validatedAt": "2026-07-20T14:37:19.512041+00:00"
               },
               "deterministic": true
             },
@@ -15751,9 +15738,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.795426+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.290285+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -15785,7 +15771,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:45.820218+00:00"
+                "validatedAt": "2026-07-20T14:37:19.512054+00:00"
               },
               "deterministic": true
             },
@@ -15797,15 +15783,14 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.795444+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:14.290297+00:00",
             "x-ves-validation-rules": {
               "ves.io.schema.rules.string.const": "system"
             },
             "x-validation-rules": {
               "ves.io.schema.rules.string.const": "system"
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Reopens a closed existing customer support ticket.",
@@ -16292,7 +16277,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:45.820289+00:00"
+                "validatedAt": "2026-07-20T14:37:19.512083+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16315,7 +16300,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:45.820322+00:00"
+                "validatedAt": "2026-07-20T14:37:19.512097+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16326,7 +16311,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.795505+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.290333+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -16388,7 +16373,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T12:59:45.820358+00:00"
+                "validatedAt": "2026-07-20T14:37:19.512112+00:00"
               },
               "deterministic": true
             },
@@ -16399,8 +16384,7 @@
               "read": false
             },
             "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "minLength": 1,
-            "format": "fqdn"
+            "minLength": 1
           },
           "last_update_time": {
             "type": "string",
@@ -16417,7 +16401,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:45.820398+00:00"
+                "validatedAt": "2026-07-20T14:37:19.512128+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16444,7 +16428,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:45.820433+00:00"
+                "validatedAt": "2026-07-20T14:37:19.512152+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16455,7 +16439,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.795539+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.290355+00:00"
           },
           "service_name": {
             "type": "string",
@@ -16472,7 +16456,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:45.820471+00:00"
+                "validatedAt": "2026-07-20T14:37:19.512167+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16505,7 +16489,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:45.820512+00:00"
+                "validatedAt": "2026-07-20T14:37:19.512184+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16516,7 +16500,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.795564+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.290371+00:00"
           },
           "type": {
             "type": "string",
@@ -16541,7 +16525,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:45.820546+00:00"
+                "validatedAt": "2026-07-20T14:37:19.512197+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16635,7 +16619,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:45.820587+00:00"
+                "validatedAt": "2026-07-20T14:37:19.512213+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16713,7 +16697,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:45.820617+00:00"
+                "validatedAt": "2026-07-20T14:37:19.512227+00:00"
               },
               "deterministic": true
             },
@@ -16725,9 +16709,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.795612+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.290401+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -16887,7 +16870,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:45.820722+00:00"
+                "validatedAt": "2026-07-20T14:37:19.512270+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -16902,7 +16885,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.795663+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.290428+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -16972,7 +16955,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:45.820763+00:00"
+                "validatedAt": "2026-07-20T14:37:19.512287+00:00"
               },
               "deterministic": true
             },
@@ -16984,9 +16967,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.795698+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.290449+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -17019,7 +17001,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:45.820790+00:00"
+                "validatedAt": "2026-07-20T14:37:19.512301+00:00"
               },
               "deterministic": true
             },
@@ -17031,9 +17013,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.795716+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.290461+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -17131,7 +17112,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:45.820863+00:00"
+                "validatedAt": "2026-07-20T14:37:19.512335+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -17146,7 +17127,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.795745+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.290479+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -17218,7 +17199,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:45.820900+00:00"
+                "validatedAt": "2026-07-20T14:37:19.512353+00:00"
               },
               "deterministic": true
             },
@@ -17230,9 +17211,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.795778+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.290501+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -17265,7 +17245,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:45.820925+00:00"
+                "validatedAt": "2026-07-20T14:37:19.512365+00:00"
               },
               "deterministic": true
             },
@@ -17277,9 +17257,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.795797+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.290514+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -17340,7 +17319,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:45.820957+00:00"
+                "validatedAt": "2026-07-20T14:37:19.512378+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17352,7 +17331,7 @@
             "readOnly": true,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.795818+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.290527+00:00"
           },
           "name": {
             "type": "string",
@@ -17385,7 +17364,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:45.820983+00:00"
+                "validatedAt": "2026-07-20T14:37:19.512391+00:00"
               },
               "deterministic": true
             },
@@ -17397,9 +17376,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.795836+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.290539+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -17432,7 +17410,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:45.821010+00:00"
+                "validatedAt": "2026-07-20T14:37:19.512404+00:00"
               },
               "deterministic": true
             },
@@ -17444,9 +17422,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.795855+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.290551+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -17465,7 +17442,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:45.821042+00:00"
+                "validatedAt": "2026-07-20T14:37:19.512523+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17478,7 +17455,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.795873+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.290564+00:00"
           },
           "uid": {
             "type": "string",
@@ -17497,7 +17474,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:45.821067+00:00"
+                "validatedAt": "2026-07-20T14:37:19.512556+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17511,7 +17488,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.795892+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.290576+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -17572,7 +17549,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:45.821110+00:00"
+                "validatedAt": "2026-07-20T14:37:19.512594+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17600,7 +17577,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:45.821151+00:00"
+                "validatedAt": "2026-07-20T14:37:19.512629+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17628,7 +17605,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:45.821189+00:00"
+                "validatedAt": "2026-07-20T14:37:19.512658+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17667,7 +17644,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:45.821229+00:00"
+                "validatedAt": "2026-07-20T14:37:19.512689+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17694,7 +17671,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:45.821255+00:00"
+                "validatedAt": "2026-07-20T14:37:19.512714+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17707,7 +17684,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.795946+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.290610+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -17723,7 +17700,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:45.821289+00:00"
+                "validatedAt": "2026-07-20T14:37:19.512743+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17864,7 +17841,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:45.821339+00:00"
+                "validatedAt": "2026-07-20T14:37:19.512785+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17875,7 +17852,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.795987+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.290634+00:00"
           },
           "status": {
             "type": "string",
@@ -17893,7 +17870,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:45.821373+00:00"
+                "validatedAt": "2026-07-20T14:37:19.512811+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17904,7 +17881,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.796006+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.290647+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -17962,7 +17939,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:45.821416+00:00"
+                "validatedAt": "2026-07-20T14:37:19.512849+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17989,7 +17966,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:45.821456+00:00"
+                "validatedAt": "2026-07-20T14:37:19.512885+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18016,7 +17993,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:45.821494+00:00"
+                "validatedAt": "2026-07-20T14:37:19.512913+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18044,7 +18021,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:45.821536+00:00"
+                "validatedAt": "2026-07-20T14:37:19.512945+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18120,7 +18097,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:45.821599+00:00"
+                "validatedAt": "2026-07-20T14:37:19.512995+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18188,7 +18165,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:45.821650+00:00"
+                "validatedAt": "2026-07-20T14:37:19.513035+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18200,7 +18177,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.796098+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.290700+00:00"
           },
           "uid": {
             "type": "string",
@@ -18219,7 +18196,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:45.821684+00:00"
+                "validatedAt": "2026-07-20T14:37:19.513056+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18232,7 +18209,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.796119+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.290712+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -18298,7 +18275,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:45.821716+00:00"
+                "validatedAt": "2026-07-20T14:37:19.513081+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18309,7 +18286,7 @@
             },
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.796139+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.290725+00:00"
           },
           "name": {
             "type": "string",
@@ -18342,7 +18319,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:45.821742+00:00"
+                "validatedAt": "2026-07-20T14:37:19.513144+00:00"
               },
               "deterministic": true
             },
@@ -18354,9 +18331,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.796157+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.290737+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -18389,7 +18365,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:45.821768+00:00"
+                "validatedAt": "2026-07-20T14:37:19.513203+00:00"
               },
               "deterministic": true
             },
@@ -18401,9 +18377,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.796176+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.290749+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "uid": {
             "type": "string",
@@ -18420,7 +18395,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:45.821793+00:00"
+                "validatedAt": "2026-07-20T14:37:19.513219+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18433,7 +18408,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.796196+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.290761+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -18493,7 +18468,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:45.821829+00:00"
+                "validatedAt": "2026-07-20T14:37:19.513236+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18539,7 +18514,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:59:45.821888+00:00"
+                "validatedAt": "2026-07-20T14:37:19.513266+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18550,7 +18525,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.796229+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.290782+00:00"
           },
           "ongoing": {
             "type": "boolean",
@@ -18594,7 +18569,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:45.821934+00:00"
+                "validatedAt": "2026-07-20T14:37:19.513285+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18648,7 +18623,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.796280+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.290813+00:00"
           },
           "subject": {
             "type": "string",
@@ -18664,7 +18639,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:45.821987+00:00"
+                "validatedAt": "2026-07-20T14:37:19.513306+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18689,7 +18664,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:45.822022+00:00"
+                "validatedAt": "2026-07-20T14:37:19.513321+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18727,7 +18702,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:45.822058+00:00"
+                "validatedAt": "2026-07-20T14:37:19.513336+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18865,7 +18840,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:45.822104+00:00"
+                "validatedAt": "2026-07-20T14:37:19.513355+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18893,7 +18868,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:45.822139+00:00"
+                "validatedAt": "2026-07-20T14:37:19.513369+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18942,7 +18917,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T12:59:45.822197+00:00"
+                "validatedAt": "2026-07-20T14:37:19.513394+00:00"
               },
               "deterministic": true
             },
@@ -18991,7 +18966,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:59:45.822254+00:00"
+                "validatedAt": "2026-07-20T14:37:19.513418+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19002,7 +18977,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.796366+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.290865+00:00"
           },
           "escalated": {
             "type": "boolean",
@@ -19076,7 +19051,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:45.822313+00:00"
+                "validatedAt": "2026-07-20T14:37:19.513442+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19130,7 +19105,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.796430+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.290903+00:00"
           },
           "subject": {
             "type": "string",
@@ -19146,7 +19121,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:45.822365+00:00"
+                "validatedAt": "2026-07-20T14:37:19.513463+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19175,7 +19150,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T12:59:45.822392+00:00"
+                "validatedAt": "2026-07-20T14:37:19.513476+00:00"
               },
               "deterministic": true
             },
@@ -19201,7 +19176,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:45.822425+00:00"
+                "validatedAt": "2026-07-20T14:37:19.513491+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19239,7 +19214,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:45.822461+00:00"
+                "validatedAt": "2026-07-20T14:37:19.513505+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19279,7 +19254,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:45.822500+00:00"
+                "validatedAt": "2026-07-20T14:37:19.513522+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19388,7 +19363,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:10.138753+00:00"
+                "validatedAt": "2026-07-20T14:37:29.044987+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19413,7 +19388,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:10.138808+00:00"
+                "validatedAt": "2026-07-20T14:37:29.045010+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19493,7 +19468,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.568064+00:00"
+                "validatedAt": "2026-07-20T14:37:41.714198+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19546,7 +19521,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.568102+00:00"
+                "validatedAt": "2026-07-20T14:37:41.714214+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19571,7 +19546,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.568133+00:00"
+                "validatedAt": "2026-07-20T14:37:41.714227+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19602,7 +19577,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.568169+00:00"
+                "validatedAt": "2026-07-20T14:37:41.714245+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19669,7 +19644,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.568216+00:00"
+                "validatedAt": "2026-07-20T14:37:41.714264+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19709,7 +19684,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.568261+00:00"
+                "validatedAt": "2026-07-20T14:37:41.714281+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19735,7 +19710,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.568297+00:00"
+                "validatedAt": "2026-07-20T14:37:41.714295+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19881,7 +19856,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.568351+00:00"
+                "validatedAt": "2026-07-20T14:37:41.714317+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19959,7 +19934,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.568407+00:00"
+                "validatedAt": "2026-07-20T14:37:41.714340+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19999,7 +19974,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:41.568440+00:00"
+                "validatedAt": "2026-07-20T14:37:41.714356+00:00"
               },
               "deterministic": true
             },
@@ -20011,9 +19986,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.879848+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.419656+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "node": {
             "type": "string",
@@ -20030,7 +20004,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.568471+00:00"
+                "validatedAt": "2026-07-20T14:37:41.714369+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20055,7 +20029,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.568502+00:00"
+                "validatedAt": "2026-07-20T14:37:41.714381+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20121,7 +20095,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.568537+00:00"
+                "validatedAt": "2026-07-20T14:37:41.714395+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20202,7 +20176,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T13:00:41.568587+00:00"
+                "validatedAt": "2026-07-20T14:37:41.714418+00:00"
               },
               "deterministic": true
             },
@@ -20213,8 +20187,7 @@
               "read": false
             },
             "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "minLength": 1,
-            "format": "fqdn"
+            "minLength": 1
           },
           "hostname": {
             "type": "string",
@@ -20236,7 +20209,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T13:00:41.568618+00:00"
+                "validatedAt": "2026-07-20T14:37:41.714433+00:00"
               },
               "deterministic": true
             },
@@ -20247,8 +20220,7 @@
               "read": false
             },
             "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "minLength": 1,
-            "format": "fqdn"
+            "minLength": 1
           },
           "initial_password_changed": {
             "type": "boolean",
@@ -20303,7 +20275,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.568677+00:00"
+                "validatedAt": "2026-07-20T14:37:41.714453+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20327,7 +20299,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.568717+00:00"
+                "validatedAt": "2026-07-20T14:37:41.714469+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20365,7 +20337,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.568769+00:00"
+                "validatedAt": "2026-07-20T14:37:41.714491+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20403,7 +20375,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.568808+00:00"
+                "validatedAt": "2026-07-20T14:37:41.714508+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20414,7 +20386,7 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.879965+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.419727+00:00"
           },
           "wifi_support": {
             "type": "boolean",
@@ -20460,7 +20432,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:03.231162+00:00"
+                "validatedAt": "2026-07-20T14:37:50.878391+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20534,7 +20506,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:00:41.568849+00:00"
+                "validatedAt": "2026-07-20T14:37:41.714527+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20560,7 +20532,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.568880+00:00"
+                "validatedAt": "2026-07-20T14:37:41.714540+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20588,7 +20560,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T13:00:41.568910+00:00"
+                "validatedAt": "2026-07-20T14:37:41.714554+00:00"
               },
               "deterministic": true
             },
@@ -20644,7 +20616,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:41.568950+00:00"
+                "validatedAt": "2026-07-20T14:37:41.714573+00:00"
               },
               "deterministic": true
             },
@@ -20656,9 +20628,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.880019+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.419761+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "node": {
             "type": "string",
@@ -20675,7 +20646,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.568982+00:00"
+                "validatedAt": "2026-07-20T14:37:41.714586+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20700,7 +20671,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.569013+00:00"
+                "validatedAt": "2026-07-20T14:37:41.714599+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20767,7 +20738,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.569050+00:00"
+                "validatedAt": "2026-07-20T14:37:41.714614+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20793,7 +20764,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.569086+00:00"
+                "validatedAt": "2026-07-20T14:37:41.714629+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20833,7 +20804,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.569131+00:00"
+                "validatedAt": "2026-07-20T14:37:41.714647+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20858,7 +20829,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.569165+00:00"
+                "validatedAt": "2026-07-20T14:37:41.714661+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20915,7 +20886,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.569233+00:00"
+                "validatedAt": "2026-07-20T14:37:41.714687+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21033,7 +21004,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.569276+00:00"
+                "validatedAt": "2026-07-20T14:37:41.714703+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21109,7 +21080,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:41.569310+00:00"
+                "validatedAt": "2026-07-20T14:37:41.714720+00:00"
               },
               "deterministic": true
             },
@@ -21121,9 +21092,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.880122+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.419822+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "node": {
             "type": "string",
@@ -21140,7 +21110,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.569340+00:00"
+                "validatedAt": "2026-07-20T14:37:41.714733+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21165,7 +21135,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.569371+00:00"
+                "validatedAt": "2026-07-20T14:37:41.714745+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21275,7 +21245,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:41.569401+00:00"
+                "validatedAt": "2026-07-20T14:37:41.714759+00:00"
               },
               "deterministic": true
             },
@@ -21287,9 +21257,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.880156+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.419844+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "node": {
             "type": "string",
@@ -21306,7 +21275,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.569430+00:00"
+                "validatedAt": "2026-07-20T14:37:41.714772+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21331,7 +21300,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.569463+00:00"
+                "validatedAt": "2026-07-20T14:37:41.714785+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21342,7 +21311,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.880181+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.419860+00:00"
           }
         },
         "x-f5xc-description-short": "Name and formal displayed name of the service.",
@@ -21413,7 +21382,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:41.569493+00:00"
+                "validatedAt": "2026-07-20T14:37:41.714800+00:00"
               },
               "deterministic": true
             },
@@ -21425,9 +21394,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.880201+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.419873+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "node": {
             "type": "string",
@@ -21444,7 +21412,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.569523+00:00"
+                "validatedAt": "2026-07-20T14:37:41.714812+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21469,7 +21437,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.569558+00:00"
+                "validatedAt": "2026-07-20T14:37:41.714827+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21494,7 +21462,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.569589+00:00"
+                "validatedAt": "2026-07-20T14:37:41.714839+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21591,7 +21559,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.569625+00:00"
+                "validatedAt": "2026-07-20T14:37:41.714854+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21630,7 +21598,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:41.569659+00:00"
+                "validatedAt": "2026-07-20T14:37:41.714894+00:00"
               },
               "deterministic": true
             },
@@ -21642,9 +21610,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.880249+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.419902+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "node": {
             "type": "string",
@@ -21661,7 +21628,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.569691+00:00"
+                "validatedAt": "2026-07-20T14:37:41.714964+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21686,7 +21653,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.569725+00:00"
+                "validatedAt": "2026-07-20T14:37:41.715125+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21697,7 +21664,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.880273+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.419918+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -21756,7 +21723,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.880295+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.419932+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -21855,7 +21822,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.569857+00:00"
+                "validatedAt": "2026-07-20T14:37:41.715502+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21896,7 +21863,7 @@
                 "confidence": 1.0,
                 "category": "content",
                 "note": "Blindfold envelope encryption (AES-256-GCM + RSA-OAEP) of an RSA-2048 TLS private key produces ~3700 char string:/// URL. 128KB max secret size = ~175KB base64. Discovery reported 1024 which is incorrect.",
-                "validatedAt": "2026-07-20T13:00:41.569903+00:00"
+                "validatedAt": "2026-07-20T14:37:41.715565+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21907,7 +21874,7 @@
             },
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.880352+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.419968+00:00"
           },
           "store_provider": {
             "type": "string",
@@ -21926,7 +21893,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.569950+00:00"
+                "validatedAt": "2026-07-20T14:37:41.715638+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21994,7 +21961,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.569986+00:00"
+                "validatedAt": "2026-07-20T14:37:41.715703+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22005,7 +21972,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.880379+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.419985+00:00"
           },
           "url": {
             "type": "string",
@@ -22043,7 +22010,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:41.570049+00:00"
+                "validatedAt": "2026-07-20T14:37:41.715823+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -22227,7 +22194,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T13:00:41.570095+00:00"
+                "validatedAt": "2026-07-20T14:37:41.715847+00:00"
               },
               "deterministic": true
             },
@@ -22254,7 +22221,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.570129+00:00"
+                "validatedAt": "2026-07-20T14:37:41.715862+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22280,7 +22247,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.570163+00:00"
+                "validatedAt": "2026-07-20T14:37:41.715876+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22291,7 +22258,7 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.880434+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.420018+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -22347,7 +22314,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.570202+00:00"
+                "validatedAt": "2026-07-20T14:37:41.715892+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22387,7 +22354,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:41.570231+00:00"
+                "validatedAt": "2026-07-20T14:37:41.715907+00:00"
               },
               "deterministic": true
             },
@@ -22399,9 +22366,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.880461+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.420035+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "serial": {
             "type": "string",
@@ -22419,7 +22385,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.570264+00:00"
+                "validatedAt": "2026-07-20T14:37:41.715921+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22445,7 +22411,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.570297+00:00"
+                "validatedAt": "2026-07-20T14:37:41.715935+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22471,7 +22437,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.570333+00:00"
+                "validatedAt": "2026-07-20T14:37:41.715948+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22482,7 +22448,7 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.880493+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.420054+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -22540,7 +22506,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.570371+00:00"
+                "validatedAt": "2026-07-20T14:37:41.715964+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22566,7 +22532,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.570405+00:00"
+                "validatedAt": "2026-07-20T14:37:41.715977+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22608,7 +22574,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.570450+00:00"
+                "validatedAt": "2026-07-20T14:37:41.715995+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22634,7 +22600,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.570485+00:00"
+                "validatedAt": "2026-07-20T14:37:41.716011+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22645,7 +22611,7 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.880539+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.420083+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -22747,7 +22713,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.570549+00:00"
+                "validatedAt": "2026-07-20T14:37:41.716054+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22802,7 +22768,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.570604+00:00"
+                "validatedAt": "2026-07-20T14:37:41.716102+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22869,7 +22835,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.570645+00:00"
+                "validatedAt": "2026-07-20T14:37:41.716121+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22894,7 +22860,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.570695+00:00"
+                "validatedAt": "2026-07-20T14:37:41.716138+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22973,7 +22939,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.570735+00:00"
+                "validatedAt": "2026-07-20T14:37:41.716155+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22998,7 +22964,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.570772+00:00"
+                "validatedAt": "2026-07-20T14:37:41.716171+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23023,7 +22989,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.570811+00:00"
+                "validatedAt": "2026-07-20T14:37:41.716187+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23086,7 +23052,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.570851+00:00"
+                "validatedAt": "2026-07-20T14:37:41.716204+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23111,7 +23077,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.570886+00:00"
+                "validatedAt": "2026-07-20T14:37:41.716219+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23136,7 +23102,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.570921+00:00"
+                "validatedAt": "2026-07-20T14:37:41.716233+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23147,7 +23113,7 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.880670+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.420157+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -23317,7 +23283,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.570976+00:00"
+                "validatedAt": "2026-07-20T14:37:41.716254+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23380,7 +23346,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.571012+00:00"
+                "validatedAt": "2026-07-20T14:37:41.716279+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23453,7 +23419,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T13:00:41.571069+00:00"
+                "validatedAt": "2026-07-20T14:37:41.716319+00:00"
               },
               "deterministic": true
             },
@@ -23493,7 +23459,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:41.571097+00:00"
+                "validatedAt": "2026-07-20T14:37:41.716336+00:00"
               },
               "deterministic": true
             },
@@ -23505,9 +23471,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.880745+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.420202+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "port": {
             "type": "string",
@@ -23526,7 +23491,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.571126+00:00"
+                "validatedAt": "2026-07-20T14:37:41.716349+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23609,7 +23574,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.571177+00:00"
+                "validatedAt": "2026-07-20T14:37:41.716371+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23648,7 +23613,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:41.571204+00:00"
+                "validatedAt": "2026-07-20T14:37:41.716385+00:00"
               },
               "deterministic": true
             },
@@ -23660,9 +23625,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.880785+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.420227+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "release": {
             "type": "string",
@@ -23679,7 +23643,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.571237+00:00"
+                "validatedAt": "2026-07-20T14:37:41.716400+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23704,7 +23668,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.571270+00:00"
+                "validatedAt": "2026-07-20T14:37:41.716414+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23729,7 +23693,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.571304+00:00"
+                "validatedAt": "2026-07-20T14:37:41.716428+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23740,7 +23704,7 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.880815+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.420246+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -23891,7 +23855,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:00:41.571360+00:00"
+                "validatedAt": "2026-07-20T14:37:41.716491+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23924,7 +23888,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:41.571408+00:00"
+                "validatedAt": "2026-07-20T14:37:41.716521+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24068,7 +24032,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:41.571467+00:00"
+                "validatedAt": "2026-07-20T14:37:41.716552+00:00"
               },
               "deterministic": true
             },
@@ -24080,9 +24044,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.880917+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.420309+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "serial": {
             "type": "string",
@@ -24101,7 +24064,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.571500+00:00"
+                "validatedAt": "2026-07-20T14:37:41.716568+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24126,7 +24089,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.571533+00:00"
+                "validatedAt": "2026-07-20T14:37:41.716582+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24152,7 +24115,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.571566+00:00"
+                "validatedAt": "2026-07-20T14:37:41.716606+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24163,7 +24126,7 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.880948+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.420329+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -24219,7 +24182,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.571601+00:00"
+                "validatedAt": "2026-07-20T14:37:41.716622+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24244,7 +24207,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.571634+00:00"
+                "validatedAt": "2026-07-20T14:37:41.716637+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24283,7 +24246,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:41.571669+00:00"
+                "validatedAt": "2026-07-20T14:37:41.716685+00:00"
               },
               "deterministic": true
             },
@@ -24295,9 +24258,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.880980+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.420349+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "serial": {
             "type": "string",
@@ -24314,7 +24276,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.571702+00:00"
+                "validatedAt": "2026-07-20T14:37:41.716732+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24354,7 +24316,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.571749+00:00"
+                "validatedAt": "2026-07-20T14:37:41.716774+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24436,7 +24398,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.571801+00:00"
+                "validatedAt": "2026-07-20T14:37:41.716817+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24462,7 +24424,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.571843+00:00"
+                "validatedAt": "2026-07-20T14:37:41.716848+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24488,7 +24450,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.571885+00:00"
+                "validatedAt": "2026-07-20T14:37:41.716879+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24528,7 +24490,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.571936+00:00"
+                "validatedAt": "2026-07-20T14:37:41.716918+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24553,7 +24515,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.571971+00:00"
+                "validatedAt": "2026-07-20T14:37:41.716944+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24598,7 +24560,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:00:41.572026+00:00"
+                "validatedAt": "2026-07-20T14:37:41.716993+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24609,7 +24571,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.881069+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.420404+00:00"
           },
           "i_manufacturer": {
             "type": "string",
@@ -24626,7 +24588,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.572065+00:00"
+                "validatedAt": "2026-07-20T14:37:41.717023+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24651,7 +24613,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.572102+00:00"
+                "validatedAt": "2026-07-20T14:37:41.717051+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24677,7 +24639,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.572136+00:00"
+                "validatedAt": "2026-07-20T14:37:41.717080+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24703,7 +24665,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.572174+00:00"
+                "validatedAt": "2026-07-20T14:37:41.717110+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24728,7 +24690,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.572209+00:00"
+                "validatedAt": "2026-07-20T14:37:41.717139+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24758,7 +24720,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:41.572237+00:00"
+                "validatedAt": "2026-07-20T14:37:41.717166+00:00"
               },
               "deterministic": true
             },
@@ -24785,7 +24747,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.572278+00:00"
+                "validatedAt": "2026-07-20T14:37:41.717202+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24811,7 +24773,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.572309+00:00"
+                "validatedAt": "2026-07-20T14:37:41.717228+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24850,7 +24812,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:41.572350+00:00"
+                "validatedAt": "2026-07-20T14:37:41.717281+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24969,7 +24931,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:43.221951+00:00"
+                "validatedAt": "2026-07-20T14:37:42.438601+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24980,7 +24942,7 @@
             },
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.918099+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.445164+00:00"
           },
           "value": {
             "type": "string",
@@ -24995,7 +24957,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:43.222007+00:00"
+                "validatedAt": "2026-07-20T14:37:42.438624+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25006,7 +24968,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.918122+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.445179+00:00"
           }
         },
         "x-f5xc-description-short": "DHCP Option information as a (key, value) pair.",
@@ -25061,7 +25023,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:43.222051+00:00"
+                "validatedAt": "2026-07-20T14:37:42.438642+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25089,7 +25051,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:00:43.222106+00:00"
+                "validatedAt": "2026-07-20T14:37:42.438666+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25100,7 +25062,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:14.918151+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.445197+00:00"
           },
           "expiry": {
             "type": "string",
@@ -25117,7 +25079,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:43.222161+00:00"
+                "validatedAt": "2026-07-20T14:37:42.438681+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25147,7 +25109,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T13:00:43.222214+00:00"
+                "validatedAt": "2026-07-20T14:37:42.438698+00:00"
               },
               "deterministic": true
             },
@@ -25158,8 +25120,7 @@
               "read": false
             },
             "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "minLength": 1,
-            "format": "fqdn"
+            "minLength": 1
           },
           "interface": {
             "type": "string",
@@ -25175,7 +25136,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:43.222266+00:00"
+                "validatedAt": "2026-07-20T14:37:42.438713+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25200,7 +25161,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:43.222291+00:00"
+                "validatedAt": "2026-07-20T14:37:42.438724+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25225,7 +25186,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:43.222330+00:00"
+                "validatedAt": "2026-07-20T14:37:42.438740+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25250,7 +25211,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:43.222357+00:00"
+                "validatedAt": "2026-07-20T14:37:42.438752+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25289,7 +25250,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:43.222407+00:00"
+                "validatedAt": "2026-07-20T14:37:42.438774+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25455,7 +25416,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:43.222502+00:00"
+                "validatedAt": "2026-07-20T14:37:42.438812+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25479,7 +25440,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:43.222536+00:00"
+                "validatedAt": "2026-07-20T14:37:42.438828+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25599,7 +25560,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:03.230335+00:00"
+                "validatedAt": "2026-07-20T14:37:50.878044+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25714,7 +25675,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:58.156356+00:00"
+                "validatedAt": "2026-07-20T14:38:59.264241+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25739,7 +25700,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:58.156438+00:00"
+                "validatedAt": "2026-07-20T14:38:59.264265+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25863,7 +25824,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:58.156495+00:00"
+                "validatedAt": "2026-07-20T14:38:59.264286+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25888,7 +25849,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:58.156532+00:00"
+                "validatedAt": "2026-07-20T14:38:59.264300+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25913,7 +25874,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:58.156558+00:00"
+                "validatedAt": "2026-07-20T14:38:59.264310+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25960,7 +25921,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:58.156600+00:00"
+                "validatedAt": "2026-07-20T14:38:59.264330+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26040,7 +26001,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:58.156637+00:00"
+                "validatedAt": "2026-07-20T14:38:59.264346+00:00"
               },
               "deterministic": true
             },
@@ -26052,9 +26013,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.921578+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.715934+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "node": {
             "type": "string",
@@ -26071,7 +26031,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:58.156680+00:00"
+                "validatedAt": "2026-07-20T14:38:59.264359+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26096,7 +26056,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:58.156712+00:00"
+                "validatedAt": "2026-07-20T14:38:59.264371+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26320,7 +26280,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:58.156757+00:00"
+                "validatedAt": "2026-07-20T14:38:59.264391+00:00"
               },
               "deterministic": true
             },
@@ -26332,9 +26292,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.921635+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.715970+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "node": {
             "type": "string",
@@ -26351,7 +26310,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:58.156787+00:00"
+                "validatedAt": "2026-07-20T14:38:59.264404+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26376,7 +26335,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:58.156817+00:00"
+                "validatedAt": "2026-07-20T14:38:59.264416+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26613,7 +26572,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:58.156891+00:00"
+                "validatedAt": "2026-07-20T14:38:59.264443+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26639,7 +26598,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:58.156923+00:00"
+                "validatedAt": "2026-07-20T14:38:59.264457+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26663,7 +26622,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:58.156954+00:00"
+                "validatedAt": "2026-07-20T14:38:59.264469+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26752,7 +26711,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:05:52.838198+00:00"
+                "validatedAt": "2026-07-20T14:39:43.478902+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26801,7 +26760,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T13:05:52.838241+00:00"
+                "validatedAt": "2026-07-20T14:39:43.478925+00:00"
               },
               "deterministic": true
             },
@@ -26855,7 +26814,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:52.838283+00:00"
+                "validatedAt": "2026-07-20T14:39:43.478945+00:00"
               },
               "deterministic": true
             },
@@ -26867,9 +26826,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.727050+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.447960+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "node": {
             "type": "string",
@@ -26901,7 +26859,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:52.838365+00:00"
+                "validatedAt": "2026-07-20T14:39:43.478979+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26950,7 +26908,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:52.838433+00:00"
+                "validatedAt": "2026-07-20T14:39:43.479001+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27019,7 +26977,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:52.838491+00:00"
+                "validatedAt": "2026-07-20T14:39:43.479019+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27044,7 +27002,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:52.838541+00:00"
+                "validatedAt": "2026-07-20T14:39:43.479032+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27084,7 +27042,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:52.838612+00:00"
+                "validatedAt": "2026-07-20T14:39:43.479051+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27109,7 +27067,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:52.838647+00:00"
+                "validatedAt": "2026-07-20T14:39:43.479066+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27164,7 +27122,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:52.838723+00:00"
+                "validatedAt": "2026-07-20T14:39:43.479092+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27280,7 +27238,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:52.838786+00:00"
+                "validatedAt": "2026-07-20T14:39:43.479124+00:00"
               },
               "deterministic": true
             },
@@ -27294,8 +27252,7 @@
               "ip"
             ],
             "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "minLength": 1,
-            "format": "hostname"
+            "minLength": 1
           },
           "ip": {
             "type": "string",
@@ -27321,7 +27278,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:52.838831+00:00"
+                "validatedAt": "2026-07-20T14:39:43.479149+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27416,7 +27373,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:52.838892+00:00"
+                "validatedAt": "2026-07-20T14:39:43.479179+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27541,7 +27498,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:27.807965+00:00"
+                "validatedAt": "2026-07-20T14:41:07.342453+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27583,7 +27540,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:27.808015+00:00"
+                "validatedAt": "2026-07-20T14:41:07.342478+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27625,7 +27582,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:27.808061+00:00"
+                "validatedAt": "2026-07-20T14:41:07.342502+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27792,7 +27749,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:27.808108+00:00"
+                "validatedAt": "2026-07-20T14:41:07.342523+00:00"
               },
               "deterministic": true
             },
@@ -27804,9 +27761,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.973523+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:23.468621+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "node": {
             "type": "string",
@@ -27838,7 +27794,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:27.808164+00:00"
+                "validatedAt": "2026-07-20T14:41:07.342550+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27864,7 +27820,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:27.808194+00:00"
+                "validatedAt": "2026-07-20T14:41:07.342563+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27942,7 +27898,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:27.808242+00:00"
+                "validatedAt": "2026-07-20T14:41:07.342584+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27968,7 +27924,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.973571+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.468652+00:00"
           }
         },
         "x-f5xc-description-short": "Status of tcpdump capture on an interface.",
@@ -28040,7 +27996,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:27.808278+00:00"
+                "validatedAt": "2026-07-20T14:41:07.342600+00:00"
               },
               "deterministic": true
             },
@@ -28052,9 +28008,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.973591+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:23.468664+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "node": {
             "type": "string",
@@ -28086,7 +28041,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:27.808332+00:00"
+                "validatedAt": "2026-07-20T14:41:07.342626+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28112,7 +28067,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:27.808362+00:00"
+                "validatedAt": "2026-07-20T14:41:07.342639+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28272,7 +28227,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:09:27.808423+00:00"
+                "validatedAt": "2026-07-20T14:41:07.342664+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28348,7 +28303,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:27.808473+00:00"
+                "validatedAt": "2026-07-20T14:41:07.342687+00:00"
               },
               "deterministic": true
             },
@@ -28360,9 +28315,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.973660+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:23.468700+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "node": {
             "type": "string",
@@ -28394,7 +28348,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:27.808528+00:00"
+                "validatedAt": "2026-07-20T14:41:07.342714+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28432,7 +28386,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:27.808583+00:00"
+                "validatedAt": "2026-07-20T14:41:07.342741+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28458,7 +28412,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:27.808615+00:00"
+                "validatedAt": "2026-07-20T14:41:07.342755+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28530,7 +28484,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:09:27.808649+00:00"
+                "validatedAt": "2026-07-20T14:41:07.342771+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28586,7 +28540,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:27.808732+00:00"
+                "validatedAt": "2026-07-20T14:41:07.342793+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28612,7 +28566,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:27.808764+00:00"
+                "validatedAt": "2026-07-20T14:41:07.342806+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28637,7 +28591,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:27.808798+00:00"
+                "validatedAt": "2026-07-20T14:41:07.342820+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28648,7 +28602,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.973735+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.468743+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -28786,7 +28740,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:50.389105+00:00"
+                "validatedAt": "2026-07-20T14:41:15.718390+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -28801,7 +28755,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.315007+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.892374+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -28871,7 +28825,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:50.389143+00:00"
+                "validatedAt": "2026-07-20T14:41:15.718408+00:00"
               },
               "deterministic": true
             },
@@ -28883,9 +28837,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.315039+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:23.892394+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -28918,7 +28871,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:50.389170+00:00"
+                "validatedAt": "2026-07-20T14:41:15.718420+00:00"
               },
               "deterministic": true
             },
@@ -28930,9 +28883,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.315058+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:23.892406+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -28989,7 +28941,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:50.389588+00:00"
+                "validatedAt": "2026-07-20T14:41:15.718586+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29000,7 +28952,7 @@
             },
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.315231+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.892511+00:00"
           },
           "location": {
             "type": "string",
@@ -29016,7 +28968,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:50.389624+00:00"
+                "validatedAt": "2026-07-20T14:41:15.718601+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29027,7 +28979,7 @@
             },
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.315250+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.892524+00:00"
           },
           "provider": {
             "type": "string",
@@ -29044,7 +28996,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:50.389666+00:00"
+                "validatedAt": "2026-07-20T14:41:15.718615+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29055,7 +29007,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.315268+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.892536+00:00"
           },
           "secret_encoding": {
             "allOf": [
@@ -29087,7 +29039,7 @@
             "maxLength": 1,
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.315295+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.892552+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Vault Secret\" VaultSecretInfoType specifies information about the Secret managed by Hashicorp Vault.",
@@ -29157,7 +29109,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:50.389823+00:00"
+                "validatedAt": "2026-07-20T14:41:15.718683+00:00"
               },
               "deterministic": true
             },
@@ -29169,9 +29121,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.315390+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:23.892612+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Wingman Secret\" WingmanSecretInfoType specifies the handle to the wingman secret.",
@@ -29225,7 +29176,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:50.389861+00:00"
+                "validatedAt": "2026-07-20T14:41:15.718699+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29252,7 +29203,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:50.389898+00:00"
+                "validatedAt": "2026-07-20T14:41:15.718714+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29279,7 +29230,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:50.389923+00:00"
+                "validatedAt": "2026-07-20T14:41:15.718725+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29319,7 +29270,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:50.389949+00:00"
+                "validatedAt": "2026-07-20T14:41:15.718740+00:00"
               },
               "deterministic": true
             },
@@ -29331,9 +29282,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.315430+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:23.892636+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Issue (ticket) type information that's specific to Jira - modeled after the JIRA REST API response format.",
@@ -29393,7 +29343,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:50.389974+00:00"
+                "validatedAt": "2026-07-20T14:41:15.718752+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29434,7 +29384,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:50.390013+00:00"
+                "validatedAt": "2026-07-20T14:41:15.718769+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29445,7 +29395,7 @@
             },
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.315463+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.892655+00:00"
           },
           "name": {
             "type": "string",
@@ -29477,7 +29427,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:50.390039+00:00"
+                "validatedAt": "2026-07-20T14:41:15.718783+00:00"
               },
               "deterministic": true
             },
@@ -29489,9 +29439,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.315481+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:23.892667+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Contains fields and information that are specific to Jira projects - modeled after the JIRA REST API response format.",
@@ -29772,7 +29721,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:50.390093+00:00"
+                "validatedAt": "2026-07-20T14:41:15.718806+00:00"
               },
               "deterministic": true
             },
@@ -29784,9 +29733,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.315551+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:23.892707+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -29818,7 +29766,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:50.390120+00:00"
+                "validatedAt": "2026-07-20T14:41:15.718819+00:00"
               },
               "deterministic": true
             },
@@ -29830,9 +29778,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.315569+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:23.892719+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -30114,7 +30061,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:50.390251+00:00"
+                "validatedAt": "2026-07-20T14:41:15.718878+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30149,7 +30096,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:50.390312+00:00"
+                "validatedAt": "2026-07-20T14:41:15.718907+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30190,7 +30137,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:50.390375+00:00"
+                "validatedAt": "2026-07-20T14:41:15.718940+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30198,8 +30145,7 @@
               "create": true,
               "update": false,
               "read": false
-            },
-            "format": "hostname"
+            }
           }
         },
         "x-f5xc-description-short": "V3 API Basic Auth for AD-hoc API Calls - https://developer.atlassian.com/cloud/jira/platform/REST/v3/ This message represents what is stored in...",
@@ -30303,7 +30249,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:50.390424+00:00"
+                "validatedAt": "2026-07-20T14:41:15.718959+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30378,7 +30324,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:50.390481+00:00"
+                "validatedAt": "2026-07-20T14:41:15.718983+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30460,7 +30406,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:09:50.390527+00:00"
+                "validatedAt": "2026-07-20T14:41:15.719004+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30539,7 +30485,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:09:50.390578+00:00"
+                "validatedAt": "2026-07-20T14:41:15.719027+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30550,7 +30496,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.315737+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.892808+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -30638,7 +30584,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:50.390619+00:00"
+                "validatedAt": "2026-07-20T14:41:15.719046+00:00"
               },
               "deterministic": true
             },
@@ -30650,9 +30596,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.315783+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:23.892835+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -30683,7 +30628,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:50.390645+00:00"
+                "validatedAt": "2026-07-20T14:41:15.719059+00:00"
               },
               "deterministic": true
             },
@@ -30695,9 +30640,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.315801+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:23.892846+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -30750,7 +30694,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:50.390692+00:00"
+                "validatedAt": "2026-07-20T14:41:15.719075+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30762,7 +30706,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.315833+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.892865+00:00"
           },
           "uid": {
             "type": "string",
@@ -30780,7 +30724,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:50.390719+00:00"
+                "validatedAt": "2026-07-20T14:41:15.719086+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30793,7 +30737,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.315852+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.892878+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of ticket_tracking_system is returned in 'List'.",
@@ -31126,7 +31070,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:11.707371+00:00"
+                "validatedAt": "2026-07-20T14:41:23.901721+00:00"
               },
               "deterministic": true
             },
@@ -31138,9 +31082,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.693405+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.336169+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "node": {
             "type": "string",
@@ -31157,7 +31100,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:11.707402+00:00"
+                "validatedAt": "2026-07-20T14:41:23.901733+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31185,7 +31128,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:10:11.707438+00:00"
+                "validatedAt": "2026-07-20T14:41:23.901750+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31210,7 +31153,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:11.707467+00:00"
+                "validatedAt": "2026-07-20T14:41:23.901762+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31277,7 +31220,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:10:11.707498+00:00"
+                "validatedAt": "2026-07-20T14:41:23.901776+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31404,7 +31347,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:11.707534+00:00"
+                "validatedAt": "2026-07-20T14:41:23.901792+00:00"
               },
               "deterministic": true
             },
@@ -31416,9 +31359,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.693462+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.336202+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "node": {
             "type": "string",
@@ -31435,7 +31377,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:11.707564+00:00"
+                "validatedAt": "2026-07-20T14:41:23.901804+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31463,7 +31405,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:10:11.707593+00:00"
+                "validatedAt": "2026-07-20T14:41:23.901817+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31488,7 +31430,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:11.707624+00:00"
+                "validatedAt": "2026-07-20T14:41:23.901829+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31555,7 +31497,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:10:11.707664+00:00"
+                "validatedAt": "2026-07-20T14:41:23.901842+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31682,7 +31624,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:11.707704+00:00"
+                "validatedAt": "2026-07-20T14:41:23.901859+00:00"
               },
               "deterministic": true
             },
@@ -31694,9 +31636,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.693518+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.336235+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "node": {
             "type": "string",
@@ -31713,7 +31654,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:11.707734+00:00"
+                "validatedAt": "2026-07-20T14:41:23.901871+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31738,7 +31679,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:11.707764+00:00"
+                "validatedAt": "2026-07-20T14:41:23.901882+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31820,7 +31761,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:10:11.707805+00:00"
+                "validatedAt": "2026-07-20T14:41:23.901899+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31910,7 +31851,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:11.707837+00:00"
+                "validatedAt": "2026-07-20T14:41:23.901914+00:00"
               },
               "deterministic": true
             },
@@ -31922,9 +31863,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.693573+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.336267+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "node": {
             "type": "string",
@@ -31941,7 +31881,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:11.707866+00:00"
+                "validatedAt": "2026-07-20T14:41:23.901926+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31966,7 +31906,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:11.707895+00:00"
+                "validatedAt": "2026-07-20T14:41:23.901938+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32062,7 +32002,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:11.707937+00:00"
+                "validatedAt": "2026-07-20T14:41:23.901954+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32088,7 +32028,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:11.707980+00:00"
+                "validatedAt": "2026-07-20T14:41:23.901971+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32114,7 +32054,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:11.708022+00:00"
+                "validatedAt": "2026-07-20T14:41:23.901988+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32140,7 +32080,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:11.708057+00:00"
+                "validatedAt": "2026-07-20T14:41:23.902001+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32166,7 +32106,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:11.708093+00:00"
+                "validatedAt": "2026-07-20T14:41:23.902015+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32191,7 +32131,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:11.708130+00:00"
+                "validatedAt": "2026-07-20T14:41:23.902030+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32301,7 +32241,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:33.030142+00:00"
+                "validatedAt": "2026-07-20T14:41:54.012081+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32404,7 +32344,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:33.030283+00:00"
+                "validatedAt": "2026-07-20T14:41:54.012121+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32506,7 +32446,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:33.030365+00:00"
+                "validatedAt": "2026-07-20T14:41:54.012142+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32601,7 +32541,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:33.030424+00:00"
+                "validatedAt": "2026-07-20T14:41:54.012163+00:00"
               },
               "deterministic": true
             },
@@ -32613,9 +32553,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:26.025442+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:26.004838+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "node": {
             "type": "string",
@@ -32632,7 +32571,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:33.030456+00:00"
+                "validatedAt": "2026-07-20T14:41:54.012176+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32657,7 +32596,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:33.030489+00:00"
+                "validatedAt": "2026-07-20T14:41:54.012190+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32866,7 +32805,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:33.030535+00:00"
+                "validatedAt": "2026-07-20T14:41:54.012207+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33053,7 +32992,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:33.030590+00:00"
+                "validatedAt": "2026-07-20T14:41:54.012229+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33143,7 +33082,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:33.030625+00:00"
+                "validatedAt": "2026-07-20T14:41:54.012245+00:00"
               },
               "deterministic": true
             },
@@ -33155,9 +33094,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:26.025533+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:26.004892+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "node": {
             "type": "string",
@@ -33174,7 +33112,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:33.030669+00:00"
+                "validatedAt": "2026-07-20T14:41:54.012259+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33199,7 +33137,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:33.030701+00:00"
+                "validatedAt": "2026-07-20T14:41:54.012271+00:00"
               }
             },
             "x-f5xc-required-for": {

--- a/docs/specifications/api/telemetry_and_insights.json
+++ b/docs/specifications/api/telemetry_and_insights.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Telemetry And Insights",
     "description": "APIs for configuring collection endpoints, metrics storage, and insight generation. Supports log aggregation, performance monitoring, and alerting integration across deployments.",
-    "version": "2.1.182",
+    "version": "2.1.181",
     "contact": {
       "name": "F5 Distributed Cloud",
       "url": "https://docs.cloud.f5.com"
@@ -6281,7 +6281,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:33.050391+00:00"
+                "validatedAt": "2026-07-20T14:37:14.623143+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6334,7 +6334,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:33.050474+00:00"
+                "validatedAt": "2026-07-20T14:37:14.623169+00:00"
               },
               "deterministic": true
             },
@@ -6346,9 +6346,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.526120+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:13.997581+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "range": {
             "type": "string",
@@ -6373,7 +6372,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:33.050530+00:00"
+                "validatedAt": "2026-07-20T14:37:14.623185+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6420,7 +6419,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:33.050602+00:00"
+                "validatedAt": "2026-07-20T14:37:14.623202+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6453,7 +6452,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:33.050641+00:00"
+                "validatedAt": "2026-07-20T14:37:14.623215+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6545,7 +6544,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:33.050693+00:00"
+                "validatedAt": "2026-07-20T14:37:14.623231+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6674,7 +6673,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:33.050733+00:00"
+                "validatedAt": "2026-07-20T14:37:14.623246+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6815,7 +6814,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:33.050777+00:00"
+                "validatedAt": "2026-07-20T14:37:14.623262+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6826,7 +6825,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.526225+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:13.997647+00:00"
           }
         },
         "x-f5xc-description-short": "Metrics used in the connectivity graph are tagged with labels listed in the enum Label.",
@@ -7068,7 +7067,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:33.050856+00:00"
+                "validatedAt": "2026-07-20T14:37:14.623290+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7173,7 +7172,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.526328+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:13.997708+00:00"
           }
         },
         "x-f5xc-description-short": "NodeInstanceMetricData contains the metric type and the corresponding value for a node instance.",
@@ -7282,7 +7281,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:33.050907+00:00"
+                "validatedAt": "2026-07-20T14:37:14.623309+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7323,7 +7322,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:33.050958+00:00"
+                "validatedAt": "2026-07-20T14:37:14.623329+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7349,7 +7348,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:33.050997+00:00"
+                "validatedAt": "2026-07-20T14:37:14.623343+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7441,7 +7440,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.526392+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:13.997747+00:00"
           }
         },
         "x-f5xc-description-short": "NodeInterfaceMetricData contains the metric type and the corresponding value for a node interface.",
@@ -7600,7 +7599,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:33.051049+00:00"
+                "validatedAt": "2026-07-20T14:37:14.623363+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7684,7 +7683,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:33.051101+00:00"
+                "validatedAt": "2026-07-20T14:37:14.623383+00:00"
               },
               "deterministic": true
             },
@@ -7696,9 +7695,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.526440+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:13.997777+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "range": {
             "type": "string",
@@ -7723,7 +7721,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:33.051136+00:00"
+                "validatedAt": "2026-07-20T14:37:14.623398+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7756,7 +7754,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:33.051175+00:00"
+                "validatedAt": "2026-07-20T14:37:14.623413+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7789,7 +7787,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:33.051208+00:00"
+                "validatedAt": "2026-07-20T14:37:14.623426+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7828,7 +7826,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:00.082426+00:00"
+                "validatedAt": "2026-07-20T14:37:25.112625+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7920,7 +7918,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:33.051246+00:00"
+                "validatedAt": "2026-07-20T14:37:14.623441+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7992,7 +7990,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:33.051285+00:00"
+                "validatedAt": "2026-07-20T14:37:14.623456+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8078,7 +8076,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:33.051343+00:00"
+                "validatedAt": "2026-07-20T14:37:14.623480+00:00"
               },
               "deterministic": true
             },
@@ -8090,9 +8088,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.526519+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:13.997827+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "start_time": {
             "type": "string",
@@ -8117,7 +8114,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:33.051382+00:00"
+                "validatedAt": "2026-07-20T14:37:14.623495+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8407,7 +8404,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:33.051461+00:00"
+                "validatedAt": "2026-07-20T14:37:14.623525+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8418,7 +8415,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.526577+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:13.997862+00:00"
           },
           "type": {
             "allOf": [
@@ -8450,7 +8447,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.526603+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:13.997879+00:00"
           }
         },
         "x-f5xc-description-short": "HealthScoreTypeData contains healthscore type and the corresponding value.",
@@ -8708,7 +8705,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.526686+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:13.997924+00:00"
           }
         },
         "x-f5xc-description-short": "EdgeMetricData contains the metric type and the corresponding metric value.",
@@ -8789,7 +8786,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:33.051613+00:00"
+                "validatedAt": "2026-07-20T14:37:14.623586+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8920,7 +8917,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.526736+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:13.997954+00:00"
           }
         },
         "x-f5xc-description-short": "NodeMetricData contains metric type and the corresponding value for a node.",
@@ -9000,7 +8997,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:33.051689+00:00"
+                "validatedAt": "2026-07-20T14:37:14.623615+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9033,7 +9030,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:33.051729+00:00"
+                "validatedAt": "2026-07-20T14:37:14.623635+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9066,7 +9063,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:33.051768+00:00"
+                "validatedAt": "2026-07-20T14:37:14.623654+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9176,7 +9173,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:59:33.051818+00:00"
+                "validatedAt": "2026-07-20T14:37:14.623675+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9187,7 +9184,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.526786+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:13.997985+00:00"
           },
           "previous_value": {
             "type": "string",
@@ -9205,7 +9202,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:33.051858+00:00"
+                "validatedAt": "2026-07-20T14:37:14.623691+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9243,7 +9240,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:33.051894+00:00"
+                "validatedAt": "2026-07-20T14:37:14.623705+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9254,7 +9251,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.526817+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:13.998005+00:00"
           }
         },
         "x-f5xc-description-short": "Trend value contains trend value, trend sentiment and trend calculation description and window size.",
@@ -9404,7 +9401,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:33.051945+00:00"
+                "validatedAt": "2026-07-20T14:37:14.623725+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9415,7 +9412,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.526851+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:13.998026+00:00"
           }
         },
         "x-f5xc-description-short": "Each metric value consists of a timestamp and a value. Timestamp in the Metric Value is based on the start_time, end_time and step in the request.",
@@ -9586,7 +9583,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.110501+00:00"
+                "validatedAt": "2026-07-20T14:37:45.899318+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9620,7 +9617,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.110570+00:00"
+                "validatedAt": "2026-07-20T14:37:45.899345+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9653,7 +9650,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:51.110627+00:00"
+                "validatedAt": "2026-07-20T14:37:45.899381+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9848,7 +9845,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.110691+00:00"
+                "validatedAt": "2026-07-20T14:37:45.899418+00:00"
               },
               "deterministic": true
             },
@@ -9860,9 +9857,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.027441+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.511996+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -9901,7 +9897,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.110725+00:00"
+                "validatedAt": "2026-07-20T14:37:45.899437+00:00"
               },
               "deterministic": true
             },
@@ -9913,9 +9909,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.027462+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.512010+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tcp_lb_request": {
             "allOf": [
@@ -10065,7 +10060,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.110767+00:00"
+                "validatedAt": "2026-07-20T14:37:45.899459+00:00"
               },
               "deterministic": true
             },
@@ -10077,9 +10072,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.027497+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.512032+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -10118,7 +10112,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.110797+00:00"
+                "validatedAt": "2026-07-20T14:37:45.899475+00:00"
               },
               "deterministic": true
             },
@@ -10130,9 +10124,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.027515+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.512045+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Disable visibility on the discovered service.",
@@ -10223,7 +10216,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.027538+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.512060+00:00"
           },
           "virtual_server_pool_members_health": {
             "allOf": [
@@ -10314,7 +10307,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.110847+00:00"
+                "validatedAt": "2026-07-20T14:37:45.899500+00:00"
               },
               "deterministic": true
             },
@@ -10326,9 +10319,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.027565+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.512077+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -10367,7 +10359,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.110875+00:00"
+                "validatedAt": "2026-07-20T14:37:45.899516+00:00"
               },
               "deterministic": true
             },
@@ -10379,9 +10371,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.027584+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.512090+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Enable visibility of the discovered service in all workspaces like WAAP, App Connect, etc.",
@@ -10641,7 +10632,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.110995+00:00"
+                "validatedAt": "2026-07-20T14:37:45.899572+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10651,9 +10642,9 @@
               "read": false
             },
             "minLength": 26,
-            "format": "fqdn",
+            "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.027662+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.512133+00:00"
           },
           "http": {
             "allOf": [
@@ -10745,7 +10736,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.111039+00:00"
+                "validatedAt": "2026-07-20T14:37:45.899595+00:00"
               },
               "deterministic": true
             },
@@ -10757,9 +10748,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.027702+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.512158+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "skip_server_verification": {
             "allOf": [
@@ -10893,7 +10883,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.111091+00:00"
+                "validatedAt": "2026-07-20T14:37:45.899623+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10927,7 +10917,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.111129+00:00"
+                "validatedAt": "2026-07-20T14:37:45.899646+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10960,7 +10950,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:51.111171+00:00"
+                "validatedAt": "2026-07-20T14:37:45.899664+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11044,7 +11034,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:00:51.111216+00:00"
+                "validatedAt": "2026-07-20T14:37:45.899686+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11123,7 +11113,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:00:51.111272+00:00"
+                "validatedAt": "2026-07-20T14:37:45.899713+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11134,7 +11124,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.027790+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.512210+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -11221,7 +11211,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.111313+00:00"
+                "validatedAt": "2026-07-20T14:37:45.899734+00:00"
               },
               "deterministic": true
             },
@@ -11233,9 +11223,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.027836+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.512240+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -11266,7 +11255,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.111341+00:00"
+                "validatedAt": "2026-07-20T14:37:45.899750+00:00"
               },
               "deterministic": true
             },
@@ -11278,9 +11267,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.027854+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.512252+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -11333,7 +11321,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:51.111380+00:00"
+                "validatedAt": "2026-07-20T14:37:45.899766+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11345,7 +11333,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.027885+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.512273+00:00"
           },
           "uid": {
             "type": "string",
@@ -11363,7 +11351,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:51.111406+00:00"
+                "validatedAt": "2026-07-20T14:37:45.899794+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11376,7 +11364,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.027905+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.512286+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of discovered_service is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -11462,7 +11450,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:00:51.111448+00:00"
+                "validatedAt": "2026-07-20T14:37:45.899821+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11542,7 +11530,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:00:51.111499+00:00"
+                "validatedAt": "2026-07-20T14:37:45.899848+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11553,7 +11541,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.027948+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.512313+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -11640,7 +11628,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.111539+00:00"
+                "validatedAt": "2026-07-20T14:37:45.899871+00:00"
               },
               "deterministic": true
             },
@@ -11652,9 +11640,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.027994+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.512341+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -11685,7 +11672,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.111566+00:00"
+                "validatedAt": "2026-07-20T14:37:45.899886+00:00"
               },
               "deterministic": true
             },
@@ -11697,9 +11684,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.028012+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.512353+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -11768,7 +11754,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:51.111619+00:00"
+                "validatedAt": "2026-07-20T14:37:45.899908+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11780,7 +11766,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.028050+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.512378+00:00"
           },
           "uid": {
             "type": "string",
@@ -11798,7 +11784,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:51.111646+00:00"
+                "validatedAt": "2026-07-20T14:37:45.899921+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11811,7 +11797,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.028069+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.512391+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of discovered services is returned in 'List'.",
@@ -11889,7 +11875,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.111711+00:00"
+                "validatedAt": "2026-07-20T14:37:45.899952+00:00"
               },
               "deterministic": true
             },
@@ -11931,7 +11917,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.111776+00:00"
+                "validatedAt": "2026-07-20T14:37:45.899985+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11957,7 +11943,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:51.111819+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900004+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12021,7 +12007,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.111860+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900026+00:00"
               },
               "deterministic": true
             },
@@ -12062,7 +12048,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.111922+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900057+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12247,7 +12233,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.111982+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900088+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12421,7 +12407,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.112065+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900127+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12455,7 +12441,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.112126+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900158+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12495,7 +12481,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.112154+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900173+00:00"
               },
               "deterministic": true
             },
@@ -12507,9 +12493,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.028207+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.512478+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "request_body": {
             "allOf": [
@@ -12626,7 +12611,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.112218+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900205+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12636,9 +12621,9 @@
               "read": false
             },
             "minLength": 26,
-            "format": "fqdn",
+            "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.028247+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.512503+00:00"
           },
           "listen_port": {
             "type": "integer",
@@ -12703,7 +12688,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.112267+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900229+00:00"
               },
               "deterministic": true
             },
@@ -12715,9 +12700,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.028273+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.512520+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "no_sni": {
             "allOf": [
@@ -12767,7 +12751,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.112333+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900262+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12924,7 +12908,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.112401+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900296+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12958,7 +12942,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.112461+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900326+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13033,7 +13017,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.112522+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900359+00:00"
               },
               "deterministic": true
             },
@@ -13068,7 +13052,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.112580+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900389+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13106,7 +13090,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.112609+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900404+00:00"
               },
               "deterministic": true
             },
@@ -13138,7 +13122,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.112675+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900434+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13164,7 +13148,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.028374+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.512582+00:00"
           },
           "sub_path": {
             "type": "string",
@@ -13187,7 +13171,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.112735+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900497+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13312,7 +13296,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.112765+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900515+00:00"
               },
               "deterministic": true
             },
@@ -13324,9 +13308,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.028402+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.512600+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "status": {
             "type": "array",
@@ -13346,7 +13329,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.028422+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.512613+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -13496,7 +13479,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:51.112821+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900540+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13521,7 +13504,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:51.112856+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900556+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13600,7 +13583,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.112886+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900573+00:00"
               },
               "deterministic": true
             },
@@ -13634,7 +13617,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:51.112924+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900590+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13760,7 +13743,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:51.112973+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900611+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13772,7 +13755,7 @@
             "readOnly": true,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.028488+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.512653+00:00"
           },
           "name": {
             "type": "string",
@@ -13805,7 +13788,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.113000+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900626+00:00"
               },
               "deterministic": true
             },
@@ -13817,9 +13800,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.028507+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.512670+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -13852,7 +13834,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.113026+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900640+00:00"
               },
               "deterministic": true
             },
@@ -13864,9 +13846,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.028525+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.512682+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -13885,7 +13866,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:51.113060+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900655+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13898,7 +13879,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.028544+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.512695+00:00"
           },
           "uid": {
             "type": "string",
@@ -13917,7 +13898,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:51.113084+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900666+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13931,7 +13912,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.028564+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.512707+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -13985,7 +13966,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:51.113121+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900682+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14008,7 +13989,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:51.113155+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900696+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14019,7 +14000,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.028591+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.512725+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -14081,7 +14062,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T13:00:51.113188+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900714+00:00"
               },
               "deterministic": true
             },
@@ -14092,8 +14073,7 @@
               "read": false
             },
             "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "minLength": 1,
-            "format": "fqdn"
+            "minLength": 1
           },
           "last_update_time": {
             "type": "string",
@@ -14110,7 +14090,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:51.113230+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900731+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14137,7 +14117,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:51.113263+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900746+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14148,7 +14128,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.028625+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.512747+00:00"
           },
           "service_name": {
             "type": "string",
@@ -14165,7 +14145,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:51.113302+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900762+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14198,7 +14178,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:51.113339+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900779+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14209,7 +14189,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.028651+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.512763+00:00"
           },
           "type": {
             "type": "string",
@@ -14234,7 +14214,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:51.113371+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900793+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14374,7 +14354,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:51.113412+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900811+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14452,7 +14432,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.113440+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900827+00:00"
               },
               "deterministic": true
             },
@@ -14464,9 +14444,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.028709+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.512793+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -14617,7 +14596,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:51.113505+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900855+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14628,7 +14607,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.028756+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.512822+00:00"
           }
         },
         "x-f5xc-description-short": "Metric data contains timestamp and the value.",
@@ -14723,7 +14702,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.113579+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900894+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -14738,7 +14717,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.028785+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.512840+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -14810,7 +14789,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.113617+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900913+00:00"
               },
               "deterministic": true
             },
@@ -14822,9 +14801,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.028818+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.512862+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -14857,7 +14835,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.113644+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900927+00:00"
               },
               "deterministic": true
             },
@@ -14869,9 +14847,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.028836+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.512874+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -14932,7 +14909,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:51.113697+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900945+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14960,7 +14937,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:51.113739+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900962+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14988,7 +14965,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:51.113776+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900978+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15027,7 +15004,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:51.113815+00:00"
+                "validatedAt": "2026-07-20T14:37:45.900995+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15054,7 +15031,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:51.113841+00:00"
+                "validatedAt": "2026-07-20T14:37:45.901006+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15067,7 +15044,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.028889+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.512908+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -15083,7 +15060,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:51.113875+00:00"
+                "validatedAt": "2026-07-20T14:37:45.901021+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15224,7 +15201,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:51.113923+00:00"
+                "validatedAt": "2026-07-20T14:37:45.901042+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15235,7 +15212,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.028929+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.512934+00:00"
           },
           "status": {
             "type": "string",
@@ -15253,7 +15230,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:51.113956+00:00"
+                "validatedAt": "2026-07-20T14:37:45.901057+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15264,7 +15241,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.028947+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.512946+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -15322,7 +15299,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:51.114001+00:00"
+                "validatedAt": "2026-07-20T14:37:45.901077+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15349,7 +15326,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:51.114041+00:00"
+                "validatedAt": "2026-07-20T14:37:45.901094+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15376,7 +15353,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:51.114077+00:00"
+                "validatedAt": "2026-07-20T14:37:45.901111+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15404,7 +15381,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:51.114118+00:00"
+                "validatedAt": "2026-07-20T14:37:45.901128+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15480,7 +15457,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:51.114182+00:00"
+                "validatedAt": "2026-07-20T14:37:45.901155+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15548,7 +15525,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:51.114233+00:00"
+                "validatedAt": "2026-07-20T14:37:45.901178+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15560,7 +15537,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.029035+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.513001+00:00"
           },
           "uid": {
             "type": "string",
@@ -15579,7 +15556,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:51.114258+00:00"
+                "validatedAt": "2026-07-20T14:37:45.901190+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15592,7 +15569,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.029055+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.513014+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -15658,7 +15635,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:51.114413+00:00"
+                "validatedAt": "2026-07-20T14:37:45.901257+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15669,7 +15646,7 @@
             },
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.029126+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.513061+00:00"
           },
           "name": {
             "type": "string",
@@ -15702,7 +15679,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.114440+00:00"
+                "validatedAt": "2026-07-20T14:37:45.901271+00:00"
               },
               "deterministic": true
             },
@@ -15714,9 +15691,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.029145+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.513073+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -15749,7 +15725,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.114467+00:00"
+                "validatedAt": "2026-07-20T14:37:45.901286+00:00"
               },
               "deterministic": true
             },
@@ -15761,9 +15737,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.029163+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.513086+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "uid": {
             "type": "string",
@@ -15780,7 +15755,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:51.114492+00:00"
+                "validatedAt": "2026-07-20T14:37:45.901298+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15793,7 +15768,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.029182+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.513099+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -16061,7 +16036,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:00:51.114575+00:00"
+                "validatedAt": "2026-07-20T14:37:45.901336+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16126,7 +16101,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:00:51.114621+00:00"
+                "validatedAt": "2026-07-20T14:37:45.901358+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16137,7 +16112,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.029270+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.513153+00:00"
           },
           "ref_value": {
             "allOf": [
@@ -16179,7 +16154,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:00:51.114670+00:00"
+                "validatedAt": "2026-07-20T14:37:45.901377+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16257,7 +16232,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.114715+00:00"
+                "validatedAt": "2026-07-20T14:37:45.901400+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16331,7 +16306,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.114758+00:00"
+                "validatedAt": "2026-07-20T14:37:45.901423+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16421,7 +16396,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.114813+00:00"
+                "validatedAt": "2026-07-20T14:37:45.901453+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -16436,9 +16411,8 @@
               "read": false
             },
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.969398+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.775570+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -16477,7 +16451,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.114860+00:00"
+                "validatedAt": "2026-07-20T14:37:45.901481+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -16492,9 +16466,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.029328+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.513188+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -16523,7 +16496,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.114913+00:00"
+                "validatedAt": "2026-07-20T14:37:45.901507+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16536,7 +16509,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.029347+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.513201+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a direct reference from one object(the referrer) to another(the referred).",
@@ -16603,7 +16576,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.114958+00:00"
+                "validatedAt": "2026-07-20T14:37:45.901531+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16799,7 +16772,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.115020+00:00"
+                "validatedAt": "2026-07-20T14:37:45.901563+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17044,7 +17017,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.115058+00:00"
+                "validatedAt": "2026-07-20T14:37:45.901581+00:00"
               },
               "deterministic": true
             },
@@ -17091,7 +17064,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.115121+00:00"
+                "validatedAt": "2026-07-20T14:37:45.901612+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17441,7 +17414,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.115211+00:00"
+                "validatedAt": "2026-07-20T14:37:45.901653+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17476,7 +17449,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.115268+00:00"
+                "validatedAt": "2026-07-20T14:37:45.901682+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17577,7 +17550,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:00:51.115313+00:00"
+                "validatedAt": "2026-07-20T14:37:45.901706+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17677,7 +17650,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:55.466020+00:00"
+                "validatedAt": "2026-07-20T14:38:10.715830+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17704,7 +17677,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:55.466085+00:00"
+                "validatedAt": "2026-07-20T14:38:10.715857+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17760,7 +17733,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:55.466165+00:00"
+                "validatedAt": "2026-07-20T14:38:10.715883+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17787,7 +17760,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:55.466216+00:00"
+                "validatedAt": "2026-07-20T14:38:10.715898+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17828,7 +17801,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:55.466281+00:00"
+                "validatedAt": "2026-07-20T14:38:10.715916+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17853,7 +17826,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:55.466353+00:00"
+                "validatedAt": "2026-07-20T14:38:10.715935+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17977,7 +17950,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.014222+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.145289+00:00"
           }
         },
         "x-f5xc-description-short": "Field Data contains key/value pairs that uniquely identifies the group_by labels specified in the request.",
@@ -18420,7 +18393,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:55.466504+00:00"
+                "validatedAt": "2026-07-20T14:38:10.715982+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18448,7 +18421,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:55.466546+00:00"
+                "validatedAt": "2026-07-20T14:38:10.715999+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18514,7 +18487,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:55.466601+00:00"
+                "validatedAt": "2026-07-20T14:38:10.716022+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18556,7 +18529,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:55.466646+00:00"
+                "validatedAt": "2026-07-20T14:38:10.716040+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18641,7 +18614,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:55.466707+00:00"
+                "validatedAt": "2026-07-20T14:38:10.716061+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18685,7 +18658,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:55.466765+00:00"
+                "validatedAt": "2026-07-20T14:38:10.716091+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18719,7 +18692,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:55.466821+00:00"
+                "validatedAt": "2026-07-20T14:38:10.716118+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18755,7 +18728,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:55.466864+00:00"
+                "validatedAt": "2026-07-20T14:38:10.716140+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18790,7 +18763,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:01:55.466905+00:00"
+                "validatedAt": "2026-07-20T14:38:10.716161+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18840,7 +18813,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:55.466957+00:00"
+                "validatedAt": "2026-07-20T14:38:10.716183+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18965,7 +18938,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:55.467013+00:00"
+                "validatedAt": "2026-07-20T14:38:10.716205+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19009,7 +18982,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:55.467062+00:00"
+                "validatedAt": "2026-07-20T14:38:10.716230+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19036,7 +19009,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:55.467095+00:00"
+                "validatedAt": "2026-07-20T14:38:10.716244+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19087,7 +19060,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:01:55.467141+00:00"
+                "validatedAt": "2026-07-20T14:38:10.716264+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19137,7 +19110,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:55.467193+00:00"
+                "validatedAt": "2026-07-20T14:38:10.716285+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19539,7 +19512,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.868749+00:00"
+                "validatedAt": "2026-07-20T14:40:24.800811+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19606,7 +19579,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.868820+00:00"
+                "validatedAt": "2026-07-20T14:40:24.800839+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19722,7 +19695,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.868948+00:00"
+                "validatedAt": "2026-07-20T14:40:24.800878+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19764,7 +19737,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.869002+00:00"
+                "validatedAt": "2026-07-20T14:40:24.800900+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19810,7 +19783,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.869050+00:00"
+                "validatedAt": "2026-07-20T14:40:24.800921+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19873,7 +19846,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.869117+00:00"
+                "validatedAt": "2026-07-20T14:40:24.800948+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19914,7 +19887,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.869160+00:00"
+                "validatedAt": "2026-07-20T14:40:24.800965+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19954,7 +19927,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.869208+00:00"
+                "validatedAt": "2026-07-20T14:40:24.800984+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20065,7 +20038,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.869297+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801017+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20259,7 +20232,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.869399+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801058+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20800,7 +20773,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.869551+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801115+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20825,7 +20798,7 @@
             "maxLength": 4,
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.522853+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.081468+00:00"
           },
           "type": {
             "allOf": [
@@ -21295,7 +21268,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.523027+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.081574+00:00"
           }
         },
         "x-f5xc-description-short": "MetricData contains the metric type and the corresponding metric value(s).",
@@ -21430,7 +21403,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:39.869901+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801247+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21481,7 +21454,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:39.869956+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801273+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21592,7 +21565,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.869994+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801288+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21617,7 +21590,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.870029+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801303+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21657,7 +21630,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:39.870065+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801319+00:00"
               },
               "deterministic": true
             },
@@ -21669,9 +21642,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.523137+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.081639+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "service": {
             "type": "string",
@@ -21689,7 +21661,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.870101+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801334+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21715,7 +21687,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.870130+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801347+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21740,7 +21712,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.870170+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801363+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21859,7 +21831,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.870215+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801380+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21892,7 +21864,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.870253+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801396+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21925,7 +21897,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.870289+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801411+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21951,7 +21923,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.870320+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801423+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21984,7 +21956,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.870361+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801440+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22158,7 +22130,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:39.870580+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801531+00:00"
               },
               "deterministic": true
             },
@@ -22170,9 +22142,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.523307+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.081741+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "List of application types for a namespace.",
@@ -22377,7 +22348,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.523363+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.081775+00:00"
           }
         },
         "x-f5xc-description-short": "CdnMetricData contains the metric type and the corresponding metric value(s).",
@@ -22797,7 +22768,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.870721+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801580+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22850,7 +22821,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:39.870753+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801595+00:00"
               },
               "deterministic": true
             },
@@ -22862,9 +22833,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.523478+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.081843+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "range": {
             "type": "string",
@@ -22889,7 +22859,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.870789+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801609+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22936,7 +22906,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.870834+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801627+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22969,7 +22939,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.870867+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801640+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23061,7 +23031,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.870904+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801655+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23263,7 +23233,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.870970+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801681+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23289,7 +23259,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.871009+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801696+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23329,7 +23299,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:39.871037+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801710+00:00"
               },
               "deterministic": true
             },
@@ -23341,9 +23311,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.523579+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.081904+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "service": {
             "type": "string",
@@ -23361,7 +23330,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.871071+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801723+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23387,7 +23356,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.871101+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801737+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23412,7 +23381,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.871135+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801752+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23438,7 +23407,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.871160+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801763+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23463,7 +23432,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.871202+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801779+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23488,7 +23457,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:06.903914+00:00"
+                "validatedAt": "2026-07-20T14:40:35.298807+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23678,7 +23647,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.871248+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801798+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23745,7 +23714,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:39.871282+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801814+00:00"
               },
               "deterministic": true
             },
@@ -23757,9 +23726,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.523673+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.081957+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "range": {
             "type": "string",
@@ -23784,7 +23752,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.871317+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801829+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23817,7 +23785,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.871356+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801845+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23850,7 +23818,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.871389+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801858+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23940,7 +23908,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.871427+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801873+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24064,7 +24032,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.871480+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801894+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24151,7 +24119,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:39.871536+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801918+00:00"
               },
               "deterministic": true
             },
@@ -24163,9 +24131,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.523761+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.082011+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "range": {
             "type": "string",
@@ -24190,7 +24157,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.871571+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801932+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24223,7 +24190,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.871611+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801948+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24256,7 +24223,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.871643+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801962+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24347,7 +24314,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.871688+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801977+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24419,7 +24386,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.871729+00:00"
+                "validatedAt": "2026-07-20T14:40:24.801993+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24480,7 +24447,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:39.871794+00:00"
+                "validatedAt": "2026-07-20T14:40:24.802023+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24525,7 +24492,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:39.871845+00:00"
+                "validatedAt": "2026-07-20T14:40:24.802047+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24565,7 +24532,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:39.871874+00:00"
+                "validatedAt": "2026-07-20T14:40:24.802061+00:00"
               },
               "deterministic": true
             },
@@ -24577,9 +24544,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.523841+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.082060+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "start_time": {
             "type": "string",
@@ -24604,7 +24570,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.871914+00:00"
+                "validatedAt": "2026-07-20T14:40:24.802078+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24637,7 +24603,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.871947+00:00"
+                "validatedAt": "2026-07-20T14:40:24.802091+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24729,7 +24695,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.871992+00:00"
+                "validatedAt": "2026-07-20T14:40:24.802110+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24818,7 +24784,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.872031+00:00"
+                "validatedAt": "2026-07-20T14:40:24.802125+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24829,7 +24795,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.523900+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.082099+00:00"
           }
         },
         "x-f5xc-description-short": "Metrics used to render the service graph are tagged with labels listed in the enum Label.",
@@ -25091,7 +25057,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.872093+00:00"
+                "validatedAt": "2026-07-20T14:40:24.802148+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25158,7 +25124,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:39.872126+00:00"
+                "validatedAt": "2026-07-20T14:40:24.802164+00:00"
               },
               "deterministic": true
             },
@@ -25170,9 +25136,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.523982+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.082149+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "range": {
             "type": "string",
@@ -25197,7 +25162,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.872159+00:00"
+                "validatedAt": "2026-07-20T14:40:24.802178+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25230,7 +25195,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.872197+00:00"
+                "validatedAt": "2026-07-20T14:40:24.802194+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25263,7 +25228,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.872229+00:00"
+                "validatedAt": "2026-07-20T14:40:24.802207+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25354,7 +25319,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.872266+00:00"
+                "validatedAt": "2026-07-20T14:40:24.802222+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25426,7 +25391,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.872305+00:00"
+                "validatedAt": "2026-07-20T14:40:24.802238+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25529,7 +25494,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:39.872364+00:00"
+                "validatedAt": "2026-07-20T14:40:24.802263+00:00"
               },
               "deterministic": true
             },
@@ -25541,9 +25506,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.524069+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.082203+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "range": {
             "type": "string",
@@ -25568,7 +25532,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.872398+00:00"
+                "validatedAt": "2026-07-20T14:40:24.802277+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25601,7 +25565,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.872437+00:00"
+                "validatedAt": "2026-07-20T14:40:24.802292+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25634,7 +25598,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.872469+00:00"
+                "validatedAt": "2026-07-20T14:40:24.802306+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25726,7 +25690,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.872506+00:00"
+                "validatedAt": "2026-07-20T14:40:24.802320+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25791,7 +25755,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.872541+00:00"
+                "validatedAt": "2026-07-20T14:40:24.802335+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25824,7 +25788,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.872580+00:00"
+                "validatedAt": "2026-07-20T14:40:24.802350+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25851,7 +25815,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.872610+00:00"
+                "validatedAt": "2026-07-20T14:40:24.802363+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25876,7 +25840,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.872634+00:00"
+                "validatedAt": "2026-07-20T14:40:24.802374+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25909,7 +25873,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:39.872683+00:00"
+                "validatedAt": "2026-07-20T14:40:24.802391+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25976,7 +25940,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:06.903172+00:00"
+                "validatedAt": "2026-07-20T14:40:35.298524+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26016,7 +25980,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:06.903202+00:00"
+                "validatedAt": "2026-07-20T14:40:35.298537+00:00"
               },
               "deterministic": true
             },
@@ -26028,9 +25992,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.154128+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.621009+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Represents a category of vulnerability as defined in the OWASP API Top 10.",

--- a/docs/specifications/api/tenant_and_identity.json
+++ b/docs/specifications/api/tenant_and_identity.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Tenant And Identity",
     "description": "Profile images and display customizations for personalized dashboard experiences. Federated authentication toggles controlling SSO behavior across organizational boundaries. Session lifecycle tracking with real-time visibility into active connections and timeout policies. Support ticket workflows including attachment handling and closure procedures for managed client escalations. Initial access provisioning sequences for new user onboarding.",
-    "version": "2.1.182",
+    "version": "2.1.181",
     "contact": {
       "name": "F5 Distributed Cloud",
       "url": "https://docs.cloud.f5.com"
@@ -1373,7 +1373,7 @@
           },
           {
             "name": "response_format",
-            "description": "The format in which the configuration object is to be fetched. This could be for example\n - in GetSpec form for the contents of object\n - in CreateRequest form to create a new similar object\n - to ReplaceRequest form to replace changeable values\n\nDefault format of returned resource\nResponse should be in CreateRequest format\nResponse should be in ReplaceRequest format\nResponse should be in StatusObject(s) format\nResponse should be in format of GetSpecType\nResponse should have other objects referring to this object\nResponse should have deleted and disabled objects referred by this object.",
+            "description": "The format in which the configuration object is to be fetched. This could be for example\n - in GetSpec form for the contents of object\n - in CreateRequest form to create a new similar object\n - to ReplaceRequest form to replace changeable values\n\nDefault format of returned resource\nResponse should be in CreateRequest format\nResponse should be in ReplaceRequest format\nResponse should be in StatusObject(s) format\nResponse should be in format of GetSpecType\nResponse should have other objects referring to this object\nResponse should have deleted and disabled objects referrred by this object.",
             "in": "query",
             "required": false,
             "x-displayname": "Broken Referred Objects.",
@@ -2513,7 +2513,7 @@
           },
           {
             "name": "response_format",
-            "description": "The format in which the configuration object is to be fetched. This could be for example\n - in GetSpec form for the contents of object\n - in CreateRequest form to create a new similar object\n - to ReplaceRequest form to replace changeable values\n\nDefault format of returned resource\nResponse should be in CreateRequest format\nResponse should be in ReplaceRequest format\nResponse should be in StatusObject(s) format\nResponse should be in format of GetSpecType\nResponse should have other objects referring to this object\nResponse should have deleted and disabled objects referred by this object.",
+            "description": "The format in which the configuration object is to be fetched. This could be for example\n - in GetSpec form for the contents of object\n - in CreateRequest form to create a new similar object\n - to ReplaceRequest form to replace changeable values\n\nDefault format of returned resource\nResponse should be in CreateRequest format\nResponse should be in ReplaceRequest format\nResponse should be in StatusObject(s) format\nResponse should be in format of GetSpecType\nResponse should have other objects referring to this object\nResponse should have deleted and disabled objects referrred by this object.",
             "in": "query",
             "required": false,
             "x-displayname": "Broken Referred Objects.",
@@ -3652,7 +3652,7 @@
           },
           {
             "name": "response_format",
-            "description": "The format in which the configuration object is to be fetched. This could be for example\n - in GetSpec form for the contents of object\n - in CreateRequest form to create a new similar object\n - to ReplaceRequest form to replace changeable values\n\nDefault format of returned resource\nResponse should be in CreateRequest format\nResponse should be in ReplaceRequest format\nResponse should be in StatusObject(s) format\nResponse should be in format of GetSpecType\nResponse should have other objects referring to this object\nResponse should have deleted and disabled objects referred by this object.",
+            "description": "The format in which the configuration object is to be fetched. This could be for example\n - in GetSpec form for the contents of object\n - in CreateRequest form to create a new similar object\n - to ReplaceRequest form to replace changeable values\n\nDefault format of returned resource\nResponse should be in CreateRequest format\nResponse should be in ReplaceRequest format\nResponse should be in StatusObject(s) format\nResponse should be in format of GetSpecType\nResponse should have other objects referring to this object\nResponse should have deleted and disabled objects referrred by this object.",
             "in": "query",
             "required": false,
             "x-displayname": "Broken Referred Objects.",
@@ -48701,7 +48701,7 @@
     "schemas": {
       "allowed_tenantAllowedAccessConfig": {
         "type": "object",
-        "description": "Shape for storing access config for a tenant.\nDefault field OPTIONS - disable, read-only, read_write provided for easy access controls\nand underlying allowed groups corresponding to each usecase will be updated accordingly.\nMainly used for storing state for support related tenant access.",
+        "description": "Shape for storing access config for a tenant.\nDefault field OPTIONS - disable, read-only, read_write provided for easy acccess controls\nand underlying allowed groups corresponding to each usecase will be updated accordingly.\nMainly used for storing state for support related tenant access.",
         "title": "AccessConfig",
         "x-displayname": "Access Config.",
         "x-ves-displayorder": "2,1",
@@ -48777,7 +48777,7 @@
           }
         },
         "x-f5xc-description-short": "Shape for storing access config for a tenant.",
-        "x-f5xc-description-medium": "Shape for storing access config for a tenant. Default field OPTIONS - disable, read-only, read_write provided for easy access controls and underlying allowed groups corresponding to each usecase will be updated accordingly. Mainly used for storing state for support related tenant access.",
+        "x-f5xc-description-medium": "Shape for storing access config for a tenant. Default field OPTIONS - disable, read-only, read_write provided for easy acccess controls and underlying allowed groups corresponding to each usecase will be updated accordingly. Mainly used for storing state for support related tenant access.",
         "x-f5xc-minimum-configuration": {
           "description": "Minimum configuration for allowed_tenantAllowedAccessConfig",
           "required_fields": [
@@ -48861,7 +48861,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:16.515014+00:00"
+                "validatedAt": "2026-07-20T14:35:31.651181+00:00"
               },
               "deterministic": true
             },
@@ -48873,9 +48873,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.965592+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.683929+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -48907,7 +48906,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:16.515060+00:00"
+                "validatedAt": "2026-07-20T14:35:31.651200+00:00"
               },
               "deterministic": true
             },
@@ -48919,9 +48918,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.965613+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.683943+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -49055,7 +49053,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:16.515129+00:00"
+                "validatedAt": "2026-07-20T14:35:31.651235+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49230,7 +49228,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:16.515187+00:00"
+                "validatedAt": "2026-07-20T14:35:31.651265+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49265,7 +49263,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:16.515257+00:00"
+                "validatedAt": "2026-07-20T14:35:31.651299+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49472,7 +49470,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:16.515303+00:00"
+                "validatedAt": "2026-07-20T14:35:31.651320+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49484,7 +49482,7 @@
             "readOnly": true,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.965707+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.683997+00:00"
           },
           "name": {
             "type": "string",
@@ -49517,7 +49515,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:16.515333+00:00"
+                "validatedAt": "2026-07-20T14:35:31.651335+00:00"
               },
               "deterministic": true
             },
@@ -49529,9 +49527,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.965727+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.684010+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -49564,7 +49561,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:16.515362+00:00"
+                "validatedAt": "2026-07-20T14:35:31.651350+00:00"
               },
               "deterministic": true
             },
@@ -49576,9 +49573,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.965745+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.684023+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -49597,7 +49593,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:16.515397+00:00"
+                "validatedAt": "2026-07-20T14:35:31.651366+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49610,7 +49606,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.965764+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.684036+00:00"
           },
           "uid": {
             "type": "string",
@@ -49629,7 +49625,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:16.515423+00:00"
+                "validatedAt": "2026-07-20T14:35:31.651378+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49643,7 +49639,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.965784+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.684050+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -49699,7 +49695,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:16.515461+00:00"
+                "validatedAt": "2026-07-20T14:35:31.651394+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49722,7 +49718,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:16.515494+00:00"
+                "validatedAt": "2026-07-20T14:35:31.651410+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49733,7 +49729,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.965812+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.684068+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -49797,7 +49793,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T12:55:16.515529+00:00"
+                "validatedAt": "2026-07-20T14:35:31.651428+00:00"
               },
               "deterministic": true
             },
@@ -49808,8 +49804,7 @@
               "read": false
             },
             "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "minLength": 1,
-            "format": "fqdn"
+            "minLength": 1
           },
           "last_update_time": {
             "type": "string",
@@ -49826,7 +49821,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:16.515570+00:00"
+                "validatedAt": "2026-07-20T14:35:31.651446+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49852,7 +49847,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:16.515604+00:00"
+                "validatedAt": "2026-07-20T14:35:31.651461+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49863,7 +49858,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.965847+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.684092+00:00"
           },
           "service_name": {
             "type": "string",
@@ -49880,7 +49875,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:16.515643+00:00"
+                "validatedAt": "2026-07-20T14:35:31.651480+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49892,7 +49887,7 @@
           },
           "status": {
             "type": "string",
-            "description": "Status of the condition\n\"Success\" Validation has succeeded. Requested operation was successful.\n\"Failed\" Validation has failed.\n\"Incomplete\" Validation of configuration has failed due to missing configuration.\n\"Installed\" Validation has passed and configuration has been installed in data path or K8s\n\"Down\" Configuration is operationally down. E.g. Down interface\n\"Disabled\" Configuration is administratively disabled i.e. objectmetatype.disable = true.\n\"NotApplicable\" Configuration is not applicable e.g. Tenant service_policy_set(s) in system namespace are not applicable on REs.",
+            "description": "Status of the condition\n\"Success\" Validtion has succeded. Requested operation was successful.\n\"Failed\" Validation has failed.\n\"Incomplete\" Validation of configuration has failed due to missing configuration.\n\"Installed\" Validation has passed and configuration has been installed in data path or K8s\n\"Down\" Configuration is operationally down. E.g. Down interface\n\"Disabled\" Configuration is administratively disabled i.e. objectmetatype.disable = true.\n\"NotApplicable\" Configuration is not applicable e.g. Tenant service_policy_set(s) in system namespace are not applicable on REs.",
             "title": "status",
             "x-displayname": "Status",
             "x-ves-example": "Failed",
@@ -49903,8 +49898,8 @@
             "x-validation-rules": {
               "ves.io.schema.rules.string.in": "[\\\"Success\\\",\\\"Failed\\\",\\\"Incomplete\\\",\\\"Installed\\\",\\\"Down\\\",\\\"Disabled\\\",\\\"NotApplicable\\\"]"
             },
-            "x-f5xc-description-short": "Status of the condition \"Success\" Validation has succeeded.",
-            "x-f5xc-description-medium": "Status of the condition \"Success\" Validation has succeeded. Requested operation was successful. \"Failed\" Validation has failed. \"Incomplete\" Validation of configuration has failed due to missing configuration. \"Installed\" Validation has passed and configuration has been installed in data path or...",
+            "x-f5xc-description-short": "Status of the condition \"Success\" Validtion has succeded.",
+            "x-f5xc-description-medium": "Status of the condition \"Success\" Validtion has succeded. Requested operation was successful. \"Failed\" Validation has failed. \"Incomplete\" Validation of configuration has failed due to missing configuration. \"Installed\" Validation has passed and configuration has been installed in data path or...",
             "maxLength": 1024,
             "x-f5xc-constraints": {
               "constraintType": "string",
@@ -49913,7 +49908,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:16.515691+00:00"
+                "validatedAt": "2026-07-20T14:35:31.651497+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49924,7 +49919,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.965872+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.684109+00:00"
           },
           "type": {
             "type": "string",
@@ -49949,7 +49944,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:16.515726+00:00"
+                "validatedAt": "2026-07-20T14:35:31.651512+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50093,7 +50088,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:16.515767+00:00"
+                "validatedAt": "2026-07-20T14:35:31.651530+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50173,7 +50168,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:16.515798+00:00"
+                "validatedAt": "2026-07-20T14:35:31.651545+00:00"
               },
               "deterministic": true
             },
@@ -50185,9 +50180,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.965921+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.684141+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -50351,7 +50345,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:16.515893+00:00"
+                "validatedAt": "2026-07-20T14:35:31.651593+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -50366,7 +50360,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.965965+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.684169+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -50436,7 +50430,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:16.515932+00:00"
+                "validatedAt": "2026-07-20T14:35:31.651613+00:00"
               },
               "deterministic": true
             },
@@ -50448,9 +50442,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.965999+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.684192+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -50483,7 +50476,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:16.515958+00:00"
+                "validatedAt": "2026-07-20T14:35:31.651627+00:00"
               },
               "deterministic": true
             },
@@ -50495,9 +50488,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.966018+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.684205+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -50597,7 +50589,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:16.516032+00:00"
+                "validatedAt": "2026-07-20T14:35:31.651666+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -50612,7 +50604,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.966045+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.684223+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -50684,7 +50676,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:16.516071+00:00"
+                "validatedAt": "2026-07-20T14:35:31.651685+00:00"
               },
               "deterministic": true
             },
@@ -50696,9 +50688,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.966078+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.684245+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -50731,7 +50722,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:16.516099+00:00"
+                "validatedAt": "2026-07-20T14:35:31.651700+00:00"
               },
               "deterministic": true
             },
@@ -50743,9 +50734,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.966096+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.684259+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -50845,7 +50835,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:16.516171+00:00"
+                "validatedAt": "2026-07-20T14:35:31.651738+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -50860,7 +50850,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.966124+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.684277+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -50930,7 +50920,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:16.516207+00:00"
+                "validatedAt": "2026-07-20T14:35:31.651758+00:00"
               },
               "deterministic": true
             },
@@ -50942,9 +50932,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.966158+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.684300+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -50977,7 +50966,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:16.516234+00:00"
+                "validatedAt": "2026-07-20T14:35:31.651772+00:00"
               },
               "deterministic": true
             },
@@ -50989,9 +50978,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.966176+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.684312+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -51054,7 +51042,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:16.516277+00:00"
+                "validatedAt": "2026-07-20T14:35:31.651791+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51082,7 +51070,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:16.516318+00:00"
+                "validatedAt": "2026-07-20T14:35:31.651809+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51110,7 +51098,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:16.516355+00:00"
+                "validatedAt": "2026-07-20T14:35:31.651825+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51149,7 +51137,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:16.516395+00:00"
+                "validatedAt": "2026-07-20T14:35:31.651843+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51176,7 +51164,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:16.516422+00:00"
+                "validatedAt": "2026-07-20T14:35:31.651856+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51189,7 +51177,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.966231+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.684347+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -51205,7 +51193,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:16.516457+00:00"
+                "validatedAt": "2026-07-20T14:35:31.651871+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51350,7 +51338,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:16.516508+00:00"
+                "validatedAt": "2026-07-20T14:35:31.651893+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51361,7 +51349,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.966271+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.684374+00:00"
           },
           "status": {
             "type": "string",
@@ -51379,7 +51367,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:16.516541+00:00"
+                "validatedAt": "2026-07-20T14:35:31.651909+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51390,7 +51378,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.966289+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.684387+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -51450,7 +51438,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:16.516583+00:00"
+                "validatedAt": "2026-07-20T14:35:31.651928+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51477,7 +51465,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:16.516622+00:00"
+                "validatedAt": "2026-07-20T14:35:31.651945+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51504,7 +51492,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:16.516669+00:00"
+                "validatedAt": "2026-07-20T14:35:31.651961+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51532,7 +51520,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:16.516712+00:00"
+                "validatedAt": "2026-07-20T14:35:31.651980+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51608,7 +51596,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:16.516777+00:00"
+                "validatedAt": "2026-07-20T14:35:31.652007+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51676,7 +51664,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:16.516827+00:00"
+                "validatedAt": "2026-07-20T14:35:31.652029+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51688,7 +51676,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.966376+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.684442+00:00"
           },
           "uid": {
             "type": "string",
@@ -51707,7 +51695,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:16.516853+00:00"
+                "validatedAt": "2026-07-20T14:35:31.652040+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51720,7 +51708,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.966396+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.684456+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -51788,7 +51776,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:16.516883+00:00"
+                "validatedAt": "2026-07-20T14:35:31.652054+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51799,7 +51787,7 @@
             },
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.966416+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.684469+00:00"
           },
           "name": {
             "type": "string",
@@ -51832,7 +51820,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:16.516911+00:00"
+                "validatedAt": "2026-07-20T14:35:31.652068+00:00"
               },
               "deterministic": true
             },
@@ -51844,9 +51832,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.966434+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.684482+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -51879,7 +51866,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:16.516938+00:00"
+                "validatedAt": "2026-07-20T14:35:31.652082+00:00"
               },
               "deterministic": true
             },
@@ -51891,9 +51878,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.966453+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.684495+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "uid": {
             "type": "string",
@@ -51910,7 +51896,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:16.516963+00:00"
+                "validatedAt": "2026-07-20T14:35:31.652093+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51923,7 +51909,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.966472+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.684508+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -52010,7 +51996,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:16.517018+00:00"
+                "validatedAt": "2026-07-20T14:35:31.652124+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -52024,8 +52010,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -52064,7 +52049,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:16.517064+00:00"
+                "validatedAt": "2026-07-20T14:35:31.652152+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -52079,9 +52064,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.966500+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.684526+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -52110,7 +52094,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:16.517117+00:00"
+                "validatedAt": "2026-07-20T14:35:31.652179+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52123,7 +52107,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.966519+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.684539+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a direct reference from one object(the referrer) to another(the referred).",
@@ -52380,7 +52364,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:16.517183+00:00"
+                "validatedAt": "2026-07-20T14:35:31.652213+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52415,7 +52399,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:16.517240+00:00"
+                "validatedAt": "2026-07-20T14:35:31.652244+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52592,7 +52576,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.966636+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.684613+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -52681,7 +52665,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:16.517358+00:00"
+                "validatedAt": "2026-07-20T14:35:31.652300+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52707,7 +52691,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.966678+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.684635+00:00"
           },
           "tenant_id": {
             "type": "string",
@@ -52734,7 +52718,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:16.517419+00:00"
+                "validatedAt": "2026-07-20T14:35:31.652332+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52819,7 +52803,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:55:16.517463+00:00"
+                "validatedAt": "2026-07-20T14:35:31.652355+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52898,7 +52882,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:55:16.517514+00:00"
+                "validatedAt": "2026-07-20T14:35:31.652379+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52909,7 +52893,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.966730+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.684667+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -52996,7 +52980,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:16.517554+00:00"
+                "validatedAt": "2026-07-20T14:35:31.652399+00:00"
               },
               "deterministic": true
             },
@@ -53008,9 +52992,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.966775+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.684697+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -53041,7 +53024,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:16.517581+00:00"
+                "validatedAt": "2026-07-20T14:35:31.652414+00:00"
               },
               "deterministic": true
             },
@@ -53053,9 +53036,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.966793+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.684709+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -53124,7 +53106,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:16.517631+00:00"
+                "validatedAt": "2026-07-20T14:35:31.652437+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53136,7 +53118,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.966830+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.684734+00:00"
           },
           "uid": {
             "type": "string",
@@ -53153,7 +53135,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:16.517665+00:00"
+                "validatedAt": "2026-07-20T14:35:31.652449+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53166,7 +53148,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:07.966856+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.684747+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of allowed_tenant is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -53717,7 +53699,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:39.066748+00:00"
+                "validatedAt": "2026-07-20T14:35:40.587444+00:00"
               },
               "deterministic": true
             },
@@ -53729,9 +53711,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.529756+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.168288+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -53763,7 +53744,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:39.066795+00:00"
+                "validatedAt": "2026-07-20T14:35:40.587461+00:00"
               },
               "deterministic": true
             },
@@ -53775,9 +53756,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.529777+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.168303+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -53942,7 +53922,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.529846+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.168346+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -54106,7 +54086,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:39.066944+00:00"
+                "validatedAt": "2026-07-20T14:35:40.587510+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54154,7 +54134,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:39.066995+00:00"
+                "validatedAt": "2026-07-20T14:35:40.587530+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54276,7 +54256,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:55:39.067044+00:00"
+                "validatedAt": "2026-07-20T14:35:40.587550+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54357,7 +54337,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:55:39.067102+00:00"
+                "validatedAt": "2026-07-20T14:35:40.587574+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54368,7 +54348,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.529942+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.168407+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -54455,7 +54435,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:39.067146+00:00"
+                "validatedAt": "2026-07-20T14:35:40.587593+00:00"
               },
               "deterministic": true
             },
@@ -54467,9 +54447,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.529988+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.168437+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -54500,7 +54479,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:39.067175+00:00"
+                "validatedAt": "2026-07-20T14:35:40.587606+00:00"
               },
               "deterministic": true
             },
@@ -54512,9 +54491,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.530007+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.168450+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -54583,7 +54561,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:39.067230+00:00"
+                "validatedAt": "2026-07-20T14:35:40.587626+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54595,7 +54573,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.530045+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.168475+00:00"
           },
           "uid": {
             "type": "string",
@@ -54612,7 +54590,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:39.067259+00:00"
+                "validatedAt": "2026-07-20T14:35:40.587642+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54625,7 +54603,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.530065+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.168489+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of authentication is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -54711,7 +54689,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:39.067335+00:00"
+                "validatedAt": "2026-07-20T14:35:40.587676+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54754,7 +54732,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:39.067406+00:00"
+                "validatedAt": "2026-07-20T14:35:40.587707+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54797,7 +54775,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:39.067471+00:00"
+                "validatedAt": "2026-07-20T14:35:40.587736+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54908,7 +54886,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:39.067541+00:00"
+                "validatedAt": "2026-07-20T14:35:40.587767+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54950,7 +54928,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:39.067608+00:00"
+                "validatedAt": "2026-07-20T14:35:40.587797+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55272,7 +55250,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:39.067933+00:00"
+                "validatedAt": "2026-07-20T14:35:40.587921+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55313,7 +55291,7 @@
                 "confidence": 1.0,
                 "category": "content",
                 "note": "Blindfold envelope encryption (AES-256-GCM + RSA-OAEP) of an RSA-2048 TLS private key produces ~3700 char string:/// URL. 128KB max secret size = ~175KB base64. Discovery reported 1024 which is incorrect.",
-                "validatedAt": "2026-07-20T12:55:39.067970+00:00"
+                "validatedAt": "2026-07-20T14:35:40.587942+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55324,7 +55302,7 @@
             },
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.530318+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.168655+00:00"
           },
           "store_provider": {
             "type": "string",
@@ -55343,7 +55321,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:39.068015+00:00"
+                "validatedAt": "2026-07-20T14:35:40.587960+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55410,7 +55388,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:39.068051+00:00"
+                "validatedAt": "2026-07-20T14:35:40.587975+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55421,7 +55399,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.530344+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.168673+00:00"
           },
           "url": {
             "type": "string",
@@ -55459,7 +55437,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:39.068109+00:00"
+                "validatedAt": "2026-07-20T14:35:40.588003+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -55757,7 +55735,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:42.627876+00:00"
+                "validatedAt": "2026-07-20T14:35:41.881002+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55852,7 +55830,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:42.627937+00:00"
+                "validatedAt": "2026-07-20T14:35:41.881026+00:00"
               },
               "deterministic": true
             },
@@ -55864,9 +55842,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.568848+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.245723+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -55898,7 +55875,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:42.627969+00:00"
+                "validatedAt": "2026-07-20T14:35:41.881040+00:00"
               },
               "deterministic": true
             },
@@ -55910,9 +55887,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.568869+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.245737+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -56077,7 +56053,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.568936+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.245781+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -56166,7 +56142,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:42.628112+00:00"
+                "validatedAt": "2026-07-20T14:35:41.881094+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56206,7 +56182,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:42.628160+00:00"
+                "validatedAt": "2026-07-20T14:35:41.881113+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56292,7 +56268,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:55:42.628208+00:00"
+                "validatedAt": "2026-07-20T14:35:41.881135+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56373,7 +56349,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:55:42.628263+00:00"
+                "validatedAt": "2026-07-20T14:35:41.881158+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56384,7 +56360,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.569009+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.245828+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -56471,7 +56447,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:42.628305+00:00"
+                "validatedAt": "2026-07-20T14:35:41.881176+00:00"
               },
               "deterministic": true
             },
@@ -56483,9 +56459,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.569054+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.245859+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -56516,7 +56491,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:42.628332+00:00"
+                "validatedAt": "2026-07-20T14:35:41.881189+00:00"
               },
               "deterministic": true
             },
@@ -56528,9 +56503,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.569073+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.245872+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -56599,7 +56573,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:42.628388+00:00"
+                "validatedAt": "2026-07-20T14:35:41.881210+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56611,7 +56585,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.569110+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.245897+00:00"
           },
           "uid": {
             "type": "string",
@@ -56629,7 +56603,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:42.628414+00:00"
+                "validatedAt": "2026-07-20T14:35:41.881221+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56642,7 +56616,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.569130+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.245911+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of authorization_server is returned in 'List'.",
@@ -56821,7 +56795,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:42.628483+00:00"
+                "validatedAt": "2026-07-20T14:35:41.881251+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57029,7 +57003,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:42.628544+00:00"
+                "validatedAt": "2026-07-20T14:35:41.881276+00:00"
               },
               "deterministic": true
             },
@@ -57041,9 +57015,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.569196+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.245952+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -57074,7 +57047,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:42.628573+00:00"
+                "validatedAt": "2026-07-20T14:35:41.881289+00:00"
               },
               "deterministic": true
             },
@@ -57086,9 +57059,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.569214+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.245965+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Request message for UpdateAuthorizationServer API.",
@@ -57182,7 +57154,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:42.629281+00:00"
+                "validatedAt": "2026-07-20T14:35:41.881580+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57194,7 +57166,7 @@
             "readOnly": true,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.569547+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.246186+00:00"
           },
           "name": {
             "type": "string",
@@ -57227,7 +57199,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:42.629307+00:00"
+                "validatedAt": "2026-07-20T14:35:41.881592+00:00"
               },
               "deterministic": true
             },
@@ -57239,9 +57211,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.569565+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.246199+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -57274,7 +57245,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:42.629334+00:00"
+                "validatedAt": "2026-07-20T14:35:41.881605+00:00"
               },
               "deterministic": true
             },
@@ -57286,9 +57257,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.569583+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:09.246213+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -57307,7 +57277,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:42.629368+00:00"
+                "validatedAt": "2026-07-20T14:35:41.881618+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57320,7 +57290,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.569601+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.246226+00:00"
           },
           "uid": {
             "type": "string",
@@ -57339,7 +57309,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:42.629393+00:00"
+                "validatedAt": "2026-07-20T14:35:41.881628+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57353,7 +57323,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.569621+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:09.246240+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -57422,7 +57392,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:21.882391+00:00"
+                "validatedAt": "2026-07-20T14:36:21.443207+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57462,7 +57432,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:21.882475+00:00"
+                "validatedAt": "2026-07-20T14:36:21.443245+00:00"
               },
               "deterministic": true
             },
@@ -57495,7 +57465,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:21.882537+00:00"
+                "validatedAt": "2026-07-20T14:36:21.443274+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57527,7 +57497,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:21.882594+00:00"
+                "validatedAt": "2026-07-20T14:36:21.443301+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57622,7 +57592,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:21.882631+00:00"
+                "validatedAt": "2026-07-20T14:36:21.443319+00:00"
               },
               "deterministic": true
             },
@@ -57634,9 +57604,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.308544+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.816033+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -57668,7 +57637,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:21.882691+00:00"
+                "validatedAt": "2026-07-20T14:36:21.443335+00:00"
               },
               "deterministic": true
             },
@@ -57680,9 +57649,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.308565+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.816046+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -57755,7 +57723,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:21.882748+00:00"
+                "validatedAt": "2026-07-20T14:36:21.443357+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57903,7 +57871,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:21.882828+00:00"
+                "validatedAt": "2026-07-20T14:36:21.443390+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58159,7 +58127,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:21.882920+00:00"
+                "validatedAt": "2026-07-20T14:36:21.443425+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58185,7 +58153,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:21.882963+00:00"
+                "validatedAt": "2026-07-20T14:36:21.443444+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58211,7 +58179,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:21.882999+00:00"
+                "validatedAt": "2026-07-20T14:36:21.443458+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58237,7 +58205,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:21.883031+00:00"
+                "validatedAt": "2026-07-20T14:36:21.443472+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58445,7 +58413,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:21.883107+00:00"
+                "validatedAt": "2026-07-20T14:36:21.443502+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58470,7 +58438,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:21.883147+00:00"
+                "validatedAt": "2026-07-20T14:36:21.443518+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58503,7 +58471,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T12:57:21.883190+00:00"
+                "validatedAt": "2026-07-20T14:36:21.443537+00:00"
               },
               "deterministic": true
             },
@@ -58530,7 +58498,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:21.883221+00:00"
+                "validatedAt": "2026-07-20T14:36:21.443550+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58555,7 +58523,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:21.883258+00:00"
+                "validatedAt": "2026-07-20T14:36:21.443565+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58581,7 +58549,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:34.350509+00:00"
+                "validatedAt": "2026-07-20T14:36:26.524590+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59159,7 +59127,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:21.885000+00:00"
+                "validatedAt": "2026-07-20T14:36:21.444369+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59184,7 +59152,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:21.885034+00:00"
+                "validatedAt": "2026-07-20T14:36:21.444384+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59209,7 +59177,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:21.885065+00:00"
+                "validatedAt": "2026-07-20T14:36:21.444397+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59247,7 +59215,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:21.885103+00:00"
+                "validatedAt": "2026-07-20T14:36:21.444413+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59272,7 +59240,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:21.885136+00:00"
+                "validatedAt": "2026-07-20T14:36:21.444427+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59298,7 +59266,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:21.885175+00:00"
+                "validatedAt": "2026-07-20T14:36:21.444445+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59323,7 +59291,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:21.885208+00:00"
+                "validatedAt": "2026-07-20T14:36:21.444458+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59348,7 +59316,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:21.885244+00:00"
+                "validatedAt": "2026-07-20T14:36:21.444474+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59373,7 +59341,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:21.885280+00:00"
+                "validatedAt": "2026-07-20T14:36:21.444489+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59596,7 +59564,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:21.885334+00:00"
+                "validatedAt": "2026-07-20T14:36:21.444512+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59642,7 +59610,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:57:21.885394+00:00"
+                "validatedAt": "2026-07-20T14:36:21.444540+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59653,7 +59621,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.309710+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.816746+00:00"
           },
           "ongoing": {
             "type": "boolean",
@@ -59697,7 +59665,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:21.885440+00:00"
+                "validatedAt": "2026-07-20T14:36:21.444558+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59751,7 +59719,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.309762+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.816779+00:00"
           },
           "subject": {
             "type": "string",
@@ -59767,7 +59735,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:21.885494+00:00"
+                "validatedAt": "2026-07-20T14:36:21.444580+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59792,7 +59760,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:21.885528+00:00"
+                "validatedAt": "2026-07-20T14:36:21.444595+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59830,7 +59798,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:21.885564+00:00"
+                "validatedAt": "2026-07-20T14:36:21.444610+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59972,7 +59940,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:21.885607+00:00"
+                "validatedAt": "2026-07-20T14:36:21.444628+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60000,7 +59968,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:21.885642+00:00"
+                "validatedAt": "2026-07-20T14:36:21.444643+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60049,7 +60017,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T12:57:21.885708+00:00"
+                "validatedAt": "2026-07-20T14:36:21.444672+00:00"
               },
               "deterministic": true
             },
@@ -60098,7 +60066,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:57:21.885768+00:00"
+                "validatedAt": "2026-07-20T14:36:21.444698+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60109,7 +60077,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.309848+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.816831+00:00"
           },
           "escalated": {
             "type": "boolean",
@@ -60183,7 +60151,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:21.885830+00:00"
+                "validatedAt": "2026-07-20T14:36:21.444724+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60237,7 +60205,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.309913+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.816871+00:00"
           },
           "subject": {
             "type": "string",
@@ -60253,7 +60221,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:21.885884+00:00"
+                "validatedAt": "2026-07-20T14:36:21.444748+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60282,7 +60250,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T12:57:21.885912+00:00"
+                "validatedAt": "2026-07-20T14:36:21.444765+00:00"
               },
               "deterministic": true
             },
@@ -60308,7 +60276,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:21.885948+00:00"
+                "validatedAt": "2026-07-20T14:36:21.444779+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60346,7 +60314,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:21.885984+00:00"
+                "validatedAt": "2026-07-20T14:36:21.444794+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60386,7 +60354,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:21.886024+00:00"
+                "validatedAt": "2026-07-20T14:36:21.444811+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60520,7 +60488,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:57:21.886089+00:00"
+                "validatedAt": "2026-07-20T14:36:21.444840+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60531,7 +60499,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.310002+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.816925+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -60618,7 +60586,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:21.886128+00:00"
+                "validatedAt": "2026-07-20T14:36:21.444859+00:00"
               },
               "deterministic": true
             },
@@ -60630,9 +60598,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.310048+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.816953+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -60663,7 +60630,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:21.886153+00:00"
+                "validatedAt": "2026-07-20T14:36:21.444873+00:00"
               },
               "deterministic": true
             },
@@ -60675,9 +60642,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.310066+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.816965+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -60746,7 +60712,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:21.886205+00:00"
+                "validatedAt": "2026-07-20T14:36:21.444895+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60758,7 +60724,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.310104+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.816990+00:00"
           },
           "uid": {
             "type": "string",
@@ -60776,7 +60742,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:21.886230+00:00"
+                "validatedAt": "2026-07-20T14:36:21.444906+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60789,7 +60755,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.310123+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.817003+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of customer_support is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -60964,7 +60930,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:57:21.886316+00:00"
+                "validatedAt": "2026-07-20T14:36:21.444942+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60990,7 +60956,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:21.886347+00:00"
+                "validatedAt": "2026-07-20T14:36:21.444955+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61070,7 +61036,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:21.886382+00:00"
+                "validatedAt": "2026-07-20T14:36:21.444970+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61188,7 +61154,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:21.886583+00:00"
+                "validatedAt": "2026-07-20T14:36:21.445080+00:00"
               },
               "deterministic": true
             },
@@ -61200,9 +61166,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.310258+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.817089+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "support_request_count": {
             "allOf": [
@@ -61340,7 +61305,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:21.886661+00:00"
+                "validatedAt": "2026-07-20T14:36:21.445108+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61384,7 +61349,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:21.886711+00:00"
+                "validatedAt": "2026-07-20T14:36:21.445132+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61618,7 +61583,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:21.886793+00:00"
+                "validatedAt": "2026-07-20T14:36:21.445170+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61701,7 +61666,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:57:21.886837+00:00"
+                "validatedAt": "2026-07-20T14:36:21.445190+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61832,7 +61797,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:21.886879+00:00"
+                "validatedAt": "2026-07-20T14:36:21.445207+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62106,7 +62071,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:21.886965+00:00"
+                "validatedAt": "2026-07-20T14:36:21.445245+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62180,7 +62145,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:21.887030+00:00"
+                "validatedAt": "2026-07-20T14:36:21.445276+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62189,9 +62154,9 @@
               "update": false,
               "read": false
             },
-            "format": "dns-label",
+            "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.310452+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:10.817208+00:00",
             "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant_profile": {
@@ -62435,7 +62400,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.310524+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.817254+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -62538,7 +62503,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:21.887169+00:00"
+                "validatedAt": "2026-07-20T14:36:21.445334+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62626,7 +62591,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:21.887234+00:00"
+                "validatedAt": "2026-07-20T14:36:21.445365+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62635,9 +62600,9 @@
               "update": false,
               "read": false
             },
-            "format": "dns-label",
+            "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.310582+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:10.817291+00:00",
             "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "status": {
@@ -62656,7 +62621,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.310601+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.817304+00:00"
           },
           "tenant_profile": {
             "allOf": [
@@ -62759,7 +62724,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:57:21.887281+00:00"
+                "validatedAt": "2026-07-20T14:36:21.445386+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62838,7 +62803,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:57:21.887332+00:00"
+                "validatedAt": "2026-07-20T14:36:21.445407+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62849,7 +62814,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.310651+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.817334+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -62936,7 +62901,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:21.887372+00:00"
+                "validatedAt": "2026-07-20T14:36:21.445426+00:00"
               },
               "deterministic": true
             },
@@ -62948,9 +62913,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.310706+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.817363+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -62981,7 +62945,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:21.887401+00:00"
+                "validatedAt": "2026-07-20T14:36:21.445444+00:00"
               },
               "deterministic": true
             },
@@ -62993,9 +62957,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.310725+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.817375+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -63064,7 +63027,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:21.887453+00:00"
+                "validatedAt": "2026-07-20T14:36:21.445465+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63076,7 +63039,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.310762+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.817399+00:00"
           },
           "uid": {
             "type": "string",
@@ -63093,7 +63056,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:21.887480+00:00"
+                "validatedAt": "2026-07-20T14:36:21.445476+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63106,7 +63069,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.310782+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.817412+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of child_tenant is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -63179,7 +63142,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:21.887544+00:00"
+                "validatedAt": "2026-07-20T14:36:21.445506+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63365,7 +63328,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:21.887636+00:00"
+                "validatedAt": "2026-07-20T14:36:21.445547+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63414,7 +63377,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:21.887695+00:00"
+                "validatedAt": "2026-07-20T14:36:21.445575+00:00"
               },
               "deterministic": true
             },
@@ -63424,8 +63387,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "LinkRefType This message defines a reference to hyperlink that can be accessed via web.",
@@ -63480,7 +63442,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:25.882612+00:00"
+                "validatedAt": "2026-07-20T14:36:23.048224+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63506,7 +63468,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:25.882669+00:00"
+                "validatedAt": "2026-07-20T14:36:23.048241+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63555,7 +63517,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:25.882712+00:00"
+                "validatedAt": "2026-07-20T14:36:23.048257+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63566,7 +63528,7 @@
             },
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.413635+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.908360+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -63644,7 +63606,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:25.882768+00:00"
+                "validatedAt": "2026-07-20T14:36:23.048284+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63748,7 +63710,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:57:25.882830+00:00"
+                "validatedAt": "2026-07-20T14:36:23.048311+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63759,7 +63721,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.413694+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.908390+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -63846,7 +63808,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:25.882877+00:00"
+                "validatedAt": "2026-07-20T14:36:23.048332+00:00"
               },
               "deterministic": true
             },
@@ -63858,9 +63820,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.413742+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.908420+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -63891,7 +63852,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:25.882905+00:00"
+                "validatedAt": "2026-07-20T14:36:23.048346+00:00"
               },
               "deterministic": true
             },
@@ -63903,9 +63864,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.413761+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.908432+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -63974,7 +63934,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:25.882959+00:00"
+                "validatedAt": "2026-07-20T14:36:23.048367+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63986,7 +63946,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.413799+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.908456+00:00"
           },
           "uid": {
             "type": "string",
@@ -64003,7 +63963,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:25.882986+00:00"
+                "validatedAt": "2026-07-20T14:36:23.048378+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64016,7 +63976,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.413819+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.908470+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -64111,7 +64071,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:25.883018+00:00"
+                "validatedAt": "2026-07-20T14:36:23.048393+00:00"
               },
               "deterministic": true
             },
@@ -64123,9 +64083,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.413846+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.908487+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -64157,7 +64116,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:25.883045+00:00"
+                "validatedAt": "2026-07-20T14:36:23.048406+00:00"
               },
               "deterministic": true
             },
@@ -64169,9 +64128,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.413864+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.908500+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -64248,7 +64206,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:57:25.883088+00:00"
+                "validatedAt": "2026-07-20T14:36:23.048426+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64350,7 +64308,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:25.883123+00:00"
+                "validatedAt": "2026-07-20T14:36:23.048443+00:00"
               },
               "deterministic": true
             },
@@ -64362,9 +64320,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.413905+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.908525+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Request to migrate child tenants to a specified child tenant manager.",
@@ -64420,7 +64377,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:25.883168+00:00"
+                "validatedAt": "2026-07-20T14:36:23.048462+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64637,7 +64594,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:25.883706+00:00"
+                "validatedAt": "2026-07-20T14:36:23.048682+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64669,7 +64626,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:25.883752+00:00"
+                "validatedAt": "2026-07-20T14:36:23.048698+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64889,7 +64846,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:25.885786+00:00"
+                "validatedAt": "2026-07-20T14:36:23.049566+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65169,7 +65126,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:25.885900+00:00"
+                "validatedAt": "2026-07-20T14:36:23.049614+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65277,7 +65234,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:57:25.885946+00:00"
+                "validatedAt": "2026-07-20T14:36:23.049633+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65356,7 +65313,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:57:25.885997+00:00"
+                "validatedAt": "2026-07-20T14:36:23.049654+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65367,7 +65324,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.415149+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.909302+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -65454,7 +65411,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:25.886037+00:00"
+                "validatedAt": "2026-07-20T14:36:23.049671+00:00"
               },
               "deterministic": true
             },
@@ -65466,9 +65423,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.415194+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.909331+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -65499,7 +65455,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:25.886063+00:00"
+                "validatedAt": "2026-07-20T14:36:23.049684+00:00"
               },
               "deterministic": true
             },
@@ -65511,9 +65467,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.415212+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:10.909343+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -65566,7 +65521,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:25.886102+00:00"
+                "validatedAt": "2026-07-20T14:36:23.049700+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65578,7 +65533,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.415243+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.909363+00:00"
           },
           "uid": {
             "type": "string",
@@ -65596,7 +65551,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:25.886128+00:00"
+                "validatedAt": "2026-07-20T14:36:23.049710+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65609,7 +65564,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:10.415262+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:10.909376+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of child_tenant_manager is returned in 'List'.",
@@ -65702,7 +65657,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:57:25.886177+00:00"
+                "validatedAt": "2026-07-20T14:36:23.049734+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65784,7 +65739,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:34.349531+00:00"
+                "validatedAt": "2026-07-20T14:36:26.524218+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65809,7 +65764,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:57:34.349604+00:00"
+                "validatedAt": "2026-07-20T14:36:26.524240+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65897,7 +65852,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:15.761447+00:00"
+                "validatedAt": "2026-07-20T14:36:42.932579+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66142,7 +66097,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:36.903144+00:00"
+                "validatedAt": "2026-07-20T14:37:16.055084+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66166,7 +66121,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:36.903201+00:00"
+                "validatedAt": "2026-07-20T14:37:16.055107+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66190,7 +66145,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:36.903233+00:00"
+                "validatedAt": "2026-07-20T14:37:16.055120+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66227,7 +66182,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:36.903292+00:00"
+                "validatedAt": "2026-07-20T14:37:16.055135+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66251,7 +66206,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:36.903339+00:00"
+                "validatedAt": "2026-07-20T14:37:16.055149+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66276,7 +66231,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:36.903401+00:00"
+                "validatedAt": "2026-07-20T14:37:16.055166+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66300,7 +66255,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:36.903455+00:00"
+                "validatedAt": "2026-07-20T14:37:16.055179+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66324,7 +66279,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:36.903516+00:00"
+                "validatedAt": "2026-07-20T14:37:16.055194+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66348,7 +66303,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:36.903553+00:00"
+                "validatedAt": "2026-07-20T14:37:16.055208+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66456,7 +66411,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:36.903598+00:00"
+                "validatedAt": "2026-07-20T14:37:16.055228+00:00"
               },
               "deterministic": true
             },
@@ -66468,9 +66423,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.580067+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.075601+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -66502,7 +66456,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:36.903629+00:00"
+                "validatedAt": "2026-07-20T14:37:16.055243+00:00"
               },
               "deterministic": true
             },
@@ -66514,9 +66468,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.580088+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.075615+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -66681,7 +66634,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.580156+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.075657+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -66757,7 +66710,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:36.903749+00:00"
+                "validatedAt": "2026-07-20T14:37:16.055284+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66781,7 +66734,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:36.903785+00:00"
+                "validatedAt": "2026-07-20T14:37:16.055298+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66805,7 +66758,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:36.903817+00:00"
+                "validatedAt": "2026-07-20T14:37:16.055311+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66842,7 +66795,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:36.903855+00:00"
+                "validatedAt": "2026-07-20T14:37:16.055325+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66866,7 +66819,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:36.903890+00:00"
+                "validatedAt": "2026-07-20T14:37:16.055338+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66891,7 +66844,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:36.903930+00:00"
+                "validatedAt": "2026-07-20T14:37:16.055354+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66915,7 +66868,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:36.903965+00:00"
+                "validatedAt": "2026-07-20T14:37:16.055368+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66939,7 +66892,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:36.904003+00:00"
+                "validatedAt": "2026-07-20T14:37:16.055382+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66963,7 +66916,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:36.904039+00:00"
+                "validatedAt": "2026-07-20T14:37:16.055396+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67056,7 +67009,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:59:36.904087+00:00"
+                "validatedAt": "2026-07-20T14:37:16.055417+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67136,7 +67089,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:59:36.904142+00:00"
+                "validatedAt": "2026-07-20T14:37:16.055441+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67147,7 +67100,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.580275+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.075728+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -67234,7 +67187,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:36.904185+00:00"
+                "validatedAt": "2026-07-20T14:37:16.055460+00:00"
               },
               "deterministic": true
             },
@@ -67246,9 +67199,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.580320+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.075756+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -67279,7 +67231,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:36.904213+00:00"
+                "validatedAt": "2026-07-20T14:37:16.055473+00:00"
               },
               "deterministic": true
             },
@@ -67291,9 +67243,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.580339+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:14.075769+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -67362,7 +67313,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:36.904265+00:00"
+                "validatedAt": "2026-07-20T14:37:16.055493+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67374,7 +67325,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.580376+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.075794+00:00"
           },
           "uid": {
             "type": "string",
@@ -67391,7 +67342,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:36.904292+00:00"
+                "validatedAt": "2026-07-20T14:37:16.055504+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67404,7 +67355,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.580395+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:14.075807+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of contact is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -67570,7 +67521,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:36.904337+00:00"
+                "validatedAt": "2026-07-20T14:37:16.055521+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67594,7 +67545,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:36.904371+00:00"
+                "validatedAt": "2026-07-20T14:37:16.055535+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67618,7 +67569,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:36.904403+00:00"
+                "validatedAt": "2026-07-20T14:37:16.055547+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67655,7 +67606,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:36.904441+00:00"
+                "validatedAt": "2026-07-20T14:37:16.055561+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67679,7 +67630,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:36.904475+00:00"
+                "validatedAt": "2026-07-20T14:37:16.055574+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67704,7 +67655,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:36.904516+00:00"
+                "validatedAt": "2026-07-20T14:37:16.055590+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67728,7 +67679,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:36.904549+00:00"
+                "validatedAt": "2026-07-20T14:37:16.055603+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67752,7 +67703,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:36.904588+00:00"
+                "validatedAt": "2026-07-20T14:37:16.055618+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67776,7 +67727,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:36.904623+00:00"
+                "validatedAt": "2026-07-20T14:37:16.055632+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67962,7 +67913,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:14.204999+00:00"
+                "validatedAt": "2026-07-20T14:39:05.418876+00:00"
               },
               "deterministic": true
             },
@@ -67974,9 +67925,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.196332+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.969599+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -68008,7 +67958,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:14.205025+00:00"
+                "validatedAt": "2026-07-20T14:39:05.418889+00:00"
               },
               "deterministic": true
             },
@@ -68020,9 +67970,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.196351+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.969612+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -68095,7 +68044,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:14.205078+00:00"
+                "validatedAt": "2026-07-20T14:39:05.418909+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68209,7 +68158,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:04:14.205159+00:00"
+                "validatedAt": "2026-07-20T14:39:05.418942+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68234,7 +68183,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:14.205195+00:00"
+                "validatedAt": "2026-07-20T14:39:05.418956+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68398,7 +68347,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:14.205271+00:00"
+                "validatedAt": "2026-07-20T14:39:05.418987+00:00"
               },
               "deterministic": true
             },
@@ -68410,9 +68359,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.196451+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.969675+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant_status": {
             "allOf": [
@@ -68739,7 +68687,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:14.208328+00:00"
+                "validatedAt": "2026-07-20T14:39:05.420260+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68772,7 +68720,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:14.208387+00:00"
+                "validatedAt": "2026-07-20T14:39:05.420288+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68949,7 +68897,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.198010+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.970628+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -69039,7 +68987,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:14.208501+00:00"
+                "validatedAt": "2026-07-20T14:39:05.420337+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69065,7 +69013,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.198043+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.970650+00:00"
           },
           "tenant_id": {
             "type": "string",
@@ -69090,7 +69038,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:14.208560+00:00"
+                "validatedAt": "2026-07-20T14:39:05.420366+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69175,7 +69123,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:04:14.208603+00:00"
+                "validatedAt": "2026-07-20T14:39:05.420385+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69254,7 +69202,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:04:14.208652+00:00"
+                "validatedAt": "2026-07-20T14:39:05.420406+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69265,7 +69213,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.198092+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.970681+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -69352,7 +69300,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:14.208701+00:00"
+                "validatedAt": "2026-07-20T14:39:05.420424+00:00"
               },
               "deterministic": true
             },
@@ -69364,9 +69312,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.198137+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.970709+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -69397,7 +69344,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:14.208727+00:00"
+                "validatedAt": "2026-07-20T14:39:05.420436+00:00"
               },
               "deterministic": true
             },
@@ -69409,9 +69356,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.198155+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.970722+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -69480,7 +69426,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:14.208778+00:00"
+                "validatedAt": "2026-07-20T14:39:05.420456+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69492,7 +69438,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.198192+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.970746+00:00"
           },
           "uid": {
             "type": "string",
@@ -69509,7 +69455,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:04:14.208803+00:00"
+                "validatedAt": "2026-07-20T14:39:05.420466+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69522,7 +69468,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.198212+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.970759+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of managed_tenant is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -69603,7 +69549,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:04:14.208846+00:00"
+                "validatedAt": "2026-07-20T14:39:05.420487+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69772,7 +69718,7 @@
             "maxLength": 43,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.846738+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.605161+00:00"
           },
           "status": {
             "type": "string",
@@ -69794,7 +69740,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:00.687675+00:00"
+                "validatedAt": "2026-07-20T14:39:23.544534+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69805,7 +69751,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.846759+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.605175+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -69954,7 +69900,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:00.687927+00:00"
+                "validatedAt": "2026-07-20T14:39:23.544646+00:00"
               },
               "deterministic": true
             },
@@ -69980,7 +69926,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:00.687962+00:00"
+                "validatedAt": "2026-07-20T14:39:23.544660+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -70046,7 +69992,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:05:00.687991+00:00"
+                "validatedAt": "2026-07-20T14:39:23.544674+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -70071,7 +70017,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:00.688027+00:00"
+                "validatedAt": "2026-07-20T14:39:23.544688+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -70151,7 +70097,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:00.688065+00:00"
+                "validatedAt": "2026-07-20T14:39:23.544704+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -70178,7 +70124,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:05:00.688106+00:00"
+                "validatedAt": "2026-07-20T14:39:23.544721+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -70258,7 +70204,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:00.688145+00:00"
+                "validatedAt": "2026-07-20T14:39:23.544736+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -70301,7 +70247,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:05:00.688187+00:00"
+                "validatedAt": "2026-07-20T14:39:23.544754+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -70769,7 +70715,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:00.688313+00:00"
+                "validatedAt": "2026-07-20T14:39:23.544804+00:00"
               },
               "deterministic": true
             },
@@ -70781,9 +70727,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.847051+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.605355+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Request shape for GET API Endpoints Stats All Namespaces.",
@@ -70852,7 +70797,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:00.688341+00:00"
+                "validatedAt": "2026-07-20T14:39:23.544818+00:00"
               },
               "deterministic": true
             },
@@ -70864,9 +70809,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.847071+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.605369+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "vhosts_filter": {
             "type": "array",
@@ -70914,7 +70858,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:00.688398+00:00"
+                "validatedAt": "2026-07-20T14:39:23.544844+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71144,7 +71088,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:00.688505+00:00"
+                "validatedAt": "2026-07-20T14:39:23.544887+00:00"
               },
               "deterministic": true
             },
@@ -71156,9 +71100,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.847157+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.605422+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "nginx_one_server_filter": {
             "allOf": [
@@ -71619,7 +71562,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:05:00.688692+00:00"
+                "validatedAt": "2026-07-20T14:39:23.544954+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71630,7 +71573,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.847310+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.605517+00:00"
           },
           "host_name": {
             "type": "string",
@@ -71646,7 +71589,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:00.688730+00:00"
+                "validatedAt": "2026-07-20T14:39:23.544969+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71684,7 +71627,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:00.688758+00:00"
+                "validatedAt": "2026-07-20T14:39:23.544982+00:00"
               },
               "deterministic": true
             },
@@ -71696,9 +71639,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.847337+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.605534+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "server_name": {
             "type": "string",
@@ -71714,7 +71656,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:00.688795+00:00"
+                "validatedAt": "2026-07-20T14:39:23.544998+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71738,7 +71680,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:00.688828+00:00"
+                "validatedAt": "2026-07-20T14:39:23.545012+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71749,7 +71691,7 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.847362+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.605551+00:00"
           },
           "waf_enforcement_mode": {
             "type": "string",
@@ -71764,7 +71706,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:00.688871+00:00"
+                "validatedAt": "2026-07-20T14:39:23.545028+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71788,7 +71730,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:00.688911+00:00"
+                "validatedAt": "2026-07-20T14:39:23.545045+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71826,7 +71768,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:24.301716+00:00"
+                "validatedAt": "2026-07-20T14:39:32.586237+00:00"
               },
               "deterministic": true
             },
@@ -71838,9 +71780,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.242409+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.947239+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "BIG-IP Virtual Server Inventory Results.",
@@ -71902,7 +71843,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:00.688953+00:00"
+                "validatedAt": "2026-07-20T14:39:23.545062+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71928,7 +71869,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:00.688990+00:00"
+                "validatedAt": "2026-07-20T14:39:23.545077+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71954,7 +71895,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:00.689028+00:00"
+                "validatedAt": "2026-07-20T14:39:23.545092+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71980,7 +71921,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:00.689064+00:00"
+                "validatedAt": "2026-07-20T14:39:23.545107+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -72060,7 +72001,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:00.689091+00:00"
+                "validatedAt": "2026-07-20T14:39:23.545120+00:00"
               },
               "deterministic": true
             },
@@ -72072,9 +72013,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.847422+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.605588+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "CascadeDeleteRequest contains the name of the namespace that has to be deleted along with the objects configured under the namespace.",
@@ -72132,7 +72072,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:05:00.689119+00:00"
+                "validatedAt": "2026-07-20T14:39:23.545134+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -72357,7 +72297,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:00.689185+00:00"
+                "validatedAt": "2026-07-20T14:39:23.545164+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -72397,7 +72337,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:00.689213+00:00"
+                "validatedAt": "2026-07-20T14:39:23.545177+00:00"
               },
               "deterministic": true
             },
@@ -72409,9 +72349,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.847498+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.605634+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -72527,7 +72466,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:00.689273+00:00"
+                "validatedAt": "2026-07-20T14:39:23.545206+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -72981,7 +72920,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.847625+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.605710+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -73939,7 +73878,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:00.689818+00:00"
+                "validatedAt": "2026-07-20T14:39:23.545439+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -73962,7 +73901,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:00.689862+00:00"
+                "validatedAt": "2026-07-20T14:39:23.545459+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74134,7 +74073,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:00.689942+00:00"
+                "validatedAt": "2026-07-20T14:39:23.545492+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74161,7 +74100,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:00.689972+00:00"
+                "validatedAt": "2026-07-20T14:39:23.545509+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74210,7 +74149,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:00.690022+00:00"
+                "validatedAt": "2026-07-20T14:39:23.545530+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74260,7 +74199,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:00.690082+00:00"
+                "validatedAt": "2026-07-20T14:39:23.545553+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74351,7 +74290,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:00.690123+00:00"
+                "validatedAt": "2026-07-20T14:39:23.545573+00:00"
               },
               "deterministic": true
             },
@@ -74363,9 +74302,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.848161+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.606027+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -74395,7 +74333,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:00.690151+00:00"
+                "validatedAt": "2026-07-20T14:39:23.545588+00:00"
               },
               "deterministic": true
             },
@@ -74407,9 +74345,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.848181+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.606040+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace_service_policy_enabled": {
             "allOf": [
@@ -74531,7 +74468,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:00.690214+00:00"
+                "validatedAt": "2026-07-20T14:39:23.545615+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74582,7 +74519,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:00.690254+00:00"
+                "validatedAt": "2026-07-20T14:39:23.545632+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74618,7 +74555,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:00.690299+00:00"
+                "validatedAt": "2026-07-20T14:39:23.545650+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74665,7 +74602,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:00.690347+00:00"
+                "validatedAt": "2026-07-20T14:39:23.545676+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74786,7 +74723,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:00.690376+00:00"
+                "validatedAt": "2026-07-20T14:39:23.545691+00:00"
               },
               "deterministic": true
             },
@@ -74798,9 +74735,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.848303+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.606113+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -74830,7 +74766,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:00.690402+00:00"
+                "validatedAt": "2026-07-20T14:39:23.545704+00:00"
               },
               "deterministic": true
             },
@@ -74842,9 +74778,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.848322+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.606126+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "HTTP Loadbalancer WAF Filter Inventory Results.",
@@ -74919,7 +74854,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:05:00.690440+00:00"
+                "validatedAt": "2026-07-20T14:39:23.545737+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74997,7 +74932,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:05:00.690489+00:00"
+                "validatedAt": "2026-07-20T14:39:23.545767+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75008,7 +74943,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.848366+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.606154+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -75095,7 +75030,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:00.690530+00:00"
+                "validatedAt": "2026-07-20T14:39:23.545789+00:00"
               },
               "deterministic": true
             },
@@ -75107,9 +75042,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.848411+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.606183+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -75140,7 +75074,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:00.690555+00:00"
+                "validatedAt": "2026-07-20T14:39:23.545804+00:00"
               },
               "deterministic": true
             },
@@ -75152,9 +75086,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.848429+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.606196+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -75223,7 +75156,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:00.690607+00:00"
+                "validatedAt": "2026-07-20T14:39:23.545825+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75235,7 +75168,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.848466+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.606219+00:00"
           },
           "uid": {
             "type": "string",
@@ -75252,7 +75185,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:00.690633+00:00"
+                "validatedAt": "2026-07-20T14:39:23.545837+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75265,7 +75198,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.848486+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.606232+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of namespace is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -75347,7 +75280,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:00.690669+00:00"
+                "validatedAt": "2026-07-20T14:39:23.545852+00:00"
               },
               "deterministic": true
             },
@@ -75359,9 +75292,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.848506+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.606245+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Request body of LookupUserRoles request.",
@@ -75626,7 +75558,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:00.690768+00:00"
+                "validatedAt": "2026-07-20T14:39:23.545893+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75665,7 +75597,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:00.690796+00:00"
+                "validatedAt": "2026-07-20T14:39:23.545908+00:00"
               },
               "deterministic": true
             },
@@ -75677,9 +75609,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.848581+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.606292+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "nginx_one_object_id": {
             "type": "string",
@@ -75694,7 +75625,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:00.690838+00:00"
+                "validatedAt": "2026-07-20T14:39:23.545925+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75720,7 +75651,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:00.690882+00:00"
+                "validatedAt": "2026-07-20T14:39:23.545943+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75745,7 +75676,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:00.690924+00:00"
+                "validatedAt": "2026-07-20T14:39:23.545959+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75782,7 +75713,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:00.690980+00:00"
+                "validatedAt": "2026-07-20T14:39:23.545981+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75806,7 +75737,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:00.691022+00:00"
+                "validatedAt": "2026-07-20T14:39:23.546004+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75837,7 +75768,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:00.691071+00:00"
+                "validatedAt": "2026-07-20T14:39:23.546025+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75861,7 +75792,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:00.691111+00:00"
+                "validatedAt": "2026-07-20T14:39:23.546041+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75972,7 +75903,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:00.691174+00:00"
+                "validatedAt": "2026-07-20T14:39:23.546073+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -76012,7 +75943,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:00.691202+00:00"
+                "validatedAt": "2026-07-20T14:39:23.546088+00:00"
               },
               "deterministic": true
             },
@@ -76024,9 +75955,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.848681+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.606349+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "NamespaceAPIListReq holds the namespace and its associated APIs.",
@@ -76111,7 +76041,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:00.691242+00:00"
+                "validatedAt": "2026-07-20T14:39:23.546106+00:00"
               },
               "deterministic": true
             },
@@ -76123,9 +76053,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.848708+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.606366+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "NamespaceAPIListResp holds the namespace and its associated APIs.",
@@ -76477,7 +76406,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:00.691372+00:00"
+                "validatedAt": "2026-07-20T14:39:23.546160+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -76516,7 +76445,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:00.691398+00:00"
+                "validatedAt": "2026-07-20T14:39:23.546173+00:00"
               },
               "deterministic": true
             },
@@ -76528,9 +76457,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.848791+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.606417+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "SetActiveAlertPoliciesRequest is the shape of the request for SetActiveAlertPolicies.",
@@ -76632,7 +76560,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:00.691425+00:00"
+                "validatedAt": "2026-07-20T14:39:23.546187+00:00"
               },
               "deterministic": true
             },
@@ -76644,9 +76572,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.848812+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.606430+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "network_policies": {
             "type": "array",
@@ -76672,7 +76599,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:00.691466+00:00"
+                "validatedAt": "2026-07-20T14:39:23.546208+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -76782,7 +76709,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:00.691493+00:00"
+                "validatedAt": "2026-07-20T14:39:23.546221+00:00"
               },
               "deterministic": true
             },
@@ -76794,9 +76721,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.848839+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.606448+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "service_policies": {
             "type": "array",
@@ -76823,7 +76749,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:00.691534+00:00"
+                "validatedAt": "2026-07-20T14:39:23.546242+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -76929,7 +76855,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:00.691577+00:00"
+                "validatedAt": "2026-07-20T14:39:23.546265+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -76968,7 +76894,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:00.691606+00:00"
+                "validatedAt": "2026-07-20T14:39:23.546280+00:00"
               },
               "deterministic": true
             },
@@ -76980,9 +76906,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.848873+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.606469+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "SetFastACLsForInternetVIPsRequest contains list of FastACLs refs that should be applied to the Internet VIPs.",
@@ -77119,7 +77044,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:00.691674+00:00"
+                "validatedAt": "2026-07-20T14:39:23.546307+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -77153,7 +77078,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:00.691733+00:00"
+                "validatedAt": "2026-07-20T14:39:23.546335+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -77193,7 +77118,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:00.691763+00:00"
+                "validatedAt": "2026-07-20T14:39:23.546349+00:00"
               },
               "deterministic": true
             },
@@ -77205,9 +77130,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.848907+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.606492+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "request_body": {
             "allOf": [
@@ -77527,7 +77451,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:00.691902+00:00"
+                "validatedAt": "2026-07-20T14:39:23.546403+00:00"
               },
               "deterministic": true
             },
@@ -77539,9 +77463,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.849007+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.606553+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -77571,7 +77494,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:00.691927+00:00"
+                "validatedAt": "2026-07-20T14:39:23.546416+00:00"
               },
               "deterministic": true
             },
@@ -77583,9 +77506,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.849026+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.606566+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace_service_policy": {
             "allOf": [
@@ -77873,7 +77795,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:00.692014+00:00"
+                "validatedAt": "2026-07-20T14:39:23.546450+00:00"
               },
               "deterministic": true
             },
@@ -77885,9 +77807,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.849112+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.606621+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Third Party Application Inventory Results.",
@@ -78159,7 +78080,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:00.692092+00:00"
+                "validatedAt": "2026-07-20T14:39:23.546482+00:00"
               },
               "deterministic": true
             },
@@ -78171,9 +78092,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.849167+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.606656+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -78203,7 +78123,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:00.692117+00:00"
+                "validatedAt": "2026-07-20T14:39:23.546495+00:00"
               },
               "deterministic": true
             },
@@ -78215,9 +78135,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.849186+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.606669+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "private_advertisement": {
             "allOf": [
@@ -78359,7 +78278,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:00.692154+00:00"
+                "validatedAt": "2026-07-20T14:39:23.546512+00:00"
               },
               "deterministic": true
             },
@@ -78371,9 +78290,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.849224+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.606694+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Request body of UpdateAllowAdvertiseOnPublic request.",
@@ -78493,7 +78411,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:00.692187+00:00"
+                "validatedAt": "2026-07-20T14:39:23.546527+00:00"
               },
               "deterministic": true
             },
@@ -78505,9 +78423,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.849252+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.606712+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "validator_evaluation": {
             "type": "object",
@@ -78539,7 +78456,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:00.692222+00:00"
+                "validatedAt": "2026-07-20T14:39:23.546541+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78550,7 +78467,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.849278+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.606729+00:00"
           }
         },
         "x-f5xc-description-short": "Request body of ValidateRulesReq request.",
@@ -78605,7 +78522,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:00.692255+00:00"
+                "validatedAt": "2026-07-20T14:39:23.546555+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78696,7 +78613,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:00.692309+00:00"
+                "validatedAt": "2026-07-20T14:39:23.546576+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78963,7 +78880,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:05:00.693862+00:00"
+                "validatedAt": "2026-07-20T14:39:23.547247+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -79028,7 +78945,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:05:00.693906+00:00"
+                "validatedAt": "2026-07-20T14:39:23.547267+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -79039,7 +78956,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.850048+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.607216+00:00"
           },
           "ref_value": {
             "allOf": [
@@ -79081,7 +78998,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:00.693945+00:00"
+                "validatedAt": "2026-07-20T14:39:23.547283+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -79110,7 +79027,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:00.693979+00:00"
+                "validatedAt": "2026-07-20T14:39:23.547297+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -79121,7 +79038,7 @@
             },
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.850078+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.607236+00:00"
           },
           "value": {
             "type": "string",
@@ -79137,7 +79054,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:00.694010+00:00"
+                "validatedAt": "2026-07-20T14:39:23.547310+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -79148,7 +79065,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.850097+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.607248+00:00"
           }
         },
         "x-f5xc-description-short": "Tuple with a suggested value and it's description.",
@@ -79331,7 +79248,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.974203+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.699567+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -79425,7 +79342,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:04.861995+00:00"
+                "validatedAt": "2026-07-20T14:39:25.275662+00:00"
               },
               "deterministic": true
             },
@@ -79437,9 +79354,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.974234+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.699586+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "role": {
             "type": "array",
@@ -79470,7 +79386,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:04.862074+00:00"
+                "validatedAt": "2026-07-20T14:39:25.275693+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -79508,7 +79424,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:04.862119+00:00"
+                "validatedAt": "2026-07-20T14:39:25.275715+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -79590,7 +79506,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:05:04.862166+00:00"
+                "validatedAt": "2026-07-20T14:39:25.275736+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -79669,7 +79585,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:05:04.862225+00:00"
+                "validatedAt": "2026-07-20T14:39:25.275760+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -79680,7 +79596,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.974293+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.699626+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -79767,7 +79683,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:04.862268+00:00"
+                "validatedAt": "2026-07-20T14:39:25.275780+00:00"
               },
               "deterministic": true
             },
@@ -79779,9 +79695,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.974339+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.699655+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -79812,7 +79727,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:04.862296+00:00"
+                "validatedAt": "2026-07-20T14:39:25.275794+00:00"
               },
               "deterministic": true
             },
@@ -79824,9 +79739,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.974357+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.699668+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -79895,7 +79809,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:04.862349+00:00"
+                "validatedAt": "2026-07-20T14:39:25.275815+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -79907,7 +79821,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.974394+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.699692+00:00"
           },
           "uid": {
             "type": "string",
@@ -79924,7 +79838,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:04.862376+00:00"
+                "validatedAt": "2026-07-20T14:39:25.275845+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -79937,7 +79851,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:18.974414+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:18.699705+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of namespace_role is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -80109,7 +80023,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:24.302186+00:00"
+                "validatedAt": "2026-07-20T14:39:32.586420+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -80147,7 +80061,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:24.302219+00:00"
+                "validatedAt": "2026-07-20T14:39:32.586434+00:00"
               },
               "deterministic": true
             },
@@ -80159,9 +80073,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.242572+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:18.947340+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "request_body": {
             "allOf": [
@@ -80361,7 +80274,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.224932+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.933717+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -80456,7 +80369,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:06:28.325589+00:00"
+                "validatedAt": "2026-07-20T14:39:57.358063+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -80537,7 +80450,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:06:28.325645+00:00"
+                "validatedAt": "2026-07-20T14:39:57.358090+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -80548,7 +80461,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.224983+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.933748+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -80635,7 +80548,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:28.325702+00:00"
+                "validatedAt": "2026-07-20T14:39:57.358109+00:00"
               },
               "deterministic": true
             },
@@ -80647,9 +80560,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.225028+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.933775+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -80680,7 +80592,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:28.325730+00:00"
+                "validatedAt": "2026-07-20T14:39:57.358129+00:00"
               },
               "deterministic": true
             },
@@ -80692,9 +80604,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.225047+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.933787+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -80763,7 +80674,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:28.325782+00:00"
+                "validatedAt": "2026-07-20T14:39:57.358149+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -80775,7 +80686,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.225085+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.933811+00:00"
           },
           "uid": {
             "type": "string",
@@ -80792,7 +80703,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:28.325808+00:00"
+                "validatedAt": "2026-07-20T14:39:57.358160+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -80805,7 +80716,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.225104+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.933823+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of rbac_policy is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -80870,7 +80781,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:28.325848+00:00"
+                "validatedAt": "2026-07-20T14:39:57.358175+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81031,7 +80942,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:28.327141+00:00"
+                "validatedAt": "2026-07-20T14:39:57.358689+00:00"
               },
               "deterministic": true
             },
@@ -81290,7 +81201,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:52.860545+00:00"
+                "validatedAt": "2026-07-20T14:40:06.599511+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81343,7 +81254,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:52.860601+00:00"
+                "validatedAt": "2026-07-20T14:40:06.599530+00:00"
               },
               "deterministic": true
             },
@@ -81355,15 +81266,14 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.675089+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:20.353157+00:00",
             "x-ves-validation-rules": {
               "ves.io.schema.rules.string.const": "system"
             },
             "x-validation-rules": {
               "ves.io.schema.rules.string.const": "system"
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "spec": {
             "allOf": [
@@ -81511,7 +81421,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:06:52.860666+00:00"
+                "validatedAt": "2026-07-20T14:40:06.599553+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81588,7 +81498,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:52.860716+00:00"
+                "validatedAt": "2026-07-20T14:40:06.599576+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81627,7 +81537,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:52.860746+00:00"
+                "validatedAt": "2026-07-20T14:40:06.599590+00:00"
               },
               "deterministic": true
             },
@@ -81639,9 +81549,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.675146+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.353193+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -81672,7 +81581,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:52.860774+00:00"
+                "validatedAt": "2026-07-20T14:40:06.599603+00:00"
               },
               "deterministic": true
             },
@@ -81684,15 +81593,14 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.675164+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:20.353205+00:00",
             "x-ves-validation-rules": {
               "ves.io.schema.rules.string.const": "system"
             },
             "x-validation-rules": {
               "ves.io.schema.rules.string.const": "system"
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "spec": {
             "allOf": [
@@ -81792,7 +81700,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:52.860810+00:00"
+                "validatedAt": "2026-07-20T14:40:06.599619+00:00"
               },
               "deterministic": true
             },
@@ -81804,9 +81712,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.675198+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.353227+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -81838,7 +81745,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:52.860837+00:00"
+                "validatedAt": "2026-07-20T14:40:06.599633+00:00"
               },
               "deterministic": true
             },
@@ -81850,9 +81757,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.675216+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.353239+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -82017,7 +81923,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.675283+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.353282+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -82107,7 +82013,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:52.860956+00:00"
+                "validatedAt": "2026-07-20T14:40:06.599680+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -82183,7 +82089,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:52.860999+00:00"
+                "validatedAt": "2026-07-20T14:40:06.599702+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -82268,7 +82174,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:06:52.861040+00:00"
+                "validatedAt": "2026-07-20T14:40:06.599719+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -82348,7 +82254,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:06:52.861093+00:00"
+                "validatedAt": "2026-07-20T14:40:06.599743+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -82359,7 +82265,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.675351+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.353324+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -82445,7 +82351,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:52.861134+00:00"
+                "validatedAt": "2026-07-20T14:40:06.599761+00:00"
               },
               "deterministic": true
             },
@@ -82457,9 +82363,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.675397+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.353353+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -82490,7 +82395,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:52.861161+00:00"
+                "validatedAt": "2026-07-20T14:40:06.599774+00:00"
               },
               "deterministic": true
             },
@@ -82502,9 +82407,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.675415+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.353365+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -82573,7 +82477,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:52.861212+00:00"
+                "validatedAt": "2026-07-20T14:40:06.599793+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -82585,7 +82489,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.675453+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.353389+00:00"
           },
           "uid": {
             "type": "string",
@@ -82602,7 +82506,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:52.861238+00:00"
+                "validatedAt": "2026-07-20T14:40:06.599805+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -82615,7 +82519,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.675472+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.353402+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of role is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -82957,7 +82861,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:52.861302+00:00"
+                "validatedAt": "2026-07-20T14:40:06.599831+00:00"
               },
               "deterministic": true
             },
@@ -82969,9 +82873,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.675549+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.353449+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -83002,7 +82905,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:52.861329+00:00"
+                "validatedAt": "2026-07-20T14:40:06.599843+00:00"
               },
               "deterministic": true
             },
@@ -83014,9 +82917,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.675568+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.353462+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -83033,7 +82935,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:52.861361+00:00"
+                "validatedAt": "2026-07-20T14:40:06.599856+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83045,7 +82947,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.675586+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.353474+00:00"
           },
           "uid": {
             "type": "string",
@@ -83062,7 +82964,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:52.861386+00:00"
+                "validatedAt": "2026-07-20T14:40:06.599867+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83075,7 +82977,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.675605+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.353487+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -83311,7 +83213,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:52.862084+00:00"
+                "validatedAt": "2026-07-20T14:40:06.600167+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -83326,7 +83228,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.675953+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.353700+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -83398,7 +83300,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:52.862120+00:00"
+                "validatedAt": "2026-07-20T14:40:06.600184+00:00"
               },
               "deterministic": true
             },
@@ -83410,9 +83312,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.675986+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.353720+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -83445,7 +83346,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:52.862145+00:00"
+                "validatedAt": "2026-07-20T14:40:06.600196+00:00"
               },
               "deterministic": true
             },
@@ -83457,9 +83358,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.676004+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.353732+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "uid": {
             "type": "string",
@@ -83478,7 +83378,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:52.862170+00:00"
+                "validatedAt": "2026-07-20T14:40:06.600206+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83492,7 +83392,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.676024+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.353745+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectMetaType is metadata(common attributes) of an object that all configuration objects will have.",
@@ -83557,7 +83457,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:52.863091+00:00"
+                "validatedAt": "2026-07-20T14:40:06.600584+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83585,7 +83485,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:52.863131+00:00"
+                "validatedAt": "2026-07-20T14:40:06.600600+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83614,7 +83514,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:52.863170+00:00"
+                "validatedAt": "2026-07-20T14:40:06.600617+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83641,7 +83541,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:52.863208+00:00"
+                "validatedAt": "2026-07-20T14:40:06.600631+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83670,7 +83570,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:52.863248+00:00"
+                "validatedAt": "2026-07-20T14:40:06.600647+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83695,7 +83595,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:52.863288+00:00"
+                "validatedAt": "2026-07-20T14:40:06.600662+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83771,7 +83671,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:52.863350+00:00"
+                "validatedAt": "2026-07-20T14:40:06.600686+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83809,7 +83709,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:52.863393+00:00"
+                "validatedAt": "2026-07-20T14:40:06.600707+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83821,7 +83721,7 @@
             "maxLength": 6,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.676508+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.354043+00:00"
           },
           "object_index": {
             "type": "integer",
@@ -83881,7 +83781,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:52.863443+00:00"
+                "validatedAt": "2026-07-20T14:40:06.600728+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83925,7 +83825,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:52.863479+00:00"
+                "validatedAt": "2026-07-20T14:40:06.600743+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83938,7 +83838,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.676553+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.354070+00:00"
           },
           "trace_info": {
             "type": "string",
@@ -83957,7 +83857,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:52.863516+00:00"
+                "validatedAt": "2026-07-20T14:40:06.600758+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83984,7 +83884,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:52.863540+00:00"
+                "validatedAt": "2026-07-20T14:40:06.600768+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83998,7 +83898,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.676578+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.354087+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -84013,7 +83913,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:52.863574+00:00"
+                "validatedAt": "2026-07-20T14:40:06.600782+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -84151,7 +84051,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:11.280617+00:00"
+                "validatedAt": "2026-07-20T14:40:13.562328+00:00"
               },
               "deterministic": true
             },
@@ -84163,9 +84063,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.998834+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.631724+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "RecreateScimTokenRequest is the request format for generating SCIM API credential.",
@@ -84229,7 +84128,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:11.280716+00:00"
+                "validatedAt": "2026-07-20T14:40:13.562351+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -84276,7 +84175,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:11.280791+00:00"
+                "validatedAt": "2026-07-20T14:40:13.562369+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -84310,7 +84209,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:11.280859+00:00"
+                "validatedAt": "2026-07-20T14:40:13.562386+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -84349,7 +84248,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:11.280928+00:00"
+                "validatedAt": "2026-07-20T14:40:13.562417+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -84376,7 +84275,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:11.280965+00:00"
+                "validatedAt": "2026-07-20T14:40:13.562432+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -84402,7 +84301,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:11.281001+00:00"
+                "validatedAt": "2026-07-20T14:40:13.562445+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -84428,7 +84327,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:11.281038+00:00"
+                "validatedAt": "2026-07-20T14:40:13.562460+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -84474,7 +84373,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:11.281081+00:00"
+                "validatedAt": "2026-07-20T14:40:13.562477+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -84500,7 +84399,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:11.281122+00:00"
+                "validatedAt": "2026-07-20T14:40:13.562493+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -84635,7 +84534,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:11.281168+00:00"
+                "validatedAt": "2026-07-20T14:40:13.562511+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -84669,7 +84568,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:11.281210+00:00"
+                "validatedAt": "2026-07-20T14:40:13.562527+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -84696,7 +84595,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:11.281249+00:00"
+                "validatedAt": "2026-07-20T14:40:13.562543+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -84773,7 +84672,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T13:07:11.281289+00:00"
+                "validatedAt": "2026-07-20T14:40:13.562559+00:00"
               },
               "deterministic": true
             },
@@ -84844,7 +84743,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:11.281335+00:00"
+                "validatedAt": "2026-07-20T14:40:13.562576+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -84877,7 +84776,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:11.281383+00:00"
+                "validatedAt": "2026-07-20T14:40:13.562595+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -84924,7 +84823,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:11.281427+00:00"
+                "validatedAt": "2026-07-20T14:40:13.562613+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -84958,7 +84857,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:11.281469+00:00"
+                "validatedAt": "2026-07-20T14:40:13.562630+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -84997,7 +84896,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:11.281532+00:00"
+                "validatedAt": "2026-07-20T14:40:13.562658+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -85040,7 +84939,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:07:11.281570+00:00"
+                "validatedAt": "2026-07-20T14:40:13.562673+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -85067,7 +84966,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:11.281614+00:00"
+                "validatedAt": "2026-07-20T14:40:13.562691+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -85094,7 +84993,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:11.281647+00:00"
+                "validatedAt": "2026-07-20T14:40:13.562704+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -85120,7 +85019,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:11.281706+00:00"
+                "validatedAt": "2026-07-20T14:40:13.562717+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -85146,7 +85045,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:11.281745+00:00"
+                "validatedAt": "2026-07-20T14:40:13.562733+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -85219,7 +85118,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:11.281795+00:00"
+                "validatedAt": "2026-07-20T14:40:13.562751+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -85245,7 +85144,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:11.281837+00:00"
+                "validatedAt": "2026-07-20T14:40:13.562767+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -85349,7 +85248,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:11.281886+00:00"
+                "validatedAt": "2026-07-20T14:40:13.562786+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -85396,7 +85295,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:11.281930+00:00"
+                "validatedAt": "2026-07-20T14:40:13.562803+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -85430,7 +85329,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:11.281971+00:00"
+                "validatedAt": "2026-07-20T14:40:13.562819+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -85469,7 +85368,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:11.282033+00:00"
+                "validatedAt": "2026-07-20T14:40:13.562848+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -85496,7 +85395,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:11.282066+00:00"
+                "validatedAt": "2026-07-20T14:40:13.562861+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -85522,7 +85421,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:11.282100+00:00"
+                "validatedAt": "2026-07-20T14:40:13.562875+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -85548,7 +85447,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:11.282137+00:00"
+                "validatedAt": "2026-07-20T14:40:13.562889+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -85594,7 +85493,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:11.282181+00:00"
+                "validatedAt": "2026-07-20T14:40:13.562906+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -85620,7 +85519,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:11.282221+00:00"
+                "validatedAt": "2026-07-20T14:40:13.562921+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -85795,7 +85694,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:11.282255+00:00"
+                "validatedAt": "2026-07-20T14:40:13.562935+00:00"
               },
               "deterministic": true
             },
@@ -85807,9 +85706,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.999168+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.631925+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -85840,7 +85738,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:11.282284+00:00"
+                "validatedAt": "2026-07-20T14:40:13.562947+00:00"
               },
               "deterministic": true
             },
@@ -85852,15 +85750,14 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.999187+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:20.631938+00:00",
             "x-ves-validation-rules": {
               "ves.io.schema.rules.string.const": "system"
             },
             "x-validation-rules": {
               "ves.io.schema.rules.string.const": "system"
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "spec": {
             "allOf": [
@@ -85983,7 +85880,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:11.282334+00:00"
+                "validatedAt": "2026-07-20T14:40:13.562966+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -86076,7 +85973,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:11.282368+00:00"
+                "validatedAt": "2026-07-20T14:40:13.562981+00:00"
               },
               "deterministic": true
             },
@@ -86088,9 +85985,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.999236+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.631968+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -86122,7 +86018,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:11.282396+00:00"
+                "validatedAt": "2026-07-20T14:40:13.562994+00:00"
               },
               "deterministic": true
             },
@@ -86134,15 +86030,14 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.999254+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:20.631981+00:00",
             "x-ves-validation-rules": {
               "ves.io.schema.rules.string.const": "system"
             },
             "x-validation-rules": {
               "ves.io.schema.rules.string.const": "system"
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "oidc_mappers": {
             "allOf": [
@@ -86229,7 +86124,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:11.282428+00:00"
+                "validatedAt": "2026-07-20T14:40:13.563008+00:00"
               },
               "deterministic": true
             },
@@ -86241,9 +86136,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.999280+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.631998+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -86274,7 +86168,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:11.282456+00:00"
+                "validatedAt": "2026-07-20T14:40:13.563021+00:00"
               },
               "deterministic": true
             },
@@ -86286,15 +86180,14 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.999298+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:20.632010+00:00",
             "x-ves-validation-rules": {
               "ves.io.schema.rules.string.const": "system"
             },
             "x-validation-rules": {
               "ves.io.schema.rules.string.const": "system"
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "scim_enabled": {
             "type": "boolean",
@@ -86433,7 +86326,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T13:07:11.282504+00:00"
+                "validatedAt": "2026-07-20T14:40:13.563040+00:00"
               },
               "deterministic": true
             },
@@ -86516,7 +86409,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:11.283756+00:00"
+                "validatedAt": "2026-07-20T14:40:13.563552+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -86540,7 +86433,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:11.283800+00:00"
+                "validatedAt": "2026-07-20T14:40:13.563569+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -86576,7 +86469,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:11.283829+00:00"
+                "validatedAt": "2026-07-20T14:40:13.563584+00:00"
               },
               "deterministic": true
             },
@@ -86588,9 +86481,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.999958+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.632424+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "CreateResponse is the response format for the credential's create request.",
@@ -86661,7 +86553,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:11.283857+00:00"
+                "validatedAt": "2026-07-20T14:40:13.563597+00:00"
               },
               "deterministic": true
             },
@@ -86673,15 +86565,14 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.999979+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:20.632437+00:00",
             "x-ves-validation-rules": {
               "ves.io.schema.rules.string.const": "system"
             },
             "x-validation-rules": {
               "ves.io.schema.rules.string.const": "system"
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "spec": {
             "allOf": [
@@ -86764,7 +86655,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:11.283909+00:00"
+                "validatedAt": "2026-07-20T14:40:13.563617+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -86791,7 +86682,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:11.283948+00:00"
+                "validatedAt": "2026-07-20T14:40:13.563632+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -87008,7 +86899,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:11.283993+00:00"
+                "validatedAt": "2026-07-20T14:40:13.563651+00:00"
               },
               "deterministic": true
             },
@@ -87020,9 +86911,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.000060+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.632486+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -87053,7 +86943,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:11.284020+00:00"
+                "validatedAt": "2026-07-20T14:40:13.563663+00:00"
               },
               "deterministic": true
             },
@@ -87065,15 +86955,14 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.000078+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:20.632498+00:00",
             "x-ves-validation-rules": {
               "ves.io.schema.rules.string.const": "system"
             },
             "x-validation-rules": {
               "ves.io.schema.rules.string.const": "system"
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "DeleteRequest is the request payload for deleting an OIDC provider/SSO configuration.",
@@ -87309,7 +87198,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:11.284080+00:00"
+                "validatedAt": "2026-07-20T14:40:13.563686+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -87395,7 +87284,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:07:11.284117+00:00"
+                "validatedAt": "2026-07-20T14:40:13.563701+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -87460,7 +87349,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:11.284160+00:00"
+                "validatedAt": "2026-07-20T14:40:13.563718+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -87499,7 +87388,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:11.284186+00:00"
+                "validatedAt": "2026-07-20T14:40:13.563730+00:00"
               },
               "deterministic": true
             },
@@ -87511,9 +87400,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.000166+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.632552+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -87544,7 +87432,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:11.284212+00:00"
+                "validatedAt": "2026-07-20T14:40:13.563743+00:00"
               },
               "deterministic": true
             },
@@ -87556,9 +87444,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.000184+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.632564+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "provider_type": {
             "allOf": [
@@ -87588,7 +87475,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:11.284239+00:00"
+                "validatedAt": "2026-07-20T14:40:13.563754+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -87601,7 +87488,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.000209+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.632580+00:00"
           }
         },
         "x-f5xc-description-short": "Shape of the OIDC provider object in a list request's response body.",
@@ -88055,7 +87942,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:25.056117+00:00"
+                "validatedAt": "2026-07-20T14:40:43.116776+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -88209,7 +88096,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:25.056201+00:00"
+                "validatedAt": "2026-07-20T14:40:43.116810+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -88327,7 +88214,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:25.056252+00:00"
+                "validatedAt": "2026-07-20T14:40:43.116832+00:00"
               },
               "deterministic": true
             },
@@ -88475,7 +88362,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:25.056303+00:00"
+                "validatedAt": "2026-07-20T14:40:43.116853+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -88528,7 +88415,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:25.056348+00:00"
+                "validatedAt": "2026-07-20T14:40:43.116871+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -88553,7 +88440,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:25.056386+00:00"
+                "validatedAt": "2026-07-20T14:40:43.116888+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -88593,7 +88480,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:25.056423+00:00"
+                "validatedAt": "2026-07-20T14:40:43.116904+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -88646,7 +88533,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:25.056463+00:00"
+                "validatedAt": "2026-07-20T14:40:43.116920+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -88658,7 +88545,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.510763+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.026449+00:00"
           },
           "email": {
             "type": "string",
@@ -88685,7 +88572,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T13:08:25.056496+00:00"
+                "validatedAt": "2026-07-20T14:40:43.116936+00:00"
               },
               "deterministic": true
             },
@@ -88711,7 +88598,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:25.056534+00:00"
+                "validatedAt": "2026-07-20T14:40:43.116953+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -88751,7 +88638,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:25.056574+00:00"
+                "validatedAt": "2026-07-20T14:40:43.116970+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -88783,7 +88670,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:25.056611+00:00"
+                "validatedAt": "2026-07-20T14:40:43.116985+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -88809,7 +88696,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:25.056662+00:00"
+                "validatedAt": "2026-07-20T14:40:43.117004+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -88835,7 +88722,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:25.056705+00:00"
+                "validatedAt": "2026-07-20T14:40:43.117021+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -88883,7 +88770,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:08:25.056747+00:00"
+                "validatedAt": "2026-07-20T14:40:43.117041+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -88911,7 +88798,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:25.056787+00:00"
+                "validatedAt": "2026-07-20T14:40:43.117059+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -88938,7 +88825,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:25.056827+00:00"
+                "validatedAt": "2026-07-20T14:40:43.117076+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -88965,7 +88852,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:25.056865+00:00"
+                "validatedAt": "2026-07-20T14:40:43.117092+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89004,7 +88891,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:25.056910+00:00"
+                "validatedAt": "2026-07-20T14:40:43.117111+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89131,7 +89018,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T13:08:25.056962+00:00"
+                "validatedAt": "2026-07-20T14:40:43.117134+00:00"
               },
               "deterministic": true
             },
@@ -89157,7 +89044,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:25.057000+00:00"
+                "validatedAt": "2026-07-20T14:40:43.117150+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89212,7 +89099,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:25.057056+00:00"
+                "validatedAt": "2026-07-20T14:40:43.117173+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89237,7 +89124,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:25.057093+00:00"
+                "validatedAt": "2026-07-20T14:40:43.117189+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89263,7 +89150,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:25.057126+00:00"
+                "validatedAt": "2026-07-20T14:40:43.117203+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89316,7 +89203,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:25.057169+00:00"
+                "validatedAt": "2026-07-20T14:40:43.117221+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89343,7 +89230,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:25.057210+00:00"
+                "validatedAt": "2026-07-20T14:40:43.117238+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89368,7 +89255,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:25.057248+00:00"
+                "validatedAt": "2026-07-20T14:40:43.117254+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89472,7 +89359,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:25.057292+00:00"
+                "validatedAt": "2026-07-20T14:40:43.117272+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89553,7 +89440,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:25.057337+00:00"
+                "validatedAt": "2026-07-20T14:40:43.117291+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89579,7 +89466,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:25.057375+00:00"
+                "validatedAt": "2026-07-20T14:40:43.117308+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89662,7 +89549,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.511016+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.026596+00:00"
           }
         },
         "x-f5xc-description-short": "Signup object including its status. Use it when you want to see the progress of the signup flow.",
@@ -89994,7 +89881,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:25.057477+00:00"
+                "validatedAt": "2026-07-20T14:40:43.117350+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -90036,7 +89923,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T13:08:25.057513+00:00"
+                "validatedAt": "2026-07-20T14:40:43.117369+00:00"
               },
               "deterministic": true
             },
@@ -90206,7 +90093,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:25.057559+00:00"
+                "validatedAt": "2026-07-20T14:40:43.117388+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -90232,7 +90119,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:25.057596+00:00"
+                "validatedAt": "2026-07-20T14:40:43.117403+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -90359,7 +90246,7 @@
             "maxLength": 18,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.511164+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:22.026681+00:00"
           },
           "user": {
             "type": "array",
@@ -90449,7 +90336,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:25.057695+00:00"
+                "validatedAt": "2026-07-20T14:40:43.117442+00:00"
               },
               "deterministic": true
             },
@@ -90461,9 +90348,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.511191+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:22.026697+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -90495,7 +90381,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:08:25.057721+00:00"
+                "validatedAt": "2026-07-20T14:40:43.117456+00:00"
               },
               "deterministic": true
             },
@@ -90507,9 +90393,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:22.511209+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:22.026709+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "spec": {
             "allOf": [
@@ -90682,7 +90567,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T13:08:25.057782+00:00"
+                "validatedAt": "2026-07-20T14:40:43.117483+00:00"
               },
               "deterministic": true
             },
@@ -90730,7 +90615,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:08:25.057822+00:00"
+                "validatedAt": "2026-07-20T14:40:43.117502+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -90867,7 +90752,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:25.057870+00:00"
+                "validatedAt": "2026-07-20T14:40:43.117524+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -90892,7 +90777,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:08:25.057909+00:00"
+                "validatedAt": "2026-07-20T14:40:43.117541+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -91083,7 +90968,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:09:07.931906+00:00"
+                "validatedAt": "2026-07-20T14:41:00.055069+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -91108,7 +90993,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:07.931968+00:00"
+                "validatedAt": "2026-07-20T14:41:00.055085+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -91135,7 +91020,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:07.932006+00:00"
+                "validatedAt": "2026-07-20T14:41:00.055096+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -91164,7 +91049,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:09:07.932061+00:00"
+                "validatedAt": "2026-07-20T14:41:00.055112+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -91283,7 +91168,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:09:07.932113+00:00"
+                "validatedAt": "2026-07-20T14:41:00.055134+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -91327,7 +91212,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:07.932163+00:00"
+                "validatedAt": "2026-07-20T14:41:00.055153+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -91383,7 +91268,7 @@
             "maxLength": 16,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.717115+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.082313+00:00"
           },
           "roles": {
             "type": "array",
@@ -91451,7 +91336,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:07.932238+00:00"
+                "validatedAt": "2026-07-20T14:41:00.055183+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -91555,7 +91440,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:07.932275+00:00"
+                "validatedAt": "2026-07-20T14:41:00.055197+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -91580,7 +91465,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:07.932307+00:00"
+                "validatedAt": "2026-07-20T14:41:00.055210+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -91591,7 +91476,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.717176+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.082345+00:00"
           }
         },
         "x-f5xc-description-short": "Email for user can be primary or secondary.",
@@ -91659,7 +91544,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:07.932353+00:00"
+                "validatedAt": "2026-07-20T14:41:00.055228+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -91749,7 +91634,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:09:07.932389+00:00"
+                "validatedAt": "2026-07-20T14:41:00.055244+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -91774,7 +91659,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:07.932425+00:00"
+                "validatedAt": "2026-07-20T14:41:00.055258+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -91801,7 +91686,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:07.932449+00:00"
+                "validatedAt": "2026-07-20T14:41:00.055268+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -91830,7 +91715,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:09:07.932483+00:00"
+                "validatedAt": "2026-07-20T14:41:00.055284+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -91882,7 +91767,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:07.932514+00:00"
+                "validatedAt": "2026-07-20T14:41:00.055299+00:00"
               },
               "deterministic": true
             },
@@ -91894,9 +91779,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.717244+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:23.082382+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "schemas": {
             "type": "array",
@@ -91974,7 +91858,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:07.932555+00:00"
+                "validatedAt": "2026-07-20T14:41:00.055314+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -91999,7 +91883,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:07.932586+00:00"
+                "validatedAt": "2026-07-20T14:41:00.055327+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -92010,7 +91894,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.717277+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.082400+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -92091,7 +91975,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:07.932641+00:00"
+                "validatedAt": "2026-07-20T14:41:00.055349+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -92141,7 +92025,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:07.932704+00:00"
+                "validatedAt": "2026-07-20T14:41:00.055370+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -92168,7 +92052,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:07.932745+00:00"
+                "validatedAt": "2026-07-20T14:41:00.055387+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -92266,7 +92150,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:07.932803+00:00"
+                "validatedAt": "2026-07-20T14:41:00.055409+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -92322,7 +92206,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:07.932858+00:00"
+                "validatedAt": "2026-07-20T14:41:00.055432+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -92355,7 +92239,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:07.932900+00:00"
+                "validatedAt": "2026-07-20T14:41:00.055449+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -92430,7 +92314,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:07.932938+00:00"
+                "validatedAt": "2026-07-20T14:41:00.055466+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -92463,7 +92347,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:07.932980+00:00"
+                "validatedAt": "2026-07-20T14:41:00.055483+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -92495,7 +92379,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:07.933017+00:00"
+                "validatedAt": "2026-07-20T14:41:00.055498+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -92506,7 +92390,7 @@
             },
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.717381+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.082457+00:00"
           },
           "resourceType": {
             "type": "string",
@@ -92530,7 +92414,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:07.933059+00:00"
+                "validatedAt": "2026-07-20T14:41:00.055515+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -92563,7 +92447,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:07.933097+00:00"
+                "validatedAt": "2026-07-20T14:41:00.055531+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -92574,7 +92458,7 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.717406+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.082472+00:00"
           }
         },
         "x-f5xc-example": "Meta",
@@ -92634,7 +92518,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:07.933136+00:00"
+                "validatedAt": "2026-07-20T14:41:00.055546+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -92660,7 +92544,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:07.933172+00:00"
+                "validatedAt": "2026-07-20T14:41:00.055561+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -92685,7 +92569,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:07.933208+00:00"
+                "validatedAt": "2026-07-20T14:41:00.055576+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -92710,7 +92594,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:07.933246+00:00"
+                "validatedAt": "2026-07-20T14:41:00.055591+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -92736,7 +92620,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:07.933285+00:00"
+                "validatedAt": "2026-07-20T14:41:00.055607+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -92761,7 +92645,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:07.933321+00:00"
+                "validatedAt": "2026-07-20T14:41:00.055622+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -92863,7 +92747,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:07.933364+00:00"
+                "validatedAt": "2026-07-20T14:41:00.055639+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -92954,7 +92838,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:07.933402+00:00"
+                "validatedAt": "2026-07-20T14:41:00.055655+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -92982,7 +92866,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:09:07.933441+00:00"
+                "validatedAt": "2026-07-20T14:41:00.055673+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -93009,7 +92893,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.717504+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.082523+00:00"
           }
         },
         "x-f5xc-description-short": "PatchOperation is the PATCH operation where user can be updated replaced or remove..",
@@ -93103,7 +92987,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:07.933490+00:00"
+                "validatedAt": "2026-07-20T14:41:00.055693+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -93202,7 +93086,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T13:09:07.933540+00:00"
+                "validatedAt": "2026-07-20T14:41:00.055713+00:00"
               },
               "deterministic": true
             },
@@ -93236,7 +93120,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:07.933568+00:00"
+                "validatedAt": "2026-07-20T14:41:00.055725+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -93294,7 +93178,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:07.933599+00:00"
+                "validatedAt": "2026-07-20T14:41:00.055740+00:00"
               },
               "deterministic": true
             },
@@ -93306,9 +93190,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.717568+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:23.082558+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "schema": {
             "type": "string",
@@ -93330,7 +93213,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:07.933633+00:00"
+                "validatedAt": "2026-07-20T14:41:00.055755+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -93429,7 +93312,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:07.933693+00:00"
+                "validatedAt": "2026-07-20T14:41:00.055775+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -93440,7 +93323,7 @@
             },
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.717601+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.082576+00:00"
           },
           "resourceType": {
             "type": "string",
@@ -93465,7 +93348,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:07.933737+00:00"
+                "validatedAt": "2026-07-20T14:41:00.055793+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -93528,7 +93411,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:07.933772+00:00"
+                "validatedAt": "2026-07-20T14:41:00.055807+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -93601,7 +93484,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:07.933834+00:00"
+                "validatedAt": "2026-07-20T14:41:00.055831+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -93612,7 +93495,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.717648+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.082602+00:00"
           },
           "totalResults": {
             "type": "string",
@@ -93638,7 +93521,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:07.933875+00:00"
+                "validatedAt": "2026-07-20T14:41:00.055847+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -93764,7 +93647,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:07.933941+00:00"
+                "validatedAt": "2026-07-20T14:41:00.055873+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -93992,7 +93875,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:09:07.934007+00:00"
+                "validatedAt": "2026-07-20T14:41:00.055901+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -94043,7 +93926,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:07.934056+00:00"
+                "validatedAt": "2026-07-20T14:41:00.055921+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -94102,7 +93985,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:07.934095+00:00"
+                "validatedAt": "2026-07-20T14:41:00.055937+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -94141,7 +94024,7 @@
             "maxLength": 16,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:23.717800+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.082679+00:00"
           },
           "nickName": {
             "type": "string",
@@ -94158,7 +94041,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:07.934134+00:00"
+                "validatedAt": "2026-07-20T14:41:00.055952+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -94246,7 +94129,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:07.934187+00:00"
+                "validatedAt": "2026-07-20T14:41:00.055976+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -94335,7 +94218,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:07.934227+00:00"
+                "validatedAt": "2026-07-20T14:41:00.055992+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -94362,7 +94245,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:07.934250+00:00"
+                "validatedAt": "2026-07-20T14:41:00.056002+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -94514,7 +94397,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T13:09:31.897190+00:00"
+                "validatedAt": "2026-07-20T14:41:08.891808+00:00"
               },
               "deterministic": true
             },
@@ -94661,7 +94544,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:31.897313+00:00"
+                "validatedAt": "2026-07-20T14:41:08.891843+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -94686,7 +94569,7 @@
             "maxLength": 43,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.040796+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.544602+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -94738,7 +94621,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:31.897356+00:00"
+                "validatedAt": "2026-07-20T14:41:08.891859+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -94810,7 +94693,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T13:09:31.897394+00:00"
+                "validatedAt": "2026-07-20T14:41:08.891875+00:00"
               },
               "deterministic": true
             },
@@ -94837,7 +94720,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:31.897433+00:00"
+                "validatedAt": "2026-07-20T14:41:08.891889+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -94876,7 +94759,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:31.897464+00:00"
+                "validatedAt": "2026-07-20T14:41:08.891904+00:00"
               },
               "deterministic": true
             },
@@ -94888,9 +94771,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.040838+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:23.544627+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "reason": {
             "allOf": [
@@ -94907,7 +94789,7 @@
             "maxLength": 43,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.040858+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.544639+00:00"
           }
         },
         "x-f5xc-description-short": "Request for marking Tenant for deletion.",
@@ -95008,7 +94890,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:31.897496+00:00"
+                "validatedAt": "2026-07-20T14:41:08.891916+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -95065,7 +94947,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:31.897547+00:00"
+                "validatedAt": "2026-07-20T14:41:08.891937+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -95175,7 +95057,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:31.897595+00:00"
+                "validatedAt": "2026-07-20T14:41:08.891955+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -95199,7 +95081,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:31.897627+00:00"
+                "validatedAt": "2026-07-20T14:41:08.891968+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -95227,7 +95109,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T13:09:31.897673+00:00"
+                "validatedAt": "2026-07-20T14:41:08.891983+00:00"
               },
               "deterministic": true
             },
@@ -95251,7 +95133,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:31.897712+00:00"
+                "validatedAt": "2026-07-20T14:41:08.891998+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -95280,7 +95162,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T13:09:31.897751+00:00"
+                "validatedAt": "2026-07-20T14:41:08.892015+00:00"
               },
               "deterministic": true
             },
@@ -95311,7 +95193,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:31.897781+00:00"
+                "validatedAt": "2026-07-20T14:41:08.892029+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -95653,7 +95535,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:31.897903+00:00"
+                "validatedAt": "2026-07-20T14:41:08.892075+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -95676,7 +95558,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:31.897930+00:00"
+                "validatedAt": "2026-07-20T14:41:08.892085+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -95736,7 +95618,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:31.897975+00:00"
+                "validatedAt": "2026-07-20T14:41:08.892103+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -95798,7 +95680,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:31.898022+00:00"
+                "validatedAt": "2026-07-20T14:41:08.892122+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -95823,7 +95705,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:31.898061+00:00"
+                "validatedAt": "2026-07-20T14:41:08.892137+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -95847,7 +95729,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:31.898095+00:00"
+                "validatedAt": "2026-07-20T14:41:08.892150+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -95859,7 +95741,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.041050+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.544751+00:00"
           },
           "max_credentials_expiry": {
             "allOf": [
@@ -95905,7 +95787,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:31.898127+00:00"
+                "validatedAt": "2026-07-20T14:41:08.892164+00:00"
               },
               "deterministic": true
             },
@@ -95917,9 +95799,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.041076+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:23.544767+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "original_tenant": {
             "type": "string",
@@ -95937,7 +95818,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:31.898167+00:00"
+                "validatedAt": "2026-07-20T14:41:08.892180+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -96086,7 +95967,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T13:09:31.898220+00:00"
+                "validatedAt": "2026-07-20T14:41:08.892201+00:00"
               },
               "deterministic": true
             },
@@ -96147,7 +96028,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:31.898261+00:00"
+                "validatedAt": "2026-07-20T14:41:08.892218+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -96173,7 +96054,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:31.898293+00:00"
+                "validatedAt": "2026-07-20T14:41:08.892231+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -96433,7 +96314,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T13:09:31.898369+00:00"
+                "validatedAt": "2026-07-20T14:41:08.892261+00:00"
               },
               "deterministic": true
             },
@@ -96548,7 +96429,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:31.898419+00:00"
+                "validatedAt": "2026-07-20T14:41:08.892281+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -96573,7 +96454,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:31.898459+00:00"
+                "validatedAt": "2026-07-20T14:41:08.892297+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -96652,7 +96533,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:31.898526+00:00"
+                "validatedAt": "2026-07-20T14:41:08.892329+00:00"
               },
               "deterministic": true,
               "pattern": "^[^<>&\\\"]+$"
@@ -97389,7 +97270,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:35.711306+00:00"
+                "validatedAt": "2026-07-20T14:41:10.322994+00:00"
               },
               "deterministic": true
             },
@@ -97401,9 +97282,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.134151+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:23.636855+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -97435,7 +97315,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:35.711332+00:00"
+                "validatedAt": "2026-07-20T14:41:10.323007+00:00"
               },
               "deterministic": true
             },
@@ -97447,9 +97327,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.134169+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:23.636867+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -97612,7 +97491,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.134235+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.636907+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -97829,7 +97708,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:09:35.711458+00:00"
+                "validatedAt": "2026-07-20T14:41:10.323057+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -97908,7 +97787,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:09:35.711511+00:00"
+                "validatedAt": "2026-07-20T14:41:10.323079+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -97919,7 +97798,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.134304+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.636948+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -98006,7 +97885,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:35.711551+00:00"
+                "validatedAt": "2026-07-20T14:41:10.323098+00:00"
               },
               "deterministic": true
             },
@@ -98018,9 +97897,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.134349+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:23.636975+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -98051,7 +97929,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:35.711578+00:00"
+                "validatedAt": "2026-07-20T14:41:10.323111+00:00"
               },
               "deterministic": true
             },
@@ -98063,9 +97941,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.134367+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:23.636987+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -98134,7 +98011,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:35.711631+00:00"
+                "validatedAt": "2026-07-20T14:41:10.323132+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -98146,7 +98023,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.134404+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.637009+00:00"
           },
           "uid": {
             "type": "string",
@@ -98164,7 +98041,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:35.711673+00:00"
+                "validatedAt": "2026-07-20T14:41:10.323142+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -98177,7 +98054,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.134423+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.637022+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of tenant_configuration is returned in 'List'.",
@@ -98678,7 +98555,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:41.122833+00:00"
+                "validatedAt": "2026-07-20T14:41:12.320279+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -98703,7 +98580,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:41.122903+00:00"
+                "validatedAt": "2026-07-20T14:41:12.320295+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -98793,7 +98670,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:41.124131+00:00"
+                "validatedAt": "2026-07-20T14:41:12.320826+00:00"
               },
               "deterministic": true
             },
@@ -98805,9 +98682,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.194122+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:23.734551+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "role": {
             "type": "string",
@@ -98839,7 +98715,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:41.124182+00:00"
+                "validatedAt": "2026-07-20T14:41:12.320851+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -98848,8 +98724,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -99058,7 +98933,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:41.124249+00:00"
+                "validatedAt": "2026-07-20T14:41:12.320880+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -99152,7 +99027,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:41.124321+00:00"
+                "validatedAt": "2026-07-20T14:41:12.320912+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -99255,7 +99130,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:41.124355+00:00"
+                "validatedAt": "2026-07-20T14:41:12.320927+00:00"
               },
               "deterministic": true
             },
@@ -99267,9 +99142,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.194232+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:23.734613+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -99301,7 +99175,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:41.124384+00:00"
+                "validatedAt": "2026-07-20T14:41:12.320941+00:00"
               },
               "deterministic": true
             },
@@ -99313,9 +99187,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.194250+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:23.734625+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -99544,7 +99417,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:41.124489+00:00"
+                "validatedAt": "2026-07-20T14:41:12.320986+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -99638,7 +99511,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:41.124558+00:00"
+                "validatedAt": "2026-07-20T14:41:12.321017+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -99729,7 +99602,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:41.124609+00:00"
+                "validatedAt": "2026-07-20T14:41:12.321042+00:00"
               },
               "deterministic": true
             },
@@ -99741,9 +99614,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.194363+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:23.734690+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace_roles": {
             "type": "array",
@@ -99773,7 +99645,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:41.124650+00:00"
+                "validatedAt": "2026-07-20T14:41:12.321062+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -99856,7 +99728,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:09:41.124706+00:00"
+                "validatedAt": "2026-07-20T14:41:12.321081+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -99935,7 +99807,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:09:41.124758+00:00"
+                "validatedAt": "2026-07-20T14:41:12.321102+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -99946,7 +99818,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.194412+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.734724+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -100033,7 +99905,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:41.124797+00:00"
+                "validatedAt": "2026-07-20T14:41:12.321120+00:00"
               },
               "deterministic": true
             },
@@ -100045,9 +99917,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.194457+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:23.734751+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -100078,7 +99949,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:41.124824+00:00"
+                "validatedAt": "2026-07-20T14:41:12.321133+00:00"
               },
               "deterministic": true
             },
@@ -100090,9 +99961,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.194475+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:23.734763+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -100145,7 +100015,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:41.124864+00:00"
+                "validatedAt": "2026-07-20T14:41:12.321148+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -100157,7 +100027,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.194506+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.734780+00:00"
           },
           "uid": {
             "type": "string",
@@ -100174,7 +100044,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:41.124889+00:00"
+                "validatedAt": "2026-07-20T14:41:12.321159+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -100187,7 +100057,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.194525+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.734791+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of tenant_profile is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -100360,7 +100230,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:41.124943+00:00"
+                "validatedAt": "2026-07-20T14:41:12.321184+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -100454,7 +100324,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:41.125015+00:00"
+                "validatedAt": "2026-07-20T14:41:12.321216+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -101142,7 +101012,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:39.675762+00:00"
+                "validatedAt": "2026-07-20T14:41:33.971658+00:00"
               },
               "deterministic": true
             },
@@ -101154,9 +101024,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.064224+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.850557+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "role": {
             "type": "string",
@@ -101188,7 +101057,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:39.675820+00:00"
+                "validatedAt": "2026-07-20T14:41:33.971685+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -101197,8 +101066,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -101426,7 +101294,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:39.676942+00:00"
+                "validatedAt": "2026-07-20T14:41:33.972136+00:00"
               },
               "deterministic": true
             },
@@ -101438,15 +101306,14 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.064757+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:24.850906+00:00",
             "x-ves-validation-rules": {
               "ves.io.schema.rules.string.const": "system"
             },
             "x-validation-rules": {
               "ves.io.schema.rules.string.const": "system"
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tos_accepted": {
             "type": "string",
@@ -101464,7 +101331,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:39.676980+00:00"
+                "validatedAt": "2026-07-20T14:41:33.972151+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -101491,7 +101358,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:39.677021+00:00"
+                "validatedAt": "2026-07-20T14:41:33.972168+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -101516,7 +101383,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:39.677059+00:00"
+                "validatedAt": "2026-07-20T14:41:33.972183+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -101669,7 +101536,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:39.677089+00:00"
+                "validatedAt": "2026-07-20T14:41:33.972197+00:00"
               },
               "deterministic": true
             },
@@ -101681,15 +101548,14 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.064798+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:24.850931+00:00",
             "x-ves-validation-rules": {
               "ves.io.schema.rules.string.const": "system"
             },
             "x-validation-rules": {
               "ves.io.schema.rules.string.const": "system"
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespaces_role": {
             "allOf": [
@@ -101792,7 +101658,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:39.677148+00:00"
+                "validatedAt": "2026-07-20T14:41:33.972220+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -101979,7 +101845,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:39.677196+00:00"
+                "validatedAt": "2026-07-20T14:41:33.972239+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -102004,7 +101870,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:39.677236+00:00"
+                "validatedAt": "2026-07-20T14:41:33.972254+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -102029,7 +101895,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:39.677274+00:00"
+                "validatedAt": "2026-07-20T14:41:33.972269+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -102054,7 +101920,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:39.677312+00:00"
+                "validatedAt": "2026-07-20T14:41:33.972284+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -102137,7 +102003,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T13:10:39.677352+00:00"
+                "validatedAt": "2026-07-20T14:41:33.972300+00:00"
               },
               "deterministic": true
             },
@@ -102177,7 +102043,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:39.677381+00:00"
+                "validatedAt": "2026-07-20T14:41:33.972313+00:00"
               },
               "deterministic": true
             },
@@ -102189,15 +102055,14 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.064896+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:24.850987+00:00",
             "x-ves-validation-rules": {
               "ves.io.schema.rules.string.const": "system"
             },
             "x-validation-rules": {
               "ves.io.schema.rules.string.const": "system"
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "CascadeDeleteRequest is the request to DELETE the user along with the associated namespace role objects.",
@@ -102274,7 +102139,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:10:39.677417+00:00"
+                "validatedAt": "2026-07-20T14:41:33.972329+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -102366,7 +102231,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:39.677448+00:00"
+                "validatedAt": "2026-07-20T14:41:33.972343+00:00"
               },
               "deterministic": true
             },
@@ -102378,9 +102243,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.064937+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.851013+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -102434,7 +102298,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:39.677479+00:00"
+                "validatedAt": "2026-07-20T14:41:33.972355+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -102459,7 +102323,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:39.677513+00:00"
+                "validatedAt": "2026-07-20T14:41:33.972369+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -102470,7 +102334,7 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.064965+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.851029+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -102538,7 +102402,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:39.677562+00:00"
+                "validatedAt": "2026-07-20T14:41:33.972388+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -102594,7 +102458,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:39.677622+00:00"
+                "validatedAt": "2026-07-20T14:41:33.972411+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -102620,7 +102484,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:39.677665+00:00"
+                "validatedAt": "2026-07-20T14:41:33.972423+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -102646,7 +102510,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:39.677703+00:00"
+                "validatedAt": "2026-07-20T14:41:33.972438+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -102671,7 +102535,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:39.677746+00:00"
+                "validatedAt": "2026-07-20T14:41:33.972454+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -102738,7 +102602,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T13:10:39.677789+00:00"
+                "validatedAt": "2026-07-20T14:41:33.972472+00:00"
               },
               "deterministic": true
             },
@@ -102763,7 +102627,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:39.677828+00:00"
+                "validatedAt": "2026-07-20T14:41:33.972488+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -102805,7 +102669,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:39.677879+00:00"
+                "validatedAt": "2026-07-20T14:41:33.972508+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -102862,7 +102726,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:39.677938+00:00"
+                "validatedAt": "2026-07-20T14:41:33.972530+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -102887,7 +102751,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:39.677974+00:00"
+                "validatedAt": "2026-07-20T14:41:33.972545+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -102943,7 +102807,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:39.678004+00:00"
+                "validatedAt": "2026-07-20T14:41:33.972559+00:00"
               },
               "deterministic": true
             },
@@ -102955,9 +102819,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.065112+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.851114+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -102989,7 +102852,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:39.678030+00:00"
+                "validatedAt": "2026-07-20T14:41:33.972571+00:00"
               },
               "deterministic": true
             },
@@ -103001,9 +102864,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.065131+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.851126+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace_access": {
             "allOf": [
@@ -103054,7 +102916,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:39.678085+00:00"
+                "validatedAt": "2026-07-20T14:41:33.972593+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -103151,7 +103013,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:39.678134+00:00"
+                "validatedAt": "2026-07-20T14:41:33.972611+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -103163,7 +103025,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.065201+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.851168+00:00"
           },
           "tenant_flags": {
             "type": "object",
@@ -103193,7 +103055,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:39.678177+00:00"
+                "validatedAt": "2026-07-20T14:41:33.972628+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -103244,7 +103106,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:39.678224+00:00"
+                "validatedAt": "2026-07-20T14:41:33.972647+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -103271,7 +103133,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:39.678264+00:00"
+                "validatedAt": "2026-07-20T14:41:33.972662+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -103296,7 +103158,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:39.678305+00:00"
+                "validatedAt": "2026-07-20T14:41:33.972679+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -103321,7 +103183,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:39.678343+00:00"
+                "validatedAt": "2026-07-20T14:41:33.972694+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -103360,7 +103222,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:39.678384+00:00"
+                "validatedAt": "2026-07-20T14:41:33.972709+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -103501,7 +103363,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T13:10:39.678434+00:00"
+                "validatedAt": "2026-07-20T14:41:33.972730+00:00"
               },
               "deterministic": true
             },
@@ -103527,7 +103389,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:39.678470+00:00"
+                "validatedAt": "2026-07-20T14:41:33.972745+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -103582,7 +103444,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:39.678527+00:00"
+                "validatedAt": "2026-07-20T14:41:33.972766+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -103607,7 +103469,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:39.678564+00:00"
+                "validatedAt": "2026-07-20T14:41:33.972780+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -103633,7 +103495,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:39.678598+00:00"
+                "validatedAt": "2026-07-20T14:41:33.972794+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -103686,7 +103548,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:39.678643+00:00"
+                "validatedAt": "2026-07-20T14:41:33.972811+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -103713,7 +103575,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:39.678695+00:00"
+                "validatedAt": "2026-07-20T14:41:33.972826+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -103738,7 +103600,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:39.678735+00:00"
+                "validatedAt": "2026-07-20T14:41:33.972842+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -103829,7 +103691,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:10:39.678769+00:00"
+                "validatedAt": "2026-07-20T14:41:33.972857+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -103890,7 +103752,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:39.678811+00:00"
+                "validatedAt": "2026-07-20T14:41:33.972873+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -103957,7 +103819,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T13:10:39.678853+00:00"
+                "validatedAt": "2026-07-20T14:41:33.972891+00:00"
               },
               "deterministic": true
             },
@@ -103983,7 +103845,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:39.678890+00:00"
+                "validatedAt": "2026-07-20T14:41:33.972906+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -104040,7 +103902,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:39.678948+00:00"
+                "validatedAt": "2026-07-20T14:41:33.972928+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -104065,7 +103927,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:39.678985+00:00"
+                "validatedAt": "2026-07-20T14:41:33.972942+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -104104,7 +103966,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:39.679011+00:00"
+                "validatedAt": "2026-07-20T14:41:33.972955+00:00"
               },
               "deterministic": true
             },
@@ -104116,9 +103978,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.065453+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.851315+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -104150,7 +104011,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:39.679038+00:00"
+                "validatedAt": "2026-07-20T14:41:33.972968+00:00"
               },
               "deterministic": true
             },
@@ -104162,9 +104023,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.065472+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.851327+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace_roles": {
             "type": "array",
@@ -104225,7 +104085,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:39.679090+00:00"
+                "validatedAt": "2026-07-20T14:41:33.972988+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -104237,7 +104097,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.065510+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.851350+00:00"
           },
           "tenant_type": {
             "allOf": [
@@ -104332,7 +104192,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:39.679131+00:00"
+                "validatedAt": "2026-07-20T14:41:33.973004+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -104371,7 +104231,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:39.679175+00:00"
+                "validatedAt": "2026-07-20T14:41:33.973021+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -104508,7 +104368,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:39.679229+00:00"
+                "validatedAt": "2026-07-20T14:41:33.973042+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -104667,7 +104527,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T13:10:39.679277+00:00"
+                "validatedAt": "2026-07-20T14:41:33.973062+00:00"
               },
               "deterministic": true
             },
@@ -104747,7 +104607,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T13:10:39.679314+00:00"
+                "validatedAt": "2026-07-20T14:41:33.973078+00:00"
               },
               "deterministic": true
             },
@@ -104787,7 +104647,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:39.679342+00:00"
+                "validatedAt": "2026-07-20T14:41:33.973091+00:00"
               },
               "deterministic": true
             },
@@ -104799,15 +104659,14 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.065621+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:24.851414+00:00",
             "x-ves-validation-rules": {
               "ves.io.schema.rules.string.const": "system"
             },
             "x-validation-rules": {
               "ves.io.schema.rules.string.const": "system"
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "SendPasswordEmailRequest is the request parameters for sending the password update.",
@@ -104979,7 +104838,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:39.679418+00:00"
+                "validatedAt": "2026-07-20T14:41:33.973125+00:00"
               },
               "byteLength": {
                 "max": 320,
@@ -105111,7 +104970,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T13:10:39.679459+00:00"
+                "validatedAt": "2026-07-20T14:41:33.973143+00:00"
               },
               "deterministic": true
             },
@@ -105144,7 +105003,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:39.679497+00:00"
+                "validatedAt": "2026-07-20T14:41:33.973159+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -105207,7 +105066,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:39.679554+00:00"
+                "validatedAt": "2026-07-20T14:41:33.973181+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -105248,7 +105107,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:39.679583+00:00"
+                "validatedAt": "2026-07-20T14:41:33.973194+00:00"
               },
               "deterministic": true
             },
@@ -105260,9 +105119,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.065714+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.851463+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -105294,7 +105152,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:39.679609+00:00"
+                "validatedAt": "2026-07-20T14:41:33.973206+00:00"
               },
               "deterministic": true
             },
@@ -105306,15 +105164,14 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.065733+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:24.851475+00:00",
             "x-ves-validation-rules": {
               "ves.io.schema.rules.string.const": "system"
             },
             "x-validation-rules": {
               "ves.io.schema.rules.string.const": "system"
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace_roles": {
             "type": "array",
@@ -105457,7 +105314,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:43.437095+00:00"
+                "validatedAt": "2026-07-20T14:41:35.372408+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -105725,7 +105582,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.127835+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.915880+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -105806,7 +105663,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:43.437230+00:00"
+                "validatedAt": "2026-07-20T14:41:35.372462+00:00"
               },
               "deterministic": true
             },
@@ -105888,7 +105745,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:10:43.437273+00:00"
+                "validatedAt": "2026-07-20T14:41:35.372481+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -105967,7 +105824,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:10:43.437323+00:00"
+                "validatedAt": "2026-07-20T14:41:35.372502+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -105978,7 +105835,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.127894+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.915915+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -106065,7 +105922,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:43.437362+00:00"
+                "validatedAt": "2026-07-20T14:41:35.372518+00:00"
               },
               "deterministic": true
             },
@@ -106077,9 +105934,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.127940+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.915942+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -106110,7 +105966,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:43.437390+00:00"
+                "validatedAt": "2026-07-20T14:41:35.372530+00:00"
               },
               "deterministic": true
             },
@@ -106122,9 +105978,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.127958+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.915954+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -106193,7 +106048,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:43.437441+00:00"
+                "validatedAt": "2026-07-20T14:41:35.372549+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -106205,7 +106060,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.127996+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.915977+00:00"
           },
           "uid": {
             "type": "string",
@@ -106222,7 +106077,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:43.437467+00:00"
+                "validatedAt": "2026-07-20T14:41:35.372560+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -106235,7 +106090,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.128015+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.915990+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of user_group is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -106370,7 +106225,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:43.437510+00:00"
+                "validatedAt": "2026-07-20T14:41:35.372578+00:00"
               },
               "deterministic": true
             },
@@ -106382,9 +106237,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.128044+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.916006+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace_roles": {
             "type": "array",
@@ -106470,7 +106324,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:43.437587+00:00"
+                "validatedAt": "2026-07-20T14:41:35.372611+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -106479,8 +106333,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "object_namespace": {
             "type": "string",
@@ -106510,7 +106363,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:43.437652+00:00"
+                "validatedAt": "2026-07-20T14:41:35.372640+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -106519,8 +106372,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "NamespaceNameIdentifier holds the name and namespace of the specific object.",
@@ -106588,7 +106440,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:10:43.437697+00:00"
+                "validatedAt": "2026-07-20T14:41:35.372656+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -106764,7 +106616,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:10:43.437775+00:00"
+                "validatedAt": "2026-07-20T14:41:35.372687+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -106775,7 +106627,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.128127+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.916054+00:00"
           },
           "display_name": {
             "type": "string",
@@ -106797,7 +106649,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:10:43.437801+00:00"
+                "validatedAt": "2026-07-20T14:41:35.372700+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -106836,7 +106688,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:43.437829+00:00"
+                "validatedAt": "2026-07-20T14:41:35.372713+00:00"
               },
               "deterministic": true
             },
@@ -106848,9 +106700,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.128151+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.916070+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace_roles": {
             "type": "array",
@@ -106884,7 +106735,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:43.437876+00:00"
+                "validatedAt": "2026-07-20T14:41:35.372731+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -106974,7 +106825,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:10:43.437935+00:00"
+                "validatedAt": "2026-07-20T14:41:35.372755+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -106985,7 +106836,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.128190+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.916093+00:00"
           },
           "display_name": {
             "type": "string",
@@ -107007,7 +106858,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:10:43.437962+00:00"
+                "validatedAt": "2026-07-20T14:41:35.372768+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -107047,7 +106898,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:43.437990+00:00"
+                "validatedAt": "2026-07-20T14:41:35.372778+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -107086,7 +106937,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:43.438016+00:00"
+                "validatedAt": "2026-07-20T14:41:35.372790+00:00"
               },
               "deterministic": true
             },
@@ -107098,9 +106949,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.128228+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.916117+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace_roles": {
             "type": "array",
@@ -107149,7 +106999,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:43.438065+00:00"
+                "validatedAt": "2026-07-20T14:41:35.372809+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -107188,7 +107038,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:43.438094+00:00"
+                "validatedAt": "2026-07-20T14:41:35.372821+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -107201,7 +107051,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.128274+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.916145+00:00"
           },
           "usernames": {
             "type": "array",
@@ -107448,7 +107298,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:47.094907+00:00"
+                "validatedAt": "2026-07-20T14:41:36.760852+00:00"
               },
               "deterministic": true
             },
@@ -107546,7 +107396,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:47.094939+00:00"
+                "validatedAt": "2026-07-20T14:41:36.760867+00:00"
               },
               "deterministic": true
             },
@@ -107558,9 +107408,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.176526+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.996418+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -107592,7 +107441,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:47.094965+00:00"
+                "validatedAt": "2026-07-20T14:41:36.760880+00:00"
               },
               "deterministic": true
             },
@@ -107604,9 +107453,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.176545+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.996430+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -107771,7 +107619,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.176611+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.996469+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -107867,7 +107715,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:47.095091+00:00"
+                "validatedAt": "2026-07-20T14:41:36.760935+00:00"
               },
               "deterministic": true
             },
@@ -107957,7 +107805,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:10:47.095130+00:00"
+                "validatedAt": "2026-07-20T14:41:36.760953+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -108038,7 +107886,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:10:47.095179+00:00"
+                "validatedAt": "2026-07-20T14:41:36.760975+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -108049,7 +107897,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.176682+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.996503+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -108136,7 +107984,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:47.095219+00:00"
+                "validatedAt": "2026-07-20T14:41:36.760993+00:00"
               },
               "deterministic": true
             },
@@ -108148,9 +107996,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.176728+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.996529+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -108181,7 +108028,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:47.095245+00:00"
+                "validatedAt": "2026-07-20T14:41:36.761006+00:00"
               },
               "deterministic": true
             },
@@ -108193,9 +108040,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.176747+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:24.996541+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -108264,7 +108110,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:47.095296+00:00"
+                "validatedAt": "2026-07-20T14:41:36.761028+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -108276,7 +108122,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.176784+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.996563+00:00"
           },
           "uid": {
             "type": "string",
@@ -108294,7 +108140,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:47.095322+00:00"
+                "validatedAt": "2026-07-20T14:41:36.761039+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -108307,7 +108153,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.176803+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:24.996576+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of user_identification is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -108494,7 +108340,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:47.095385+00:00"
+                "validatedAt": "2026-07-20T14:41:36.761069+00:00"
               },
               "deterministic": true
             },
@@ -108819,7 +108665,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:47.095495+00:00"
+                "validatedAt": "2026-07-20T14:41:36.761116+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -108878,7 +108724,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:47.095559+00:00"
+                "validatedAt": "2026-07-20T14:41:36.761147+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -108937,7 +108783,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:47.095623+00:00"
+                "validatedAt": "2026-07-20T14:41:36.761178+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -109082,7 +108928,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:47.095702+00:00"
+                "validatedAt": "2026-07-20T14:41:36.761210+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -109167,7 +109013,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:10:47.095767+00:00"
+                "validatedAt": "2026-07-20T14:41:36.761241+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -109308,7 +109154,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:48.989807+00:00"
+                "validatedAt": "2026-07-20T14:41:37.454458+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -109387,7 +109233,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:48.989845+00:00"
+                "validatedAt": "2026-07-20T14:41:37.454472+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -109416,7 +109262,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:10:48.989901+00:00"
+                "validatedAt": "2026-07-20T14:41:37.454495+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -109427,7 +109273,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.233602+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.038707+00:00"
           },
           "enabled": {
             "type": "boolean",
@@ -109460,7 +109306,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:48.989936+00:00"
+                "validatedAt": "2026-07-20T14:41:37.454510+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -109635,7 +109481,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:48.990002+00:00"
+                "validatedAt": "2026-07-20T14:41:37.454533+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -109902,7 +109748,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:48.990074+00:00"
+                "validatedAt": "2026-07-20T14:41:37.454560+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -109928,7 +109774,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:48.990109+00:00"
+                "validatedAt": "2026-07-20T14:41:37.454573+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -109993,7 +109839,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:48.990148+00:00"
+                "validatedAt": "2026-07-20T14:41:37.454587+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -110061,7 +109907,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T13:10:48.990186+00:00"
+                "validatedAt": "2026-07-20T14:41:37.454603+00:00"
               },
               "deterministic": true
             },
@@ -110089,7 +109935,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:48.990226+00:00"
+                "validatedAt": "2026-07-20T14:41:37.454618+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -110116,7 +109962,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:48.990259+00:00"
+                "validatedAt": "2026-07-20T14:41:37.454631+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -110254,7 +110100,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:48.990329+00:00"
+                "validatedAt": "2026-07-20T14:41:37.454656+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -110281,7 +110127,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:48.990362+00:00"
+                "validatedAt": "2026-07-20T14:41:37.454669+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -110306,7 +110152,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:48.990401+00:00"
+                "validatedAt": "2026-07-20T14:41:37.454684+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -110390,7 +110236,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:10:48.990438+00:00"
+                "validatedAt": "2026-07-20T14:41:37.454698+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -110661,7 +110507,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:38.625201+00:00"
+                "validatedAt": "2026-07-20T14:41:56.066104+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -110688,7 +110534,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T13:11:38.625266+00:00"
+                "validatedAt": "2026-07-20T14:41:56.066133+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -110714,7 +110560,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:38.625302+00:00"
+                "validatedAt": "2026-07-20T14:41:56.066148+00:00"
               }
             },
             "x-f5xc-required-for": {

--- a/docs/specifications/api/threat_campaign.json
+++ b/docs/specifications/api/threat_campaign.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Threat Campaign",
     "description": "APIs for configuring detection policies and attack tracking. Supports campaign analysis, risk assessment, and automated mitigation rule generation across security domains.",
-    "version": "2.1.182",
+    "version": "2.1.181",
     "contact": {
       "name": "F5 Distributed Cloud",
       "url": "https://docs.cloud.f5.com"
@@ -543,7 +543,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.997051+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067444+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -567,7 +567,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:29.997097+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067463+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -662,7 +662,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.997142+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067484+00:00"
               },
               "deterministic": true
             },
@@ -674,9 +674,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.248552+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.961526+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -708,7 +707,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.997172+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067500+00:00"
               },
               "deterministic": true
             },
@@ -720,9 +719,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.248573+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.961540+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "path": {
             "type": "string",
@@ -753,7 +751,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.997266+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067538+00:00"
               },
               "deterministic": true
             },
@@ -896,7 +894,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.997340+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067571+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -959,7 +957,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.997421+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067611+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -999,7 +997,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.997454+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067627+00:00"
               },
               "deterministic": true
             },
@@ -1011,9 +1009,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.248636+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.961582+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -1045,7 +1042,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.997483+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067640+00:00"
               },
               "deterministic": true
             },
@@ -1057,9 +1054,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.248661+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.961595+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "user_id": {
             "type": "string",
@@ -1083,7 +1079,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.997540+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067670+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -1182,7 +1178,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.997573+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067686+00:00"
               },
               "deterministic": true
             },
@@ -1194,9 +1190,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.248696+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.961617+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "rule": {
             "allOf": [
@@ -1293,7 +1288,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.997631+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067717+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -1360,7 +1355,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.997677+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067732+00:00"
               },
               "deterministic": true
             },
@@ -1372,9 +1367,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.248749+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.961652+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -1406,7 +1400,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.997705+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067750+00:00"
               },
               "deterministic": true
             },
@@ -1418,9 +1412,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.248768+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.961665+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tls_fingerprint_matcher": {
             "allOf": [
@@ -1525,7 +1518,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:29.997761+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067772+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -1638,7 +1631,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.997807+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067793+00:00"
               },
               "deterministic": true
             },
@@ -1650,9 +1643,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.248830+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.961705+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -1684,7 +1676,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.997836+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067807+00:00"
               },
               "deterministic": true
             },
@@ -1696,9 +1688,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.248848+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.961718+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "path": {
             "type": "string",
@@ -1729,7 +1720,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.997902+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067838+00:00"
               },
               "deterministic": true
             },
@@ -1918,7 +1909,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.997944+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067857+00:00"
               },
               "deterministic": true
             },
@@ -1930,9 +1921,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.248903+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.961753+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -1964,7 +1954,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.997971+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067869+00:00"
               },
               "deterministic": true
             },
@@ -1976,9 +1966,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.248922+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.961766+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "path": {
             "type": "string",
@@ -2009,7 +1998,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.998031+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067898+00:00"
               },
               "deterministic": true
             },
@@ -2175,7 +2164,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.998070+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067915+00:00"
               },
               "deterministic": true
             },
@@ -2187,9 +2176,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.248971+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.961798+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -2221,7 +2209,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.998097+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067928+00:00"
               },
               "deterministic": true
             },
@@ -2233,9 +2221,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.248989+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.961811+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "path": {
             "type": "string",
@@ -2266,7 +2253,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.998157+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067957+00:00"
               },
               "deterministic": true
             },
@@ -2409,7 +2396,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.998224+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067987+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2472,7 +2459,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.998300+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068020+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2528,7 +2515,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.998335+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068036+00:00"
               },
               "deterministic": true
             },
@@ -2540,9 +2527,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.249058+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.961855+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -2574,7 +2560,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.998363+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068049+00:00"
               },
               "deterministic": true
             },
@@ -2586,9 +2572,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.249076+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.961868+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "sec_event_name": {
             "type": "string",
@@ -2605,7 +2590,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:29.998404+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068065+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2644,7 +2629,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.998451+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068087+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2692,7 +2677,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.998512+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068114+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2795,7 +2780,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.998543+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068129+00:00"
               },
               "deterministic": true
             },
@@ -2807,9 +2792,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.249129+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.961903+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "rule": {
             "allOf": [
@@ -2905,7 +2889,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.998608+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068157+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2917,7 +2901,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.249164+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.961926+00:00"
           },
           "exclude_bot_names": {
             "type": "array",
@@ -2948,7 +2932,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.998662+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068180+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2987,7 +2971,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.998711+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068202+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3026,7 +3010,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.998758+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068224+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3066,7 +3050,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.998787+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068237+00:00"
               },
               "deterministic": true
             },
@@ -3078,9 +3062,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.249202+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.961952+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -3112,7 +3095,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.998815+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068250+00:00"
               },
               "deterministic": true
             },
@@ -3124,9 +3107,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.249220+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.961965+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "req_path": {
             "type": "string",
@@ -3150,7 +3132,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.998870+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068275+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3184,7 +3166,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.998942+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068309+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3285,7 +3267,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.998978+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068325+00:00"
               },
               "deterministic": true
             },
@@ -3297,9 +3279,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.249259+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.961992+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "waf_exclusion_policy": {
             "allOf": [
@@ -3409,7 +3390,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.999014+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068341+00:00"
               },
               "deterministic": true
             },
@@ -3421,9 +3402,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.249293+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.962014+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -3454,7 +3434,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.999041+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068353+00:00"
               },
               "deterministic": true
             },
@@ -3466,9 +3446,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.249311+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.962027+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "request_data": {
             "allOf": [
@@ -3556,7 +3535,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:29.999082+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068369+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3584,7 +3563,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:29.999119+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068383+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3612,7 +3591,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:29.999154+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068397+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3713,7 +3692,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.999204+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068420+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3725,7 +3704,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.249379+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.962071+00:00"
           }
         },
         "x-f5xc-description-short": "Metric label filter can be specified to query specific metrics based on label match.",
@@ -3874,7 +3853,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.999251+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068443+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3914,7 +3893,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.999282+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068458+00:00"
               },
               "deterministic": true
             },
@@ -3926,9 +3905,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.249408+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.962091+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "GET a list of virtual hosts in all the namespaces matching filter provided in the request.",
@@ -4113,7 +4091,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:29.999342+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068482+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4153,7 +4131,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.999370+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068495+00:00"
               },
               "deterministic": true
             },
@@ -4165,9 +4143,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.249452+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.962120+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query": {
             "type": "string",
@@ -4187,7 +4164,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T12:55:29.999412+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068514+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4220,7 +4197,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:29.999452+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068530+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4305,7 +4282,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:29.999496+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068548+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4378,7 +4355,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:29.999536+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068563+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4452,7 +4429,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.999590+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068587+00:00"
               },
               "deterministic": true
             },
@@ -4464,9 +4441,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.249521+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.962165+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "start_time": {
             "type": "string",
@@ -4491,7 +4467,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:29.999629+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068602+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4524,7 +4500,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:29.999670+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068615+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4617,7 +4593,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:29.999717+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068633+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4684,7 +4660,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:29.999750+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068646+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4712,7 +4688,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:29.999787+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068660+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4740,7 +4716,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:29.999822+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068677+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4827,7 +4803,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:29.999866+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068694+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4856,7 +4832,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T12:55:29.999902+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068714+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4896,7 +4872,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.999930+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068728+00:00"
               },
               "deterministic": true
             },
@@ -4908,9 +4884,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.249611+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.962222+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query": {
             "type": "string",
@@ -4930,7 +4905,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T12:55:29.999972+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068747+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4986,7 +4961,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.000013+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068763+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5019,7 +4994,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.000054+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068779+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5155,7 +5130,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.000108+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068799+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5184,7 +5159,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.000147+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068814+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5280,7 +5255,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.000176+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068828+00:00"
               },
               "deterministic": true
             },
@@ -5292,9 +5267,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.249704+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.962275+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "scroll_id": {
             "type": "string",
@@ -5312,7 +5286,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.000213+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068843+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5401,7 +5375,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.000257+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068878+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5441,7 +5415,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.000285+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068906+00:00"
               },
               "deterministic": true
             },
@@ -5453,9 +5427,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.249746+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.962303+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query": {
             "type": "string",
@@ -5475,7 +5448,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T12:55:30.000325+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068927+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5508,7 +5481,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.000365+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068946+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5593,7 +5566,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.000408+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068965+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5680,7 +5653,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.000453+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068985+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5709,7 +5682,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T12:55:30.000486+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069002+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5749,7 +5722,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.000513+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069016+00:00"
               },
               "deterministic": true
             },
@@ -5761,9 +5734,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.249814+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.962348+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query": {
             "type": "string",
@@ -5783,7 +5755,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T12:55:30.000553+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069034+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5839,7 +5811,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.000593+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069050+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5872,7 +5844,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.000633+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069067+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6008,7 +5980,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.000697+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069090+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6037,7 +6009,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.000736+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069105+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6133,7 +6105,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.000767+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069119+00:00"
               },
               "deterministic": true
             },
@@ -6145,9 +6117,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.249895+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.962402+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "scroll_id": {
             "type": "string",
@@ -6165,7 +6136,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.000804+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069133+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6254,7 +6225,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.000847+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069151+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6294,7 +6265,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.000875+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069164+00:00"
               },
               "deterministic": true
             },
@@ -6306,9 +6277,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.249935+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.962429+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query": {
             "type": "string",
@@ -6328,7 +6298,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T12:55:30.000915+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069184+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6361,7 +6331,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.000954+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069199+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6446,7 +6416,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.000996+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069216+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6533,7 +6503,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.001041+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069233+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6562,7 +6532,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T12:55:30.001074+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069248+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6602,7 +6572,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.001102+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069262+00:00"
               },
               "deterministic": true
             },
@@ -6614,9 +6584,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.250003+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.962474+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query": {
             "type": "string",
@@ -6636,7 +6605,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T12:55:30.001143+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069279+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6692,7 +6661,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.001183+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069295+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6725,7 +6694,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.001224+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069311+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6861,7 +6830,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.001277+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069331+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6890,7 +6859,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.001316+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069345+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6986,7 +6955,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.001346+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069359+00:00"
               },
               "deterministic": true
             },
@@ -6998,9 +6967,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.250084+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.962527+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "scroll_id": {
             "type": "string",
@@ -7018,7 +6986,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.001383+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069373+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7085,7 +7053,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.001424+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069389+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7114,7 +7082,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:55:30.001471+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069409+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7125,7 +7093,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.250117+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.962549+00:00"
           },
           "id": {
             "type": "string",
@@ -7151,7 +7119,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.001498+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069420+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7176,7 +7144,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.001532+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069433+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7209,7 +7177,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.001573+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069449+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7280,7 +7248,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.001618+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069469+00:00"
               },
               "deterministic": true
             },
@@ -7292,9 +7260,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.250162+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.962579+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "references": {
             "type": "array",
@@ -7335,7 +7302,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.001674+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069488+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7482,7 +7449,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.001728+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069509+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8038,7 +8005,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.001830+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069548+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8388,7 +8355,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.001920+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069589+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8526,7 +8493,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.001980+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069612+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8681,7 +8648,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.002059+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069647+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8760,7 +8727,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.002131+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069741+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8771,8 +8738,7 @@
             },
             "x-f5xc-conflicts-with": [
               "any_domain"
-            ],
-            "format": "fqdn"
+            ]
           }
         },
         "x-f5xc-description-short": "API Protection Rule for a specific endpoint.",
@@ -8924,7 +8890,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.002184+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069804+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8962,7 +8928,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.002245+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069849+00:00"
               },
               "deterministic": true
             },
@@ -9071,7 +9037,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.002314+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069883+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9178,7 +9144,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.002389+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069916+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9189,8 +9155,7 @@
             },
             "x-f5xc-conflicts-with": [
               "any_domain"
-            ],
-            "format": "fqdn"
+            ]
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -9313,7 +9278,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.002437+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069940+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9456,7 +9421,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.002508+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069972+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9495,7 +9460,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.002565+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069999+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9597,7 +9562,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.002626+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070030+00:00"
               },
               "deterministic": true
             },
@@ -9704,7 +9669,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T12:55:30.002674+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070049+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10235,7 +10200,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.002780+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070093+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10354,7 +10319,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.002834+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070122+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10463,7 +10428,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.002897+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070152+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10502,7 +10467,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.002953+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070178+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10554,7 +10519,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.003017+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070207+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10565,8 +10530,7 @@
             },
             "x-f5xc-conflicts-with": [
               "any_domain"
-            ],
-            "format": "fqdn"
+            ]
           },
           "validation_mode": {
             "allOf": [
@@ -10658,7 +10622,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.003065+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070231+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10741,7 +10705,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.003129+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070256+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10793,7 +10757,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.003171+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070273+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10831,7 +10795,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.003212+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070291+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10900,7 +10864,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.003280+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070323+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11157,7 +11121,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.003346+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070355+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11338,7 +11302,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.003424+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070388+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11409,7 +11373,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.003485+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070423+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -11423,8 +11387,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "presence": {
             "type": "boolean",
@@ -11469,7 +11432,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.003554+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070457+00:00"
               },
               "byteLength": {
                 "max": 256
@@ -11548,7 +11511,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.003588+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070469+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11560,7 +11523,7 @@
             "readOnly": true,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.250997+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.963121+00:00"
           },
           "name": {
             "type": "string",
@@ -11593,7 +11556,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.003616+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070482+00:00"
               },
               "deterministic": true
             },
@@ -11605,9 +11568,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.251017+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.963135+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -11640,7 +11602,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.003644+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070496+00:00"
               },
               "deterministic": true
             },
@@ -11652,9 +11614,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.251035+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.963148+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -11673,7 +11634,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.003686+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070509+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11686,7 +11647,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.251054+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.963161+00:00"
           },
           "uid": {
             "type": "string",
@@ -11705,7 +11666,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.003713+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070519+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11719,7 +11680,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.251074+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.963175+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -11777,7 +11738,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.251095+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.963189+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Avg Aggregation Data\" Average Aggregation data.",
@@ -11831,7 +11792,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.003774+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070538+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11909,7 +11870,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.003819+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070552+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11948,7 +11909,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T12:55:30.003866+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070571+00:00"
               },
               "deterministic": true
             },
@@ -12044,7 +12005,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.003919+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070589+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12107,7 +12068,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.003955+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070603+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12130,7 +12091,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.003983+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070617+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12141,7 +12102,7 @@
             },
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.251180+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.963246+00:00"
           },
           "order_by": {
             "allOf": [
@@ -12291,7 +12252,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.004047+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070640+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12315,7 +12276,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.004073+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070651+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12326,7 +12287,7 @@
             },
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.251235+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.963283+00:00"
           },
           "order_by": {
             "allOf": [
@@ -12396,7 +12357,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.004113+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070666+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12420,7 +12381,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.004139+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070677+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12431,7 +12392,7 @@
             },
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.251268+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.963306+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Field Sub Field Aggregation Bucket\" Field sub aggregation bucket containing field values and the number of logs.",
@@ -12487,7 +12448,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.004176+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070691+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12562,7 +12523,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.004216+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070706+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12586,7 +12547,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.004243+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070717+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12597,7 +12558,7 @@
             },
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.251311+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.963334+00:00"
           },
           "sub_aggs": {
             "type": "object",
@@ -12665,7 +12626,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.251339+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.963353+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Max Aggregation Data\" Max Aggregation data.",
@@ -12768,7 +12729,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.251367+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.963372+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Min Aggregation Data\" Min Aggregation data.",
@@ -12822,7 +12783,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.004313+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070742+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12979,7 +12940,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.004375+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070764+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13092,7 +13053,7 @@
             "maxLength": 16,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.251442+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.963421+00:00"
           },
           "value": {
             "type": "number",
@@ -13108,7 +13069,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.251460+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.963434+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Percentile Aggregation Data\" Percentile Aggregation data.",
@@ -13163,7 +13124,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.004440+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070791+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13327,7 +13288,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.004501+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070816+00:00"
               },
               "deterministic": true
             },
@@ -13339,9 +13300,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.251510+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.963466+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "sec_event_type": {
             "type": "string",
@@ -13358,7 +13318,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.004546+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070831+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13383,7 +13343,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.004589+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070847+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13408,7 +13368,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.004627+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070861+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13433,7 +13393,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.004682+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070875+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13570,7 +13530,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.004727+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070911+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13581,7 +13541,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.251570+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.963505+00:00"
           }
         },
         "x-f5xc-description-short": "Label based filtering for Security Events metrics. Security Events metrics are tagged with labels mentioned in MetricLabel.",
@@ -13695,7 +13655,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.004779+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070935+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13706,7 +13666,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.251596+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.963524+00:00"
           }
         },
         "x-f5xc-description-short": "Value returned for a Security Events Metrics query.",
@@ -13785,7 +13745,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.004850+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070970+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13876,7 +13836,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.004902+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070997+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13914,7 +13874,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.004949+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071021+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13951,7 +13911,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.004996+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071046+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13988,7 +13948,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.005042+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071068+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14078,7 +14038,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.005108+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071101+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14195,7 +14155,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.005192+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071136+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14298,7 +14258,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.005244+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071162+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14375,7 +14335,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.005287+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071183+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14446,7 +14406,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.005329+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071200+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14773,7 +14733,7 @@
             "maxLength": 26,
             "minLength": 15,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.251817+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:08.963660+00:00",
             "x-f5xc-conflicts-with": [
               "check_not_present",
               "check_present"
@@ -14818,7 +14778,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.005427+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071247+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -14833,9 +14793,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.251837+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.963674+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Cookie matcher specifies the name of a single cookie and the criteria to match it.",
@@ -15264,7 +15223,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.005474+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071270+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15406,7 +15365,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.005521+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071292+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15486,7 +15445,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.005568+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071314+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15602,7 +15561,7 @@
             "maxLength": 26,
             "minLength": 15,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.251916+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:08.963725+00:00",
             "x-f5xc-conflicts-with": [
               "check_not_present",
               "check_present"
@@ -15646,7 +15605,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.005632+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071345+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -15661,9 +15620,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.251934+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.963738+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "JWT claim matcher specifies the name of a single JWT claim and the criteria for the input request to match it.",
@@ -15796,7 +15754,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.005685+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071367+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15842,7 +15800,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.005728+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071388+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15880,7 +15838,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.005771+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071409+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15977,7 +15935,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.005821+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071432+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16052,7 +16010,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.005866+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071454+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16089,7 +16047,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.005919+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071481+00:00"
               },
               "deterministic": true
             },
@@ -16125,7 +16083,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.005958+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071501+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16160,7 +16118,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.006001+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071521+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16296,7 +16254,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.006076+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071554+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16308,8 +16266,7 @@
             "x-f5xc-conflicts-with": [
               "any_domain",
               "suffix_value"
-            ],
-            "format": "hostname"
+            ]
           },
           "expiration_timestamp": {
             "type": "string",
@@ -16330,7 +16287,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.006119+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071571+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16384,7 +16341,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.006167+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071594+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16420,7 +16377,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.006228+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071621+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16463,7 +16420,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.006287+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071649+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16508,7 +16465,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.006349+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071677+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16520,8 +16477,7 @@
             "x-f5xc-conflicts-with": [
               "any_domain",
               "exact_value"
-            ],
-            "format": "hostname"
+            ]
           },
           "waf_skip_processing": {
             "allOf": [
@@ -16617,7 +16573,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.006395+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071700+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16658,7 +16614,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.006438+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071722+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16700,7 +16656,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.006482+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071743+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16966,7 +16922,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.006525+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071765+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17039,7 +16995,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.006592+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071797+00:00"
               },
               "deterministic": true
             },
@@ -17051,7 +17007,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.252121+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.963860+00:00"
           },
           "name": {
             "type": "string",
@@ -17095,7 +17051,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.006642+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071822+00:00"
               },
               "deterministic": true
             },
@@ -17105,8 +17061,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "MessageMetaType is metadata (common attributes) of a message that only certain messages have.",
@@ -17292,7 +17247,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:55:30.006699+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071843+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17303,7 +17258,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.252153+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.963880+00:00"
           },
           "previous_value": {
             "type": "string",
@@ -17318,7 +17273,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.006738+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071858+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17354,7 +17309,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.006775+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071874+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17365,7 +17320,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.252185+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.963903+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Trend Value\" Trend value contains trend value, trend sentiment and trend calculation description and window size.",
@@ -17474,7 +17429,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.006812+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071890+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18096,7 +18051,7 @@
             "maxLength": 26,
             "minLength": 15,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.252328+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:08.963995+00:00",
             "x-f5xc-conflicts-with": [
               "check_not_present",
               "check_present"
@@ -18143,7 +18098,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.006949+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071949+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -18158,9 +18113,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.252347+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.964008+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Header matcher specifies the name of a single HTTP header and the criteria for the input request to match it.",
@@ -18238,7 +18192,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.006993+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071971+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18352,7 +18306,7 @@
             "maxLength": 26,
             "minLength": 15,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.252395+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:08.964039+00:00",
             "x-f5xc-conflicts-with": [
               "check_not_present",
               "check_present"
@@ -18387,7 +18341,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.007056+00:00"
+                "validatedAt": "2026-07-20T14:35:37.072000+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18398,7 +18352,7 @@
             },
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.252413+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.964052+00:00"
           }
         },
         "x-f5xc-description-short": "Query parameter matcher specifies the name of a single query parameter and the criteria for the input request to match it.",
@@ -18487,7 +18441,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.007107+00:00"
+                "validatedAt": "2026-07-20T14:35:37.072027+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -18501,8 +18455,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -18541,7 +18494,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.007155+00:00"
+                "validatedAt": "2026-07-20T14:35:37.072052+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -18556,9 +18509,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.252441+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.964071+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -18587,7 +18539,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.007207+00:00"
+                "validatedAt": "2026-07-20T14:35:37.072077+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18600,7 +18552,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.252460+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.964084+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a direct reference from one object(the referrer) to another(the referred).",
@@ -18865,7 +18817,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:35.072442+00:00"
+                "validatedAt": "2026-07-20T14:35:39.091566+00:00"
               }
             },
             "x-f5xc-required-for": {

--- a/docs/specifications/api/users.json
+++ b/docs/specifications/api/users.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Users",
     "description": "Token lifecycle governs automated site onboarding through cloud-init integration with configurable validity periods. Explicit category keys establish permitted classification hierarchies enforced across deployments. Inferred attributes attach automatically based on object characteristics and placement context. Namespace-scoped operations handle credential generation, revocation, and state transitions for streamlined provisioning workflows.",
-    "version": "2.1.182",
+    "version": "2.1.181",
     "contact": {
       "name": "F5 Distributed Cloud",
       "url": "https://docs.cloud.f5.com"
@@ -3415,7 +3415,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:02:45.822509+00:00"
+                "validatedAt": "2026-07-20T14:38:30.949650+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3426,7 +3426,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.807977+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.730136+00:00"
           },
           "key": {
             "type": "string",
@@ -3443,7 +3443,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:45.822541+00:00"
+                "validatedAt": "2026-07-20T14:38:30.949665+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3454,7 +3454,7 @@
             },
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.807999+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.730148+00:00"
           },
           "value": {
             "type": "string",
@@ -3471,7 +3471,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:45.822585+00:00"
+                "validatedAt": "2026-07-20T14:38:30.949679+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3482,7 +3482,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.808018+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.730160+00:00"
           }
         },
         "x-f5xc-description-short": "Generic Label type label.key(label.value).",
@@ -3544,7 +3544,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:03:45.512510+00:00"
+                "validatedAt": "2026-07-20T14:38:54.668913+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3555,7 +3555,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.774906+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.551701+00:00"
           },
           "key": {
             "type": "string",
@@ -3572,7 +3572,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:45.512554+00:00"
+                "validatedAt": "2026-07-20T14:38:54.668927+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3583,7 +3583,7 @@
             },
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.774927+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.551714+00:00"
           },
           "namespace": {
             "type": "string",
@@ -3614,7 +3614,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:45.512603+00:00"
+                "validatedAt": "2026-07-20T14:38:54.668943+00:00"
               },
               "deterministic": true
             },
@@ -3626,9 +3626,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.774946+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.551726+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "value": {
             "type": "string",
@@ -3651,7 +3650,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:45.512675+00:00"
+                "validatedAt": "2026-07-20T14:38:54.668961+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3662,7 +3661,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.774965+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.551737+00:00"
           }
         },
         "x-f5xc-description-short": "Create label request in shared namespace. Only shared namespace supported.",
@@ -3768,7 +3767,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:45.512728+00:00"
+                "validatedAt": "2026-07-20T14:38:54.668974+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3779,7 +3778,7 @@
             },
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.774994+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.551755+00:00"
           },
           "namespace": {
             "type": "string",
@@ -3810,7 +3809,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:45.512778+00:00"
+                "validatedAt": "2026-07-20T14:38:54.668989+00:00"
               },
               "deterministic": true
             },
@@ -3822,9 +3821,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.775012+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.551766+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "value": {
             "type": "string",
@@ -3847,7 +3845,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:45.512825+00:00"
+                "validatedAt": "2026-07-20T14:38:54.669003+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3858,7 +3856,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.775030+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.551778+00:00"
           }
         },
         "x-f5xc-description-short": "Deletes Label matching label.key=label.value.",
@@ -4001,7 +3999,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:03:45.512890+00:00"
+                "validatedAt": "2026-07-20T14:38:54.669032+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4012,7 +4010,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.775059+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.551795+00:00"
           },
           "key": {
             "type": "string",
@@ -4029,7 +4027,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:45.512915+00:00"
+                "validatedAt": "2026-07-20T14:38:54.669043+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4040,7 +4038,7 @@
             },
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.775077+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.551806+00:00"
           },
           "value": {
             "type": "string",
@@ -4057,7 +4055,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:45.512949+00:00"
+                "validatedAt": "2026-07-20T14:38:54.669056+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4068,7 +4066,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.775095+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.551818+00:00"
           }
         },
         "x-f5xc-description-short": "Generic Label type label.key(label.value).",
@@ -4128,7 +4126,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:03:50.734503+00:00"
+                "validatedAt": "2026-07-20T14:38:56.536950+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4139,7 +4137,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.830026+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.610262+00:00"
           },
           "key": {
             "type": "string",
@@ -4156,7 +4154,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:50.734537+00:00"
+                "validatedAt": "2026-07-20T14:38:56.536964+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4167,7 +4165,7 @@
             },
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.830046+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.610276+00:00"
           },
           "namespace": {
             "type": "string",
@@ -4198,7 +4196,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:50.734571+00:00"
+                "validatedAt": "2026-07-20T14:38:56.536980+00:00"
               },
               "deterministic": true
             },
@@ -4210,9 +4208,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.830065+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.610289+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Create label Key request in shared namespace. Only shared namespace supported.",
@@ -4317,7 +4314,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:50.734604+00:00"
+                "validatedAt": "2026-07-20T14:38:56.536993+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4328,7 +4325,7 @@
             },
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.830094+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.610308+00:00"
           },
           "namespace": {
             "type": "string",
@@ -4360,7 +4357,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:03:50.734632+00:00"
+                "validatedAt": "2026-07-20T14:38:56.537007+00:00"
               },
               "deterministic": true
             },
@@ -4372,9 +4369,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.830113+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:17.610320+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -4516,7 +4512,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:03:50.734711+00:00"
+                "validatedAt": "2026-07-20T14:38:56.537035+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4527,7 +4523,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.830142+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.610338+00:00"
           },
           "key": {
             "type": "string",
@@ -4544,7 +4540,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:03:50.734735+00:00"
+                "validatedAt": "2026-07-20T14:38:56.537046+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4555,7 +4551,7 @@
             },
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:17.830160+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:17.610350+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -4604,7 +4600,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:54.492234+00:00"
+                "validatedAt": "2026-07-20T14:41:17.364093+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4627,7 +4623,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:54.492291+00:00"
+                "validatedAt": "2026-07-20T14:41:17.364119+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4638,7 +4634,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.397258+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.974008+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -4702,7 +4698,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T13:09:54.492339+00:00"
+                "validatedAt": "2026-07-20T14:41:17.364141+00:00"
               },
               "deterministic": true
             },
@@ -4713,8 +4709,7 @@
               "read": false
             },
             "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "minLength": 1,
-            "format": "fqdn"
+            "minLength": 1
           },
           "last_update_time": {
             "type": "string",
@@ -4731,7 +4726,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:54.492401+00:00"
+                "validatedAt": "2026-07-20T14:41:17.364160+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4758,7 +4753,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:54.492448+00:00"
+                "validatedAt": "2026-07-20T14:41:17.364175+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4769,7 +4764,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.397297+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.974032+00:00"
           },
           "service_name": {
             "type": "string",
@@ -4786,7 +4781,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:54.492510+00:00"
+                "validatedAt": "2026-07-20T14:41:17.364194+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4819,7 +4814,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:54.492574+00:00"
+                "validatedAt": "2026-07-20T14:41:17.364212+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4830,7 +4825,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.397324+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.974048+00:00"
           },
           "type": {
             "type": "string",
@@ -4855,7 +4850,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:54.492626+00:00"
+                "validatedAt": "2026-07-20T14:41:17.364227+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4999,7 +4994,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:54.492685+00:00"
+                "validatedAt": "2026-07-20T14:41:17.364245+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5079,7 +5074,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:54.492720+00:00"
+                "validatedAt": "2026-07-20T14:41:17.364263+00:00"
               },
               "deterministic": true
             },
@@ -5091,9 +5086,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.397374+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:23.974079+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -5257,7 +5251,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:54.492828+00:00"
+                "validatedAt": "2026-07-20T14:41:17.364315+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -5272,7 +5266,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.397418+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.974106+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -5342,7 +5336,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:54.492869+00:00"
+                "validatedAt": "2026-07-20T14:41:17.364335+00:00"
               },
               "deterministic": true
             },
@@ -5354,9 +5348,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.397451+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:23.974128+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -5389,7 +5382,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:54.492896+00:00"
+                "validatedAt": "2026-07-20T14:41:17.364349+00:00"
               },
               "deterministic": true
             },
@@ -5401,9 +5394,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.397470+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:23.974141+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -5503,7 +5495,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:54.492969+00:00"
+                "validatedAt": "2026-07-20T14:41:17.364390+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -5518,7 +5510,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.397497+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.974159+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -5590,7 +5582,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:54.493007+00:00"
+                "validatedAt": "2026-07-20T14:41:17.364409+00:00"
               },
               "deterministic": true
             },
@@ -5602,9 +5594,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.397530+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:23.974180+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -5637,7 +5628,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:54.493034+00:00"
+                "validatedAt": "2026-07-20T14:41:17.364423+00:00"
               },
               "deterministic": true
             },
@@ -5649,9 +5640,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.397549+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:23.974193+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -5751,7 +5741,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:54.493112+00:00"
+                "validatedAt": "2026-07-20T14:41:17.364461+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -5766,7 +5756,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.397577+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.974211+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -5838,7 +5828,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:54.493150+00:00"
+                "validatedAt": "2026-07-20T14:41:17.364481+00:00"
               },
               "deterministic": true
             },
@@ -5850,9 +5840,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.397609+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:23.974232+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -5885,7 +5874,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:54.493177+00:00"
+                "validatedAt": "2026-07-20T14:41:17.364495+00:00"
               },
               "deterministic": true
             },
@@ -5897,9 +5886,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.397628+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:23.974244+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "uid": {
             "type": "string",
@@ -5918,7 +5906,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:54.493202+00:00"
+                "validatedAt": "2026-07-20T14:41:17.364506+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5932,7 +5920,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.397648+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.974257+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectMetaType is metadata(common attributes) of an object that all configuration objects will have.",
@@ -5997,7 +5985,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:54.493233+00:00"
+                "validatedAt": "2026-07-20T14:41:17.364520+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6009,7 +5997,7 @@
             "readOnly": true,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.397678+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.974271+00:00"
           },
           "name": {
             "type": "string",
@@ -6042,7 +6030,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:54.493259+00:00"
+                "validatedAt": "2026-07-20T14:41:17.364535+00:00"
               },
               "deterministic": true
             },
@@ -6054,9 +6042,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.397697+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:23.974283+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -6089,7 +6076,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:54.493285+00:00"
+                "validatedAt": "2026-07-20T14:41:17.364549+00:00"
               },
               "deterministic": true
             },
@@ -6101,9 +6088,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.397715+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:23.974295+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -6122,7 +6108,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:54.493316+00:00"
+                "validatedAt": "2026-07-20T14:41:17.364563+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6135,7 +6121,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.397733+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.974307+00:00"
           },
           "uid": {
             "type": "string",
@@ -6154,7 +6140,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:54.493341+00:00"
+                "validatedAt": "2026-07-20T14:41:17.364575+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6168,7 +6154,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.397753+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.974320+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -6268,7 +6254,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:54.493415+00:00"
+                "validatedAt": "2026-07-20T14:41:17.364614+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -6283,7 +6269,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.397781+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.974338+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -6353,7 +6339,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:54.493452+00:00"
+                "validatedAt": "2026-07-20T14:41:17.364633+00:00"
               },
               "deterministic": true
             },
@@ -6365,9 +6351,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.397814+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:23.974359+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -6400,7 +6385,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:54.493478+00:00"
+                "validatedAt": "2026-07-20T14:41:17.364647+00:00"
               },
               "deterministic": true
             },
@@ -6412,9 +6397,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.397832+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:23.974371+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -6477,7 +6461,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:54.493519+00:00"
+                "validatedAt": "2026-07-20T14:41:17.364666+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6505,7 +6489,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:54.493559+00:00"
+                "validatedAt": "2026-07-20T14:41:17.364684+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6533,7 +6517,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:54.493595+00:00"
+                "validatedAt": "2026-07-20T14:41:17.364700+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6572,7 +6556,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:54.493634+00:00"
+                "validatedAt": "2026-07-20T14:41:17.364717+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6599,7 +6583,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:54.493668+00:00"
+                "validatedAt": "2026-07-20T14:41:17.364729+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6612,7 +6596,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.397887+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.974405+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -6628,7 +6612,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:54.493705+00:00"
+                "validatedAt": "2026-07-20T14:41:17.364744+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6773,7 +6757,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:54.493757+00:00"
+                "validatedAt": "2026-07-20T14:41:17.364766+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6784,7 +6768,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.397929+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.974430+00:00"
           },
           "status": {
             "type": "string",
@@ -6802,7 +6786,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:54.493791+00:00"
+                "validatedAt": "2026-07-20T14:41:17.364780+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6813,7 +6797,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.397947+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.974442+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -6873,7 +6857,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:54.493834+00:00"
+                "validatedAt": "2026-07-20T14:41:17.364799+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6900,7 +6884,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:54.493874+00:00"
+                "validatedAt": "2026-07-20T14:41:17.364817+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6927,7 +6911,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:54.493910+00:00"
+                "validatedAt": "2026-07-20T14:41:17.364833+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6955,7 +6939,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:54.493952+00:00"
+                "validatedAt": "2026-07-20T14:41:17.364851+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7031,7 +7015,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:54.494015+00:00"
+                "validatedAt": "2026-07-20T14:41:17.364878+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7099,7 +7083,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:54.494065+00:00"
+                "validatedAt": "2026-07-20T14:41:17.364900+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7111,7 +7095,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.398034+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.974496+00:00"
           },
           "uid": {
             "type": "string",
@@ -7130,7 +7114,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:54.494090+00:00"
+                "validatedAt": "2026-07-20T14:41:17.364911+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7143,7 +7127,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.398053+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.974508+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -7213,7 +7197,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:54.494133+00:00"
+                "validatedAt": "2026-07-20T14:41:17.364930+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7241,7 +7225,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:54.494173+00:00"
+                "validatedAt": "2026-07-20T14:41:17.364947+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7270,7 +7254,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:54.494211+00:00"
+                "validatedAt": "2026-07-20T14:41:17.364964+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7297,7 +7281,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:54.494248+00:00"
+                "validatedAt": "2026-07-20T14:41:17.364981+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7326,7 +7310,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:54.494289+00:00"
+                "validatedAt": "2026-07-20T14:41:17.364999+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7351,7 +7335,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:54.494329+00:00"
+                "validatedAt": "2026-07-20T14:41:17.365016+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7427,7 +7411,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:54.494392+00:00"
+                "validatedAt": "2026-07-20T14:41:17.365042+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7465,7 +7449,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:54.494438+00:00"
+                "validatedAt": "2026-07-20T14:41:17.365068+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7477,7 +7461,7 @@
             "maxLength": 6,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.398141+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.974562+00:00"
           },
           "object_index": {
             "type": "integer",
@@ -7537,7 +7521,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:54.494489+00:00"
+                "validatedAt": "2026-07-20T14:41:17.365090+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7581,7 +7565,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:54.494526+00:00"
+                "validatedAt": "2026-07-20T14:41:17.365107+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7594,7 +7578,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.398185+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.974590+00:00"
           },
           "trace_info": {
             "type": "string",
@@ -7613,7 +7597,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:54.494563+00:00"
+                "validatedAt": "2026-07-20T14:41:17.365124+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7640,7 +7624,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:54.494589+00:00"
+                "validatedAt": "2026-07-20T14:41:17.365136+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7654,7 +7638,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.398212+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.974607+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -7669,7 +7653,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:54.494622+00:00"
+                "validatedAt": "2026-07-20T14:41:17.365151+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7768,7 +7752,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:54.494666+00:00"
+                "validatedAt": "2026-07-20T14:41:17.365167+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7779,7 +7763,7 @@
             },
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.398245+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.974628+00:00"
           },
           "name": {
             "type": "string",
@@ -7812,7 +7796,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:54.494695+00:00"
+                "validatedAt": "2026-07-20T14:41:17.365181+00:00"
               },
               "deterministic": true
             },
@@ -7824,9 +7808,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.398264+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:23.974640+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -7859,7 +7842,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:54.494722+00:00"
+                "validatedAt": "2026-07-20T14:41:17.365195+00:00"
               },
               "deterministic": true
             },
@@ -7871,9 +7854,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.398282+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:23.974653+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "uid": {
             "type": "string",
@@ -7890,7 +7872,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:54.494746+00:00"
+                "validatedAt": "2026-07-20T14:41:17.365206+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7903,7 +7885,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.398301+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.974665+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -8166,7 +8148,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:54.494795+00:00"
+                "validatedAt": "2026-07-20T14:41:17.365228+00:00"
               },
               "deterministic": true
             },
@@ -8178,9 +8160,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.398364+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:23.974704+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -8212,7 +8193,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:54.494821+00:00"
+                "validatedAt": "2026-07-20T14:41:17.365243+00:00"
               },
               "deterministic": true
             },
@@ -8224,9 +8205,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.398382+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:23.974716+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -8279,7 +8259,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:54.494863+00:00"
+                "validatedAt": "2026-07-20T14:41:17.365262+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8290,7 +8270,7 @@
             },
             "minLength": 279,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.398403+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.974730+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -8451,7 +8431,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.398469+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.974771+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -8648,7 +8628,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:09:54.494983+00:00"
+                "validatedAt": "2026-07-20T14:41:17.365313+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8726,7 +8706,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:09:54.495031+00:00"
+                "validatedAt": "2026-07-20T14:41:17.365336+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8737,7 +8717,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.398535+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.974810+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -8824,7 +8804,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:54.495072+00:00"
+                "validatedAt": "2026-07-20T14:41:17.365358+00:00"
               },
               "deterministic": true
             },
@@ -8836,9 +8816,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.398579+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:23.974838+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -8869,7 +8848,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:54.495097+00:00"
+                "validatedAt": "2026-07-20T14:41:17.365372+00:00"
               },
               "deterministic": true
             },
@@ -8881,9 +8860,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.398598+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:23.974851+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -8952,7 +8930,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:54.495147+00:00"
+                "validatedAt": "2026-07-20T14:41:17.365395+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8964,7 +8942,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.398635+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.974874+00:00"
           },
           "uid": {
             "type": "string",
@@ -8981,7 +8959,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:09:54.495171+00:00"
+                "validatedAt": "2026-07-20T14:41:17.365406+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8994,7 +8972,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.398661+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:23.974887+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of token is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -9424,7 +9402,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:54.495224+00:00"
+                "validatedAt": "2026-07-20T14:41:17.365430+00:00"
               },
               "deterministic": true
             },
@@ -9436,9 +9414,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.398736+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:23.974931+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -9469,7 +9446,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:09:54.495250+00:00"
+                "validatedAt": "2026-07-20T14:41:17.365445+00:00"
               },
               "deterministic": true
             },
@@ -9481,9 +9458,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:24.398754+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:23.974943+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "state": {
             "allOf": [

--- a/docs/specifications/api/validation.json
+++ b/docs/specifications/api/validation.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "version": "2.1.0",
   "description": "Centralized validation specification for F5 XC API",
-  "generated_at": "2026-07-20T13:12:52.612137+00:00",
+  "generated_at": "2026-07-20T14:42:40.652620+00:00",
   "source": "api-specs-enriched",
   "required_fields": {
     "common": {
@@ -1209,8 +1209,5 @@
     "oneof_defaults_exported": 0,
     "ui_vs_server_defaults_exported": 1,
     "warnings": []
-  },
-  "info": {
-    "version": "2.1.182"
   }
 }

--- a/docs/specifications/api/virtual.json
+++ b/docs/specifications/api/virtual.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Virtual",
     "description": "Load balancing for HTTP, TCP, and UDP traffic with configurable routing rules and origin pool management. Supports health checks, session persistence, and automatic failover. Enables geographic distribution, rate limiting, and service policy enforcement across load balancers and routes.",
-    "version": "2.1.182",
+    "version": "2.1.181",
     "contact": {
       "name": "F5 Distributed Cloud",
       "url": "https://docs.cloud.f5.com"
@@ -1625,7 +1625,7 @@
           },
           {
             "name": "response_format",
-            "description": "The format in which the configuration object is to be fetched. This could be for example\n - in GetSpec form for the contents of object\n - in CreateRequest form to create a new similar object\n - to ReplaceRequest form to replace changeable values\n\nDefault format of returned resource\nResponse should be in CreateRequest format\nResponse should be in ReplaceRequest format\nResponse should be in StatusObject(s) format\nResponse should be in format of GetSpecType\nResponse should have other objects referring to this object\nResponse should have deleted and disabled objects referred by this object.",
+            "description": "The format in which the configuration object is to be fetched. This could be for example\n - in GetSpec form for the contents of object\n - in CreateRequest form to create a new similar object\n - to ReplaceRequest form to replace changeable values\n\nDefault format of returned resource\nResponse should be in CreateRequest format\nResponse should be in ReplaceRequest format\nResponse should be in StatusObject(s) format\nResponse should be in format of GetSpecType\nResponse should have other objects referring to this object\nResponse should have deleted and disabled objects referrred by this object.",
             "in": "query",
             "required": false,
             "x-displayname": "Broken Referred Objects.",
@@ -34801,7 +34801,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:24.888558+00:00"
+                "validatedAt": "2026-07-20T14:35:34.998915+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34985,7 +34985,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:24.888639+00:00"
+                "validatedAt": "2026-07-20T14:35:34.998951+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35066,7 +35066,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:24.888732+00:00"
+                "validatedAt": "2026-07-20T14:35:34.998990+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35146,7 +35146,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:24.888779+00:00"
+                "validatedAt": "2026-07-20T14:35:34.999009+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35227,7 +35227,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:24.888844+00:00"
+                "validatedAt": "2026-07-20T14:35:34.999042+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35466,7 +35466,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:24.888893+00:00"
+                "validatedAt": "2026-07-20T14:35:34.999067+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36283,7 +36283,7 @@
                 "confidence": 0.99,
                 "category": "content",
                 "note": "Must be a valid URI (uri_ref). API rejects inline HTML despite the description example.",
-                "validatedAt": "2026-07-20T12:55:24.889012+00:00"
+                "validatedAt": "2026-07-20T14:35:34.999124+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36394,7 +36394,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:24.889061+00:00"
+                "validatedAt": "2026-07-20T14:35:34.999150+00:00"
               },
               "deterministic": true
             },
@@ -36406,9 +36406,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.148146+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.877242+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -36440,7 +36439,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:24.889092+00:00"
+                "validatedAt": "2026-07-20T14:35:34.999166+00:00"
               },
               "deterministic": true
             },
@@ -36452,9 +36451,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.148167+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.877256+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -36911,7 +36909,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.148318+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.877351+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -37402,7 +37400,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:55:24.889306+00:00"
+                "validatedAt": "2026-07-20T14:35:34.999251+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37488,7 +37486,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:55:24.889362+00:00"
+                "validatedAt": "2026-07-20T14:35:34.999277+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37499,7 +37497,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.148464+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.877445+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -37586,7 +37584,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:24.889402+00:00"
+                "validatedAt": "2026-07-20T14:35:34.999296+00:00"
               },
               "deterministic": true
             },
@@ -37598,9 +37596,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.148509+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.877475+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -37631,7 +37628,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:24.889430+00:00"
+                "validatedAt": "2026-07-20T14:35:34.999310+00:00"
               },
               "deterministic": true
             },
@@ -37643,9 +37640,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.148528+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.877489+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -37714,7 +37710,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:24.889484+00:00"
+                "validatedAt": "2026-07-20T14:35:34.999332+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37726,7 +37722,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.148565+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.877514+00:00"
           },
           "uid": {
             "type": "string",
@@ -37743,7 +37739,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:24.889511+00:00"
+                "validatedAt": "2026-07-20T14:35:34.999343+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37756,7 +37752,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.148585+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.877528+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of app_firewall is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -37973,7 +37969,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:24.889571+00:00"
+                "validatedAt": "2026-07-20T14:35:34.999367+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38018,7 +38014,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:24.889619+00:00"
+                "validatedAt": "2026-07-20T14:35:34.999392+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38045,7 +38041,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:24.889663+00:00"
+                "validatedAt": "2026-07-20T14:35:34.999407+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38114,7 +38110,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:24.889711+00:00"
+                "validatedAt": "2026-07-20T14:35:34.999432+00:00"
               },
               "deterministic": true
             },
@@ -38126,9 +38122,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.148667+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.877576+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "range": {
             "type": "string",
@@ -38153,7 +38148,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:24.889746+00:00"
+                "validatedAt": "2026-07-20T14:35:34.999447+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38186,7 +38181,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:24.889787+00:00"
+                "validatedAt": "2026-07-20T14:35:34.999464+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38219,7 +38214,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:24.889820+00:00"
+                "validatedAt": "2026-07-20T14:35:34.999479+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38321,7 +38316,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:24.889864+00:00"
+                "validatedAt": "2026-07-20T14:35:34.999497+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39101,7 +39096,7 @@
                 "confidence": 0.99,
                 "category": "timing",
                 "note": "Staging period in days. Default 7, max 20. Applies to both stage_new_and_updated_signatures and stage_new_signatures.",
-                "validatedAt": "2026-07-20T12:55:24.889955+00:00"
+                "validatedAt": "2026-07-20T14:35:34.999534+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39262,7 +39257,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:55:24.890038+00:00"
+                "validatedAt": "2026-07-20T14:35:34.999570+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39273,7 +39268,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.148923+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.877720+00:00"
           },
           "enabled": {
             "type": "boolean",
@@ -39303,7 +39298,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:24.890087+00:00"
+                "validatedAt": "2026-07-20T14:35:34.999591+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39341,7 +39336,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:24.890115+00:00"
+                "validatedAt": "2026-07-20T14:35:34.999605+00:00"
               },
               "deterministic": true
             },
@@ -39353,9 +39348,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.148957+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.877742+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "title": {
             "type": "string",
@@ -39371,7 +39365,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:24.890148+00:00"
+                "validatedAt": "2026-07-20T14:35:34.999619+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39382,7 +39376,7 @@
             },
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.148976+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.877755+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -39461,7 +39455,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:24.890196+00:00"
+                "validatedAt": "2026-07-20T14:35:34.999644+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39564,7 +39558,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:24.890235+00:00"
+                "validatedAt": "2026-07-20T14:35:34.999660+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39587,7 +39581,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:24.890269+00:00"
+                "validatedAt": "2026-07-20T14:35:34.999675+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39598,7 +39592,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.149012+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.877779+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -39667,7 +39661,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T12:55:24.890305+00:00"
+                "validatedAt": "2026-07-20T14:35:34.999691+00:00"
               },
               "deterministic": true
             },
@@ -39678,8 +39672,7 @@
               "read": false
             },
             "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "minLength": 1,
-            "format": "fqdn"
+            "minLength": 1
           },
           "last_update_time": {
             "type": "string",
@@ -39696,7 +39689,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:24.890367+00:00"
+                "validatedAt": "2026-07-20T14:35:34.999708+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39722,7 +39715,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:24.890416+00:00"
+                "validatedAt": "2026-07-20T14:35:34.999722+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39733,7 +39726,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.149048+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.877801+00:00"
           },
           "service_name": {
             "type": "string",
@@ -39750,7 +39743,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:24.890468+00:00"
+                "validatedAt": "2026-07-20T14:35:34.999738+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39762,7 +39755,7 @@
           },
           "status": {
             "type": "string",
-            "description": "Status of the condition\n\"Success\" Validation has succeeded. Requested operation was successful.\n\"Failed\" Validation has failed.\n\"Incomplete\" Validation of configuration has failed due to missing configuration.\n\"Installed\" Validation has passed and configuration has been installed in data path or K8s\n\"Down\" Configuration is operationally down. E.g. Down interface\n\"Disabled\" Configuration is administratively disabled i.e. objectmetatype.disable = true.\n\"NotApplicable\" Configuration is not applicable e.g. Tenant service_policy_set(s) in system namespace are not applicable on REs.",
+            "description": "Status of the condition\n\"Success\" Validtion has succeded. Requested operation was successful.\n\"Failed\" Validation has failed.\n\"Incomplete\" Validation of configuration has failed due to missing configuration.\n\"Installed\" Validation has passed and configuration has been installed in data path or K8s\n\"Down\" Configuration is operationally down. E.g. Down interface\n\"Disabled\" Configuration is administratively disabled i.e. objectmetatype.disable = true.\n\"NotApplicable\" Configuration is not applicable e.g. Tenant service_policy_set(s) in system namespace are not applicable on REs.",
             "title": "status",
             "x-displayname": "Status",
             "x-ves-example": "Failed",
@@ -39773,8 +39766,8 @@
             "x-validation-rules": {
               "ves.io.schema.rules.string.in": "[\\\"Success\\\",\\\"Failed\\\",\\\"Incomplete\\\",\\\"Installed\\\",\\\"Down\\\",\\\"Disabled\\\",\\\"NotApplicable\\\"]"
             },
-            "x-f5xc-description-short": "Status of the condition \"Success\" Validation has succeeded.",
-            "x-f5xc-description-medium": "Status of the condition \"Success\" Validation has succeeded. Requested operation was successful. \"Failed\" Validation has failed. \"Incomplete\" Validation of configuration has failed due to missing configuration. \"Installed\" Validation has passed and configuration has been installed in data path or...",
+            "x-f5xc-description-short": "Status of the condition \"Success\" Validtion has succeded.",
+            "x-f5xc-description-medium": "Status of the condition \"Success\" Validtion has succeded. Requested operation was successful. \"Failed\" Validation has failed. \"Incomplete\" Validation of configuration has failed due to missing configuration. \"Installed\" Validation has passed and configuration has been installed in data path or...",
             "maxLength": 1024,
             "x-f5xc-constraints": {
               "constraintType": "string",
@@ -39783,7 +39776,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:24.890516+00:00"
+                "validatedAt": "2026-07-20T14:35:34.999753+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39794,7 +39787,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.149073+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.877819+00:00"
           },
           "type": {
             "type": "string",
@@ -39819,7 +39812,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:24.890579+00:00"
+                "validatedAt": "2026-07-20T14:35:34.999767+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39973,7 +39966,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:24.890640+00:00"
+                "validatedAt": "2026-07-20T14:35:34.999784+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40159,7 +40152,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:24.890701+00:00"
+                "validatedAt": "2026-07-20T14:35:34.999798+00:00"
               },
               "deterministic": true
             },
@@ -40171,9 +40164,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.149121+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.877850+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -40338,7 +40330,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:24.890777+00:00"
+                "validatedAt": "2026-07-20T14:35:34.999824+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40349,7 +40341,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.149168+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.877881+00:00"
           }
         },
         "x-f5xc-description-short": "Metric data contains timestamp and the value.",
@@ -40450,7 +40442,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:24.890860+00:00"
+                "validatedAt": "2026-07-20T14:35:34.999861+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -40465,7 +40457,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.149196+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.877900+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -40535,7 +40527,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:24.890900+00:00"
+                "validatedAt": "2026-07-20T14:35:34.999880+00:00"
               },
               "deterministic": true
             },
@@ -40547,9 +40539,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.149229+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.877922+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -40582,7 +40573,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:24.890928+00:00"
+                "validatedAt": "2026-07-20T14:35:34.999893+00:00"
               },
               "deterministic": true
             },
@@ -40594,9 +40585,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.149257+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.877935+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -40701,7 +40691,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:24.891002+00:00"
+                "validatedAt": "2026-07-20T14:35:34.999929+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -40716,7 +40706,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.149292+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.877953+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -40788,7 +40778,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:24.891040+00:00"
+                "validatedAt": "2026-07-20T14:35:34.999952+00:00"
               },
               "deterministic": true
             },
@@ -40800,9 +40790,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.149325+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.877975+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -40835,7 +40824,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:24.891067+00:00"
+                "validatedAt": "2026-07-20T14:35:34.999965+00:00"
               },
               "deterministic": true
             },
@@ -40847,9 +40836,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.149343+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.877988+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -40917,7 +40905,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:24.891099+00:00"
+                "validatedAt": "2026-07-20T14:35:34.999984+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40929,7 +40917,7 @@
             "readOnly": true,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.149363+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.878002+00:00"
           },
           "name": {
             "type": "string",
@@ -40962,7 +40950,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:24.891127+00:00"
+                "validatedAt": "2026-07-20T14:35:34.999998+00:00"
               },
               "deterministic": true
             },
@@ -40974,9 +40962,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.149382+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.878015+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -41009,7 +40996,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:24.891156+00:00"
+                "validatedAt": "2026-07-20T14:35:35.000012+00:00"
               },
               "deterministic": true
             },
@@ -41021,9 +41008,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.149400+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.878027+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -41042,7 +41028,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:24.891190+00:00"
+                "validatedAt": "2026-07-20T14:35:35.000026+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41055,7 +41041,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.149418+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.878040+00:00"
           },
           "uid": {
             "type": "string",
@@ -41074,7 +41060,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:24.891216+00:00"
+                "validatedAt": "2026-07-20T14:35:35.000038+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41088,7 +41074,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.149437+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.878054+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -41193,7 +41179,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:24.891292+00:00"
+                "validatedAt": "2026-07-20T14:35:35.000074+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -41208,7 +41194,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.149466+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.878073+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -41278,7 +41264,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:24.891330+00:00"
+                "validatedAt": "2026-07-20T14:35:35.000092+00:00"
               },
               "deterministic": true
             },
@@ -41290,9 +41276,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.149497+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.878095+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -41325,7 +41310,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:24.891358+00:00"
+                "validatedAt": "2026-07-20T14:35:35.000106+00:00"
               },
               "deterministic": true
             },
@@ -41337,9 +41322,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.149515+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.878107+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -41407,7 +41391,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:24.891401+00:00"
+                "validatedAt": "2026-07-20T14:35:35.000124+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41435,7 +41419,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:24.891442+00:00"
+                "validatedAt": "2026-07-20T14:35:35.000141+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41463,7 +41447,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:24.891480+00:00"
+                "validatedAt": "2026-07-20T14:35:35.000157+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41502,7 +41486,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:24.891520+00:00"
+                "validatedAt": "2026-07-20T14:35:35.000173+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41529,7 +41513,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:24.891546+00:00"
+                "validatedAt": "2026-07-20T14:35:35.000184+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41542,7 +41526,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.149569+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.878142+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -41558,7 +41542,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:24.891582+00:00"
+                "validatedAt": "2026-07-20T14:35:35.000198+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41713,7 +41697,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:24.891630+00:00"
+                "validatedAt": "2026-07-20T14:35:35.000217+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41724,7 +41708,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.149610+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.878168+00:00"
           },
           "status": {
             "type": "string",
@@ -41742,7 +41726,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:24.891680+00:00"
+                "validatedAt": "2026-07-20T14:35:35.000231+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41753,7 +41737,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.149628+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.878181+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -41818,7 +41802,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:24.891726+00:00"
+                "validatedAt": "2026-07-20T14:35:35.000249+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41845,7 +41829,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:24.891767+00:00"
+                "validatedAt": "2026-07-20T14:35:35.000265+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41872,7 +41856,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:24.891805+00:00"
+                "validatedAt": "2026-07-20T14:35:35.000280+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41900,7 +41884,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:24.891848+00:00"
+                "validatedAt": "2026-07-20T14:35:35.000298+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41976,7 +41960,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:24.891912+00:00"
+                "validatedAt": "2026-07-20T14:35:35.000324+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42044,7 +42028,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:24.891963+00:00"
+                "validatedAt": "2026-07-20T14:35:35.000344+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42056,7 +42040,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.149723+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.878237+00:00"
           },
           "uid": {
             "type": "string",
@@ -42075,7 +42059,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:24.891988+00:00"
+                "validatedAt": "2026-07-20T14:35:35.000355+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42088,7 +42072,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.149742+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.878250+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -42213,7 +42197,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:55:24.892037+00:00"
+                "validatedAt": "2026-07-20T14:35:35.000376+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42224,7 +42208,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.149763+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.878264+00:00"
           },
           "previous_value": {
             "type": "string",
@@ -42242,7 +42226,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:24.892076+00:00"
+                "validatedAt": "2026-07-20T14:35:35.000392+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42280,7 +42264,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:24.892112+00:00"
+                "validatedAt": "2026-07-20T14:35:35.000406+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42291,7 +42275,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.149794+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.878285+00:00"
           }
         },
         "x-f5xc-description-short": "Trend value contains trend value, trend sentiment and trend calculation description and window size.",
@@ -42426,7 +42410,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:24.892144+00:00"
+                "validatedAt": "2026-07-20T14:35:35.000419+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42437,7 +42421,7 @@
             },
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.149815+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.878299+00:00"
           },
           "name": {
             "type": "string",
@@ -42470,7 +42454,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:24.892172+00:00"
+                "validatedAt": "2026-07-20T14:35:35.000433+00:00"
               },
               "deterministic": true
             },
@@ -42482,9 +42466,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.149833+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.878311+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -42517,7 +42500,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:24.892199+00:00"
+                "validatedAt": "2026-07-20T14:35:35.000446+00:00"
               },
               "deterministic": true
             },
@@ -42529,9 +42512,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.149851+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.878324+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "uid": {
             "type": "string",
@@ -42548,7 +42530,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:24.892223+00:00"
+                "validatedAt": "2026-07-20T14:35:35.000456+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42561,7 +42543,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.149870+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.878337+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -42672,7 +42654,7 @@
             "maxLength": 16,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.149893+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.878352+00:00"
           },
           "value": {
             "type": "array",
@@ -42691,7 +42673,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.149914+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.878366+00:00"
           }
         },
         "x-f5xc-description-short": "Metric Type Data contains key/value pair that uniquely identifies the group_by labels specified in the request.",
@@ -42762,7 +42744,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.997051+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067444+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42786,7 +42768,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:29.997097+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067463+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42886,7 +42868,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.997142+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067484+00:00"
               },
               "deterministic": true
             },
@@ -42898,9 +42880,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.248552+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.961526+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -42932,7 +42913,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.997172+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067500+00:00"
               },
               "deterministic": true
             },
@@ -42944,9 +42925,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.248573+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.961540+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "path": {
             "type": "string",
@@ -42977,7 +42957,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.997266+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067538+00:00"
               },
               "deterministic": true
             },
@@ -43130,7 +43110,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.997340+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067571+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43193,7 +43173,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.997421+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067611+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43233,7 +43213,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.997454+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067627+00:00"
               },
               "deterministic": true
             },
@@ -43245,9 +43225,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.248636+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.961582+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -43279,7 +43258,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.997483+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067640+00:00"
               },
               "deterministic": true
             },
@@ -43291,9 +43270,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.248661+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.961595+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "user_id": {
             "type": "string",
@@ -43317,7 +43295,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.997540+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067670+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43421,7 +43399,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.997573+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067686+00:00"
               },
               "deterministic": true
             },
@@ -43433,9 +43411,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.248696+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.961617+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "rule": {
             "allOf": [
@@ -43537,7 +43514,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.997631+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067717+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43604,7 +43581,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.997677+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067732+00:00"
               },
               "deterministic": true
             },
@@ -43616,9 +43593,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.248749+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.961652+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -43650,7 +43626,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.997705+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067750+00:00"
               },
               "deterministic": true
             },
@@ -43662,9 +43638,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.248768+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.961665+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tls_fingerprint_matcher": {
             "allOf": [
@@ -43774,7 +43749,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:29.997761+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067772+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43892,7 +43867,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.997807+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067793+00:00"
               },
               "deterministic": true
             },
@@ -43904,9 +43879,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.248830+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.961705+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -43938,7 +43912,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.997836+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067807+00:00"
               },
               "deterministic": true
             },
@@ -43950,9 +43924,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.248848+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.961718+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "path": {
             "type": "string",
@@ -43983,7 +43956,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.997902+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067838+00:00"
               },
               "deterministic": true
             },
@@ -44182,7 +44155,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.997944+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067857+00:00"
               },
               "deterministic": true
             },
@@ -44194,9 +44167,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.248903+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.961753+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -44228,7 +44200,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.997971+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067869+00:00"
               },
               "deterministic": true
             },
@@ -44240,9 +44212,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.248922+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.961766+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "path": {
             "type": "string",
@@ -44273,7 +44244,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.998031+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067898+00:00"
               },
               "deterministic": true
             },
@@ -44449,7 +44420,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.998070+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067915+00:00"
               },
               "deterministic": true
             },
@@ -44461,9 +44432,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.248971+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.961798+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -44495,7 +44465,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.998097+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067928+00:00"
               },
               "deterministic": true
             },
@@ -44507,9 +44477,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.248989+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.961811+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "path": {
             "type": "string",
@@ -44540,7 +44509,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.998157+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067957+00:00"
               },
               "deterministic": true
             },
@@ -44693,7 +44662,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.998224+00:00"
+                "validatedAt": "2026-07-20T14:35:37.067987+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44756,7 +44725,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.998300+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068020+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44812,7 +44781,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.998335+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068036+00:00"
               },
               "deterministic": true
             },
@@ -44824,9 +44793,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.249058+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.961855+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -44858,7 +44826,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.998363+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068049+00:00"
               },
               "deterministic": true
             },
@@ -44870,9 +44838,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.249076+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.961868+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "sec_event_name": {
             "type": "string",
@@ -44889,7 +44856,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:29.998404+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068065+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44928,7 +44895,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.998451+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068087+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44976,7 +44943,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.998512+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068114+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45084,7 +45051,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.998543+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068129+00:00"
               },
               "deterministic": true
             },
@@ -45096,9 +45063,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.249129+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.961903+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "rule": {
             "allOf": [
@@ -45199,7 +45165,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.998608+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068157+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45211,7 +45177,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.249164+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.961926+00:00"
           },
           "exclude_bot_names": {
             "type": "array",
@@ -45242,7 +45208,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.998662+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068180+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45281,7 +45247,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.998711+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068202+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45320,7 +45286,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.998758+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068224+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45360,7 +45326,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.998787+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068237+00:00"
               },
               "deterministic": true
             },
@@ -45372,9 +45338,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.249202+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.961952+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -45406,7 +45371,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.998815+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068250+00:00"
               },
               "deterministic": true
             },
@@ -45418,9 +45383,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.249220+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.961965+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "req_path": {
             "type": "string",
@@ -45444,7 +45408,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.998870+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068275+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45478,7 +45442,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.998942+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068309+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45584,7 +45548,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.998978+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068325+00:00"
               },
               "deterministic": true
             },
@@ -45596,9 +45560,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.249259+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.961992+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "waf_exclusion_policy": {
             "allOf": [
@@ -45713,7 +45676,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.999014+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068341+00:00"
               },
               "deterministic": true
             },
@@ -45725,9 +45688,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.249293+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.962014+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -45758,7 +45720,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.999041+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068353+00:00"
               },
               "deterministic": true
             },
@@ -45770,9 +45732,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.249311+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.962027+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "request_data": {
             "allOf": [
@@ -45865,7 +45826,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:29.999082+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068369+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45893,7 +45854,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:29.999119+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068383+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45921,7 +45882,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:29.999154+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068397+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46027,7 +45988,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.999204+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068420+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46039,7 +46000,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.249379+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.962071+00:00"
           }
         },
         "x-f5xc-description-short": "Metric label filter can be specified to query specific metrics based on label match.",
@@ -46203,7 +46164,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.999251+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068443+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46243,7 +46204,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.999282+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068458+00:00"
               },
               "deterministic": true
             },
@@ -46255,9 +46216,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.249408+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.962091+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "GET a list of virtual hosts in all the namespaces matching filter provided in the request.",
@@ -46457,7 +46417,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:29.999342+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068482+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46497,7 +46457,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.999370+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068495+00:00"
               },
               "deterministic": true
             },
@@ -46509,9 +46469,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.249452+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.962120+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query": {
             "type": "string",
@@ -46531,7 +46490,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T12:55:29.999412+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068514+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46564,7 +46523,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:29.999452+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068530+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46654,7 +46613,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:29.999496+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068548+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46732,7 +46691,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:29.999536+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068563+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46806,7 +46765,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.999590+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068587+00:00"
               },
               "deterministic": true
             },
@@ -46818,9 +46777,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.249521+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.962165+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "start_time": {
             "type": "string",
@@ -46845,7 +46803,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:29.999629+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068602+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46878,7 +46836,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:29.999670+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068615+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46976,7 +46934,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:29.999717+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068633+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47048,7 +47006,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:29.999750+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068646+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47076,7 +47034,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:29.999787+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068660+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47104,7 +47062,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:29.999822+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068677+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47196,7 +47154,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:29.999866+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068694+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47225,7 +47183,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T12:55:29.999902+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068714+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47265,7 +47223,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:29.999930+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068728+00:00"
               },
               "deterministic": true
             },
@@ -47277,9 +47235,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.249611+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.962222+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query": {
             "type": "string",
@@ -47299,7 +47256,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T12:55:29.999972+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068747+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47355,7 +47312,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.000013+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068763+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47388,7 +47345,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.000054+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068779+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47529,7 +47486,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.000108+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068799+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47558,7 +47515,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.000147+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068814+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47659,7 +47616,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.000176+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068828+00:00"
               },
               "deterministic": true
             },
@@ -47671,9 +47628,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.249704+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.962275+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "scroll_id": {
             "type": "string",
@@ -47691,7 +47647,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.000213+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068843+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47785,7 +47741,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.000257+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068878+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47825,7 +47781,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.000285+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068906+00:00"
               },
               "deterministic": true
             },
@@ -47837,9 +47793,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.249746+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.962303+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query": {
             "type": "string",
@@ -47859,7 +47814,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T12:55:30.000325+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068927+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47892,7 +47847,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.000365+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068946+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47982,7 +47937,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.000408+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068965+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48074,7 +48029,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.000453+00:00"
+                "validatedAt": "2026-07-20T14:35:37.068985+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48103,7 +48058,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T12:55:30.000486+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069002+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48143,7 +48098,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.000513+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069016+00:00"
               },
               "deterministic": true
             },
@@ -48155,9 +48110,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.249814+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.962348+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query": {
             "type": "string",
@@ -48177,7 +48131,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T12:55:30.000553+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069034+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48233,7 +48187,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.000593+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069050+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48266,7 +48220,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.000633+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069067+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48407,7 +48361,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.000697+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069090+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48436,7 +48390,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.000736+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069105+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48537,7 +48491,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.000767+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069119+00:00"
               },
               "deterministic": true
             },
@@ -48549,9 +48503,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.249895+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.962402+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "scroll_id": {
             "type": "string",
@@ -48569,7 +48522,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.000804+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069133+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48663,7 +48616,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.000847+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069151+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48703,7 +48656,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.000875+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069164+00:00"
               },
               "deterministic": true
             },
@@ -48715,9 +48668,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.249935+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.962429+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query": {
             "type": "string",
@@ -48737,7 +48689,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T12:55:30.000915+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069184+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48770,7 +48722,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.000954+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069199+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48860,7 +48812,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.000996+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069216+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48952,7 +48904,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.001041+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069233+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48981,7 +48933,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T12:55:30.001074+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069248+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49021,7 +48973,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.001102+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069262+00:00"
               },
               "deterministic": true
             },
@@ -49033,9 +48985,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.250003+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.962474+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query": {
             "type": "string",
@@ -49055,7 +49006,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T12:55:30.001143+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069279+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49111,7 +49062,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.001183+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069295+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49144,7 +49095,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.001224+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069311+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49285,7 +49236,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.001277+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069331+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49314,7 +49265,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.001316+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069345+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49415,7 +49366,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.001346+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069359+00:00"
               },
               "deterministic": true
             },
@@ -49427,9 +49378,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.250084+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.962527+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "scroll_id": {
             "type": "string",
@@ -49447,7 +49397,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.001383+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069373+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49519,7 +49469,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.001424+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069389+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49548,7 +49498,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:55:30.001471+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069409+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49559,7 +49509,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.250117+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.962549+00:00"
           },
           "id": {
             "type": "string",
@@ -49585,7 +49535,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.001498+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069420+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49610,7 +49560,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.001532+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069433+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49643,7 +49593,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.001573+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069449+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49714,7 +49664,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.001618+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069469+00:00"
               },
               "deterministic": true
             },
@@ -49726,9 +49676,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.250162+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.962579+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "references": {
             "type": "array",
@@ -49769,7 +49718,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.001674+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069488+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49926,7 +49875,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.001728+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069509+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50527,7 +50476,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.001830+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069548+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50902,7 +50851,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.001920+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069589+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51045,7 +50994,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.001980+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069612+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51205,7 +51154,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.002059+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069647+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51284,7 +51233,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.002131+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069741+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51295,8 +51244,7 @@
             },
             "x-f5xc-conflicts-with": [
               "any_domain"
-            ],
-            "format": "fqdn"
+            ]
           }
         },
         "x-f5xc-description-short": "API Protection Rule for a specific endpoint.",
@@ -51458,7 +51406,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.002184+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069804+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51496,7 +51444,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.002245+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069849+00:00"
               },
               "deterministic": true
             },
@@ -51610,7 +51558,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.002314+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069883+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51717,7 +51665,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.002389+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069916+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51728,8 +51676,7 @@
             },
             "x-f5xc-conflicts-with": [
               "any_domain"
-            ],
-            "format": "fqdn"
+            ]
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -51862,7 +51809,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.002437+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069940+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52010,7 +51957,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.002508+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069972+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52049,7 +51996,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.002565+00:00"
+                "validatedAt": "2026-07-20T14:35:37.069999+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52156,7 +52103,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.002626+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070030+00:00"
               },
               "deterministic": true
             },
@@ -52268,7 +52215,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-07-20T12:55:30.002674+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070049+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52824,7 +52771,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.002780+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070093+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52948,7 +52895,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.002834+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070122+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53062,7 +53009,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.002897+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070152+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53101,7 +53048,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.002953+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070178+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53153,7 +53100,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.003017+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070207+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53164,8 +53111,7 @@
             },
             "x-f5xc-conflicts-with": [
               "any_domain"
-            ],
-            "format": "fqdn"
+            ]
           },
           "validation_mode": {
             "allOf": [
@@ -53262,7 +53208,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.003065+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070231+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53345,7 +53291,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.003129+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070256+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53397,7 +53343,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.003171+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070273+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53435,7 +53381,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.003212+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070291+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53504,7 +53450,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.003280+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070323+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53776,7 +53722,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.003346+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070355+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53957,7 +53903,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.003424+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070388+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54028,7 +53974,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.003485+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070423+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -54042,8 +53988,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "presence": {
             "type": "boolean",
@@ -54088,7 +54033,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.003554+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070457+00:00"
               },
               "byteLength": {
                 "max": 256
@@ -54172,7 +54117,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.003588+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070469+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54184,7 +54129,7 @@
             "readOnly": true,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.250997+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.963121+00:00"
           },
           "name": {
             "type": "string",
@@ -54217,7 +54162,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.003616+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070482+00:00"
               },
               "deterministic": true
             },
@@ -54229,9 +54174,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.251017+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.963135+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -54264,7 +54208,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.003644+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070496+00:00"
               },
               "deterministic": true
             },
@@ -54276,9 +54220,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.251035+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.963148+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -54297,7 +54240,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.003686+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070509+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54310,7 +54253,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.251054+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.963161+00:00"
           },
           "uid": {
             "type": "string",
@@ -54329,7 +54272,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.003713+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070519+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54343,7 +54286,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.251074+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.963175+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -54406,7 +54349,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.251095+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.963189+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Avg Aggregation Data\" Average Aggregation data.",
@@ -54465,7 +54408,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.003774+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070538+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54548,7 +54491,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.003819+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070552+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54587,7 +54530,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T12:55:30.003866+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070571+00:00"
               },
               "deterministic": true
             },
@@ -54688,7 +54631,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.003919+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070589+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54756,7 +54699,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.003955+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070603+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54779,7 +54722,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.003983+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070617+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54790,7 +54733,7 @@
             },
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.251180+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.963246+00:00"
           },
           "order_by": {
             "allOf": [
@@ -54950,7 +54893,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.004047+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070640+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54974,7 +54917,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.004073+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070651+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54985,7 +54928,7 @@
             },
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.251235+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.963283+00:00"
           },
           "order_by": {
             "allOf": [
@@ -55060,7 +55003,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.004113+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070666+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55084,7 +55027,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.004139+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070677+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55095,7 +55038,7 @@
             },
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.251268+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.963306+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Field Sub Field Aggregation Bucket\" Field sub aggregation bucket containing field values and the number of logs.",
@@ -55156,7 +55099,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.004176+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070691+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55236,7 +55179,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.004216+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070706+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55260,7 +55203,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.004243+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070717+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55271,7 +55214,7 @@
             },
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.251311+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.963334+00:00"
           },
           "sub_aggs": {
             "type": "object",
@@ -55344,7 +55287,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.251339+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.963353+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Max Aggregation Data\" Max Aggregation data.",
@@ -55457,7 +55400,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.251367+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.963372+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Min Aggregation Data\" Min Aggregation data.",
@@ -55516,7 +55459,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.004313+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070742+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55683,7 +55626,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.004375+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070764+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55806,7 +55749,7 @@
             "maxLength": 16,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.251442+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.963421+00:00"
           },
           "value": {
             "type": "number",
@@ -55822,7 +55765,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.251460+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.963434+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Percentile Aggregation Data\" Percentile Aggregation data.",
@@ -55882,7 +55825,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.004440+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070791+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56056,7 +55999,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.004501+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070816+00:00"
               },
               "deterministic": true
             },
@@ -56068,9 +56011,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.251510+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.963466+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "sec_event_type": {
             "type": "string",
@@ -56087,7 +56029,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.004546+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070831+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56112,7 +56054,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.004589+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070847+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56137,7 +56079,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.004627+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070861+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56162,7 +56104,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.004682+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070875+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56309,7 +56251,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.004727+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070911+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56320,7 +56262,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.251570+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.963505+00:00"
           }
         },
         "x-f5xc-description-short": "Label based filtering for Security Events metrics. Security Events metrics are tagged with labels mentioned in MetricLabel.",
@@ -56444,7 +56386,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.004779+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070935+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56455,7 +56397,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.251596+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.963524+00:00"
           }
         },
         "x-f5xc-description-short": "Value returned for a Security Events Metrics query.",
@@ -56539,7 +56481,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.004850+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070970+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56635,7 +56577,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.004902+00:00"
+                "validatedAt": "2026-07-20T14:35:37.070997+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56673,7 +56615,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.004949+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071021+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56710,7 +56652,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.004996+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071046+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56747,7 +56689,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.005042+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071068+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56842,7 +56784,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.005108+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071101+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56964,7 +56906,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.005192+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071136+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57072,7 +57014,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.005244+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071162+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57154,7 +57096,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.005287+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071183+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57230,7 +57172,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.005329+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071200+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57567,7 +57509,7 @@
             "maxLength": 26,
             "minLength": 15,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.251817+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:08.963660+00:00",
             "x-f5xc-conflicts-with": [
               "check_not_present",
               "check_present"
@@ -57612,7 +57554,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.005427+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071247+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -57627,9 +57569,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.251837+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.963674+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Cookie matcher specifies the name of a single cookie and the criteria to match it.",
@@ -58073,7 +58014,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.005474+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071270+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58225,7 +58166,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.005521+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071292+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58310,7 +58251,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.005568+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071314+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58431,7 +58372,7 @@
             "maxLength": 26,
             "minLength": 15,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.251916+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:08.963725+00:00",
             "x-f5xc-conflicts-with": [
               "check_not_present",
               "check_present"
@@ -58475,7 +58416,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.005632+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071345+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -58490,9 +58431,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.251934+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.963738+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "JWT claim matcher specifies the name of a single JWT claim and the criteria for the input request to match it.",
@@ -58635,7 +58575,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.005685+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071367+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58681,7 +58621,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.005728+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071388+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58719,7 +58659,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.005771+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071409+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58821,7 +58761,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.005821+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071432+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58901,7 +58841,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.005866+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071454+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58938,7 +58878,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.005919+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071481+00:00"
               },
               "deterministic": true
             },
@@ -58974,7 +58914,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.005958+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071501+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59009,7 +58949,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.006001+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071521+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59150,7 +59090,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.006076+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071554+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59162,8 +59102,7 @@
             "x-f5xc-conflicts-with": [
               "any_domain",
               "suffix_value"
-            ],
-            "format": "hostname"
+            ]
           },
           "expiration_timestamp": {
             "type": "string",
@@ -59184,7 +59123,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.006119+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071571+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59238,7 +59177,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.006167+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071594+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59274,7 +59213,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.006228+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071621+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59317,7 +59256,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.006287+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071649+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59362,7 +59301,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.006349+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071677+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59374,8 +59313,7 @@
             "x-f5xc-conflicts-with": [
               "any_domain",
               "exact_value"
-            ],
-            "format": "hostname"
+            ]
           },
           "waf_skip_processing": {
             "allOf": [
@@ -59476,7 +59414,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.006395+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071700+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59517,7 +59455,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.006438+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071722+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59559,7 +59497,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.006482+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071743+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59846,7 +59784,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.006525+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071765+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59919,7 +59857,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.006592+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071797+00:00"
               },
               "deterministic": true
             },
@@ -59931,7 +59869,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.252121+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.963860+00:00"
           },
           "name": {
             "type": "string",
@@ -59975,7 +59913,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.006642+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071822+00:00"
               },
               "deterministic": true
             },
@@ -59985,8 +59923,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "MessageMetaType is metadata (common attributes) of a message that only certain messages have.",
@@ -60200,7 +60137,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:30.006812+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071890+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60862,7 +60799,7 @@
             "maxLength": 26,
             "minLength": 15,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.252328+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:08.963995+00:00",
             "x-f5xc-conflicts-with": [
               "check_not_present",
               "check_present"
@@ -60909,7 +60846,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.006949+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071949+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -60924,9 +60861,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.252347+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.964008+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Header matcher specifies the name of a single HTTP header and the criteria for the input request to match it.",
@@ -61009,7 +60945,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.006993+00:00"
+                "validatedAt": "2026-07-20T14:35:37.071971+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61128,7 +61064,7 @@
             "maxLength": 26,
             "minLength": 15,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.252395+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:08.964039+00:00",
             "x-f5xc-conflicts-with": [
               "check_not_present",
               "check_present"
@@ -61163,7 +61099,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.007056+00:00"
+                "validatedAt": "2026-07-20T14:35:37.072000+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61174,7 +61110,7 @@
             },
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.252413+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.964052+00:00"
           }
         },
         "x-f5xc-description-short": "Query parameter matcher specifies the name of a single query parameter and the criteria for the input request to match it.",
@@ -61268,7 +61204,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.007107+00:00"
+                "validatedAt": "2026-07-20T14:35:37.072027+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -61282,8 +61218,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -61322,7 +61257,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.007155+00:00"
+                "validatedAt": "2026-07-20T14:35:37.072052+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -61337,9 +61272,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.252441+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:08.964071+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "tenant": {
             "type": "string",
@@ -61368,7 +61302,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:55:30.007207+00:00"
+                "validatedAt": "2026-07-20T14:35:37.072077+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61381,7 +61315,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:08.252460+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:08.964084+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a direct reference from one object(the referrer) to another(the referred).",
@@ -61671,7 +61605,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:55:35.072442+00:00"
+                "validatedAt": "2026-07-20T14:35:39.091566+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61852,7 +61786,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:10.351076+00:00"
+                "validatedAt": "2026-07-20T14:36:40.901033+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62201,7 +62135,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:10.351198+00:00"
+                "validatedAt": "2026-07-20T14:36:40.901082+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62236,7 +62170,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:10.351260+00:00"
+                "validatedAt": "2026-07-20T14:36:40.901113+00:00"
               },
               "deterministic": true
             },
@@ -62284,7 +62218,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:10.351307+00:00"
+                "validatedAt": "2026-07-20T14:36:40.901135+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62639,7 +62573,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:10.351410+00:00"
+                "validatedAt": "2026-07-20T14:36:40.901175+00:00"
               },
               "deterministic": true
             },
@@ -62651,9 +62585,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.254154+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.812746+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -62685,7 +62618,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:10.351442+00:00"
+                "validatedAt": "2026-07-20T14:36:40.901191+00:00"
               },
               "deterministic": true
             },
@@ -62697,9 +62630,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.254174+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.812769+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -62824,7 +62756,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:10.351485+00:00"
+                "validatedAt": "2026-07-20T14:36:40.901212+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63002,7 +62934,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.254251+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.812822+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -63236,7 +63168,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:10.351638+00:00"
+                "validatedAt": "2026-07-20T14:36:40.901275+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63271,7 +63203,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:10.351706+00:00"
+                "validatedAt": "2026-07-20T14:36:40.901303+00:00"
               },
               "deterministic": true
             },
@@ -63319,7 +63251,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:10.351752+00:00"
+                "validatedAt": "2026-07-20T14:36:40.901325+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63777,7 +63709,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:58:10.351863+00:00"
+                "validatedAt": "2026-07-20T14:36:40.901369+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63862,7 +63794,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:58:10.351920+00:00"
+                "validatedAt": "2026-07-20T14:36:40.901392+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63873,7 +63805,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.254471+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.812956+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -63960,7 +63892,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:10.351963+00:00"
+                "validatedAt": "2026-07-20T14:36:40.901412+00:00"
               },
               "deterministic": true
             },
@@ -63972,9 +63904,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.254517+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.812985+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -64005,7 +63936,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:10.351992+00:00"
+                "validatedAt": "2026-07-20T14:36:40.901425+00:00"
               },
               "deterministic": true
             },
@@ -64017,9 +63948,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.254536+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:11.812998+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -64088,7 +64018,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:10.352048+00:00"
+                "validatedAt": "2026-07-20T14:36:40.901454+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64100,7 +64030,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.254574+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.813022+00:00"
           },
           "uid": {
             "type": "string",
@@ -64117,7 +64047,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:10.352075+00:00"
+                "validatedAt": "2026-07-20T14:36:40.901465+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64130,7 +64060,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.254593+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.813035+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of cluster is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -64333,7 +64263,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T12:58:10.352163+00:00"
+                "validatedAt": "2026-07-20T14:36:40.901500+00:00"
               },
               "deterministic": true
             },
@@ -64658,7 +64588,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:10.352271+00:00"
+                "validatedAt": "2026-07-20T14:36:40.901544+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64693,7 +64623,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:10.352327+00:00"
+                "validatedAt": "2026-07-20T14:36:40.901571+00:00"
               },
               "deterministic": true
             },
@@ -64741,7 +64671,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:10.352372+00:00"
+                "validatedAt": "2026-07-20T14:36:40.901592+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65202,7 +65132,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:10.352580+00:00"
+                "validatedAt": "2026-07-20T14:36:40.901672+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65243,7 +65173,7 @@
                 "confidence": 1.0,
                 "category": "content",
                 "note": "Blindfold envelope encryption (AES-256-GCM + RSA-OAEP) of an RSA-2048 TLS private key produces ~3700 char string:/// URL. 128KB max secret size = ~175KB base64. Discovery reported 1024 which is incorrect.",
-                "validatedAt": "2026-07-20T12:58:10.352621+00:00"
+                "validatedAt": "2026-07-20T14:36:40.901694+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65254,7 +65184,7 @@
             },
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.254870+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.813194+00:00"
           },
           "store_provider": {
             "type": "string",
@@ -65273,7 +65203,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:10.352676+00:00"
+                "validatedAt": "2026-07-20T14:36:40.901713+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65340,7 +65270,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:10.352715+00:00"
+                "validatedAt": "2026-07-20T14:36:40.901728+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65351,7 +65281,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.254897+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.813212+00:00"
           },
           "url": {
             "type": "string",
@@ -65389,7 +65319,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:10.352773+00:00"
+                "validatedAt": "2026-07-20T14:36:40.901758+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -65529,7 +65459,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:10.353087+00:00"
+                "validatedAt": "2026-07-20T14:36:40.901887+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65896,7 +65826,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:10.354404+00:00"
+                "validatedAt": "2026-07-20T14:36:40.902437+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65943,7 +65873,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:58:10.354453+00:00"
+                "validatedAt": "2026-07-20T14:36:40.902457+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65954,7 +65884,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:11.255651+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:11.813697+00:00"
           },
           "disable_ocsp_stapling": {
             "allOf": [
@@ -66084,7 +66014,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:10.354506+00:00"
+                "validatedAt": "2026-07-20T14:36:40.902481+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66306,7 +66236,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:10.354599+00:00"
+                "validatedAt": "2026-07-20T14:36:40.902521+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66409,7 +66339,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:10.354669+00:00"
+                "validatedAt": "2026-07-20T14:36:40.902548+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66513,7 +66443,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:10.354728+00:00"
+                "validatedAt": "2026-07-20T14:36:40.902577+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66836,7 +66766,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:10.354826+00:00"
+                "validatedAt": "2026-07-20T14:36:40.902619+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66848,8 +66778,7 @@
             "x-f5xc-conflicts-with": [
               "disable_sni",
               "use_host_header_as_sni"
-            ],
-            "format": "hostname"
+            ]
           },
           "use_host_header_as_sni": {
             "allOf": [
@@ -66928,7 +66857,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.652693+00:00"
+                "validatedAt": "2026-07-20T14:37:00.599935+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66953,7 +66882,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.652753+00:00"
+                "validatedAt": "2026-07-20T14:37:00.599957+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67122,7 +67051,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.652819+00:00"
+                "validatedAt": "2026-07-20T14:37:00.599983+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67213,7 +67142,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.652872+00:00"
+                "validatedAt": "2026-07-20T14:37:00.600007+00:00"
               },
               "deterministic": true
             },
@@ -67225,9 +67154,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.461320+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.970006+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-example": "[EMAIL, CC]",
@@ -67359,7 +67287,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.652930+00:00"
+                "validatedAt": "2026-07-20T14:37:00.600030+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67384,7 +67312,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.652969+00:00"
+                "validatedAt": "2026-07-20T14:37:00.600047+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67449,7 +67377,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.653020+00:00"
+                "validatedAt": "2026-07-20T14:37:00.600068+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67665,7 +67593,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.653082+00:00"
+                "validatedAt": "2026-07-20T14:37:00.600092+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67786,7 +67714,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.653153+00:00"
+                "validatedAt": "2026-07-20T14:37:00.600120+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67810,7 +67738,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.653192+00:00"
+                "validatedAt": "2026-07-20T14:37:00.600137+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68046,7 +67974,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.653256+00:00"
+                "validatedAt": "2026-07-20T14:37:00.600161+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68070,7 +67998,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.653295+00:00"
+                "validatedAt": "2026-07-20T14:37:00.600176+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68231,7 +68159,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.653624+00:00"
+                "validatedAt": "2026-07-20T14:37:00.600315+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68393,7 +68321,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.653668+00:00"
+                "validatedAt": "2026-07-20T14:37:00.600331+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68417,7 +68345,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.653702+00:00"
+                "validatedAt": "2026-07-20T14:37:00.600345+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68443,7 +68371,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.461678+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.970216+00:00"
           }
         },
         "x-f5xc-description-short": "CDN status is per site and it indicates the status of the CDN service for the LB on the site.",
@@ -68528,7 +68456,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.653744+00:00"
+                "validatedAt": "2026-07-20T14:37:00.600364+00:00"
               },
               "deterministic": true
             },
@@ -68540,9 +68468,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.461702+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.970230+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -68581,7 +68508,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.653774+00:00"
+                "validatedAt": "2026-07-20T14:37:00.600379+00:00"
               },
               "deterministic": true
             },
@@ -68593,9 +68520,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.461721+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.970243+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "service_op_id": {
             "type": "integer",
@@ -68698,7 +68624,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:58:57.653828+00:00"
+                "validatedAt": "2026-07-20T14:37:00.600401+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68798,7 +68724,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.653888+00:00"
+                "validatedAt": "2026-07-20T14:37:00.600433+00:00"
               },
               "deterministic": true
             },
@@ -68814,8 +68740,7 @@
               "url"
             ],
             "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "minLength": 1,
-            "format": "fqdn"
+            "minLength": 1
           },
           "pattern": {
             "type": "string",
@@ -68847,7 +68772,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.653949+00:00"
+                "validatedAt": "2026-07-20T14:37:00.600463+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68920,7 +68845,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T12:58:57.653988+00:00"
+                "validatedAt": "2026-07-20T14:37:00.600481+00:00"
               },
               "deterministic": true
             },
@@ -69091,7 +69016,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.654046+00:00"
+                "validatedAt": "2026-07-20T14:37:00.600506+00:00"
               },
               "deterministic": true
             },
@@ -69103,9 +69028,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.461821+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.970304+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -69144,7 +69068,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.654078+00:00"
+                "validatedAt": "2026-07-20T14:37:00.600521+00:00"
               },
               "deterministic": true
             },
@@ -69156,9 +69080,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.461841+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.970318+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "time_range": {
             "allOf": [
@@ -69255,7 +69178,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:58:57.654115+00:00"
+                "validatedAt": "2026-07-20T14:37:00.600538+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69325,7 +69248,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.654158+00:00"
+                "validatedAt": "2026-07-20T14:37:00.600555+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69351,7 +69274,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.654198+00:00"
+                "validatedAt": "2026-07-20T14:37:00.600571+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69383,7 +69306,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.654240+00:00"
+                "validatedAt": "2026-07-20T14:37:00.600588+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69428,7 +69351,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.654286+00:00"
+                "validatedAt": "2026-07-20T14:37:00.600607+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69453,7 +69376,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.654321+00:00"
+                "validatedAt": "2026-07-20T14:37:00.600621+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69477,7 +69400,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.654351+00:00"
+                "validatedAt": "2026-07-20T14:37:00.600633+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69508,7 +69431,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.654392+00:00"
+                "validatedAt": "2026-07-20T14:37:00.600650+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69614,7 +69537,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.654446+00:00"
+                "validatedAt": "2026-07-20T14:37:00.600671+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69625,7 +69548,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.461956+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.970387+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -69691,7 +69614,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.654490+00:00"
+                "validatedAt": "2026-07-20T14:37:00.600689+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69720,7 +69643,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.654531+00:00"
+                "validatedAt": "2026-07-20T14:37:00.600706+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69831,7 +69754,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.654601+00:00"
+                "validatedAt": "2026-07-20T14:37:00.600733+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69866,7 +69789,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.654642+00:00"
+                "validatedAt": "2026-07-20T14:37:00.600750+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69977,7 +69900,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.462036+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:12.970435+00:00",
             "x-f5xc-conflicts-with": [
               "any_domain"
             ]
@@ -70025,7 +69948,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.654723+00:00"
+                "validatedAt": "2026-07-20T14:37:00.600784+00:00"
               },
               "deterministic": true
             },
@@ -70073,7 +69996,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.654769+00:00"
+                "validatedAt": "2026-07-20T14:37:00.600807+00:00"
               },
               "source": "minimum_configs",
               "enumValues": [
@@ -70209,7 +70132,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.654833+00:00"
+                "validatedAt": "2026-07-20T14:37:00.600837+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -70622,7 +70545,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.654919+00:00"
+                "validatedAt": "2026-07-20T14:37:00.600876+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -70703,7 +70626,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.654963+00:00"
+                "validatedAt": "2026-07-20T14:37:00.600898+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -70747,7 +70670,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.655017+00:00"
+                "validatedAt": "2026-07-20T14:37:00.600925+00:00"
               },
               "deterministic": true
             },
@@ -70838,7 +70761,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.462233+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:12.970571+00:00",
             "x-f5xc-conflicts-with": [
               "any_domain"
             ]
@@ -71129,7 +71052,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.655195+00:00"
+                "validatedAt": "2026-07-20T14:37:00.601000+00:00"
               },
               "deterministic": true
             },
@@ -71141,9 +71064,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.462361+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.970709+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Response of DELETE DoS Auto-Mitigation Rule API.",
@@ -71426,7 +71348,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.655343+00:00"
+                "validatedAt": "2026-07-20T14:37:00.601061+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71513,7 +71435,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.462447+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.970762+00:00"
           },
           "http_methods": {
             "type": "array",
@@ -71537,7 +71459,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.655399+00:00"
+                "validatedAt": "2026-07-20T14:37:00.601085+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71753,7 +71675,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.655467+00:00"
+                "validatedAt": "2026-07-20T14:37:00.601118+00:00"
               },
               "deterministic": true
             },
@@ -71946,7 +71868,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.655528+00:00"
+                "validatedAt": "2026-07-20T14:37:00.601142+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -72066,7 +71988,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.655588+00:00"
+                "validatedAt": "2026-07-20T14:37:00.601171+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -72262,7 +72184,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T12:58:57.655636+00:00"
+                "validatedAt": "2026-07-20T14:37:00.601192+00:00"
               },
               "deterministic": true
             },
@@ -72356,7 +72278,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.462609+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:12.970863+00:00",
             "x-f5xc-conflicts-with": [
               "any_domain"
             ]
@@ -72520,7 +72442,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.655711+00:00"
+                "validatedAt": "2026-07-20T14:37:00.601223+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -72615,7 +72537,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.655759+00:00"
+                "validatedAt": "2026-07-20T14:37:00.601248+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -72659,7 +72581,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.655813+00:00"
+                "validatedAt": "2026-07-20T14:37:00.601274+00:00"
               },
               "deterministic": true
             },
@@ -72750,7 +72672,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.462695+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:12.970911+00:00",
             "x-f5xc-conflicts-with": [
               "any_domain"
             ]
@@ -73003,7 +72925,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.656043+00:00"
+                "validatedAt": "2026-07-20T14:37:00.601376+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -73040,7 +72962,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.656098+00:00"
+                "validatedAt": "2026-07-20T14:37:00.601403+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -73118,7 +73040,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.656171+00:00"
+                "validatedAt": "2026-07-20T14:37:00.601436+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -73129,8 +73051,7 @@
             },
             "x-f5xc-conflicts-with": [
               "any_domain"
-            ],
-            "format": "fqdn"
+            ]
           }
         },
         "x-f5xc-description-short": "API Protection Rule for a group or a base URL.",
@@ -73214,7 +73135,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.656216+00:00"
+                "validatedAt": "2026-07-20T14:37:00.601459+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -73293,7 +73214,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.656270+00:00"
+                "validatedAt": "2026-07-20T14:37:00.601485+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -73329,7 +73250,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.656311+00:00"
+                "validatedAt": "2026-07-20T14:37:00.601507+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -73409,7 +73330,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.656355+00:00"
+                "validatedAt": "2026-07-20T14:37:00.601529+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -73518,7 +73439,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.656409+00:00"
+                "validatedAt": "2026-07-20T14:37:00.601555+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -73873,7 +73794,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.656496+00:00"
+                "validatedAt": "2026-07-20T14:37:00.601597+00:00"
               },
               "deterministic": true
             },
@@ -74021,7 +73942,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.656545+00:00"
+                "validatedAt": "2026-07-20T14:37:00.601622+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74267,7 +74188,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.656867+00:00"
+                "validatedAt": "2026-07-20T14:37:00.601771+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74354,7 +74275,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.656912+00:00"
+                "validatedAt": "2026-07-20T14:37:00.601793+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74505,7 +74426,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.656982+00:00"
+                "validatedAt": "2026-07-20T14:37:00.601825+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74574,7 +74495,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.657049+00:00"
+                "validatedAt": "2026-07-20T14:37:00.601856+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74585,8 +74506,7 @@
             },
             "x-f5xc-conflicts-with": [
               "any_domain"
-            ],
-            "format": "fqdn"
+            ]
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -74664,7 +74584,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.657098+00:00"
+                "validatedAt": "2026-07-20T14:37:00.601881+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74820,7 +74740,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.657156+00:00"
+                "validatedAt": "2026-07-20T14:37:00.601909+00:00"
               },
               "deterministic": true
             },
@@ -75007,7 +74927,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.657260+00:00"
+                "validatedAt": "2026-07-20T14:37:00.601960+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75241,7 +75161,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.657553+00:00"
+                "validatedAt": "2026-07-20T14:37:00.602093+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75469,7 +75389,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.657621+00:00"
+                "validatedAt": "2026-07-20T14:37:00.602123+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75723,7 +75643,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.658043+00:00"
+                "validatedAt": "2026-07-20T14:37:00.602346+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75877,7 +75797,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.658117+00:00"
+                "validatedAt": "2026-07-20T14:37:00.602381+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75915,7 +75835,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.658172+00:00"
+                "validatedAt": "2026-07-20T14:37:00.602407+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -76022,7 +75942,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.658244+00:00"
+                "validatedAt": "2026-07-20T14:37:00.602441+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -76033,8 +75953,7 @@
             },
             "x-f5xc-conflicts-with": [
               "any_domain"
-            ],
-            "format": "fqdn"
+            ]
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -76121,7 +76040,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.658290+00:00"
+                "validatedAt": "2026-07-20T14:37:00.602464+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -76213,7 +76132,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.658612+00:00"
+                "validatedAt": "2026-07-20T14:37:00.602613+00:00"
               },
               "deterministic": true
             },
@@ -76470,7 +76389,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.658685+00:00"
+                "validatedAt": "2026-07-20T14:37:00.602643+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -76657,7 +76576,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.658763+00:00"
+                "validatedAt": "2026-07-20T14:37:00.602680+00:00"
               },
               "deterministic": true
             },
@@ -76796,7 +76715,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.658826+00:00"
+                "validatedAt": "2026-07-20T14:37:00.602706+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -76822,7 +76741,7 @@
             "maxLength": 26,
             "minLength": 15,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.463933+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.971650+00:00"
           },
           "name": {
             "type": "string",
@@ -76862,7 +76781,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.658861+00:00"
+                "validatedAt": "2026-07-20T14:37:00.602723+00:00"
               },
               "deterministic": true
             },
@@ -76874,9 +76793,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.463953+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.971663+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "uid": {
             "type": "string",
@@ -76895,7 +76813,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.658887+00:00"
+                "validatedAt": "2026-07-20T14:37:00.602734+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -76908,7 +76826,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.463973+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.971676+00:00"
           }
         },
         "x-f5xc-description-short": "DoS Mitigation Object to auto-configure rules to block attackers.",
@@ -77007,7 +76925,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:58:57.658945+00:00"
+                "validatedAt": "2026-07-20T14:37:00.602760+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -77286,7 +77204,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.659088+00:00"
+                "validatedAt": "2026-07-20T14:37:00.602819+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -77329,7 +77247,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.659136+00:00"
+                "validatedAt": "2026-07-20T14:37:00.602843+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -77367,7 +77285,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.659180+00:00"
+                "validatedAt": "2026-07-20T14:37:00.602865+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -77412,7 +77330,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.659227+00:00"
+                "validatedAt": "2026-07-20T14:37:00.602889+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -77450,7 +77368,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.659271+00:00"
+                "validatedAt": "2026-07-20T14:37:00.602912+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -77494,7 +77412,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.659318+00:00"
+                "validatedAt": "2026-07-20T14:37:00.602936+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -77532,7 +77450,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.659364+00:00"
+                "validatedAt": "2026-07-20T14:37:00.602960+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -77577,7 +77495,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.659410+00:00"
+                "validatedAt": "2026-07-20T14:37:00.602984+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -77750,7 +77668,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.659459+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603009+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -77761,7 +77679,7 @@
             },
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.464142+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.971780+00:00"
           },
           "value": {
             "allOf": [
@@ -77778,7 +77696,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.464162+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.971793+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -77840,7 +77758,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.659527+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603039+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -77878,7 +77796,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.659573+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603065+00:00"
               },
               "deterministic": true
             },
@@ -78048,7 +77966,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.659622+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603086+00:00"
               },
               "deterministic": true
             },
@@ -78060,9 +77978,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.464228+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.971834+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -78093,7 +78010,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.659650+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603100+00:00"
               },
               "deterministic": true
             },
@@ -78105,9 +78022,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.464247+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.971846+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -78226,7 +78142,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.659713+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603128+00:00"
               },
               "deterministic": true
             },
@@ -78914,7 +78830,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.659864+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603195+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -79047,7 +78963,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.659906+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603214+00:00"
               },
               "deterministic": true
             },
@@ -79059,9 +78975,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.464398+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.971938+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -79093,7 +79008,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.659935+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603228+00:00"
               },
               "deterministic": true
             },
@@ -79105,9 +79020,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.464416+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.971951+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -79179,7 +79093,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.659964+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603242+00:00"
               },
               "deterministic": true
             },
@@ -79191,9 +79105,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.464437+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.971964+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -79225,7 +79138,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.659991+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603256+00:00"
               },
               "deterministic": true
             },
@@ -79237,9 +79150,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.464455+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.971977+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Request shape for GET API Endpoints For Groups.",
@@ -79315,7 +79227,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.660050+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603279+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -79390,7 +79302,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.660096+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603302+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -79430,7 +79342,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.660124+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603317+00:00"
               },
               "deterministic": true
             },
@@ -79442,9 +79354,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.464496+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.972003+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -79476,7 +79387,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.660151+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603330+00:00"
               },
               "deterministic": true
             },
@@ -79488,9 +79399,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.464515+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.972015+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query_type": {
             "allOf": [
@@ -79795,7 +79705,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.464610+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.972074+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -79921,7 +79831,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.660302+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603388+00:00"
               },
               "deterministic": true
             },
@@ -79933,9 +79843,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.464649+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.972098+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Request of GET Security Config Spec API.",
@@ -80015,7 +79924,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.660349+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603412+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -80094,7 +80003,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.660393+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603434+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -80486,7 +80395,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:58:57.660502+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603477+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -80567,7 +80476,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:58:57.660555+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603500+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -80578,7 +80487,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.464791+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.972179+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -80665,7 +80574,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.660597+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603518+00:00"
               },
               "deterministic": true
             },
@@ -80677,9 +80586,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.464836+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.972207+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -80710,7 +80618,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.660624+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603531+00:00"
               },
               "deterministic": true
             },
@@ -80722,9 +80630,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.464855+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.972219+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -80793,7 +80700,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.660689+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603553+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -80805,7 +80712,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.464892+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.972243+00:00"
           },
           "uid": {
             "type": "string",
@@ -80823,7 +80730,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.660716+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603564+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -80836,7 +80743,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.464912+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.972256+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of http_loadbalancer is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -80945,7 +80852,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.660787+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603597+00:00"
               },
               "deterministic": true
             },
@@ -80977,7 +80884,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.660833+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603616+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81057,7 +80964,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.660879+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603638+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81148,7 +81055,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.660915+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603655+00:00"
               },
               "deterministic": true
             },
@@ -81194,7 +81101,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.660978+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603685+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81290,7 +81197,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.661045+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603716+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81500,7 +81407,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.661123+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603749+00:00"
               },
               "deterministic": true
             },
@@ -81546,7 +81453,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.661186+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603779+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81582,7 +81489,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.661244+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603806+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81731,7 +81638,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.661319+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603840+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81994,7 +81901,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.661403+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603874+00:00"
               },
               "deterministic": true,
               "source": "minimum_configs",
@@ -82043,7 +81950,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.661463+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603904+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -82079,7 +81986,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.661521+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603932+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -82987,7 +82894,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.661684+00:00"
+                "validatedAt": "2026-07-20T14:37:00.603997+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83061,7 +82968,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.661739+00:00"
+                "validatedAt": "2026-07-20T14:37:00.604022+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83104,7 +83011,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.661787+00:00"
+                "validatedAt": "2026-07-20T14:37:00.604048+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83141,7 +83048,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.661831+00:00"
+                "validatedAt": "2026-07-20T14:37:00.604071+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83186,7 +83093,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.661875+00:00"
+                "validatedAt": "2026-07-20T14:37:00.604094+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83224,7 +83131,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.661919+00:00"
+                "validatedAt": "2026-07-20T14:37:00.604116+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83268,7 +83175,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.661966+00:00"
+                "validatedAt": "2026-07-20T14:37:00.604139+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83305,7 +83212,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.662012+00:00"
+                "validatedAt": "2026-07-20T14:37:00.604163+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83350,7 +83257,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.662057+00:00"
+                "validatedAt": "2026-07-20T14:37:00.604185+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83439,7 +83346,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T12:58:57.662100+00:00"
+                "validatedAt": "2026-07-20T14:37:00.604205+00:00"
               },
               "deterministic": true
             },
@@ -83697,7 +83604,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.662167+00:00"
+                "validatedAt": "2026-07-20T14:37:00.604237+00:00"
               },
               "deterministic": true
             },
@@ -83835,7 +83742,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.662233+00:00"
+                "validatedAt": "2026-07-20T14:37:00.604269+00:00"
               },
               "deterministic": true
             },
@@ -84022,7 +83929,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.662307+00:00"
+                "validatedAt": "2026-07-20T14:37:00.604303+00:00"
               },
               "deterministic": true
             },
@@ -84058,7 +83965,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.662364+00:00"
+                "validatedAt": "2026-07-20T14:37:00.604330+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -84070,8 +83977,7 @@
             "x-f5xc-conflicts-with": [
               "auto_host_rewrite",
               "disable_host_rewrite"
-            ],
-            "format": "hostname"
+            ]
           },
           "http_method": {
             "allOf": [
@@ -84134,7 +84040,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.662416+00:00"
+                "validatedAt": "2026-07-20T14:37:00.604354+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -84285,7 +84191,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.662469+00:00"
+                "validatedAt": "2026-07-20T14:37:00.604380+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -84372,7 +84278,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.662515+00:00"
+                "validatedAt": "2026-07-20T14:37:00.604402+00:00"
               },
               "deterministic": true
             },
@@ -84384,9 +84290,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.465650+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.972707+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -84425,7 +84330,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.662545+00:00"
+                "validatedAt": "2026-07-20T14:37:00.604417+00:00"
               },
               "deterministic": true
             },
@@ -84437,9 +84342,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.465677+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.972719+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "rps_threshold": {
             "type": "integer",
@@ -84814,7 +84718,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.662677+00:00"
+                "validatedAt": "2026-07-20T14:37:00.604469+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -84854,7 +84758,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.662706+00:00"
+                "validatedAt": "2026-07-20T14:37:00.604482+00:00"
               },
               "deterministic": true
             },
@@ -84866,9 +84770,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.465778+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.972784+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -84900,7 +84803,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.662734+00:00"
+                "validatedAt": "2026-07-20T14:37:00.604496+00:00"
               },
               "deterministic": true
             },
@@ -84912,9 +84815,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.465796+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.972797+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Request shape for Update API Endpoints Schemas.",
@@ -85041,7 +84943,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.663194+00:00"
+                "validatedAt": "2026-07-20T14:37:00.604689+00:00"
               },
               "deterministic": true
             },
@@ -85081,7 +84983,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.663247+00:00"
+                "validatedAt": "2026-07-20T14:37:00.604715+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -85122,7 +85024,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.663312+00:00"
+                "validatedAt": "2026-07-20T14:37:00.604748+00:00"
               },
               "byteLength": {
                 "max": 256,
@@ -85232,7 +85134,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.663347+00:00"
+                "validatedAt": "2026-07-20T14:37:00.604764+00:00"
               },
               "deterministic": true
             },
@@ -85276,7 +85178,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.663416+00:00"
+                "validatedAt": "2026-07-20T14:37:00.604793+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -85937,7 +85839,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.663610+00:00"
+                "validatedAt": "2026-07-20T14:37:00.604862+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -86031,7 +85933,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.663670+00:00"
+                "validatedAt": "2026-07-20T14:37:00.604882+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -86140,7 +86042,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.663728+00:00"
+                "validatedAt": "2026-07-20T14:37:00.604902+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -86368,7 +86270,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.663803+00:00"
+                "validatedAt": "2026-07-20T14:37:00.604928+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -86511,7 +86413,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.663869+00:00"
+                "validatedAt": "2026-07-20T14:37:00.604957+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -86672,7 +86574,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T12:58:57.663924+00:00"
+                "validatedAt": "2026-07-20T14:37:00.604979+00:00"
               },
               "deterministic": true
             },
@@ -86683,8 +86585,7 @@
               "read": false
             },
             "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "minLength": 1,
-            "format": "fqdn"
+            "minLength": 1
           },
           "inside_network": {
             "allOf": [
@@ -86869,7 +86770,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.664007+00:00"
+                "validatedAt": "2026-07-20T14:37:00.605017+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -86959,7 +86860,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.664069+00:00"
+                "validatedAt": "2026-07-20T14:37:00.605046+00:00"
               },
               "deterministic": true
             },
@@ -86969,8 +86870,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "format": "hostname"
+            "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$"
           },
           "refresh_interval": {
             "type": "integer",
@@ -87371,7 +87271,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.664178+00:00"
+                "validatedAt": "2026-07-20T14:37:00.605091+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -87478,7 +87378,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T12:58:57.664223+00:00"
+                "validatedAt": "2026-07-20T14:37:00.605109+00:00"
               },
               "deterministic": true
             },
@@ -87489,8 +87389,7 @@
               "read": false
             },
             "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "minLength": 1,
-            "format": "fqdn"
+            "minLength": 1
           },
           "private_network": {
             "allOf": [
@@ -87626,7 +87525,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.664283+00:00"
+                "validatedAt": "2026-07-20T14:37:00.605135+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -87823,7 +87722,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.664382+00:00"
+                "validatedAt": "2026-07-20T14:37:00.605175+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -87835,8 +87734,7 @@
             "x-f5xc-conflicts-with": [
               "disable_sni",
               "use_host_header_as_sni"
-            ],
-            "format": "hostname"
+            ]
           },
           "tls_config": {
             "allOf": [
@@ -87853,7 +87751,7 @@
                 "confidence": 0.99,
                 "category": "tls",
                 "note": "Required when use_tls is selected — API returns 400 if nil",
-                "validatedAt": "2026-07-20T12:58:57.664402+00:00"
+                "validatedAt": "2026-07-20T14:37:00.605185+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -88076,7 +87974,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.664503+00:00"
+                "validatedAt": "2026-07-20T14:37:00.605229+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -88194,7 +88092,7 @@
             "maxLength": 26,
             "minLength": 15,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.466691+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:12.973333+00:00",
             "x-f5xc-conflicts-with": [
               "check_not_present",
               "check_present"
@@ -88241,7 +88139,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.665000+00:00"
+                "validatedAt": "2026-07-20T14:37:00.605451+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -88256,9 +88154,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.466712+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.973346+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Argument matcher specifies the name of a single argument in the body and the criteria to match it.",
@@ -88357,7 +88254,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.665304+00:00"
+                "validatedAt": "2026-07-20T14:37:00.605584+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -88397,7 +88294,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.665372+00:00"
+                "validatedAt": "2026-07-20T14:37:00.605613+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -88409,8 +88306,7 @@
             "x-f5xc-conflicts-with": [
               "any_domain",
               "suffix_value"
-            ],
-            "format": "hostname"
+            ]
           },
           "graphql_settings": {
             "allOf": [
@@ -88504,7 +88400,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.665452+00:00"
+                "validatedAt": "2026-07-20T14:37:00.605646+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -88516,8 +88412,7 @@
             "x-f5xc-conflicts-with": [
               "any_domain",
               "exact_value"
-            ],
-            "format": "hostname"
+            ]
           }
         },
         "x-f5xc-description-short": "Section defines various configuration OPTIONS for GraphQL inspection.",
@@ -88715,7 +88610,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:46.663794+00:00"
+                "validatedAt": "2026-07-20T14:40:27.399129+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -88826,7 +88721,7 @@
             "maxLength": 26,
             "minLength": 15,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.466973+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:12.973505+00:00",
             "x-f5xc-conflicts-with": [
               "check_not_present",
               "check_present"
@@ -88873,7 +88768,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.665576+00:00"
+                "validatedAt": "2026-07-20T14:37:00.605698+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -88888,9 +88783,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.466992+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.973518+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Header matcher specifies the name of a single HTTP header and the criteria for the input request to match it.",
@@ -88974,7 +88868,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.665978+00:00"
+                "validatedAt": "2026-07-20T14:37:00.605886+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89020,7 +88914,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.666021+00:00"
+                "validatedAt": "2026-07-20T14:37:00.605908+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89194,7 +89088,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.666084+00:00"
+                "validatedAt": "2026-07-20T14:37:00.605937+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89331,7 +89225,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.666148+00:00"
+                "validatedAt": "2026-07-20T14:37:00.605965+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89424,7 +89318,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.666447+00:00"
+                "validatedAt": "2026-07-20T14:37:00.606111+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89450,7 +89344,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.467272+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.973689+00:00"
           },
           "body_hash": {
             "type": "string",
@@ -89466,7 +89360,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:46.664735+00:00"
+                "validatedAt": "2026-07-20T14:40:27.399533+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89631,7 +89525,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.666530+00:00"
+                "validatedAt": "2026-07-20T14:37:00.606147+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89672,7 +89566,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.666595+00:00"
+                "validatedAt": "2026-07-20T14:37:00.606178+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89865,7 +89759,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.666637+00:00"
+                "validatedAt": "2026-07-20T14:37:00.606196+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89986,7 +89880,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.666718+00:00"
+                "validatedAt": "2026-07-20T14:37:00.606228+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89998,8 +89892,7 @@
             "x-f5xc-conflicts-with": [
               "any_domain",
               "suffix_value"
-            ],
-            "format": "hostname"
+            ]
           },
           "metadata": {
             "allOf": [
@@ -90077,7 +89970,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.666789+00:00"
+                "validatedAt": "2026-07-20T14:37:00.606259+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -90089,8 +89982,7 @@
             "x-f5xc-conflicts-with": [
               "any_domain",
               "exact_value"
-            ],
-            "format": "hostname"
+            ]
           }
         },
         "x-f5xc-description-short": "Simple Data Guard rule specifies a simple set of match conditions to enable data guard protection.",
@@ -90768,7 +90660,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.667508+00:00"
+                "validatedAt": "2026-07-20T14:37:00.606587+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -90865,7 +90757,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.667561+00:00"
+                "validatedAt": "2026-07-20T14:37:00.606612+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -91043,7 +90935,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.667632+00:00"
+                "validatedAt": "2026-07-20T14:37:00.606644+00:00"
               },
               "deterministic": true
             },
@@ -91053,8 +90945,7 @@
               "update": false,
               "read": false
             },
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "path": {
             "type": "string",
@@ -91075,7 +90966,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:58:57.667679+00:00"
+                "validatedAt": "2026-07-20T14:37:00.606661+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -91250,7 +91141,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.667763+00:00"
+                "validatedAt": "2026-07-20T14:37:00.606698+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -91372,7 +91263,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.667839+00:00"
+                "validatedAt": "2026-07-20T14:37:00.606732+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -91409,7 +91300,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.667884+00:00"
+                "validatedAt": "2026-07-20T14:37:00.606754+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -91500,7 +91391,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.667951+00:00"
+                "validatedAt": "2026-07-20T14:37:00.606786+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -91601,7 +91492,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.668024+00:00"
+                "validatedAt": "2026-07-20T14:37:00.606819+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -91691,7 +91582,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.668083+00:00"
+                "validatedAt": "2026-07-20T14:37:00.606842+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -91726,7 +91617,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.668145+00:00"
+                "validatedAt": "2026-07-20T14:37:00.606870+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -91765,7 +91656,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.668205+00:00"
+                "validatedAt": "2026-07-20T14:37:00.606899+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -91801,7 +91692,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.668249+00:00"
+                "validatedAt": "2026-07-20T14:37:00.606917+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -91854,7 +91745,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.668316+00:00"
+                "validatedAt": "2026-07-20T14:37:00.606947+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -91990,7 +91881,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.668400+00:00"
+                "validatedAt": "2026-07-20T14:37:00.606985+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -93492,7 +93383,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.668761+00:00"
+                "validatedAt": "2026-07-20T14:37:00.607128+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -93507,10 +93398,9 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.468174+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:12.974231+00:00",
             "x-f5xc-description-short": "X-displayName: \"Header Name\" A case-insensitive HTTP header name.",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "regex_values": {
             "type": "array",
@@ -93548,7 +93438,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.668805+00:00"
+                "validatedAt": "2026-07-20T14:37:00.607150+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -93574,7 +93464,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.468201+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.974248+00:00"
           }
         },
         "x-f5xc-description-short": "Bot Defense Transaction Result Condition.",
@@ -93649,7 +93539,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.668854+00:00"
+                "validatedAt": "2026-07-20T14:37:00.607174+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -93686,7 +93576,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.668899+00:00"
+                "validatedAt": "2026-07-20T14:37:00.607197+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -94082,7 +93972,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.669336+00:00"
+                "validatedAt": "2026-07-20T14:37:00.607388+00:00"
               },
               "deterministic": true
             },
@@ -94094,9 +93984,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.468399+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.974374+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "samesite_lax": {
             "allOf": [
@@ -94249,7 +94138,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.669396+00:00"
+                "validatedAt": "2026-07-20T14:37:00.607418+00:00"
               },
               "deterministic": true
             },
@@ -94261,9 +94150,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.468438+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.974398+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "overwrite": {
             "type": "boolean",
@@ -94317,7 +94205,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.669455+00:00"
+                "validatedAt": "2026-07-20T14:37:00.607445+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -94328,7 +94216,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.468469+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:12.974418+00:00",
             "x-f5xc-conflicts-with": [
               "secret_value"
             ]
@@ -94411,7 +94299,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.669502+00:00"
+                "validatedAt": "2026-07-20T14:37:00.607463+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -94443,7 +94331,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.669544+00:00"
+                "validatedAt": "2026-07-20T14:37:00.607481+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -94489,7 +94377,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.669592+00:00"
+                "validatedAt": "2026-07-20T14:37:00.607506+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -94537,7 +94425,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.669637+00:00"
+                "validatedAt": "2026-07-20T14:37:00.607528+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -94579,7 +94467,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.669689+00:00"
+                "validatedAt": "2026-07-20T14:37:00.607546+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -94616,7 +94504,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.669740+00:00"
+                "validatedAt": "2026-07-20T14:37:00.607571+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -94861,7 +94749,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.468572+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:12.974493+00:00",
             "x-f5xc-conflicts-with": [
               "any_domain"
             ]
@@ -94954,7 +94842,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.669814+00:00"
+                "validatedAt": "2026-07-20T14:37:00.607606+00:00"
               },
               "deterministic": true
             },
@@ -95040,7 +94928,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.669876+00:00"
+                "validatedAt": "2026-07-20T14:37:00.607635+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -95052,8 +94940,7 @@
             "x-f5xc-conflicts-with": [
               "regex_value",
               "suffix_value"
-            ],
-            "format": "hostname"
+            ]
           },
           "regex_value": {
             "type": "string",
@@ -95084,7 +94971,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.669937+00:00"
+                "validatedAt": "2026-07-20T14:37:00.607664+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -95129,7 +95016,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.669998+00:00"
+                "validatedAt": "2026-07-20T14:37:00.607695+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -95141,8 +95028,7 @@
             "x-f5xc-conflicts-with": [
               "exact_value",
               "regex_value"
-            ],
-            "format": "hostname"
+            ]
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -95327,7 +95213,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.670167+00:00"
+                "validatedAt": "2026-07-20T14:37:00.607772+00:00"
               },
               "deterministic": true
             },
@@ -95339,9 +95225,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.468686+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.974565+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "secret_value": {
             "allOf": [
@@ -95380,7 +95265,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.670224+00:00"
+                "validatedAt": "2026-07-20T14:37:00.607799+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -95391,7 +95276,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.468711+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:12.974582+00:00",
             "x-f5xc-conflicts-with": [
               "secret_value"
             ]
@@ -95567,7 +95452,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.670949+00:00"
+                "validatedAt": "2026-07-20T14:37:00.608140+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -95601,7 +95486,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.671009+00:00"
+                "validatedAt": "2026-07-20T14:37:00.608168+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -95831,7 +95716,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.671126+00:00"
+                "validatedAt": "2026-07-20T14:37:00.608217+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -95880,7 +95765,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.671174+00:00"
+                "validatedAt": "2026-07-20T14:37:00.608241+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -95975,7 +95860,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.671247+00:00"
+                "validatedAt": "2026-07-20T14:37:00.608273+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -95986,8 +95871,7 @@
             },
             "x-f5xc-conflicts-with": [
               "ignore_domain"
-            ],
-            "format": "hostname"
+            ]
           },
           "add_expiry": {
             "type": "string",
@@ -96010,7 +95894,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.671306+00:00"
+                "validatedAt": "2026-07-20T14:37:00.608300+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -96080,7 +95964,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.671369+00:00"
+                "validatedAt": "2026-07-20T14:37:00.608329+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -96326,7 +96210,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.671469+00:00"
+                "validatedAt": "2026-07-20T14:37:00.608399+00:00"
               },
               "deterministic": true
             },
@@ -96338,9 +96222,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.469251+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.974918+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "overwrite": {
             "type": "boolean",
@@ -96449,7 +96332,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.671538+00:00"
+                "validatedAt": "2026-07-20T14:37:00.608453+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -96460,7 +96343,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.469301+00:00",
+            "x-reconciled-at": "2026-07-20T14:42:12.974949+00:00",
             "x-f5xc-conflicts-with": [
               "ignore_value",
               "secret_value"
@@ -96753,7 +96636,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.672492+00:00"
+                "validatedAt": "2026-07-20T14:37:00.608926+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -96789,7 +96672,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.672535+00:00"
+                "validatedAt": "2026-07-20T14:37:00.608950+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -96847,7 +96730,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.672586+00:00"
+                "validatedAt": "2026-07-20T14:37:00.608971+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -96920,7 +96803,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.672648+00:00"
+                "validatedAt": "2026-07-20T14:37:00.609003+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -96963,7 +96846,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.672698+00:00"
+                "validatedAt": "2026-07-20T14:37:00.609025+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -97003,7 +96886,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.672744+00:00"
+                "validatedAt": "2026-07-20T14:37:00.609050+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -97160,7 +97043,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.672907+00:00"
+                "validatedAt": "2026-07-20T14:37:00.609133+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -97219,7 +97102,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.672955+00:00"
+                "validatedAt": "2026-07-20T14:37:00.609157+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -97265,7 +97148,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.672997+00:00"
+                "validatedAt": "2026-07-20T14:37:00.609179+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -97309,7 +97192,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.673041+00:00"
+                "validatedAt": "2026-07-20T14:37:00.609203+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -97347,7 +97230,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.673084+00:00"
+                "validatedAt": "2026-07-20T14:37:00.609226+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -97496,7 +97379,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.673200+00:00"
+                "validatedAt": "2026-07-20T14:37:00.609284+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -97662,7 +97545,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.673422+00:00"
+                "validatedAt": "2026-07-20T14:37:00.609392+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -97806,7 +97689,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.673491+00:00"
+                "validatedAt": "2026-07-20T14:37:00.609424+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -97904,7 +97787,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.673546+00:00"
+                "validatedAt": "2026-07-20T14:37:00.609451+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -97997,7 +97880,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.673603+00:00"
+                "validatedAt": "2026-07-20T14:37:00.609474+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -98032,7 +97915,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.673666+00:00"
+                "validatedAt": "2026-07-20T14:37:00.609504+00:00"
               },
               "deterministic": true
             },
@@ -98128,7 +98011,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.673723+00:00"
+                "validatedAt": "2026-07-20T14:37:00.609530+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -98251,7 +98134,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.673773+00:00"
+                "validatedAt": "2026-07-20T14:37:00.609555+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -98414,7 +98297,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.673843+00:00"
+                "validatedAt": "2026-07-20T14:37:00.609589+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -98509,7 +98392,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.673911+00:00"
+                "validatedAt": "2026-07-20T14:37:00.609623+00:00"
               },
               "byteLength": {
                 "max": 1024,
@@ -98600,7 +98483,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.673954+00:00"
+                "validatedAt": "2026-07-20T14:37:00.609645+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -98737,7 +98620,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.674007+00:00"
+                "validatedAt": "2026-07-20T14:37:00.609671+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -98958,7 +98841,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.674098+00:00"
+                "validatedAt": "2026-07-20T14:37:00.609712+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -99069,7 +98952,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.674144+00:00"
+                "validatedAt": "2026-07-20T14:37:00.609731+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -99108,7 +98991,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.470329+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.975601+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -99167,7 +99050,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:58:57.674185+00:00"
+                "validatedAt": "2026-07-20T14:37:00.609751+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -99195,7 +99078,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.674215+00:00"
+                "validatedAt": "2026-07-20T14:37:00.609766+00:00"
               },
               "deterministic": true
             },
@@ -99219,7 +99102,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.674253+00:00"
+                "validatedAt": "2026-07-20T14:37:00.609782+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -99242,7 +99125,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.674289+00:00"
+                "validatedAt": "2026-07-20T14:37:00.609797+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -99253,7 +99136,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.470371+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.975626+00:00"
           },
           "status": {
             "type": "string",
@@ -99269,7 +99152,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.674325+00:00"
+                "validatedAt": "2026-07-20T14:37:00.609813+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -99280,7 +99163,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.470390+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.975639+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -99344,7 +99227,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:58:57.674359+00:00"
+                "validatedAt": "2026-07-20T14:37:00.609828+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -99382,7 +99265,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.674390+00:00"
+                "validatedAt": "2026-07-20T14:37:00.609843+00:00"
               },
               "deterministic": true
             },
@@ -99394,9 +99277,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.470417+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.975656+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "nlb_cname": {
             "type": "string",
@@ -99412,7 +99294,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.674428+00:00"
+                "validatedAt": "2026-07-20T14:37:00.609859+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -99435,7 +99317,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.674468+00:00"
+                "validatedAt": "2026-07-20T14:37:00.609875+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -99458,7 +99340,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.674503+00:00"
+                "validatedAt": "2026-07-20T14:37:00.609890+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -99469,7 +99351,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.470449+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.975676+00:00"
           },
           "target_group_status": {
             "type": "array",
@@ -99546,7 +99428,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:58:57.674554+00:00"
+                "validatedAt": "2026-07-20T14:37:00.609913+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -99599,7 +99481,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.674596+00:00"
+                "validatedAt": "2026-07-20T14:37:00.609933+00:00"
               },
               "deterministic": true
             },
@@ -99611,9 +99493,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.470489+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.975701+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "protocol": {
             "type": "string",
@@ -99628,7 +99509,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.674632+00:00"
+                "validatedAt": "2026-07-20T14:37:00.609948+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -99651,7 +99532,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.674676+00:00"
+                "validatedAt": "2026-07-20T14:37:00.609963+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -99662,7 +99543,7 @@
             },
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.470514+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.975717+00:00"
           },
           "status": {
             "type": "string",
@@ -99678,7 +99559,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.674712+00:00"
+                "validatedAt": "2026-07-20T14:37:00.609978+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -99689,7 +99570,7 @@
             },
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.470534+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.975729+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -99765,7 +99646,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.674767+00:00"
+                "validatedAt": "2026-07-20T14:37:00.610005+00:00"
               },
               "deterministic": true
             },
@@ -99917,7 +99798,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:58:57.674815+00:00"
+                "validatedAt": "2026-07-20T14:37:00.610026+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -99945,7 +99826,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:58:57.674846+00:00"
+                "validatedAt": "2026-07-20T14:37:00.610041+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -100029,7 +99910,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.674892+00:00"
+                "validatedAt": "2026-07-20T14:37:00.610063+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -100484,7 +100365,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.674968+00:00"
+                "validatedAt": "2026-07-20T14:37:00.610097+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -100632,7 +100513,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.675010+00:00"
+                "validatedAt": "2026-07-20T14:37:00.610116+00:00"
               },
               "deterministic": true
             },
@@ -100679,7 +100560,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.675072+00:00"
+                "validatedAt": "2026-07-20T14:37:00.610147+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -101043,7 +100924,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.675166+00:00"
+                "validatedAt": "2026-07-20T14:37:00.610187+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -101078,7 +100959,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.675224+00:00"
+                "validatedAt": "2026-07-20T14:37:00.610215+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -101269,7 +101150,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.675279+00:00"
+                "validatedAt": "2026-07-20T14:37:00.610242+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -101472,7 +101353,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.675355+00:00"
+                "validatedAt": "2026-07-20T14:37:00.610274+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -101506,7 +101387,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.675407+00:00"
+                "validatedAt": "2026-07-20T14:37:00.610293+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -101640,7 +101521,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.675466+00:00"
+                "validatedAt": "2026-07-20T14:37:00.610322+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -101650,9 +101531,9 @@
               "read": false
             },
             "minLength": 26,
-            "format": "fqdn",
+            "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.470867+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.975918+00:00"
           },
           "simple_login": {
             "allOf": [
@@ -101744,7 +101625,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.675519+00:00"
+                "validatedAt": "2026-07-20T14:37:00.610350+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -102327,7 +102208,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.675641+00:00"
+                "validatedAt": "2026-07-20T14:37:00.610401+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -102557,7 +102438,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.675723+00:00"
+                "validatedAt": "2026-07-20T14:37:00.610433+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -102605,7 +102486,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.675769+00:00"
+                "validatedAt": "2026-07-20T14:37:00.610457+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -102706,7 +102587,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.675820+00:00"
+                "validatedAt": "2026-07-20T14:37:00.610482+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -103039,7 +102920,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.675922+00:00"
+                "validatedAt": "2026-07-20T14:37:00.610527+00:00"
               },
               "deterministic": true,
               "source": "minimum_configs",
@@ -103183,7 +103064,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.675986+00:00"
+                "validatedAt": "2026-07-20T14:37:00.610556+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -103529,7 +103410,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.676087+00:00"
+                "validatedAt": "2026-07-20T14:37:00.610600+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -103659,7 +103540,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.676144+00:00"
+                "validatedAt": "2026-07-20T14:37:00.610627+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -103862,7 +103743,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.676211+00:00"
+                "validatedAt": "2026-07-20T14:37:00.610658+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -104359,7 +104240,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.676299+00:00"
+                "validatedAt": "2026-07-20T14:37:00.610698+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -104369,9 +104250,9 @@
               "read": false
             },
             "minLength": 26,
-            "format": "fqdn",
+            "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.471498+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.976295+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -104682,7 +104563,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.676383+00:00"
+                "validatedAt": "2026-07-20T14:37:00.610735+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -104925,7 +104806,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.676455+00:00"
+                "validatedAt": "2026-07-20T14:37:00.610768+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -104973,7 +104854,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.676502+00:00"
+                "validatedAt": "2026-07-20T14:37:00.610791+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -105074,7 +104955,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.676554+00:00"
+                "validatedAt": "2026-07-20T14:37:00.610816+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -105421,7 +105302,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.676678+00:00"
+                "validatedAt": "2026-07-20T14:37:00.610865+00:00"
               },
               "deterministic": true,
               "source": "minimum_configs",
@@ -105565,7 +105446,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.676741+00:00"
+                "validatedAt": "2026-07-20T14:37:00.610893+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -105590,7 +105471,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.676783+00:00"
+                "validatedAt": "2026-07-20T14:37:00.610910+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -105958,7 +105839,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.676902+00:00"
+                "validatedAt": "2026-07-20T14:37:00.610959+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -106088,7 +105969,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.676959+00:00"
+                "validatedAt": "2026-07-20T14:37:00.610986+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -106305,7 +106186,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.677030+00:00"
+                "validatedAt": "2026-07-20T14:37:00.611017+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -107065,7 +106946,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.677128+00:00"
+                "validatedAt": "2026-07-20T14:37:00.611058+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -107295,7 +107176,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.677197+00:00"
+                "validatedAt": "2026-07-20T14:37:00.611090+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -107343,7 +107224,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.677243+00:00"
+                "validatedAt": "2026-07-20T14:37:00.611113+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -107444,7 +107325,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.677294+00:00"
+                "validatedAt": "2026-07-20T14:37:00.611138+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -107777,7 +107658,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.677394+00:00"
+                "validatedAt": "2026-07-20T14:37:00.611182+00:00"
               },
               "deterministic": true,
               "source": "minimum_configs",
@@ -107921,7 +107802,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.677456+00:00"
+                "validatedAt": "2026-07-20T14:37:00.611211+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -108267,7 +108148,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.677559+00:00"
+                "validatedAt": "2026-07-20T14:37:00.611253+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -108397,7 +108278,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.677617+00:00"
+                "validatedAt": "2026-07-20T14:37:00.611281+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -108600,7 +108481,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.677694+00:00"
+                "validatedAt": "2026-07-20T14:37:00.611311+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -109265,7 +109146,7 @@
                 "confidence": 0.99,
                 "category": "networking",
                 "note": "Asymmetry: port enforces [1,65535], health_check_port allows 0",
-                "validatedAt": "2026-07-20T12:58:57.677754+00:00"
+                "validatedAt": "2026-07-20T14:37:00.611335+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -109302,7 +109183,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.677803+00:00"
+                "validatedAt": "2026-07-20T14:37:00.611361+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -109412,7 +109293,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.677863+00:00"
+                "validatedAt": "2026-07-20T14:37:00.611389+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -109502,7 +109383,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.677895+00:00"
+                "validatedAt": "2026-07-20T14:37:00.611404+00:00"
               },
               "deterministic": true
             },
@@ -109693,7 +109574,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.677959+00:00"
+                "validatedAt": "2026-07-20T14:37:00.611429+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -109716,7 +109597,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.678003+00:00"
+                "validatedAt": "2026-07-20T14:37:00.611447+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -109753,7 +109634,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.678051+00:00"
+                "validatedAt": "2026-07-20T14:37:00.611468+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -109873,7 +109754,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.678151+00:00"
+                "validatedAt": "2026-07-20T14:37:00.611513+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -110020,7 +109901,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.678200+00:00"
+                "validatedAt": "2026-07-20T14:37:00.611537+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -110124,7 +110005,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.678263+00:00"
+                "validatedAt": "2026-07-20T14:37:00.611567+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -110237,7 +110118,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.678304+00:00"
+                "validatedAt": "2026-07-20T14:37:00.611586+00:00"
               },
               "deterministic": true
             },
@@ -110249,9 +110130,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.472793+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:12.977064+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "type": {
             "type": "string",
@@ -110268,7 +110148,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.678337+00:00"
+                "validatedAt": "2026-07-20T14:37:00.611599+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -110291,7 +110171,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.678372+00:00"
+                "validatedAt": "2026-07-20T14:37:00.611614+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -110302,7 +110182,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.472820+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:12.977080+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -110358,7 +110238,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.678419+00:00"
+                "validatedAt": "2026-07-20T14:37:00.611634+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -110383,7 +110263,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.678467+00:00"
+                "validatedAt": "2026-07-20T14:37:00.611654+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -110436,7 +110316,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:58:57.678516+00:00"
+                "validatedAt": "2026-07-20T14:37:00.611674+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -110640,7 +110520,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.678612+00:00"
+                "validatedAt": "2026-07-20T14:37:00.611717+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -110858,7 +110738,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.678744+00:00"
+                "validatedAt": "2026-07-20T14:37:00.611768+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -110976,7 +110856,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:58:57.678805+00:00"
+                "validatedAt": "2026-07-20T14:37:00.611799+00:00"
               },
               "deterministic": true
             },
@@ -111315,7 +111195,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:06.190081+00:00"
+                "validatedAt": "2026-07-20T14:37:03.918903+00:00"
               },
               "deterministic": true
             },
@@ -111327,9 +111207,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.785271+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:13.280890+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -111361,7 +111240,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:06.190110+00:00"
+                "validatedAt": "2026-07-20T14:37:03.918917+00:00"
               },
               "deterministic": true
             },
@@ -111373,9 +111252,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.785290+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:13.280902+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -111702,7 +111580,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.785385+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:13.280955+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -111897,7 +111775,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:59:06.190258+00:00"
+                "validatedAt": "2026-07-20T14:37:03.918976+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -111978,7 +111856,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:59:06.190314+00:00"
+                "validatedAt": "2026-07-20T14:37:03.919004+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -111989,7 +111867,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.785459+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:13.280995+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -112076,7 +111954,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:06.190356+00:00"
+                "validatedAt": "2026-07-20T14:37:03.919023+00:00"
               },
               "deterministic": true
             },
@@ -112088,9 +111966,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.785505+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:13.281034+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -112121,7 +111998,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:06.190385+00:00"
+                "validatedAt": "2026-07-20T14:37:03.919036+00:00"
               },
               "deterministic": true
             },
@@ -112133,9 +112010,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.785524+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:13.281048+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -112204,7 +112080,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:06.190438+00:00"
+                "validatedAt": "2026-07-20T14:37:03.919065+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -112216,7 +112092,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.785561+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:13.281070+00:00"
           },
           "uid": {
             "type": "string",
@@ -112234,7 +112110,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:06.190464+00:00"
+                "validatedAt": "2026-07-20T14:37:03.919076+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -112247,7 +112123,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:12.785581+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:13.281081+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of protocol_inspection is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -112979,7 +112855,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:20.184898+00:00"
+                "validatedAt": "2026-07-20T14:37:09.423402+00:00"
               },
               "deterministic": true
             },
@@ -112991,9 +112867,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.127144+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:13.650228+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -113025,7 +112900,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:20.184924+00:00"
+                "validatedAt": "2026-07-20T14:37:09.423415+00:00"
               },
               "deterministic": true
             },
@@ -113037,9 +112912,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.127162+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:13.650242+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -113255,7 +113129,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.127236+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:13.650288+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -113352,7 +113226,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:59:20.185040+00:00"
+                "validatedAt": "2026-07-20T14:37:09.423471+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -113433,7 +113307,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:59:20.185090+00:00"
+                "validatedAt": "2026-07-20T14:37:09.423493+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -113444,7 +113318,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.127286+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:13.650320+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -113531,7 +113405,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:20.185129+00:00"
+                "validatedAt": "2026-07-20T14:37:09.423511+00:00"
               },
               "deterministic": true
             },
@@ -113543,9 +113417,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.127331+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:13.650348+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -113576,7 +113449,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:20.185156+00:00"
+                "validatedAt": "2026-07-20T14:37:09.423524+00:00"
               },
               "deterministic": true
             },
@@ -113588,9 +113461,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.127349+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:13.650362+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -113659,7 +113531,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:20.185208+00:00"
+                "validatedAt": "2026-07-20T14:37:09.423543+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -113671,7 +113543,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.127387+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:13.650386+00:00"
           },
           "uid": {
             "type": "string",
@@ -113689,7 +113561,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:20.185233+00:00"
+                "validatedAt": "2026-07-20T14:37:09.423553+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -113702,7 +113574,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.127406+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:13.650398+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of tcp_loadbalancer is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -114105,7 +113977,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:20.185307+00:00"
+                "validatedAt": "2026-07-20T14:37:09.423588+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -114436,7 +114308,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:20.186731+00:00"
+                "validatedAt": "2026-07-20T14:37:09.424387+00:00"
               },
               "deterministic": true
             },
@@ -114634,7 +114506,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:20.186825+00:00"
+                "validatedAt": "2026-07-20T14:37:09.424428+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -114675,7 +114547,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:20.186891+00:00"
+                "validatedAt": "2026-07-20T14:37:09.424460+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -115133,7 +115005,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:20.187000+00:00"
+                "validatedAt": "2026-07-20T14:37:09.424513+00:00"
               },
               "deterministic": true
             },
@@ -115235,7 +115107,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:20.187047+00:00"
+                "validatedAt": "2026-07-20T14:37:09.424532+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -115370,7 +115242,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:20.187142+00:00"
+                "validatedAt": "2026-07-20T14:37:09.424572+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -115411,7 +115283,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:20.187201+00:00"
+                "validatedAt": "2026-07-20T14:37:09.424600+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -115823,7 +115695,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:20.187298+00:00"
+                "validatedAt": "2026-07-20T14:37:09.424642+00:00"
               },
               "deterministic": true
             },
@@ -116021,7 +115893,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:20.187392+00:00"
+                "validatedAt": "2026-07-20T14:37:09.424681+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -116062,7 +115934,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:20.187451+00:00"
+                "validatedAt": "2026-07-20T14:37:09.424709+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -116545,7 +116417,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:27.249590+00:00"
+                "validatedAt": "2026-07-20T14:37:12.444614+00:00"
               },
               "deterministic": true
             },
@@ -116557,9 +116429,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.419787+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:13.861480+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -116591,7 +116462,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:27.249618+00:00"
+                "validatedAt": "2026-07-20T14:37:12.444629+00:00"
               },
               "deterministic": true
             },
@@ -116603,9 +116474,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.419806+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:13.861493+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -116817,7 +116687,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.419880+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:13.861538+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -116912,7 +116782,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T12:59:27.249745+00:00"
+                "validatedAt": "2026-07-20T14:37:12.444696+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -116991,7 +116861,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T12:59:27.249797+00:00"
+                "validatedAt": "2026-07-20T14:37:12.444723+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -117002,7 +116872,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.419930+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:13.861569+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -117089,7 +116959,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:27.249837+00:00"
+                "validatedAt": "2026-07-20T14:37:12.444743+00:00"
               },
               "deterministic": true
             },
@@ -117101,9 +116971,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.419975+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:13.861598+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -117134,7 +117003,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:27.249865+00:00"
+                "validatedAt": "2026-07-20T14:37:12.444757+00:00"
               },
               "deterministic": true
             },
@@ -117146,9 +117015,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.419994+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:13.861611+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -117217,7 +117085,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:27.249920+00:00"
+                "validatedAt": "2026-07-20T14:37:12.444780+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -117229,7 +117097,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.420031+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:13.861635+00:00"
           },
           "uid": {
             "type": "string",
@@ -117247,7 +117115,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:27.249947+00:00"
+                "validatedAt": "2026-07-20T14:37:12.444790+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -117260,7 +117128,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:13.420050+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:13.861648+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of udp_loadbalancer is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -117629,7 +117497,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:27.251151+00:00"
+                "validatedAt": "2026-07-20T14:37:12.445308+00:00"
               },
               "deterministic": true
             },
@@ -117779,7 +117647,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:27.251243+00:00"
+                "validatedAt": "2026-07-20T14:37:12.445347+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -117820,7 +117688,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:27.251304+00:00"
+                "validatedAt": "2026-07-20T14:37:12.445375+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -118097,7 +117965,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:27.251388+00:00"
+                "validatedAt": "2026-07-20T14:37:12.445412+00:00"
               },
               "deterministic": true
             },
@@ -118190,7 +118058,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T12:59:27.251437+00:00"
+                "validatedAt": "2026-07-20T14:37:12.445431+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -118286,7 +118154,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:27.251528+00:00"
+                "validatedAt": "2026-07-20T14:37:12.445469+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -118327,7 +118195,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:27.251589+00:00"
+                "validatedAt": "2026-07-20T14:37:12.445497+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -118586,7 +118454,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:27.251669+00:00"
+                "validatedAt": "2026-07-20T14:37:12.445529+00:00"
               },
               "deterministic": true
             },
@@ -118736,7 +118604,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:27.251760+00:00"
+                "validatedAt": "2026-07-20T14:37:12.445567+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -118777,7 +118645,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T12:59:27.251819+00:00"
+                "validatedAt": "2026-07-20T14:37:12.445598+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -119098,7 +118966,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:01.051264+00:00"
+                "validatedAt": "2026-07-20T14:37:49.916995+00:00"
               },
               "deterministic": true
             },
@@ -119110,9 +118978,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.198332+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.620503+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -119144,7 +119011,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:01.051314+00:00"
+                "validatedAt": "2026-07-20T14:37:49.917016+00:00"
               },
               "deterministic": true
             },
@@ -119156,9 +119023,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.198353+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.620516+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -119284,7 +119150,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:01.051407+00:00"
+                "validatedAt": "2026-07-20T14:37:49.917041+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -119324,7 +119190,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:01.051456+00:00"
+                "validatedAt": "2026-07-20T14:37:49.917055+00:00"
               },
               "deterministic": true
             },
@@ -119336,9 +119202,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.198395+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.620542+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "policy": {
             "type": "string",
@@ -119355,7 +119220,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:01.051506+00:00"
+                "validatedAt": "2026-07-20T14:37:49.917069+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -119380,7 +119245,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:01.051549+00:00"
+                "validatedAt": "2026-07-20T14:37:49.917085+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -119405,7 +119270,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:01.051580+00:00"
+                "validatedAt": "2026-07-20T14:37:49.917097+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -119482,7 +119347,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:01.051628+00:00"
+                "validatedAt": "2026-07-20T14:37:49.917117+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -119556,7 +119421,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:01.051699+00:00"
+                "validatedAt": "2026-07-20T14:37:49.917160+00:00"
               },
               "deterministic": true
             },
@@ -119568,9 +119433,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.198453+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.620579+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "start_time": {
             "type": "string",
@@ -119595,7 +119459,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:01.051741+00:00"
+                "validatedAt": "2026-07-20T14:37:49.917181+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -119628,7 +119492,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:01.051774+00:00"
+                "validatedAt": "2026-07-20T14:37:49.917196+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -119722,7 +119586,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:01.051820+00:00"
+                "validatedAt": "2026-07-20T14:37:49.917215+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -119857,7 +119721,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:01.051862+00:00"
+                "validatedAt": "2026-07-20T14:37:49.917232+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -119868,7 +119732,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.198514+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.620617+00:00"
           }
         },
         "x-f5xc-description-short": "Label filter can be specified to filter metrics based on label match.",
@@ -119942,7 +119806,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:01.051925+00:00"
+                "validatedAt": "2026-07-20T14:37:49.917266+00:00"
               },
               "deterministic": true
             },
@@ -120761,7 +120625,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.198767+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.620767+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -120858,7 +120722,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:01:01.052119+00:00"
+                "validatedAt": "2026-07-20T14:37:49.917344+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -120939,7 +120803,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:01:01.052175+00:00"
+                "validatedAt": "2026-07-20T14:37:49.917368+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -120950,7 +120814,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.198818+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.620798+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -121038,7 +120902,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:01.052217+00:00"
+                "validatedAt": "2026-07-20T14:37:49.917387+00:00"
               },
               "deterministic": true
             },
@@ -121050,9 +120914,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.198864+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.620826+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -121083,7 +120946,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:01.052246+00:00"
+                "validatedAt": "2026-07-20T14:37:49.917402+00:00"
               },
               "deterministic": true
             },
@@ -121095,9 +120958,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.198882+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:15.620838+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -121166,7 +121028,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:01.052298+00:00"
+                "validatedAt": "2026-07-20T14:37:49.917482+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -121178,7 +121040,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.198920+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.620868+00:00"
           },
           "uid": {
             "type": "string",
@@ -121196,7 +121058,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:01.052323+00:00"
+                "validatedAt": "2026-07-20T14:37:49.917518+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -121209,7 +121071,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:15.198939+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:15.620881+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of enhanced_firewall_policy is returned in 'List'.",
@@ -121634,7 +121496,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:01.052574+00:00"
+                "validatedAt": "2026-07-20T14:37:49.917644+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -121666,7 +121528,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:01:01.052612+00:00"
+                "validatedAt": "2026-07-20T14:37:49.917660+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -121842,7 +121704,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:01.052745+00:00"
+                "validatedAt": "2026-07-20T14:37:49.917717+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -121920,7 +121782,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:01.053090+00:00"
+                "validatedAt": "2026-07-20T14:37:49.917871+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -122009,7 +121871,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:01.053132+00:00"
+                "validatedAt": "2026-07-20T14:37:49.917892+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -122130,7 +121992,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:01:01.053812+00:00"
+                "validatedAt": "2026-07-20T14:37:49.918218+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -123229,7 +123091,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:07.694745+00:00"
+                "validatedAt": "2026-07-20T14:38:15.601524+00:00"
               },
               "deterministic": true
             },
@@ -123241,9 +123103,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.218494+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.280745+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -123275,7 +123136,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:07.694781+00:00"
+                "validatedAt": "2026-07-20T14:38:15.601541+00:00"
               },
               "deterministic": true
             },
@@ -123287,9 +123148,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.218514+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.280757+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -123452,7 +123312,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.218582+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.280797+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -123634,7 +123494,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:02:07.694973+00:00"
+                "validatedAt": "2026-07-20T14:38:15.601597+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -123713,7 +123573,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:02:07.695033+00:00"
+                "validatedAt": "2026-07-20T14:38:15.601622+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -123724,7 +123584,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.218661+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.280839+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -123811,7 +123671,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:07.695075+00:00"
+                "validatedAt": "2026-07-20T14:38:15.601641+00:00"
               },
               "deterministic": true
             },
@@ -123823,9 +123683,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.218709+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.280867+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -123856,7 +123715,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:07.695105+00:00"
+                "validatedAt": "2026-07-20T14:38:15.601655+00:00"
               },
               "deterministic": true
             },
@@ -123868,9 +123727,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.218728+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.280878+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -123939,7 +123797,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:07.695159+00:00"
+                "validatedAt": "2026-07-20T14:38:15.601676+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -123951,7 +123809,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.218766+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.280901+00:00"
           },
           "uid": {
             "type": "string",
@@ -123969,7 +123827,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:07.695185+00:00"
+                "validatedAt": "2026-07-20T14:38:15.601687+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -123982,7 +123840,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.218786+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.280914+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of geo_location_set is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -124473,7 +124331,7 @@
                 "source": "api-probed",
                 "confidence": 0.99,
                 "category": "threshold",
-                "validatedAt": "2026-07-20T13:02:22.855595+00:00"
+                "validatedAt": "2026-07-20T14:38:21.615340+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -124530,7 +124388,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T13:02:22.855685+00:00"
+                "validatedAt": "2026-07-20T14:38:21.615378+00:00"
               },
               "deterministic": true
             },
@@ -124577,7 +124435,7 @@
                 "confidence": 0.99,
                 "category": "timing",
                 "note": "Non-contiguous: {0} union [10, 50] — values 1-9 rejected by API",
-                "validatedAt": "2026-07-20T13:02:22.855717+00:00"
+                "validatedAt": "2026-07-20T14:38:21.615392+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -124640,7 +124498,7 @@
                 "confidence": 0.99,
                 "category": "timing",
                 "note": "API rejects timeout > 600 for healthchecks (global pattern says 3600)",
-                "validatedAt": "2026-07-20T13:02:22.855754+00:00"
+                "validatedAt": "2026-07-20T14:38:21.615409+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -124700,7 +124558,7 @@
                 "source": "api-probed",
                 "confidence": 0.99,
                 "category": "threshold",
-                "validatedAt": "2026-07-20T13:02:22.855786+00:00"
+                "validatedAt": "2026-07-20T14:38:21.615421+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -124936,7 +124794,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:22.855856+00:00"
+                "validatedAt": "2026-07-20T14:38:21.615447+00:00"
               },
               "deterministic": true
             },
@@ -124948,9 +124806,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.454649+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.451372+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -124982,7 +124839,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:22.855904+00:00"
+                "validatedAt": "2026-07-20T14:38:21.615463+00:00"
               },
               "deterministic": true
             },
@@ -124994,9 +124851,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.454678+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.451385+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -125161,7 +125017,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.454744+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.451426+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -125255,7 +125111,7 @@
                 "source": "api-probed",
                 "confidence": 0.99,
                 "category": "threshold",
-                "validatedAt": "2026-07-20T13:02:22.856034+00:00"
+                "validatedAt": "2026-07-20T14:38:21.615501+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -125312,7 +125168,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T13:02:22.856078+00:00"
+                "validatedAt": "2026-07-20T14:38:21.615521+00:00"
               },
               "deterministic": true
             },
@@ -125359,7 +125215,7 @@
                 "confidence": 0.99,
                 "category": "timing",
                 "note": "Non-contiguous: {0} union [10, 50] — values 1-9 rejected by API",
-                "validatedAt": "2026-07-20T13:02:22.856098+00:00"
+                "validatedAt": "2026-07-20T14:38:21.615531+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -125422,7 +125278,7 @@
                 "confidence": 0.99,
                 "category": "timing",
                 "note": "API rejects timeout > 600 for healthchecks (global pattern says 3600)",
-                "validatedAt": "2026-07-20T13:02:22.856123+00:00"
+                "validatedAt": "2026-07-20T14:38:21.615545+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -125482,7 +125338,7 @@
                 "source": "api-probed",
                 "confidence": 0.99,
                 "category": "threshold",
-                "validatedAt": "2026-07-20T13:02:22.856146+00:00"
+                "validatedAt": "2026-07-20T14:38:21.615557+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -125590,7 +125446,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:22.856206+00:00"
+                "validatedAt": "2026-07-20T14:38:21.615588+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -125662,7 +125518,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:22.856282+00:00"
+                "validatedAt": "2026-07-20T14:38:21.615625+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -125704,7 +125560,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:22.856349+00:00"
+                "validatedAt": "2026-07-20T14:38:21.615658+00:00"
               },
               "deterministic": true
             },
@@ -125746,7 +125602,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:22.856394+00:00"
+                "validatedAt": "2026-07-20T14:38:21.615680+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -125823,7 +125679,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:44.206077+00:00"
+                "validatedAt": "2026-07-20T14:38:30.354941+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -125916,7 +125772,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:02:22.856447+00:00"
+                "validatedAt": "2026-07-20T14:38:21.615703+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -125997,7 +125853,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:02:22.856501+00:00"
+                "validatedAt": "2026-07-20T14:38:21.615728+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -126008,7 +125864,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.454897+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.451517+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -126095,7 +125951,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:22.856543+00:00"
+                "validatedAt": "2026-07-20T14:38:21.615747+00:00"
               },
               "deterministic": true
             },
@@ -126107,9 +125963,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.454942+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.451545+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -126140,7 +125995,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:22.856571+00:00"
+                "validatedAt": "2026-07-20T14:38:21.615761+00:00"
               },
               "deterministic": true
             },
@@ -126152,9 +126007,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.454961+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:16.451557+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -126223,7 +126077,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:22.856625+00:00"
+                "validatedAt": "2026-07-20T14:38:21.615783+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -126235,7 +126089,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.454998+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.451580+00:00"
           },
           "uid": {
             "type": "string",
@@ -126252,7 +126106,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:02:22.856652+00:00"
+                "validatedAt": "2026-07-20T14:38:21.615793+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -126265,7 +126119,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:16.455017+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:16.451592+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of healthcheck is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -126462,7 +126316,7 @@
                 "source": "api-probed",
                 "confidence": 0.99,
                 "category": "threshold",
-                "validatedAt": "2026-07-20T13:02:22.856711+00:00"
+                "validatedAt": "2026-07-20T14:38:21.615806+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -126519,7 +126373,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-07-20T13:02:22.856753+00:00"
+                "validatedAt": "2026-07-20T14:38:21.615828+00:00"
               },
               "deterministic": true
             },
@@ -126566,7 +126420,7 @@
                 "confidence": 0.99,
                 "category": "timing",
                 "note": "Non-contiguous: {0} union [10, 50] — values 1-9 rejected by API",
-                "validatedAt": "2026-07-20T13:02:22.856770+00:00"
+                "validatedAt": "2026-07-20T14:38:21.615837+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -126629,7 +126483,7 @@
                 "confidence": 0.99,
                 "category": "timing",
                 "note": "API rejects timeout > 600 for healthchecks (global pattern says 3600)",
-                "validatedAt": "2026-07-20T13:02:22.856795+00:00"
+                "validatedAt": "2026-07-20T14:38:21.615850+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -126689,7 +126543,7 @@
                 "source": "api-probed",
                 "confidence": 0.99,
                 "category": "threshold",
-                "validatedAt": "2026-07-20T13:02:22.856819+00:00"
+                "validatedAt": "2026-07-20T14:38:21.615862+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -126869,7 +126723,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:22.856922+00:00"
+                "validatedAt": "2026-07-20T14:38:21.615909+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -126906,7 +126760,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:02:22.856982+00:00"
+                "validatedAt": "2026-07-20T14:38:21.615937+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -127147,7 +127001,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:45.464273+00:00"
+                "validatedAt": "2026-07-20T14:39:40.439824+00:00"
               },
               "deterministic": true
             },
@@ -127159,9 +127013,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.604403+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.301740+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -127193,7 +127046,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:45.464301+00:00"
+                "validatedAt": "2026-07-20T14:39:40.439838+00:00"
               },
               "deterministic": true
             },
@@ -127205,9 +127058,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.604422+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.301752+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -127447,7 +127299,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:05:45.464410+00:00"
+                "validatedAt": "2026-07-20T14:39:40.439899+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -127528,7 +127380,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:05:45.464466+00:00"
+                "validatedAt": "2026-07-20T14:39:40.439928+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -127539,7 +127391,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.604520+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.301812+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -127626,7 +127478,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:45.464509+00:00"
+                "validatedAt": "2026-07-20T14:39:40.439952+00:00"
               },
               "deterministic": true
             },
@@ -127638,9 +127490,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.604566+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.301841+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -127671,7 +127522,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:45.464536+00:00"
+                "validatedAt": "2026-07-20T14:39:40.439966+00:00"
               },
               "deterministic": true
             },
@@ -127683,9 +127534,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.604584+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.301853+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -127738,7 +127588,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:45.464577+00:00"
+                "validatedAt": "2026-07-20T14:39:40.439983+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -127750,7 +127600,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.604616+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.301873+00:00"
           },
           "uid": {
             "type": "string",
@@ -127767,7 +127617,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:05:45.464604+00:00"
+                "validatedAt": "2026-07-20T14:39:40.439996+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -127780,7 +127630,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:19.604635+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.301886+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of origin_pool is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -128017,7 +127867,7 @@
                 "confidence": 0.99,
                 "category": "networking",
                 "note": "Asymmetry: port enforces [1,65535], health_check_port allows 0",
-                "validatedAt": "2026-07-20T13:05:45.467477+00:00"
+                "validatedAt": "2026-07-20T14:39:40.441325+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -128053,7 +127903,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:45.467525+00:00"
+                "validatedAt": "2026-07-20T14:39:40.441349+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -128162,7 +128012,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:45.467584+00:00"
+                "validatedAt": "2026-07-20T14:39:40.441377+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -128226,7 +128076,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:45.467618+00:00"
+                "validatedAt": "2026-07-20T14:39:40.441397+00:00"
               },
               "deterministic": true
             },
@@ -128447,7 +128297,7 @@
                 "confidence": 0.99,
                 "category": "networking",
                 "note": "Asymmetry: port enforces [1,65535], health_check_port allows 0",
-                "validatedAt": "2026-07-20T13:05:45.467666+00:00"
+                "validatedAt": "2026-07-20T14:39:40.441416+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -128483,7 +128333,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:45.467714+00:00"
+                "validatedAt": "2026-07-20T14:39:40.441440+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -128592,7 +128442,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:45.467773+00:00"
+                "validatedAt": "2026-07-20T14:39:40.441470+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -128656,7 +128506,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:45.467807+00:00"
+                "validatedAt": "2026-07-20T14:39:40.441488+00:00"
               },
               "deterministic": true
             },
@@ -128873,7 +128723,7 @@
                 "confidence": 0.99,
                 "category": "networking",
                 "note": "Asymmetry: port enforces [1,65535], health_check_port allows 0",
-                "validatedAt": "2026-07-20T13:05:45.467849+00:00"
+                "validatedAt": "2026-07-20T14:39:40.441508+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -128909,7 +128759,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:45.467896+00:00"
+                "validatedAt": "2026-07-20T14:39:40.441531+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -129018,7 +128868,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:45.467954+00:00"
+                "validatedAt": "2026-07-20T14:39:40.441557+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -129082,7 +128932,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:05:45.467985+00:00"
+                "validatedAt": "2026-07-20T14:39:40.441572+00:00"
               },
               "deterministic": true
             },
@@ -129414,7 +129264,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:19.101887+00:00"
+                "validatedAt": "2026-07-20T14:39:53.922701+00:00"
               },
               "deterministic": true
             },
@@ -129426,9 +129276,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.088437+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.798707+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -129460,7 +129309,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:19.101915+00:00"
+                "validatedAt": "2026-07-20T14:39:53.922715+00:00"
               },
               "deterministic": true
             },
@@ -129472,9 +129321,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.088455+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.798719+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -129711,7 +129559,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:19.101989+00:00"
+                "validatedAt": "2026-07-20T14:39:53.922749+00:00"
               },
               "deterministic": true
             },
@@ -130028,7 +129876,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.088593+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.798802+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -130203,7 +130051,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:06:19.102136+00:00"
+                "validatedAt": "2026-07-20T14:39:53.922808+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -130288,7 +130136,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:06:19.102190+00:00"
+                "validatedAt": "2026-07-20T14:39:53.922831+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -130299,7 +130147,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.088665+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.798842+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -130386,7 +130234,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:19.102231+00:00"
+                "validatedAt": "2026-07-20T14:39:53.922849+00:00"
               },
               "deterministic": true
             },
@@ -130398,9 +130246,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.088713+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.798871+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -130431,7 +130278,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:19.102259+00:00"
+                "validatedAt": "2026-07-20T14:39:53.922861+00:00"
               },
               "deterministic": true
             },
@@ -130443,9 +130290,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.088732+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:19.798883+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -130514,7 +130360,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:19.102312+00:00"
+                "validatedAt": "2026-07-20T14:39:53.922882+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -130526,7 +130372,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.088769+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.798907+00:00"
           },
           "uid": {
             "type": "string",
@@ -130543,7 +130389,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:19.102338+00:00"
+                "validatedAt": "2026-07-20T14:39:53.922894+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -130556,7 +130402,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.088789+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:19.798920+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of proxy is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -130849,7 +130695,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:19.104953+00:00"
+                "validatedAt": "2026-07-20T14:39:53.924042+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -131080,7 +130926,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:19.105037+00:00"
+                "validatedAt": "2026-07-20T14:39:53.924080+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -131207,7 +131053,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:19.105203+00:00"
+                "validatedAt": "2026-07-20T14:39:53.924156+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -131288,7 +131134,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:19.105454+00:00"
+                "validatedAt": "2026-07-20T14:39:53.924282+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -131372,7 +131218,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:19.105691+00:00"
+                "validatedAt": "2026-07-20T14:39:53.924389+00:00"
               },
               "deterministic": true
             },
@@ -132264,7 +132110,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:38.733602+00:00"
+                "validatedAt": "2026-07-20T14:40:01.289819+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -132522,7 +132368,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:38.734120+00:00"
+                "validatedAt": "2026-07-20T14:40:01.290054+00:00"
               },
               "deterministic": true
             },
@@ -132534,9 +132380,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.410561+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.085281+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -132568,7 +132413,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:38.734148+00:00"
+                "validatedAt": "2026-07-20T14:40:01.290067+00:00"
               },
               "deterministic": true
             },
@@ -132580,9 +132425,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.410580+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.085293+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -132747,7 +132591,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.410647+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.085336+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -132844,7 +132688,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:06:38.734265+00:00"
+                "validatedAt": "2026-07-20T14:40:01.290112+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -132925,7 +132769,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:06:38.734320+00:00"
+                "validatedAt": "2026-07-20T14:40:01.290136+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -132936,7 +132780,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.410709+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.085367+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -133023,7 +132867,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:38.734360+00:00"
+                "validatedAt": "2026-07-20T14:40:01.290154+00:00"
               },
               "deterministic": true
             },
@@ -133035,9 +132879,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.410755+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.085396+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -133068,7 +132911,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:38.734386+00:00"
+                "validatedAt": "2026-07-20T14:40:01.290166+00:00"
               },
               "deterministic": true
             },
@@ -133080,9 +132923,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.410773+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:20.085408+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -133151,7 +132993,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:38.734439+00:00"
+                "validatedAt": "2026-07-20T14:40:01.290186+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -133163,7 +133005,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.410811+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.085432+00:00"
           },
           "uid": {
             "type": "string",
@@ -133181,7 +133023,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:06:38.734466+00:00"
+                "validatedAt": "2026-07-20T14:40:01.290198+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -133194,7 +133036,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:20.410831+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:20.085445+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of rate_limiter_policy is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -133712,7 +133554,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:38.736661+00:00"
+                "validatedAt": "2026-07-20T14:40:01.291154+00:00"
               },
               "deterministic": true
             },
@@ -133888,7 +133730,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:38.736728+00:00"
+                "validatedAt": "2026-07-20T14:40:01.291185+00:00"
               },
               "deterministic": true
             },
@@ -133927,7 +133769,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:38.736786+00:00"
+                "validatedAt": "2026-07-20T14:40:01.291212+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -134072,7 +133914,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:38.736847+00:00"
+                "validatedAt": "2026-07-20T14:40:01.291242+00:00"
               },
               "deterministic": true
             },
@@ -134111,7 +133953,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:38.736904+00:00"
+                "validatedAt": "2026-07-20T14:40:01.291268+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -134252,7 +134094,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:38.736965+00:00"
+                "validatedAt": "2026-07-20T14:40:01.291297+00:00"
               },
               "deterministic": true
             },
@@ -134291,7 +134133,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:06:38.737020+00:00"
+                "validatedAt": "2026-07-20T14:40:01.291323+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -134523,7 +134365,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:46.663373+00:00"
+                "validatedAt": "2026-07-20T14:40:27.398966+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -134534,7 +134376,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.650798+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.173332+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"BotAdvanced Domain Matcher Type\" Bot Advanced Domain Matcher Type.",
@@ -134696,7 +134538,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.650858+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.173362+00:00"
           },
           "http_methods": {
             "type": "array",
@@ -134880,7 +134722,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:46.663468+00:00"
+                "validatedAt": "2026-07-20T14:40:27.399002+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -134891,7 +134733,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.650949+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.173400+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Bot Advanced Path Matcher Type\" Bot Advanced Path Matcher Type.",
@@ -135142,7 +134984,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:46.663568+00:00"
+                "validatedAt": "2026-07-20T14:40:27.399041+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -135166,7 +135008,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:46.663608+00:00"
+                "validatedAt": "2026-07-20T14:40:27.399057+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -136415,7 +136257,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:46.664638+00:00"
+                "validatedAt": "2026-07-20T14:40:27.399499+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -136691,7 +136533,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:46.664921+00:00"
+                "validatedAt": "2026-07-20T14:40:27.399605+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -136839,7 +136681,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.664977+00:00"
+                "validatedAt": "2026-07-20T14:40:27.399630+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -136907,7 +136749,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:46.665150+00:00"
+                "validatedAt": "2026-07-20T14:40:27.399711+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -136931,7 +136773,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:46.665188+00:00"
+                "validatedAt": "2026-07-20T14:40:27.399726+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -136955,7 +136797,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:46.665226+00:00"
+                "validatedAt": "2026-07-20T14:40:27.399741+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -136979,7 +136821,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:46.665262+00:00"
+                "validatedAt": "2026-07-20T14:40:27.399756+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -137003,7 +136845,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:46.665299+00:00"
+                "validatedAt": "2026-07-20T14:40:27.399771+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -137406,7 +137248,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.667744+00:00"
+                "validatedAt": "2026-07-20T14:40:27.400803+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -137722,7 +137564,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.667923+00:00"
+                "validatedAt": "2026-07-20T14:40:27.400877+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -138038,7 +137880,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.668014+00:00"
+                "validatedAt": "2026-07-20T14:40:27.400916+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -138354,7 +138196,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.668106+00:00"
+                "validatedAt": "2026-07-20T14:40:27.400955+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -138597,7 +138439,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.668174+00:00"
+                "validatedAt": "2026-07-20T14:40:27.400985+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -138695,7 +138537,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.668248+00:00"
+                "validatedAt": "2026-07-20T14:40:27.401018+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -138776,7 +138618,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.668297+00:00"
+                "validatedAt": "2026-07-20T14:40:27.401041+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -138819,7 +138661,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:46.668345+00:00"
+                "validatedAt": "2026-07-20T14:40:27.401061+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -138856,7 +138698,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.668401+00:00"
+                "validatedAt": "2026-07-20T14:40:27.401089+00:00"
               },
               "deterministic": true
             },
@@ -138977,7 +138819,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.668458+00:00"
+                "validatedAt": "2026-07-20T14:40:27.401114+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -139067,7 +138909,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.668514+00:00"
+                "validatedAt": "2026-07-20T14:40:27.401140+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -139262,7 +139104,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.668578+00:00"
+                "validatedAt": "2026-07-20T14:40:27.401168+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -139534,7 +139376,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.668792+00:00"
+                "validatedAt": "2026-07-20T14:40:27.401265+00:00"
               },
               "deterministic": true
             },
@@ -139546,9 +139388,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.653580+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.174988+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -139580,7 +139421,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.668818+00:00"
+                "validatedAt": "2026-07-20T14:40:27.401277+00:00"
               },
               "deterministic": true
             },
@@ -139592,9 +139433,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.653598+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.175000+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -139764,7 +139604,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.653672+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.175040+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -139858,7 +139698,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.668940+00:00"
+                "validatedAt": "2026-07-20T14:40:27.401328+00:00"
               },
               "deterministic": true
             },
@@ -139949,7 +139789,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:07:46.668980+00:00"
+                "validatedAt": "2026-07-20T14:40:27.401345+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -140035,7 +139875,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:07:46.669030+00:00"
+                "validatedAt": "2026-07-20T14:40:27.401366+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -140046,7 +139886,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.653732+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.175074+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -140133,7 +139973,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.669070+00:00"
+                "validatedAt": "2026-07-20T14:40:27.401383+00:00"
               },
               "deterministic": true
             },
@@ -140145,9 +139985,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.653777+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.175102+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -140178,7 +140017,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.669097+00:00"
+                "validatedAt": "2026-07-20T14:40:27.401396+00:00"
               },
               "deterministic": true
             },
@@ -140190,9 +140029,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.653802+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.175114+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -140261,7 +140099,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:46.669150+00:00"
+                "validatedAt": "2026-07-20T14:40:27.401417+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -140273,7 +140111,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.653840+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.175138+00:00"
           },
           "uid": {
             "type": "string",
@@ -140290,7 +140128,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:46.669175+00:00"
+                "validatedAt": "2026-07-20T14:40:27.401428+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -140303,7 +140141,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.653859+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.175150+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of service_policy is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -140593,7 +140431,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.669240+00:00"
+                "validatedAt": "2026-07-20T14:40:27.401459+00:00"
               },
               "deterministic": true
             },
@@ -140737,7 +140575,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:46.669291+00:00"
+                "validatedAt": "2026-07-20T14:40:27.401479+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -140777,7 +140615,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.669318+00:00"
+                "validatedAt": "2026-07-20T14:40:27.401492+00:00"
               },
               "deterministic": true
             },
@@ -140789,9 +140627,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.653937+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.175199+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "policy": {
             "type": "string",
@@ -140808,7 +140645,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:46.669351+00:00"
+                "validatedAt": "2026-07-20T14:40:27.401506+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -140833,7 +140670,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:46.669388+00:00"
+                "validatedAt": "2026-07-20T14:40:27.401522+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -140858,7 +140695,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:46.669425+00:00"
+                "validatedAt": "2026-07-20T14:40:27.401536+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -140883,7 +140720,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:46.669455+00:00"
+                "validatedAt": "2026-07-20T14:40:27.401549+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -140908,7 +140745,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:46.669492+00:00"
+                "validatedAt": "2026-07-20T14:40:27.401565+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -140992,7 +140829,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:46.669531+00:00"
+                "validatedAt": "2026-07-20T14:40:27.401580+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -141066,7 +140903,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.669583+00:00"
+                "validatedAt": "2026-07-20T14:40:27.401603+00:00"
               },
               "deterministic": true
             },
@@ -141078,9 +140915,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.654010+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.175243+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "start_time": {
             "type": "string",
@@ -141105,7 +140941,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:46.669621+00:00"
+                "validatedAt": "2026-07-20T14:40:27.401618+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -141138,7 +140974,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:46.669661+00:00"
+                "validatedAt": "2026-07-20T14:40:27.401632+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -141236,7 +141072,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:46.669706+00:00"
+                "validatedAt": "2026-07-20T14:40:27.401650+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -141382,7 +141218,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:46.669747+00:00"
+                "validatedAt": "2026-07-20T14:40:27.401665+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -141393,7 +141229,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.654072+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.175280+00:00"
           }
         },
         "x-f5xc-description-short": "Label filter can be specified to filter metrics based on label match.",
@@ -141484,7 +141320,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.669796+00:00"
+                "validatedAt": "2026-07-20T14:40:27.401689+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -141526,7 +141362,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.669840+00:00"
+                "validatedAt": "2026-07-20T14:40:27.401711+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -141615,7 +141451,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.669892+00:00"
+                "validatedAt": "2026-07-20T14:40:27.401737+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -141665,7 +141501,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.669939+00:00"
+                "validatedAt": "2026-07-20T14:40:27.401760+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -141706,7 +141542,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:46.669981+00:00"
+                "validatedAt": "2026-07-20T14:40:27.401781+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -141970,7 +141806,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:51.074327+00:00"
+                "validatedAt": "2026-07-20T14:40:29.111458+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -142067,7 +141903,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:51.074399+00:00"
+                "validatedAt": "2026-07-20T14:40:29.111489+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -142147,7 +141983,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:51.074451+00:00"
+                "validatedAt": "2026-07-20T14:40:29.111513+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -142189,7 +142025,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:51.074497+00:00"
+                "validatedAt": "2026-07-20T14:40:29.111531+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -142225,7 +142061,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:51.074552+00:00"
+                "validatedAt": "2026-07-20T14:40:29.111559+00:00"
               },
               "deterministic": true
             },
@@ -142345,7 +142181,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:51.074609+00:00"
+                "validatedAt": "2026-07-20T14:40:29.111585+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -142434,7 +142270,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:51.074675+00:00"
+                "validatedAt": "2026-07-20T14:40:29.111609+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -142681,7 +142517,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:51.074747+00:00"
+                "validatedAt": "2026-07-20T14:40:29.111639+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -142778,7 +142614,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:51.074817+00:00"
+                "validatedAt": "2026-07-20T14:40:29.111669+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -142858,7 +142694,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:51.074867+00:00"
+                "validatedAt": "2026-07-20T14:40:29.111692+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -142900,7 +142736,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:51.074911+00:00"
+                "validatedAt": "2026-07-20T14:40:29.111709+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -142936,7 +142772,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:51.074964+00:00"
+                "validatedAt": "2026-07-20T14:40:29.111734+00:00"
               },
               "deterministic": true
             },
@@ -143056,7 +142892,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:51.075022+00:00"
+                "validatedAt": "2026-07-20T14:40:29.111759+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -143145,7 +142981,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:51.075074+00:00"
+                "validatedAt": "2026-07-20T14:40:29.111783+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -143392,7 +143228,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:51.075194+00:00"
+                "validatedAt": "2026-07-20T14:40:29.111835+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -143489,7 +143325,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:51.075265+00:00"
+                "validatedAt": "2026-07-20T14:40:29.111866+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -143569,7 +143405,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:51.075316+00:00"
+                "validatedAt": "2026-07-20T14:40:29.111890+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -143611,7 +143447,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:51.075361+00:00"
+                "validatedAt": "2026-07-20T14:40:29.111907+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -143647,7 +143483,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:51.075415+00:00"
+                "validatedAt": "2026-07-20T14:40:29.111933+00:00"
               },
               "deterministic": true
             },
@@ -143767,7 +143603,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:51.075474+00:00"
+                "validatedAt": "2026-07-20T14:40:29.111958+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -143856,7 +143692,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:51.075526+00:00"
+                "validatedAt": "2026-07-20T14:40:29.111982+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -144213,7 +144049,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:51.075756+00:00"
+                "validatedAt": "2026-07-20T14:40:29.112084+00:00"
               },
               "deterministic": true
             },
@@ -144225,9 +144061,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.754414+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.260685+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -144259,7 +144094,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:51.075783+00:00"
+                "validatedAt": "2026-07-20T14:40:29.112097+00:00"
               },
               "deterministic": true
             },
@@ -144271,9 +144106,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.754432+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.260697+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -144443,7 +144277,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.754498+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.260738+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -144545,7 +144379,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:07:51.075897+00:00"
+                "validatedAt": "2026-07-20T14:40:29.112139+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -144631,7 +144465,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:07:51.075947+00:00"
+                "validatedAt": "2026-07-20T14:40:29.112159+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -144642,7 +144476,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.754547+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.260768+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -144729,7 +144563,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:51.075986+00:00"
+                "validatedAt": "2026-07-20T14:40:29.112176+00:00"
               },
               "deterministic": true
             },
@@ -144741,9 +144575,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.754592+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.260796+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -144774,7 +144607,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:51.076013+00:00"
+                "validatedAt": "2026-07-20T14:40:29.112188+00:00"
               },
               "deterministic": true
             },
@@ -144786,9 +144619,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.754610+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.260808+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -144857,7 +144689,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:51.076065+00:00"
+                "validatedAt": "2026-07-20T14:40:29.112208+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -144869,7 +144701,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.754647+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.260831+00:00"
           },
           "uid": {
             "type": "string",
@@ -144887,7 +144719,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:51.076095+00:00"
+                "validatedAt": "2026-07-20T14:40:29.112218+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -144900,7 +144732,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.754675+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.260844+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of service_policy_rule is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -145201,7 +145033,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:54.920130+00:00"
+                "validatedAt": "2026-07-20T14:40:30.533343+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -145375,7 +145207,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.836911+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.336772+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -145475,7 +145307,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:07:54.920239+00:00"
+                "validatedAt": "2026-07-20T14:40:30.533386+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -145561,7 +145393,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:07:54.920290+00:00"
+                "validatedAt": "2026-07-20T14:40:30.533407+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -145572,7 +145404,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.836961+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.336803+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -145659,7 +145491,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:54.920329+00:00"
+                "validatedAt": "2026-07-20T14:40:30.533424+00:00"
               },
               "deterministic": true
             },
@@ -145671,9 +145503,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.837005+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.336831+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -145704,7 +145535,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:07:54.920359+00:00"
+                "validatedAt": "2026-07-20T14:40:30.533437+00:00"
               },
               "deterministic": true
             },
@@ -145716,9 +145547,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.837023+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:21.336844+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -145787,7 +145617,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:54.920412+00:00"
+                "validatedAt": "2026-07-20T14:40:30.533456+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -145799,7 +145629,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.837060+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.336867+00:00"
           },
           "uid": {
             "type": "string",
@@ -145817,7 +145647,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:07:54.920438+00:00"
+                "validatedAt": "2026-07-20T14:40:30.533467+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -145830,7 +145660,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:21.837079+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:21.336880+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of service_policy_set is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -146014,7 +145844,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:02.969089+00:00"
+                "validatedAt": "2026-07-20T14:41:42.800898+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -146081,7 +145911,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:02.969157+00:00"
+                "validatedAt": "2026-07-20T14:41:42.800917+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -146197,7 +146027,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:02.969310+00:00"
+                "validatedAt": "2026-07-20T14:41:42.800955+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -146239,7 +146069,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:02.969404+00:00"
+                "validatedAt": "2026-07-20T14:41:42.800977+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -146285,7 +146115,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:02.969452+00:00"
+                "validatedAt": "2026-07-20T14:41:42.800998+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -146348,7 +146178,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:02.969516+00:00"
+                "validatedAt": "2026-07-20T14:41:42.801024+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -146389,7 +146219,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:02.969559+00:00"
+                "validatedAt": "2026-07-20T14:41:42.801042+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -146429,7 +146259,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:02.969608+00:00"
+                "validatedAt": "2026-07-20T14:41:42.801062+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -146540,7 +146370,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:02.969732+00:00"
+                "validatedAt": "2026-07-20T14:41:42.801096+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -146734,7 +146564,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:02.969850+00:00"
+                "validatedAt": "2026-07-20T14:41:42.801135+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -147322,7 +147152,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:02.970038+00:00"
+                "validatedAt": "2026-07-20T14:41:42.801195+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -147347,7 +147177,7 @@
             "maxLength": 4,
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.401783+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.308551+00:00"
           },
           "type": {
             "allOf": [
@@ -147420,7 +147250,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:02.970096+00:00"
+                "validatedAt": "2026-07-20T14:41:42.801215+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -147757,7 +147587,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:02.970261+00:00"
+                "validatedAt": "2026-07-20T14:41:42.801265+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -147848,7 +147678,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:02.970322+00:00"
+                "validatedAt": "2026-07-20T14:41:42.801290+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -147886,7 +147716,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:02.970370+00:00"
+                "validatedAt": "2026-07-20T14:41:42.801306+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -147910,7 +147740,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:02.970416+00:00"
+                "validatedAt": "2026-07-20T14:41:42.801324+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -148213,7 +148043,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:02.970538+00:00"
+                "validatedAt": "2026-07-20T14:41:42.801370+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -148261,7 +148091,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:02.970589+00:00"
+                "validatedAt": "2026-07-20T14:41:42.801390+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -148455,7 +148285,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.970662+00:00"
+                "validatedAt": "2026-07-20T14:41:42.801419+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -148638,7 +148468,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.971158+00:00"
+                "validatedAt": "2026-07-20T14:41:42.801642+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -148770,7 +148600,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.971218+00:00"
+                "validatedAt": "2026-07-20T14:41:42.801673+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -149066,7 +148896,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.974516+00:00"
+                "validatedAt": "2026-07-20T14:41:42.803151+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -149097,7 +148927,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:02.974554+00:00"
+                "validatedAt": "2026-07-20T14:41:42.803168+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -149204,7 +149034,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.974639+00:00"
+                "validatedAt": "2026-07-20T14:41:42.803207+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -149490,7 +149320,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.974776+00:00"
+                "validatedAt": "2026-07-20T14:41:42.803259+00:00"
               },
               "deterministic": true
             },
@@ -149708,7 +149538,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.974884+00:00"
+                "validatedAt": "2026-07-20T14:41:42.803305+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -149745,7 +149575,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.974928+00:00"
+                "validatedAt": "2026-07-20T14:41:42.803329+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -149787,7 +149617,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.974972+00:00"
+                "validatedAt": "2026-07-20T14:41:42.803353+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -149824,7 +149654,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.975018+00:00"
+                "validatedAt": "2026-07-20T14:41:42.803377+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -149862,7 +149692,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.975063+00:00"
+                "validatedAt": "2026-07-20T14:41:42.803401+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -149899,7 +149729,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.975108+00:00"
+                "validatedAt": "2026-07-20T14:41:42.803426+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -149942,7 +149772,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.975152+00:00"
+                "validatedAt": "2026-07-20T14:41:42.803450+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -149979,7 +149809,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.975199+00:00"
+                "validatedAt": "2026-07-20T14:41:42.803474+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -150017,7 +149847,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.975244+00:00"
+                "validatedAt": "2026-07-20T14:41:42.803499+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -150065,7 +149895,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.975291+00:00"
+                "validatedAt": "2026-07-20T14:41:42.803524+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -150113,7 +149943,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.975365+00:00"
+                "validatedAt": "2026-07-20T14:41:42.803558+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -150200,7 +150030,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.975418+00:00"
+                "validatedAt": "2026-07-20T14:41:42.803585+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -150420,7 +150250,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.975503+00:00"
+                "validatedAt": "2026-07-20T14:41:42.803624+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -150465,7 +150295,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:02.975548+00:00"
+                "validatedAt": "2026-07-20T14:41:42.803644+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -150809,7 +150639,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.975703+00:00"
+                "validatedAt": "2026-07-20T14:41:42.803702+00:00"
               },
               "deterministic": true
             },
@@ -150865,7 +150695,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:02.975747+00:00"
+                "validatedAt": "2026-07-20T14:41:42.803720+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -151105,7 +150935,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.975858+00:00"
+                "validatedAt": "2026-07-20T14:41:42.803767+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -151160,7 +150990,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.975906+00:00"
+                "validatedAt": "2026-07-20T14:41:42.803791+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -151202,7 +151032,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.975950+00:00"
+                "validatedAt": "2026-07-20T14:41:42.803813+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -151239,7 +151069,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.975994+00:00"
+                "validatedAt": "2026-07-20T14:41:42.803836+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -151277,7 +151107,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.976039+00:00"
+                "validatedAt": "2026-07-20T14:41:42.803858+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -151314,7 +151144,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.976083+00:00"
+                "validatedAt": "2026-07-20T14:41:42.803882+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -151357,7 +151187,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.976127+00:00"
+                "validatedAt": "2026-07-20T14:41:42.803905+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -151394,7 +151224,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.976169+00:00"
+                "validatedAt": "2026-07-20T14:41:42.803928+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -151432,7 +151262,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.976213+00:00"
+                "validatedAt": "2026-07-20T14:41:42.803951+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -151480,7 +151310,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.976258+00:00"
+                "validatedAt": "2026-07-20T14:41:42.803975+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -151528,7 +151358,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.976330+00:00"
+                "validatedAt": "2026-07-20T14:41:42.804009+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -151642,7 +151472,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.976390+00:00"
+                "validatedAt": "2026-07-20T14:41:42.804039+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -151865,7 +151695,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.976479+00:00"
+                "validatedAt": "2026-07-20T14:41:42.804080+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -152151,7 +151981,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.976592+00:00"
+                "validatedAt": "2026-07-20T14:41:42.804129+00:00"
               },
               "deterministic": true
             },
@@ -152369,7 +152199,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.976714+00:00"
+                "validatedAt": "2026-07-20T14:41:42.804174+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -152406,7 +152236,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.976757+00:00"
+                "validatedAt": "2026-07-20T14:41:42.804197+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -152448,7 +152278,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.976802+00:00"
+                "validatedAt": "2026-07-20T14:41:42.804219+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -152485,7 +152315,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.976846+00:00"
+                "validatedAt": "2026-07-20T14:41:42.804242+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -152523,7 +152353,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.976890+00:00"
+                "validatedAt": "2026-07-20T14:41:42.804265+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -152560,7 +152390,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.976935+00:00"
+                "validatedAt": "2026-07-20T14:41:42.804289+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -152603,7 +152433,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.976980+00:00"
+                "validatedAt": "2026-07-20T14:41:42.804311+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -152640,7 +152470,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.977024+00:00"
+                "validatedAt": "2026-07-20T14:41:42.804334+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -152678,7 +152508,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.977068+00:00"
+                "validatedAt": "2026-07-20T14:41:42.804357+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -152726,7 +152556,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.977112+00:00"
+                "validatedAt": "2026-07-20T14:41:42.804380+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -152774,7 +152604,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.977185+00:00"
+                "validatedAt": "2026-07-20T14:41:42.804414+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -152861,7 +152691,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.977238+00:00"
+                "validatedAt": "2026-07-20T14:41:42.804439+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -153041,7 +152871,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:02.977335+00:00"
+                "validatedAt": "2026-07-20T14:41:42.804480+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -153066,7 +152896,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:02.977361+00:00"
+                "validatedAt": "2026-07-20T14:41:42.804491+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -153077,7 +152907,7 @@
             },
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.404735+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.310259+00:00"
           }
         },
         "x-f5xc-description-short": "Top level object representing a Jira issue (ticket) - modeled after the JIRA REST API response format.",
@@ -153142,7 +152972,7 @@
             "maxLength": 0,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.404759+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.310307+00:00"
           },
           "issuetype": {
             "allOf": [
@@ -153186,7 +153016,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.404792+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.310342+00:00"
           },
           "summary": {
             "type": "string",
@@ -153201,7 +153031,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:02.977411+00:00"
+                "validatedAt": "2026-07-20T14:41:42.804511+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -153276,7 +153106,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:02.977448+00:00"
+                "validatedAt": "2026-07-20T14:41:42.804526+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -153303,7 +153133,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:02.977475+00:00"
+                "validatedAt": "2026-07-20T14:41:42.804537+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -153343,7 +153173,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.977503+00:00"
+                "validatedAt": "2026-07-20T14:41:42.804551+00:00"
               },
               "deterministic": true
             },
@@ -153355,9 +153185,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.404832+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.310382+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "status_category": {
             "allOf": [
@@ -153435,7 +153264,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:02.977546+00:00"
+                "validatedAt": "2026-07-20T14:41:42.804568+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -153463,7 +153292,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:02.977570+00:00"
+                "validatedAt": "2026-07-20T14:41:42.804579+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -153534,7 +153363,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:02.977607+00:00"
+                "validatedAt": "2026-07-20T14:41:42.804595+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -153561,7 +153390,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:02.977642+00:00"
+                "validatedAt": "2026-07-20T14:41:42.804609+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -153588,7 +153417,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:02.977692+00:00"
+                "validatedAt": "2026-07-20T14:41:42.804620+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -153628,7 +153457,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.977724+00:00"
+                "validatedAt": "2026-07-20T14:41:42.804634+00:00"
               },
               "deterministic": true
             },
@@ -153640,9 +153469,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.404892+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.310415+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Issue (ticket) type information that's specific to Jira - modeled after the JIRA REST API response format.",
@@ -153709,7 +153537,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:02.977754+00:00"
+                "validatedAt": "2026-07-20T14:41:42.804645+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -153750,7 +153578,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:02.977793+00:00"
+                "validatedAt": "2026-07-20T14:41:42.804660+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -153761,7 +153589,7 @@
             },
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.404925+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.310434+00:00"
           },
           "name": {
             "type": "string",
@@ -153793,7 +153621,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.977821+00:00"
+                "validatedAt": "2026-07-20T14:41:42.804673+00:00"
               },
               "deterministic": true
             },
@@ -153805,9 +153633,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.404943+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.310446+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Contains fields and information that are specific to Jira projects - modeled after the JIRA REST API response format.",
@@ -153974,7 +153801,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.978027+00:00"
+                "validatedAt": "2026-07-20T14:41:42.804766+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -154200,7 +154027,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.978121+00:00"
+                "validatedAt": "2026-07-20T14:41:42.804809+00:00"
               },
               "deterministic": true
             },
@@ -154228,7 +154055,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:02.978157+00:00"
+                "validatedAt": "2026-07-20T14:41:42.804824+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -154255,7 +154082,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:02.978192+00:00"
+                "validatedAt": "2026-07-20T14:41:42.804839+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -154361,7 +154188,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:02.978248+00:00"
+                "validatedAt": "2026-07-20T14:41:42.804862+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -154517,7 +154344,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.978330+00:00"
+                "validatedAt": "2026-07-20T14:41:42.804894+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -154550,7 +154377,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:02.978382+00:00"
+                "validatedAt": "2026-07-20T14:41:42.804912+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -154598,7 +154425,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.978436+00:00"
+                "validatedAt": "2026-07-20T14:41:42.804939+00:00"
               },
               "deterministic": true
             },
@@ -154632,7 +154459,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:02.978475+00:00"
+                "validatedAt": "2026-07-20T14:41:42.804954+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -154671,7 +154498,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.978504+00:00"
+                "validatedAt": "2026-07-20T14:41:42.804967+00:00"
               },
               "deterministic": true
             },
@@ -154683,9 +154510,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.405130+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.310543+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -154717,7 +154543,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.978534+00:00"
+                "validatedAt": "2026-07-20T14:41:42.804981+00:00"
               },
               "deterministic": true
             },
@@ -154729,9 +154555,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.405148+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.310553+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -154856,7 +154681,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:02.978599+00:00"
+                "validatedAt": "2026-07-20T14:41:42.805005+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -155120,7 +154945,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.978731+00:00"
+                "validatedAt": "2026-07-20T14:41:42.805046+00:00"
               },
               "deterministic": true
             },
@@ -155132,9 +154957,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.405238+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.310601+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -155165,7 +154989,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.978760+00:00"
+                "validatedAt": "2026-07-20T14:41:42.805059+00:00"
               },
               "deterministic": true
             },
@@ -155177,9 +155001,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.405256+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.310612+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -155282,7 +155105,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.978809+00:00"
+                "validatedAt": "2026-07-20T14:41:42.805083+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -155356,7 +155179,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.978885+00:00"
+                "validatedAt": "2026-07-20T14:41:42.805116+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -155438,7 +155261,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:02.979068+00:00"
+                "validatedAt": "2026-07-20T14:41:42.805186+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -155462,7 +155285,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:02.979100+00:00"
+                "validatedAt": "2026-07-20T14:41:42.805198+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -155532,7 +155355,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-07-20T13:11:02.979137+00:00"
+                "validatedAt": "2026-07-20T14:41:42.805214+00:00"
               },
               "deterministic": true
             },
@@ -155543,8 +155366,7 @@
               "read": false
             },
             "pattern": "^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-            "minLength": 1,
-            "format": "fqdn"
+            "minLength": 1
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Public DNS Name\" Specify origin server with public DNS name.",
@@ -155599,7 +155421,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.979169+00:00"
+                "validatedAt": "2026-07-20T14:41:42.805230+00:00"
               },
               "deterministic": true
             },
@@ -155777,7 +155599,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:25.461476+00:00"
+                "validatedAt": "2026-07-20T14:41:51.229317+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -155846,7 +155668,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.979414+00:00"
+                "validatedAt": "2026-07-20T14:41:42.805337+00:00"
               },
               "deterministic": true
             },
@@ -155858,7 +155680,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.405447+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.310713+00:00"
           },
           "issue_type": {
             "type": "string",
@@ -155885,7 +155707,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.979474+00:00"
+                "validatedAt": "2026-07-20T14:41:42.805364+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -155921,7 +155743,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.979531+00:00"
+                "validatedAt": "2026-07-20T14:41:42.805391+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -155954,7 +155776,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.979586+00:00"
+                "validatedAt": "2026-07-20T14:41:42.805417+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -156217,7 +156039,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.979690+00:00"
+                "validatedAt": "2026-07-20T14:41:42.805452+00:00"
               },
               "deterministic": true
             },
@@ -156229,9 +156051,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.405536+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.310764+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -156270,7 +156091,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.979737+00:00"
+                "validatedAt": "2026-07-20T14:41:42.805477+00:00"
               },
               "deterministic": true
             },
@@ -156282,9 +156103,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.405554+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.310775+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "ticket_tracking_system": {
             "type": "string",
@@ -156314,7 +156134,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.979806+00:00"
+                "validatedAt": "2026-07-20T14:41:42.805507+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -156584,7 +156404,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.979981+00:00"
+                "validatedAt": "2026-07-20T14:41:42.805577+00:00"
               },
               "deterministic": true
             },
@@ -156596,9 +156416,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.405681+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.310838+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -156630,7 +156449,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.980009+00:00"
+                "validatedAt": "2026-07-20T14:41:42.805591+00:00"
               },
               "deterministic": true
             },
@@ -156642,9 +156461,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.405700+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.310848+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -156836,7 +156654,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.980083+00:00"
+                "validatedAt": "2026-07-20T14:41:42.805624+00:00"
               },
               "deterministic": true
             },
@@ -156848,9 +156666,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.405754+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.310876+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -156882,7 +156699,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.980111+00:00"
+                "validatedAt": "2026-07-20T14:41:42.805637+00:00"
               },
               "deterministic": true
             },
@@ -156894,9 +156711,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.405773+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.310887+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Request model for GetAPICallSummary API.",
@@ -156968,7 +156784,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:02.980169+00:00"
+                "validatedAt": "2026-07-20T14:41:42.805661+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -157041,7 +156857,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.980219+00:00"
+                "validatedAt": "2026-07-20T14:41:42.805686+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -157081,7 +156897,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.980248+00:00"
+                "validatedAt": "2026-07-20T14:41:42.805700+00:00"
               },
               "deterministic": true
             },
@@ -157093,9 +156909,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.405814+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.310909+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -157127,7 +156942,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.980276+00:00"
+                "validatedAt": "2026-07-20T14:41:42.805714+00:00"
               },
               "deterministic": true
             },
@@ -157139,9 +156954,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.405832+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.310920+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "query_type": {
             "allOf": [
@@ -157440,7 +157254,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.405925+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.310974+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -157542,7 +157356,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.980419+00:00"
+                "validatedAt": "2026-07-20T14:41:42.805771+00:00"
               },
               "deterministic": true
             },
@@ -157554,9 +157368,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.405958+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.310994+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -157588,7 +157401,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.980446+00:00"
+                "validatedAt": "2026-07-20T14:41:42.805785+00:00"
               },
               "deterministic": true
             },
@@ -157600,9 +157413,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.405977+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.311006+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "top_by_metric": {
             "allOf": [
@@ -157709,7 +157521,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.980508+00:00"
+                "validatedAt": "2026-07-20T14:41:42.805814+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -157812,7 +157624,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.980573+00:00"
+                "validatedAt": "2026-07-20T14:41:42.805846+00:00"
               },
               "deterministic": true
             },
@@ -157852,7 +157664,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.980600+00:00"
+                "validatedAt": "2026-07-20T14:41:42.805859+00:00"
               },
               "deterministic": true
             },
@@ -157864,9 +157676,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.406032+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.311038+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -157898,7 +157709,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.980626+00:00"
+                "validatedAt": "2026-07-20T14:41:42.805872+00:00"
               },
               "deterministic": true
             },
@@ -157910,9 +157721,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.406056+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.311049+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "topk": {
             "type": "integer",
@@ -158086,7 +157896,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.980727+00:00"
+                "validatedAt": "2026-07-20T14:41:42.805910+00:00"
               },
               "deterministic": true
             },
@@ -158126,7 +157936,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.980754+00:00"
+                "validatedAt": "2026-07-20T14:41:42.805923+00:00"
               },
               "deterministic": true
             },
@@ -158138,9 +157948,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.406103+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.311077+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -158172,7 +157981,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.980781+00:00"
+                "validatedAt": "2026-07-20T14:41:42.805936+00:00"
               },
               "deterministic": true
             },
@@ -158184,9 +157993,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.406121+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.311089+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Request model for GetVulnerabilitiesReq API.",
@@ -158420,7 +158228,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:11:02.981015+00:00"
+                "validatedAt": "2026-07-20T14:41:42.806030+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -158499,7 +158307,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:11:02.981066+00:00"
+                "validatedAt": "2026-07-20T14:41:42.806053+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -158510,7 +158318,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.406241+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.311159+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -158597,7 +158405,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.981107+00:00"
+                "validatedAt": "2026-07-20T14:41:42.806072+00:00"
               },
               "deterministic": true
             },
@@ -158609,9 +158417,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.406286+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.311186+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -158642,7 +158449,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.981133+00:00"
+                "validatedAt": "2026-07-20T14:41:42.806085+00:00"
               },
               "deterministic": true
             },
@@ -158654,9 +158461,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.406305+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.311197+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -158725,7 +158531,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:02.981186+00:00"
+                "validatedAt": "2026-07-20T14:41:42.806106+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -158737,7 +158543,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.406342+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.311220+00:00"
           },
           "uid": {
             "type": "string",
@@ -158754,7 +158560,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:02.981212+00:00"
+                "validatedAt": "2026-07-20T14:41:42.806117+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -158767,7 +158573,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.406362+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.311232+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of virtual_host is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -159261,7 +159067,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:11:02.981307+00:00"
+                "validatedAt": "2026-07-20T14:41:42.806156+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -159339,7 +159145,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:11:02.981341+00:00"
+                "validatedAt": "2026-07-20T14:41:42.806172+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -159377,7 +159183,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:02.981374+00:00"
+                "validatedAt": "2026-07-20T14:41:42.806186+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -159488,7 +159294,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.406545+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.311337+00:00"
           }
         },
         "x-f5xc-description-short": "Most recently observed status of object.",
@@ -159545,7 +159351,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:02.981499+00:00"
+                "validatedAt": "2026-07-20T14:41:42.806234+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -159643,7 +159449,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.981570+00:00"
+                "validatedAt": "2026-07-20T14:41:42.806267+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -159695,7 +159501,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.981620+00:00"
+                "validatedAt": "2026-07-20T14:41:42.806294+00:00"
               },
               "deterministic": true
             },
@@ -159707,9 +159513,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.406593+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.311366+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -159748,7 +159553,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.981677+00:00"
+                "validatedAt": "2026-07-20T14:41:42.806319+00:00"
               },
               "deterministic": true
             },
@@ -159760,9 +159565,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.406612+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.311377+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "ticket_uid": {
             "type": "string",
@@ -159785,7 +159589,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.981734+00:00"
+                "validatedAt": "2026-07-20T14:41:42.806346+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -159916,7 +159720,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:02.981776+00:00"
+                "validatedAt": "2026-07-20T14:41:42.806364+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -159955,7 +159759,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.981804+00:00"
+                "validatedAt": "2026-07-20T14:41:42.806377+00:00"
               },
               "deterministic": true
             },
@@ -159967,9 +159771,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.406667+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.311405+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -160001,7 +159804,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.981831+00:00"
+                "validatedAt": "2026-07-20T14:41:42.806391+00:00"
               },
               "deterministic": true
             },
@@ -160013,9 +159816,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.406687+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.311418+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -160088,7 +159890,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.981883+00:00"
+                "validatedAt": "2026-07-20T14:41:42.806416+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -160128,7 +159930,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.981912+00:00"
+                "validatedAt": "2026-07-20T14:41:42.806431+00:00"
               },
               "deterministic": true
             },
@@ -160140,9 +159942,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.406713+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.311434+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -160174,7 +159975,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.981940+00:00"
+                "validatedAt": "2026-07-20T14:41:42.806445+00:00"
               },
               "deterministic": true
             },
@@ -160186,9 +159987,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.406731+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.311445+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Request shape for Update API Endpoints Schemas.",
@@ -160321,7 +160121,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:02.981999+00:00"
+                "validatedAt": "2026-07-20T14:41:42.806468+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -160333,7 +160133,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.406767+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.311466+00:00"
           },
           "name": {
             "type": "string",
@@ -160364,7 +160164,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.982025+00:00"
+                "validatedAt": "2026-07-20T14:41:42.806482+00:00"
               },
               "deterministic": true
             },
@@ -160376,9 +160176,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.406785+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.311477+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -160410,7 +160209,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.982052+00:00"
+                "validatedAt": "2026-07-20T14:41:42.806496+00:00"
               },
               "deterministic": true
             },
@@ -160422,9 +160221,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.406803+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.311489+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "vuln_id": {
             "type": "string",
@@ -160447,7 +160245,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:02.982089+00:00"
+                "validatedAt": "2026-07-20T14:41:42.806511+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -160592,7 +160390,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.982141+00:00"
+                "validatedAt": "2026-07-20T14:41:42.806537+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -160626,7 +160424,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:02.982185+00:00"
+                "validatedAt": "2026-07-20T14:41:42.806560+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -160777,7 +160575,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:02.982225+00:00"
+                "validatedAt": "2026-07-20T14:41:42.806576+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -160833,7 +160631,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:02.982282+00:00"
+                "validatedAt": "2026-07-20T14:41:42.806598+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -160912,7 +160710,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:02.982333+00:00"
+                "validatedAt": "2026-07-20T14:41:42.806618+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -161161,7 +160959,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:02.982387+00:00"
+                "validatedAt": "2026-07-20T14:41:42.806639+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -161201,7 +160999,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:02.982431+00:00"
+                "validatedAt": "2026-07-20T14:41:42.806658+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -161228,7 +161026,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:11:02.982477+00:00"
+                "validatedAt": "2026-07-20T14:41:42.806678+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -161239,7 +161037,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.406939+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.311569+00:00"
           },
           "domain": {
             "type": "string",
@@ -161256,7 +161054,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:02.982511+00:00"
+                "validatedAt": "2026-07-20T14:41:42.806692+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -161268,7 +161066,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.406959+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.311581+00:00"
           },
           "evidence": {
             "allOf": [
@@ -161300,7 +161098,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:02.982556+00:00"
+                "validatedAt": "2026-07-20T14:41:42.806711+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -161367,7 +161165,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.407009+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.311611+00:00"
           },
           "status_change_time": {
             "type": "string",
@@ -161386,7 +161184,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:02.982626+00:00"
+                "validatedAt": "2026-07-20T14:41:42.806736+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -161423,7 +161221,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:02.982670+00:00"
+                "validatedAt": "2026-07-20T14:41:42.806751+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -161434,7 +161232,7 @@
             },
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.407041+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.311631+00:00"
           },
           "vuln_id": {
             "type": "string",
@@ -161450,7 +161248,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:02.982705+00:00"
+                "validatedAt": "2026-07-20T14:41:42.806766+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -161709,7 +161507,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:22.046853+00:00"
+                "validatedAt": "2026-07-20T14:41:49.826500+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -161720,7 +161518,7 @@
             },
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.767484+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.733841+00:00"
           }
         },
         "x-f5xc-description-short": "Label based filtering of WAF metrics. WAF metrics are tagged with labels mentioned in MetricLabel.",
@@ -161792,7 +161590,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:22.046901+00:00"
+                "validatedAt": "2026-07-20T14:41:49.826543+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -161866,7 +161664,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:22.046965+00:00"
+                "validatedAt": "2026-07-20T14:41:49.826598+00:00"
               },
               "deterministic": true
             },
@@ -161878,9 +161676,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.767525+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.733865+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "range": {
             "type": "string",
@@ -161905,7 +161702,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:22.047001+00:00"
+                "validatedAt": "2026-07-20T14:41:49.826628+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -161938,7 +161735,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:22.047041+00:00"
+                "validatedAt": "2026-07-20T14:41:49.826660+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -161971,7 +161768,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:22.047076+00:00"
+                "validatedAt": "2026-07-20T14:41:49.826689+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -162070,7 +161867,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:22.047121+00:00"
+                "validatedAt": "2026-07-20T14:41:49.826727+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -162215,7 +162012,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:22.047174+00:00"
+                "validatedAt": "2026-07-20T14:41:49.826769+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -162241,7 +162038,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:22.047209+00:00"
+                "validatedAt": "2026-07-20T14:41:49.826798+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -162266,7 +162063,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:22.047243+00:00"
+                "validatedAt": "2026-07-20T14:41:49.826826+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -162292,7 +162089,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:22.047277+00:00"
+                "validatedAt": "2026-07-20T14:41:49.826854+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -162332,7 +162129,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:22.047307+00:00"
+                "validatedAt": "2026-07-20T14:41:49.826882+00:00"
               },
               "deterministic": true
             },
@@ -162344,9 +162141,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.767622+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.733919+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "rule_id": {
             "type": "string",
@@ -162364,7 +162160,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:22.047342+00:00"
+                "validatedAt": "2026-07-20T14:41:49.826909+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -162391,7 +162187,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:22.047382+00:00"
+                "validatedAt": "2026-07-20T14:41:49.826941+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -162417,7 +162213,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:22.047417+00:00"
+                "validatedAt": "2026-07-20T14:41:49.826970+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -162443,7 +162239,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:22.047451+00:00"
+                "validatedAt": "2026-07-20T14:41:49.826997+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -162469,7 +162265,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:22.047482+00:00"
+                "validatedAt": "2026-07-20T14:41:49.827022+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -162495,7 +162291,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:22.047522+00:00"
+                "validatedAt": "2026-07-20T14:41:49.827054+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -162520,7 +162316,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:22.047563+00:00"
+                "validatedAt": "2026-07-20T14:41:49.827086+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -162610,7 +162406,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:22.047602+00:00"
+                "validatedAt": "2026-07-20T14:41:49.827119+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -162684,7 +162480,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:22.047661+00:00"
+                "validatedAt": "2026-07-20T14:41:49.827164+00:00"
               },
               "deterministic": true
             },
@@ -162696,9 +162492,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.767718+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.733989+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "range": {
             "type": "string",
@@ -162723,7 +162518,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:22.047700+00:00"
+                "validatedAt": "2026-07-20T14:41:49.827194+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -162756,7 +162551,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:22.047740+00:00"
+                "validatedAt": "2026-07-20T14:41:49.827226+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -162789,7 +162584,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:22.047774+00:00"
+                "validatedAt": "2026-07-20T14:41:49.827253+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -162888,7 +162683,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:22.047819+00:00"
+                "validatedAt": "2026-07-20T14:41:49.827289+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -163034,7 +162829,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:22.047873+00:00"
+                "validatedAt": "2026-07-20T14:41:49.827330+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -163060,7 +162855,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:22.047907+00:00"
+                "validatedAt": "2026-07-20T14:41:49.827358+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -163085,7 +162880,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:22.047943+00:00"
+                "validatedAt": "2026-07-20T14:41:49.827386+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -163111,7 +162906,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:22.047978+00:00"
+                "validatedAt": "2026-07-20T14:41:49.827414+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -163151,7 +162946,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:22.048008+00:00"
+                "validatedAt": "2026-07-20T14:41:49.827442+00:00"
               },
               "deterministic": true
             },
@@ -163163,9 +162958,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.767814+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.734046+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "service": {
             "type": "string",
@@ -163183,7 +162977,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:22.048041+00:00"
+                "validatedAt": "2026-07-20T14:41:49.827469+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -163209,7 +163003,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:22.048071+00:00"
+                "validatedAt": "2026-07-20T14:41:49.827494+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -163235,7 +163029,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:22.048109+00:00"
+                "validatedAt": "2026-07-20T14:41:49.827525+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -163260,7 +163054,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:22.048150+00:00"
+                "validatedAt": "2026-07-20T14:41:49.827556+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -163286,7 +163080,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:22.048185+00:00"
+                "validatedAt": "2026-07-20T14:41:49.827585+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -163366,7 +163160,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:25.455089+00:00"
+                "validatedAt": "2026-07-20T14:41:51.226549+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -163406,7 +163200,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:25.455119+00:00"
+                "validatedAt": "2026-07-20T14:41:51.226562+00:00"
               },
               "deterministic": true
             },
@@ -163418,9 +163212,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.814950+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.783920+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-description-short": "Represents a category of vulnerability as defined in the OWASP API Top 10.",
@@ -163495,7 +163288,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:27.617484+00:00"
+                "validatedAt": "2026-07-20T14:41:52.054289+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -163601,7 +163394,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:27.617529+00:00"
+                "validatedAt": "2026-07-20T14:41:52.054312+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -163703,7 +163496,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:27.617573+00:00"
+                "validatedAt": "2026-07-20T14:41:52.054333+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -163997,7 +163790,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:27.617624+00:00"
+                "validatedAt": "2026-07-20T14:41:52.054356+00:00"
               },
               "deterministic": true
             },
@@ -164009,9 +163802,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.924296+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.862763+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -164043,7 +163835,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:27.617651+00:00"
+                "validatedAt": "2026-07-20T14:41:52.054369+00:00"
               },
               "deterministic": true
             },
@@ -164055,9 +163847,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.924314+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.862775+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -164227,7 +164018,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.924380+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.862813+00:00"
           },
           "system_metadata": {
             "allOf": [
@@ -164329,7 +164120,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:11:27.617773+00:00"
+                "validatedAt": "2026-07-20T14:41:52.054414+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -164415,7 +164206,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-07-20T13:11:27.617824+00:00"
+                "validatedAt": "2026-07-20T14:41:52.054438+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -164426,7 +164217,7 @@
             },
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.924430+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.862841+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -164513,7 +164304,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:27.617864+00:00"
+                "validatedAt": "2026-07-20T14:41:52.054456+00:00"
               },
               "deterministic": true
             },
@@ -164525,9 +164316,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.924475+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.862868+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "namespace": {
             "type": "string",
@@ -164558,7 +164348,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:27.617892+00:00"
+                "validatedAt": "2026-07-20T14:41:52.054469+00:00"
               },
               "deterministic": true
             },
@@ -164570,9 +164360,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.924494+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.862879+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "owner_view": {
             "allOf": [
@@ -164641,7 +164430,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:27.617944+00:00"
+                "validatedAt": "2026-07-20T14:41:52.054490+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -164653,7 +164442,7 @@
             "x-field-mutability": "read-only",
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.924531+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.862902+00:00"
           },
           "uid": {
             "type": "string",
@@ -164671,7 +164460,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:27.617970+00:00"
+                "validatedAt": "2026-07-20T14:41:52.054501+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -164684,7 +164473,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:25.924550+00:00"
+            "x-reconciled-at": "2026-07-20T14:42:25.862913+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of waf_exclusion_policy is returned in 'List'.",
@@ -164992,7 +164781,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:31.347322+00:00"
+                "validatedAt": "2026-07-20T14:41:53.416406+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -165140,7 +164929,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:31.347448+00:00"
+                "validatedAt": "2026-07-20T14:41:53.416441+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -165165,7 +164954,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:31.347515+00:00"
+                "validatedAt": "2026-07-20T14:41:53.416457+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -165188,7 +164977,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:31.347568+00:00"
+                "validatedAt": "2026-07-20T14:41:53.416470+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -165216,7 +165005,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-07-20T13:11:31.347613+00:00"
+                "validatedAt": "2026-07-20T14:41:53.416490+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -165243,7 +165032,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:31.347641+00:00"
+                "validatedAt": "2026-07-20T14:41:53.416501+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -165268,7 +165057,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:31.347689+00:00"
+                "validatedAt": "2026-07-20T14:41:53.416515+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -165294,7 +165083,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:31.347730+00:00"
+                "validatedAt": "2026-07-20T14:41:53.416531+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -165333,7 +165122,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:31.347764+00:00"
+                "validatedAt": "2026-07-20T14:41:53.416547+00:00"
               },
               "deterministic": true
             },
@@ -165345,9 +165134,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:26.013500+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.969296+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "state": {
             "type": "string",
@@ -165364,7 +165152,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:31.347799+00:00"
+                "validatedAt": "2026-07-20T14:41:53.416561+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -165441,7 +165229,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:31.347835+00:00"
+                "validatedAt": "2026-07-20T14:41:53.416576+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -165481,7 +165269,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-07-20T13:11:31.347865+00:00"
+                "validatedAt": "2026-07-20T14:41:53.416589+00:00"
               },
               "deterministic": true
             },
@@ -165493,9 +165281,8 @@
             },
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-07-20T13:12:26.013536+00:00",
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
-            "format": "dns-label"
+            "x-reconciled-at": "2026-07-20T14:42:25.969316+00:00",
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "start_time": {
             "type": "string",
@@ -165513,7 +165300,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:31.347902+00:00"
+                "validatedAt": "2026-07-20T14:41:53.416604+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -165538,7 +165325,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-07-20T13:11:31.347936+00:00"
+                "validatedAt": "2026-07-20T14:41:53.416617+00:00"
               }
             },
             "x-f5xc-required-for": {

--- a/docs/specifications/api/vpm_and_node_management.json
+++ b/docs/specifications/api/vpm_and_node_management.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Vpm And Node Management",
     "description": "APIs for configuring node policies, fleet management, and lifecycle operations. Supports node registration, configuration deployment, and status monitoring across distributed infrastructure.",
-    "version": "2.1.182",
+    "version": "2.1.181",
     "contact": {
       "name": "F5 Distributed Cloud",
       "url": "https://docs.cloud.f5.com"

--- a/scripts/utils/schema_constraint_projector.py
+++ b/scripts/utils/schema_constraint_projector.py
@@ -6,8 +6,10 @@ A downstream consumer using a standard OpenAPI/JSON-Schema validator or code
 generator does not read vendor extensions, so it cannot pull those rules
 deterministically. This projector runs dead-last in the pipeline (after all
 enrichers and the constraint reconciler) and mirrors the naming constraint's
-``pattern``/``minLength``/``maxLength``/``format`` up to the standard property
-level, overwriting any stale generic value a prior stage may have left there.
+``pattern``/``minLength``/``maxLength`` up to the standard property level,
+overwriting any stale generic value a prior stage may have left there. The
+custom ``format`` (``dns-label``/``fqdn``) is deliberately NOT mirrored — it is
+not a registered OpenAPI format and stays in ``x-f5xc-constraints``.
 
 Scope: only ``category == "naming"`` constraints are projected, keeping this a
 targeted change that serves the resource-naming use case without altering the
@@ -26,7 +28,13 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 # Standard JSON-Schema keywords that are safe and meaningful to mirror.
-_MIRRORED_KEYS = ("pattern", "minLength", "maxLength", "format")
+# NOTE: `format` is intentionally excluded. The naming formats (`dns-label`,
+# `fqdn`) are custom vendor semantics, not registered OpenAPI formats, so
+# writing them to the standard `format` keyword would break the API contract
+# (contract-diff gate: only registered formats are additive) and mislead
+# standard tooling. The custom format stays in `x-f5xc-constraints`; the
+# mirrored `pattern` already encodes the real rule.
+_MIRRORED_KEYS = ("pattern", "minLength", "maxLength")
 _CONSTRAINT_KEY = "x-f5xc-constraints"
 _NAMING_CATEGORY = "naming"
 # Naming/identifier formats that must be projected regardless of the constraint's

--- a/tests/test_naming_constraints_specs.py
+++ b/tests/test_naming_constraints_specs.py
@@ -49,14 +49,16 @@ def test_create_meta_name_is_dns1035_everywhere():
     assert entries, "expected schemaObjectCreateMetaType in generated specs"
     for filename, name in entries:
         # Standard JSON-Schema keys (projected — pullable by any consumer).
+        # `format` is intentionally NOT projected (dns-label is a custom vendor
+        # format, kept only in x-f5xc-constraints); `pattern` carries the rule.
         assert name.get("pattern") == DNS_1035, f"{filename}: standard pattern"
         assert name.get("minLength") == 1, f"{filename}: standard minLength"
         assert name.get("maxLength") == 63, f"{filename}: standard maxLength (API enforces 63)"
-        assert name.get("format") == "dns-label", f"{filename}: standard format"
-        # Vendor extension agrees.
+        # Vendor extension carries the full constraint incl. the custom format.
         c = name.get("x-f5xc-constraints", {})
         assert c.get("pattern") == DNS_1035, f"{filename}: constraint pattern"
         assert c.get("maxLength") == 63, f"{filename}: constraint maxLength"
+        assert c.get("format") == "dns-label", f"{filename}: constraint format"
 
 
 def test_no_native_name_claims_1024_maxlength():

--- a/tests/test_schema_constraint_projector.py
+++ b/tests/test_schema_constraint_projector.py
@@ -51,7 +51,10 @@ def test_projects_naming_constraint_to_standard_keys():
     assert name["pattern"] == DNS_1035
     assert name["minLength"] == 1
     assert name["maxLength"] == 63
-    assert name["format"] == "dns-label"
+    # Custom vendor format stays in the extension, NOT the standard schema
+    # (dns-label is not a registered OpenAPI format).
+    assert "format" not in name
+    assert name["x-f5xc-constraints"]["format"] == "dns-label"
 
 
 def test_overwrites_stale_standard_values():


### PR DESCRIPTION
Closes #1010. Follow-up to #1004 / #1003.

## Problem

#1004 auto-merged at its first commit (the Contract-diff gate is non-blocking), shipping a projector that mirrored the **custom** `format` (`dns-label`/`fqdn`) onto the **standard** JSON-Schema `format` keyword. Those aren't registered OpenAPI formats, so the **Contract-diff gate now fails on `main`** (1470 `constraint-change` violations).

## Fix

- `SchemaConstraintProjector` mirrors only `pattern`/`minLength`/`maxLength` to the standard schema — all additive-safe per the contract allowlist, and `pattern` already encodes the DNS rule.
- Custom `format` stays in `x-f5xc-constraints` (unchanged).
- Specs regenerated.

## Verification

- `python -m scripts.contract_diff --input specs/original --output docs/specifications/api` → **No violations**.
- Native `name`/`namespace` keep standard `pattern`/`minLength`/`maxLength` (DNS-1035, 1–63); `x-f5xc-constraints.format` unchanged (`dns-label`).
- Full suite: **2152 passed**, 2 skipped, 1 xfailed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
