### PR TITLE
fix(ci): least-privilege permissions and env-bound expansions

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -10,6 +10,10 @@ on:
     branches:
       - 'version-bump/**'
 
+# Read-only: the single job just echoes and exits.
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/sync-and-enrich.yml
+++ b/.github/workflows/sync-and-enrich.yml
@@ -15,13 +15,16 @@ on:
       - 'docs/**/*.html'
   workflow_dispatch:
 
+# Read-only default; each job declares what it consumes. Traced per write:
+#   sync-and-enrich  contents: write   `gh release create` runs as GITHUB_TOKEN
+#   deploy-docs      pages + id-token  actions/deploy-pages
+#   monitor-failures issues: write     opens/updates the failure issue as GITHUB_TOKEN
+# Two of the previous workflow-wide scopes had no GITHUB_TOKEN consumer at all and
+# are gone rather than pushed down: `pull-requests: write`, because every `gh pr`
+# call authenticates with VERSION_BUMP_PAT (as do the pushes, via an explicit
+# remote URL), and `actions: read`, because nothing reads the Actions API.
 permissions:
-  contents: write
-  pages: write
-  id-token: write
-  issues: write
-  actions: read
-  pull-requests: write
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -94,6 +97,11 @@ jobs:
     needs: check-updates
     if: needs.check-updates.outputs.has_updates == 'true'
     runs-on: ubuntu-latest
+    # `gh release create` runs as GITHUB_TOKEN and needs contents: write. The
+    # branch pushes, PR create/merge/close and tag push all authenticate with
+    # VERSION_BUMP_PAT instead, so no pull-requests scope is required here.
+    permissions:
+      contents: write
     outputs:
       version: ${{ steps.version.outputs.new_version }}
       has_changes: ${{ steps.version.outputs.has_changes }}
@@ -369,8 +377,9 @@ jobs:
 
       - name: Update version in specs
         if: steps.version.outputs.has_changes == 'true'
+        env:
+          VERSION: ${{ steps.version.outputs.new_version }}
         run: |
-          VERSION="${{ steps.version.outputs.new_version }}"
           echo "Updating specs to version: $VERSION"
 
           # Update index.json
@@ -389,8 +398,9 @@ jobs:
 
       - name: Verify version consistency
         if: steps.version.outputs.has_changes == 'true'
+        env:
+          EXPECTED_VERSION: ${{ steps.version.outputs.new_version }}
         run: |
-          EXPECTED_VERSION="${{ steps.version.outputs.new_version }}"
           INDEX_VERSION=$(jq -r '.version' docs/specifications/api/index.json)
 
           if [ "$EXPECTED_VERSION" != "$INDEX_VERSION" ]; then
@@ -402,8 +412,9 @@ jobs:
 
       - name: Align catalog version with release
         if: steps.version.outputs.has_changes == 'true'
+        env:
+          VERSION: ${{ steps.version.outputs.new_version }}
         run: |
-          VERSION="${{ steps.version.outputs.new_version }}"
           if [ -f release/api-catalog.json ]; then
             jq --arg v "$VERSION" '.version = $v' release/api-catalog.json > /tmp/catalog.json
             mv /tmp/catalog.json release/api-catalog.json
@@ -428,22 +439,23 @@ jobs:
 
       - name: Generate changelog
         if: steps.version.outputs.has_changes == 'true'
+        env:
+          VERSION: ${{ steps.version.outputs.new_version }}
+          BUMP_TYPE: ${{ steps.version.outputs.bump_type }}
+          HAS_DISCOVERY: ${{ steps.check-discovery.outputs.has_discovery }}
+          DISCOVERY_ENDPOINTS: ${{ steps.discovery-summary.outputs.endpoints_total }}
+          DISCOVERY_SUCCESS: ${{ steps.discovery-summary.outputs.endpoints_success }}
+          DISCOVERY_TIMESTAMP: ${{ steps.discovery-summary.outputs.discovery_timestamp }}
         run: |
-          VERSION="${{ steps.version.outputs.new_version }}"
-          BUMP_TYPE="${{ steps.version.outputs.bump_type }}"
           DATE=$(date -u +"%Y-%m-%d")
 
           # Extract upstream info from index.json
           UPSTREAM_TS=$(jq -r '."x-upstream-timestamp" // "unknown"' docs/specifications/api/index.json)
           UPSTREAM_ETAG=$(jq -r '."x-upstream-etag" // "unknown"' docs/specifications/api/index.json)
-          ENRICHED_VER=$(jq -r '."x-enriched-version" // "'$VERSION'"' docs/specifications/api/index.json)
+          ENRICHED_VER=$(jq -r '."x-enriched-version" // "'"$VERSION"'"' docs/specifications/api/index.json)
           FULL_VERSION=$(jq -r '.version' docs/specifications/api/index.json)
 
-          # Discovery info (if available)
-          HAS_DISCOVERY="${{ steps.check-discovery.outputs.has_discovery }}"
-          DISCOVERY_ENDPOINTS="${{ steps.discovery-summary.outputs.endpoints_total }}"
-          DISCOVERY_SUCCESS="${{ steps.discovery-summary.outputs.endpoints_success }}"
-          DISCOVERY_TIMESTAMP="${{ steps.discovery-summary.outputs.discovery_timestamp }}"
+          # Discovery info (if available) arrives via env — see the step's env block.
 
           # Preserve existing changelog entries (prepend-only strategy to avoid merge conflicts)
           EXISTING_ENTRIES=""
@@ -636,14 +648,15 @@ jobs:
 
       - name: Create release package
         if: steps.version.outputs.has_changes == 'true'
+        env:
+          VERSION: ${{ steps.version.outputs.new_version }}
         run: |
-          VERSION="${{ steps.version.outputs.new_version }}"
           RELEASE_DIR="release-package"
           DATE=$(date -u +"%Y-%m-%d")
 
           # Extract upstream info from index.json
           UPSTREAM_TS=$(jq -r '."x-upstream-timestamp" // "unknown"' docs/specifications/api/index.json)
-          ENRICHED_VER=$(jq -r '."x-enriched-version" // "'$VERSION'"' docs/specifications/api/index.json)
+          ENRICHED_VER=$(jq -r '."x-enriched-version" // "'"$VERSION"'"' docs/specifications/api/index.json)
 
           # Create ZIP filename
           ZIP_NAME="f5xc-api-specs-v${VERSION}.zip"
@@ -707,9 +720,8 @@ jobs:
         if: steps.version.outputs.has_changes == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.new_version }}
         run: |
-          VERSION="${{ steps.version.outputs.new_version }}"
-
           # Check if release already exists
           if gh release view "v$VERSION" >/dev/null 2>&1; then
             echo "Release v$VERSION already exists, skipping"
@@ -733,6 +745,11 @@ jobs:
     needs: sync-and-enrich
     if: needs.sync-and-enrich.outputs.has_changes == 'true'
     runs-on: ubuntu-latest
+    # actions/deploy-pages needs both of these; id-token is for its OIDC exchange.
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -839,6 +856,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: [check-updates, sync-and-enrich, deploy-docs, build-downstream-matrix, notify-downstream]
     if: always()
+    # Ensures the monitoring labels exist and opens or updates the failure issue,
+    # both as GITHUB_TOKEN.
+    permissions:
+      contents: read
+      issues: write
     steps:
       - name: Check for failures
         id: check_failure


### PR DESCRIPTION
## Problem

The scheduled Workflow Security Audit (docs-control#775) fails on this repo with 17
findings: **5 excessive-permissions + 11 template-injections** in `sync-and-enrich.yml`,
and **1 excessive-permissions** in `pr-check.yml`.

## Change

### Permissions — traced per write, not guessed

`sync-and-enrich.yml` granted six write scopes at the workflow level, so all six jobs held
all of them. I traced every write the pipeline performs to the token that authorises it:

| Scope | Kept on | Why |
|---|---|---|
| `contents: write` | `sync-and-enrich` | `gh release create` runs as `GITHUB_TOKEN` |
| `pages: write`, `id-token: write` | `deploy-docs` | `actions/deploy-pages` + its OIDC exchange |
| `issues: write` | `monitor-failures` | opens/updates the failure issue as `GITHUB_TOKEN` |
| `pull-requests: write` | **dropped entirely** | every `gh pr create/merge/close` uses `VERSION_BUMP_PAT`; the branch and tag pushes use it too, via an explicit `git remote set-url` |
| `actions: read` | **dropped entirely** | nothing reads the Actions API — no `gh run`, no `/actions/` call |

`check-updates`, `build-downstream-matrix` and `notify-downstream` write nothing and inherit
the read-only default (`notify-downstream` dispatches with `DOWNSTREAM_DISPATCH_TOKEN`).

`pr-check.yml`'s only job echoes and exits, so it is read-only.

### Template injections

All 11 are step outputs computed inside the workflow (version, bump type, discovery
counts), so none carries untrusted data. Bound through `env:` anyway — it keeps the audit
enabled on the file, and the gate requires it (super-linter fails on zizmor's non-zero
exit, which any severity produces).

### One thing I broke and fixed

Binding `VERSION` as env changed how shellcheck reads two `jq` fallbacks that spliced it in
unquoted — `// "'$VERSION'"` — raising **SC2086** where `main` was clean. I verified this
was mine, not pre-existing (`actionlint` exits 0 on `main`). Both are now
`// "'"$VERSION"'"`, and I checked both the fallback and present-value paths still resolve
identically:

```
fallback path: 1.2.3     present path: 9.9.9
```

## Verification

Run with zizmor **1.25.2**, the version super-linter pins.

| | exit | findings |
|---|---|---|
| before | 14 | 5 high, 1 medium, 11 informational |
| after | **0** | **none, any severity** |

`actionlint` clean.

This is the repo's release and Pages pipeline, and it is the highest-risk change in this
sweep — six jobs, a PAT-authenticated PR-merge-and-tag flow, and a Pages deploy. Every
scope a job actually consumes is retained, but the next real sync should be confirmed by
artifact: that the release appears, Pages republishes, and the downstream dispatches land.
A green check here would not prove any of that.

Closes #1068
