### PR TITLE
feat(extensions): register x-f5xc-wire-name as a known extension

### DIFF
--- a/config/extension_registry.yaml
+++ b/config/extension_registry.yaml
@@ -428,6 +428,21 @@ property_level:
         confidence: 0.95
         validatedAt: "2026-01-19T00:00:00Z"
 
+  x-f5xc-wire-name:
+    type: string
+    purpose: >-
+      Original upstream property key that must be used on the wire. The buffer
+      zone (api-specs) renames F5's misspelled property names and records the
+      original key here; the F5 server accepts only the original spelling.
+    consumers: [terraform]
+    source: "upstream pass-through from f5-sales-demo/api-specs (never injected here)"
+    example: "blocked_sevice"
+    issue: "api-specs#686"
+    note: >-
+      Code generators that build API requests must send this key, not the
+      presented property name. Emitting the corrected name makes F5 silently
+      discard the field (terraform-provider-xcsh#1257).
+
   x-f5xc-console-field:
     type: object
     purpose: Console form widget metadata for this API property

--- a/docs/ar/extensions/catalog.md
+++ b/docs/ar/extensions/catalog.md
@@ -2,7 +2,7 @@
 title: كتالوج امتدادات الإثراء
 description: المرجع المعتمد لكل امتداد x-* في مواصفات OpenAPI المحسّنة
 i18n:
-  sourceHash: d286a6006907
+  sourceHash: 5d455612b759
   translator: machine
 ---
 
@@ -904,4 +904,16 @@ i18n:
 - **Injected by:** upstream
 - **Driven by config:** upstream
 - **Example:** راجع وثائق F5 الأصلية.
+- **Pass-through from upstream:** yes
+
+### x-f5xc-wire-name
+
+- **Applied at:** schema property
+- **Purpose:** مفتاح الخاصية الأصلي من المصدر الذي يجب إرساله في الطلب. تعيد المنطقة الوسيطة تسمية أسماء الخصائص المكتوبة بشكل خاطئ في F5 وتسجل المفتاح الأصلي هنا، لأن خادم F5 لا يقبل سوى التهجئة الأصلية.
+- **Consumers:** Terraform
+- **Value type:** string
+- **Value schema:** `{"type": "string"}`
+- **Injected by:** upstream (f5-sales-demo/api-specs)
+- **Driven by config:** upstream
+- **Example:** `"blocked_service": {"x-f5xc-wire-name": "blocked_sevice"}`
 - **Pass-through from upstream:** yes

--- a/docs/de/extensions/catalog.md
+++ b/docs/de/extensions/catalog.md
@@ -4,7 +4,7 @@ description: >-
   Maßgebliche Referenz für jede x-* Erweiterung in den erweiterten
   OpenAPI-Spezifikationen
 i18n:
-  sourceHash: d286a6006907
+  sourceHash: 5d455612b759
   translator: machine
 ---
 
@@ -907,4 +907,16 @@ solange der `### x-name`-Header vorhanden ist und das
 - **Injected by:** upstream
 - **Driven by config:** upstream
 - **Example:** Siehe F5-Upstream-Dokumentation.
+- **Pass-through from upstream:** yes
+
+### x-f5xc-wire-name
+
+- **Applied at:** schema property
+- **Purpose:** Ursprünglicher vorgelagerter Eigenschaftsschlüssel, der auf dem Übertragungsweg verwendet werden muss. Die Pufferzone benennt die falsch geschriebenen Eigenschaftsnamen von F5 um und hinterlegt hier den ursprünglichen Schlüssel, da der F5-Server nur die ursprüngliche Schreibweise akzeptiert.
+- **Consumers:** Terraform
+- **Value type:** string
+- **Value schema:** `{"type": "string"}`
+- **Injected by:** upstream (f5-sales-demo/api-specs)
+- **Driven by config:** upstream
+- **Example:** `"blocked_service": {"x-f5xc-wire-name": "blocked_sevice"}`
 - **Pass-through from upstream:** yes

--- a/docs/en/extensions/catalog.md
+++ b/docs/en/extensions/catalog.md
@@ -903,3 +903,15 @@ stubby as long as the `### x-name` header exists and the
 - **Driven by config:** upstream
 - **Example:** See F5 upstream docs.
 - **Pass-through from upstream:** yes
+
+### x-f5xc-wire-name
+
+- **Applied at:** schema property
+- **Purpose:** Original upstream property key that must appear on the wire. The buffer zone renames F5's misspelled property names and records the original key here, because the F5 server accepts only the original spelling.
+- **Consumers:** Terraform
+- **Value type:** string
+- **Value schema:** `{"type": "string"}`
+- **Injected by:** upstream (f5-sales-demo/api-specs)
+- **Driven by config:** upstream
+- **Example:** `"blocked_service": {"x-f5xc-wire-name": "blocked_sevice"}`
+- **Pass-through from upstream:** yes

--- a/docs/es/extensions/catalog.md
+++ b/docs/es/extensions/catalog.md
@@ -4,7 +4,7 @@ description: >-
   Fuente de verdad para cada extensión x-* en las especificaciones OpenAPI
   enriquecidas
 i18n:
-  sourceHash: d286a6006907
+  sourceHash: 5d455612b759
   translator: machine
 ---
 
@@ -906,4 +906,16 @@ escueto, siempre que exista el encabezado `### x-name` y el indicador
 - **Injected by:** upstream
 - **Driven by config:** upstream
 - **Example:** Consulte la documentación upstream de F5.
+- **Pass-through from upstream:** yes
+
+### x-f5xc-wire-name
+
+- **Applied at:** schema property
+- **Purpose:** Clave de propiedad upstream original que debe enviarse por la red. La zona de amortiguación renombra los nombres de propiedad mal escritos de F5 y registra aquí la clave original, porque el servidor de F5 solo acepta la ortografía original.
+- **Consumers:** Terraform
+- **Value type:** string
+- **Value schema:** `{"type": "string"}`
+- **Injected by:** upstream (f5-sales-demo/api-specs)
+- **Driven by config:** upstream
+- **Example:** `"blocked_service": {"x-f5xc-wire-name": "blocked_sevice"}`
 - **Pass-through from upstream:** yes

--- a/docs/fr/extensions/catalog.md
+++ b/docs/fr/extensions/catalog.md
@@ -4,7 +4,7 @@ description: >-
   Source de vérité pour chaque extension x-* dans les spécifications OpenAPI
   enrichies
 i18n:
-  sourceHash: d286a6006907
+  sourceHash: 5d455612b759
   translator: machine
 ---
 
@@ -906,4 +906,16 @@ Chaque entrée ci-dessous possède exactement cette forme. Le test de parité da
 - **Injected by:** upstream
 - **Driven by config:** upstream
 - **Example:** Voir la documentation F5 en amont.
+- **Pass-through from upstream:** yes
+
+### x-f5xc-wire-name
+
+- **Applied at:** schema property
+- **Purpose:** Clé de propriété d'origine en amont qui doit apparaître sur le réseau. La zone tampon renomme les noms de propriétés mal orthographiés de F5 et enregistre ici la clé d'origine, car le serveur F5 n'accepte que l'orthographe d'origine.
+- **Consumers:** Terraform
+- **Value type:** string
+- **Value schema:** `{"type": "string"}`
+- **Injected by:** upstream (f5-sales-demo/api-specs)
+- **Driven by config:** upstream
+- **Example:** `"blocked_service": {"x-f5xc-wire-name": "blocked_sevice"}`
 - **Pass-through from upstream:** yes

--- a/docs/hi/extensions/catalog.md
+++ b/docs/hi/extensions/catalog.md
@@ -2,7 +2,7 @@
 title: संवर्धन एक्सटेंशन कैटलॉग
 description: संवर्धित OpenAPI विनिर्देशों में प्रत्येक x-* एक्सटेंशन का सत्य का स्रोत
 i18n:
-  sourceHash: d286a6006907
+  sourceHash: 5d455612b759
   translator: machine
 ---
 
@@ -893,4 +893,16 @@ i18n:
 - **Injected by:** upstream
 - **Driven by config:** upstream
 - **Example:** F5 अपस्ट्रीम दस्तावेज़ देखें।
+- **Pass-through from upstream:** yes
+
+### x-f5xc-wire-name
+
+- **Applied at:** schema property
+- **Purpose:** मूल अपस्ट्रीम प्रॉपर्टी कुंजी जिसे अनुरोध में भेजा जाना चाहिए। बफर ज़ोन F5 के गलत लिखे गए प्रॉपर्टी नामों को बदलता है और मूल कुंजी यहाँ दर्ज करता है, क्योंकि F5 सर्वर केवल मूल स्पेलिंग स्वीकार करता है।
+- **Consumers:** Terraform
+- **Value type:** string
+- **Value schema:** `{"type": "string"}`
+- **Injected by:** upstream (f5-sales-demo/api-specs)
+- **Driven by config:** upstream
+- **Example:** `"blocked_service": {"x-f5xc-wire-name": "blocked_sevice"}`
 - **Pass-through from upstream:** yes

--- a/docs/it/extensions/catalog.md
+++ b/docs/it/extensions/catalog.md
@@ -4,7 +4,7 @@ description: >-
   Fonte di riferimento autorevole per ogni estensione x-* nelle specifiche
   OpenAPI arricchite
 i18n:
-  sourceHash: d286a6006907
+  sourceHash: 5d455612b759
   translator: machine
 ---
 
@@ -906,4 +906,16 @@ ridotto purché l'intestazione `### x-name` esista e il flag
 - **Injected by:** upstream
 - **Driven by config:** upstream
 - **Example:** Consultare la documentazione upstream F5.
+- **Pass-through from upstream:** yes
+
+### x-f5xc-wire-name
+
+- **Applied at:** schema property
+- **Purpose:** Chiave di proprietà upstream originale che deve essere inviata nella richiesta. La zona di buffer rinomina i nomi di proprietà scritti in modo errato da F5 e registra qui la chiave originale, poiché il server F5 accetta solo la grafia originale.
+- **Consumers:** Terraform
+- **Value type:** string
+- **Value schema:** `{"type": "string"}`
+- **Injected by:** upstream (f5-sales-demo/api-specs)
+- **Driven by config:** upstream
+- **Example:** `"blocked_service": {"x-f5xc-wire-name": "blocked_sevice"}`
 - **Pass-through from upstream:** yes

--- a/docs/ja/extensions/catalog.md
+++ b/docs/ja/extensions/catalog.md
@@ -2,7 +2,7 @@
 title: エンリッチメント拡張機能カタログ
 description: エンリッチされた OpenAPI 仕様に含まれるすべての x-* 拡張機能の信頼できる情報源
 i18n:
-  sourceHash: d286a6006907
+  sourceHash: 5d455612b759
   translator: machine
 ---
 
@@ -895,4 +895,16 @@ i18n:
 - **Injected by:** upstream
 - **Driven by config:** upstream
 - **Example:** F5 アップストリームドキュメントを参照してください。
+- **Pass-through from upstream:** yes
+
+### x-f5xc-wire-name
+
+- **Applied at:** schema property
+- **Purpose:** 通信時に使用する必要があるアップストリームの元のプロパティキー。バッファゾーンは F5 のスペルミスのあるプロパティ名を変更し、元のキーをここに記録します。F5 サーバーは元のスペルのみを受け付けるためです。
+- **Consumers:** Terraform
+- **Value type:** string
+- **Value schema:** `{"type": "string"}`
+- **Injected by:** upstream (f5-sales-demo/api-specs)
+- **Driven by config:** upstream
+- **Example:** `"blocked_service": {"x-f5xc-wire-name": "blocked_sevice"}`
 - **Pass-through from upstream:** yes

--- a/docs/ko/extensions/catalog.md
+++ b/docs/ko/extensions/catalog.md
@@ -2,7 +2,7 @@
 title: 강화 확장 카탈로그
 description: 강화된 OpenAPI 사양의 모든 x-* 확장에 대한 단일 진실 공급원
 i18n:
-  sourceHash: d286a6006907
+  sourceHash: 5d455612b759
   translator: machine
 ---
 
@@ -893,4 +893,16 @@ i18n:
 - **Injected by:** upstream
 - **Driven by config:** upstream
 - **Example:** F5 업스트림 문서를 참조하십시오.
+- **Pass-through from upstream:** yes
+
+### x-f5xc-wire-name
+
+- **Applied at:** schema property
+- **Purpose:** 전송 시 사용해야 하는 업스트림 원본 속성 키입니다. 버퍼 영역은 F5의 잘못 표기된 속성 이름을 변경하고 원본 키를 여기에 기록합니다. F5 서버는 원본 표기만 허용하기 때문입니다.
+- **Consumers:** Terraform
+- **Value type:** string
+- **Value schema:** `{"type": "string"}`
+- **Injected by:** upstream (f5-sales-demo/api-specs)
+- **Driven by config:** upstream
+- **Example:** `"blocked_service": {"x-f5xc-wire-name": "blocked_sevice"}`
 - **Pass-through from upstream:** yes

--- a/docs/pt-br/extensions/catalog.md
+++ b/docs/pt-br/extensions/catalog.md
@@ -4,7 +4,7 @@ description: >-
   Fonte de referência para cada extensão x-* nas especificações OpenAPI
   enriquecidas
 i18n:
-  sourceHash: d286a6006907
+  sourceHash: 5d455612b759
   translator: machine
 ---
 
@@ -906,4 +906,16 @@ desde que o cabeçalho `### x-nome` exista e o sinalizador
 - **Injected by:** upstream
 - **Driven by config:** upstream
 - **Example:** Consulte a documentação upstream do F5.
+- **Pass-through from upstream:** yes
+
+### x-f5xc-wire-name
+
+- **Applied at:** schema property
+- **Purpose:** Chave de propriedade upstream original que deve ser enviada na requisição. A zona de amortecimento renomeia os nomes de propriedade escritos incorretamente pelo F5 e registra aqui a chave original, porque o servidor do F5 aceita apenas a grafia original.
+- **Consumers:** Terraform
+- **Value type:** string
+- **Value schema:** `{"type": "string"}`
+- **Injected by:** upstream (f5-sales-demo/api-specs)
+- **Driven by config:** upstream
+- **Example:** `"blocked_service": {"x-f5xc-wire-name": "blocked_sevice"}`
 - **Pass-through from upstream:** yes

--- a/docs/th/extensions/catalog.md
+++ b/docs/th/extensions/catalog.md
@@ -4,7 +4,7 @@ description: >-
   แหล่งข้อมูลหลักสำหรับส่วนขยาย x-* ทุกรายการในข้อกำหนด OpenAPI
   ที่เพิ่มประสิทธิภาพแล้ว
 i18n:
-  sourceHash: d286a6006907
+  sourceHash: 5d455612b759
   translator: machine
 ---
 
@@ -906,4 +906,16 @@ i18n:
 - **Injected by:** upstream
 - **Driven by config:** upstream
 - **Example:** ดูเอกสาร F5 upstream
+- **Pass-through from upstream:** yes
+
+### x-f5xc-wire-name
+
+- **Applied at:** schema property
+- **Purpose:** คีย์ property ต้นทางดั้งเดิมที่ต้องส่งไปในคำขอ buffer zone จะเปลี่ยนชื่อ property ที่ F5 สะกดผิด และบันทึกคีย์ดั้งเดิมไว้ที่นี่ เนื่องจากเซิร์ฟเวอร์ F5 ยอมรับเฉพาะการสะกดดั้งเดิมเท่านั้น
+- **Consumers:** Terraform
+- **Value type:** string
+- **Value schema:** `{"type": "string"}`
+- **Injected by:** upstream (f5-sales-demo/api-specs)
+- **Driven by config:** upstream
+- **Example:** `"blocked_service": {"x-f5xc-wire-name": "blocked_sevice"}`
 - **Pass-through from upstream:** yes

--- a/docs/zh-cn/extensions/catalog.md
+++ b/docs/zh-cn/extensions/catalog.md
@@ -2,7 +2,7 @@
 title: 扩展目录（Enrichment Extension Catalog）
 description: enriched OpenAPI 规范中所有 x-* 扩展的权威参考来源
 i18n:
-  sourceHash: d286a6006907
+  sourceHash: 5d455612b759
   translator: machine
 ---
 
@@ -900,4 +900,16 @@ i18n:
 - **Injected by:** upstream
 - **Driven by config:** upstream
 - **Example:** 请参阅 F5 上游文档。
+- **Pass-through from upstream:** yes
+
+### x-f5xc-wire-name
+
+- **Applied at:** schema property
+- **Purpose:** 必须在请求中使用的上游原始属性键。缓冲区会重命名 F5 拼写错误的属性名，并在此记录原始键，因为 F5 服务器仅接受原始拼写。
+- **Consumers:** Terraform
+- **Value type:** string
+- **Value schema:** `{"type": "string"}`
+- **Injected by:** upstream (f5-sales-demo/api-specs)
+- **Driven by config:** upstream
+- **Example:** `"blocked_service": {"x-f5xc-wire-name": "blocked_sevice"}`
 - **Pass-through from upstream:** yes

--- a/docs/zh-tw/extensions/catalog.md
+++ b/docs/zh-tw/extensions/catalog.md
@@ -2,7 +2,7 @@
 title: 擴充功能擴充目錄
 description: 豐富化 OpenAPI 規格中每個 x-* 擴充功能的真實來源
 i18n:
-  sourceHash: d286a6006907
+  sourceHash: 5d455612b759
   translator: machine
 ---
 
@@ -898,4 +898,16 @@ i18n:
 - **Injected by:** upstream
 - **Driven by config:** upstream
 - **Example:** 請參閱 F5 上游文件。
+- **Pass-through from upstream:** yes
+
+### x-f5xc-wire-name
+
+- **Applied at:** schema property
+- **Purpose:** 必須在請求中使用的上游原始屬性索引鍵。緩衝區會重新命名 F5 拼字錯誤的屬性名稱，並在此記錄原始索引鍵，因為 F5 伺服器僅接受原始拼字。
+- **Consumers:** Terraform
+- **Value type:** string
+- **Value schema:** `{"type": "string"}`
+- **Injected by:** upstream (f5-sales-demo/api-specs)
+- **Driven by config:** upstream
+- **Example:** `"blocked_service": {"x-f5xc-wire-name": "blocked_sevice"}`
 - **Pass-through from upstream:** yes

--- a/scripts/compile_catalog.py
+++ b/scripts/compile_catalog.py
@@ -291,6 +291,10 @@ _ENRICHMENT_KEYS = frozenset(
         "x-f5xc-conflicts-with",
         "x-f5xc-requires",
         "x-f5xc-description",
+        # Upstream pass-through (api-specs#686): the original misspelled key that
+        # F5 accepts on the wire. Request builders need it, so it must survive
+        # this projection — see terraform-provider-xcsh#1257.
+        "x-f5xc-wire-name",
     }
 )
 
@@ -372,6 +376,10 @@ def _extract_field_metadata(
             requires = prop_resolved.get("x-f5xc-requires")
             if requires:
                 entry["requires"] = requires
+
+            wire_name = prop_resolved.get("x-f5xc-wire-name")
+            if wire_name:
+                entry["wireName"] = wire_name
 
             result[field_path] = entry
 

--- a/scripts/utils/extension_constants.py
+++ b/scripts/utils/extension_constants.py
@@ -82,6 +82,10 @@ X_F5XC_REFERENCES = "x-f5xc-references"
 X_F5XC_FIELD_EXAMPLES = "x-f5xc-field-examples"
 X_F5XC_UNIQUENESS = "x-f5xc-uniqueness"
 
+# Original (misspelled) upstream property key, preserved when the buffer zone
+# renames the presented property name (api-specs #686)
+X_F5XC_WIRE_NAME = "x-f5xc-wire-name"
+
 # Console UI field enrichment (Issue #679)
 X_F5XC_CONSOLE_FIELD = "x-f5xc-console-field"
 
@@ -195,6 +199,7 @@ VALID_X_F5XC_EXTENSIONS = frozenset(
         X_F5XC_REFERENCES,
         X_F5XC_FIELD_EXAMPLES,
         X_F5XC_UNIQUENESS,
+        X_F5XC_WIRE_NAME,
         # Operation-level
         X_F5XC_REQUIRED_FIELDS,
         X_F5XC_DANGER_LEVEL,

--- a/tests/test_wire_name_extension.py
+++ b/tests/test_wire_name_extension.py
@@ -196,7 +196,7 @@ class TestSurvivesPipeline:
 
     def test_survives_normalize_and_enrich(self, pipeline_config: dict) -> None:
         spec = _spec_with_wire_name()
-        expected = {}
+        expected: dict[str, str] = {}
         _collect_wire_names(copy.deepcopy(spec), expected)
         assert len(expected) == 2, "fixture must carry two annotations"
 

--- a/tests/test_wire_name_extension.py
+++ b/tests/test_wire_name_extension.py
@@ -1,0 +1,388 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+"""Tests for the ``x-f5xc-wire-name`` property-level extension.
+
+``x-f5xc-wire-name`` is produced by the buffer-zone repo
+(``f5-sales-demo/api-specs#686``), not by this repo. Upstream corrects F5's
+misspelled property *names* while preserving the wire contract: the property is
+presented under the corrected name and the original (misspelled) key is
+recorded on it::
+
+    "blocked_service": {"x-f5xc-wire-name": "blocked_sevice", ...}
+
+Downstream code generators build API requests from the wire name, because F5's
+server only accepts the misspelling. If this repo were to drop the annotation
+during enrichment, the generated provider would emit the corrected key, which
+F5 silently discards — exactly
+``f5-sales-demo/terraform-provider-xcsh#1257``.
+
+These tests therefore cover two things:
+
+1. **Registration** — the extension is a known, documented member of the
+   ``x-f5xc-*`` namespace (constant, valid set, catalog, registry).
+2. **Preservation** — a property carrying the annotation still carries it,
+   byte-identical, after the normalization + enrichment pipeline runs.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from scripts.pipeline import (
+    _remove_ref_siblings,
+    enrich_spec,
+    load_config,
+    normalize_spec,
+)
+from scripts.utils.extension_constants import (
+    VALID_X_F5XC_EXTENSIONS,
+    X_F5XC_WIRE_NAME,
+    is_valid_extension,
+    validate_no_invalid_extensions,
+)
+
+REPO_ROOT = Path(__file__).parent.parent
+CATALOG = REPO_ROOT / "docs" / "en" / "extensions" / "catalog.md"
+REGISTRY = REPO_ROOT / "config" / "extension_registry.yaml"
+API_DIR = REPO_ROOT / "docs" / "specifications" / "api"
+
+# The real upstream case: F5 accepts only the misspelling on the wire.
+PRESENTED_NAME = "blocked_service"
+WIRE_NAME = "blocked_sevice"  # codespell:ignore sevice
+
+
+# =============================================================================
+# REGISTRATION
+# =============================================================================
+
+
+class TestRegistration:
+    """``x-f5xc-wire-name`` must be a known member of the namespace."""
+
+    def test_constant_value(self) -> None:
+        assert X_F5XC_WIRE_NAME == "x-f5xc-wire-name"
+
+    def test_in_valid_extensions(self) -> None:
+        assert X_F5XC_WIRE_NAME in VALID_X_F5XC_EXTENSIONS
+
+    def test_is_valid_extension(self) -> None:
+        assert is_valid_extension(X_F5XC_WIRE_NAME)
+
+    def test_not_reported_as_invalid_extension(self) -> None:
+        """A spec carrying the annotation must not be flagged by the validator."""
+        spec = {
+            "components": {
+                "schemas": {
+                    "fooSpec": {
+                        "type": "object",
+                        "properties": {
+                            PRESENTED_NAME: {
+                                "type": "boolean",
+                                X_F5XC_WIRE_NAME: WIRE_NAME,
+                            },
+                        },
+                    },
+                },
+            },
+        }
+        errors = validate_no_invalid_extensions(spec)
+        assert len(errors) == 0, errors
+
+    def test_has_catalog_entry(self) -> None:
+        headers = set(re.findall(r"^### (x-[a-z0-9-]+)\s*$", CATALOG.read_text(), re.MULTILINE))
+        assert X_F5XC_WIRE_NAME in headers
+
+    def test_registered_in_extension_registry(self) -> None:
+        with REGISTRY.open() as handle:
+            registry = yaml.safe_load(handle)
+        entry = registry["property_level"][X_F5XC_WIRE_NAME]
+        assert entry["type"] == "string"
+        assert entry["purpose"]
+        # Consumed by the code generators that build API requests.
+        assert "terraform" in entry["consumers"]
+
+
+# =============================================================================
+# PRESERVATION THROUGH THE PIPELINE
+# =============================================================================
+
+
+def _spec_with_wire_name() -> dict[str, Any]:
+    """Synthetic spec exercising both property shapes that carry the annotation.
+
+    ``blocked_service`` is an inline scalar property; ``origin_service`` is a
+    ``$ref`` property, which normalization rewrites into an ``allOf`` wrapper
+    (see :func:`scripts.pipeline._remove_ref_siblings`) and is therefore the
+    shape most at risk of losing sibling keys.
+    """
+    return {
+        "openapi": "3.0.3",
+        "info": {"title": "Wire Name Fixture", "version": "1.0.0"},
+        "paths": {
+            "/api/config/namespaces/{namespace}/widgets": {
+                "post": {
+                    "operationId": "createWidget",
+                    "summary": "Create widget",
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/widgetCreateSpecType",
+                                },
+                            },
+                        },
+                    },
+                    "responses": {"200": {"description": "OK"}},
+                },
+            },
+        },
+        "components": {
+            "schemas": {
+                "widgetCreateSpecType": {
+                    "type": "object",
+                    "description": "Widget create specification.",
+                    "x-ves-proto-message": "ves.io.schema.widget.CreateSpecType",
+                    "properties": {
+                        "name": {"type": "string", "description": "Widget name."},
+                        PRESENTED_NAME: {
+                            "type": "boolean",
+                            "description": "Whether the service is blocked.",
+                            X_F5XC_WIRE_NAME: WIRE_NAME,
+                        },
+                        "origin_service": {
+                            "$ref": "#/components/schemas/serviceRefType",
+                            "description": "Origin service reference.",
+                            X_F5XC_WIRE_NAME: "origin_sevice",
+                        },
+                    },
+                },
+                "serviceRefType": {
+                    "type": "object",
+                    "properties": {"name": {"type": "string"}},
+                },
+            },
+        },
+    }
+
+
+def _collect_wire_names(obj: Any, acc: dict[str, str], path: str = "") -> None:
+    """Collect every ``x-f5xc-wire-name`` value keyed by its JSON path."""
+    if isinstance(obj, dict):
+        for key, value in obj.items():
+            child = f"{path}.{key}" if path else key
+            if key == X_F5XC_WIRE_NAME:
+                acc[child] = value
+            else:
+                _collect_wire_names(value, acc, child)
+    elif isinstance(obj, list):
+        for index, item in enumerate(obj):
+            _collect_wire_names(item, acc, f"{path}[{index}]")
+
+
+@pytest.fixture(scope="module")
+def pipeline_config() -> dict:
+    return load_config()
+
+
+class TestSurvivesPipeline:
+    """The annotation must reach downstream byte-identical."""
+
+    def test_survives_normalize_and_enrich(self, pipeline_config: dict) -> None:
+        spec = _spec_with_wire_name()
+        expected = {}
+        _collect_wire_names(copy.deepcopy(spec), expected)
+        assert len(expected) == 2, "fixture must carry two annotations"
+
+        normalized, _ = normalize_spec(copy.deepcopy(spec), pipeline_config)
+        enriched, _ = enrich_spec(normalized, pipeline_config)
+
+        actual: dict[str, str] = {}
+        _collect_wire_names(enriched, actual)
+
+        assert sorted(actual.values()) == sorted(expected.values()), (
+            "x-f5xc-wire-name values were dropped or rewritten by the enrichment "
+            f"pipeline: expected {sorted(expected.values())}, got {sorted(actual.values())}"
+        )
+
+    def test_inline_property_annotation_is_byte_identical(self, pipeline_config: dict) -> None:
+        normalized, _ = normalize_spec(_spec_with_wire_name(), pipeline_config)
+        enriched, _ = enrich_spec(normalized, pipeline_config)
+        prop = enriched["components"]["schemas"]["widgetCreateSpecType"]["properties"][
+            PRESENTED_NAME
+        ]
+        assert prop[X_F5XC_WIRE_NAME] == WIRE_NAME
+
+    def test_ref_sibling_normalization_keeps_annotation(self) -> None:
+        """``$ref`` siblings are filtered down to ``x-*`` keys plus ``default``.
+
+        This is the one place in the pipeline that rebuilds a property dict from
+        an allowlist rather than copying every key, so it is asserted directly.
+        """
+        spec = {
+            "components": {
+                "schemas": {
+                    "widgetCreateSpecType": {
+                        "properties": {
+                            "origin_service": {
+                                "$ref": "#/components/schemas/serviceRefType",
+                                "description": "dropped by OAS3 $ref-sibling rules",
+                                X_F5XC_WIRE_NAME: "origin_sevice",
+                            },
+                        },
+                    },
+                },
+            },
+        }
+        normalized, wrapped = _remove_ref_siblings(spec)
+        prop = normalized["components"]["schemas"]["widgetCreateSpecType"]["properties"][
+            "origin_service"
+        ]
+        assert wrapped == 1
+        assert prop[X_F5XC_WIRE_NAME] == "origin_sevice"
+        assert prop["allOf"] == [{"$ref": "#/components/schemas/serviceRefType"}]
+
+    def test_schema_fixer_property_rename_carries_annotation(self) -> None:
+        """This repo's own misspelling rename must move the annotation with the property.
+
+        ``SchemaFixer`` renames wire-safe misspellings (``config/enrichment.yaml``
+        ``schema_fixes.rename_properties``). If a renamed property already carries an
+        upstream ``x-f5xc-wire-name``, the annotation must travel with it.
+        """
+        from scripts.utils.schema_fixer import SchemaFixer
+
+        fixer = SchemaFixer()
+        fixer._property_renames = {"WidgetSpec": {"lables": "labels"}}  # codespell:ignore lables
+        spec = {
+            "components": {
+                "schemas": {
+                    "widgetSpec": {
+                        "x-ves-proto-message": "ves.io.schema.widget.WidgetSpec",
+                        "properties": {
+                            "lables": {  # codespell:ignore lables
+                                "type": "object",
+                                X_F5XC_WIRE_NAME: "lables",  # codespell:ignore lables
+                            },
+                        },
+                    },
+                },
+            },
+        }
+        out = fixer.fix_spec(spec)
+        props = out["components"]["schemas"]["widgetSpec"]["properties"]
+        assert "labels" in props
+        assert props["labels"][X_F5XC_WIRE_NAME] == "lables"  # codespell:ignore lables
+
+
+# =============================================================================
+# DERIVED-ARTIFACT PROJECTION
+# =============================================================================
+
+
+class TestCatalogProjection:
+    """``scripts/compile_catalog.py`` projects a narrow allowlist of ``x-f5xc-*``
+    keys into ``release/api-catalog.json``.
+
+    That catalog feeds ``xcsh``, which builds API requests from it, so the wire
+    name has to survive the projection for the same reason the provider needs
+    it: sending the presented name makes F5 silently discard the field.
+    """
+
+    def test_wire_name_is_projected_from_an_inline_property(self) -> None:
+        from scripts.compile_catalog import _extract_field_metadata
+
+        schema = {
+            "type": "object",
+            "properties": {
+                PRESENTED_NAME: {"type": "boolean", X_F5XC_WIRE_NAME: WIRE_NAME},
+            },
+        }
+        result = _extract_field_metadata(schema, {"schemas": {}}, prefix="", depth=0, max_depth=3)
+        assert PRESENTED_NAME in result, (
+            "a property whose only enrichment is x-f5xc-wire-name must still reach the catalog"
+        )
+        assert result[PRESENTED_NAME]["wireName"] == WIRE_NAME
+
+    def test_wire_name_is_projected_from_a_ref_wrapper(self) -> None:
+        from scripts.compile_catalog import _extract_field_metadata
+
+        components = {
+            "schemas": {
+                "serviceRefType": {
+                    "type": "object",
+                    "properties": {"name": {"type": "string"}},
+                },
+            },
+        }
+        schema = {
+            "type": "object",
+            "properties": {
+                "origin_service": {
+                    "$ref": "#/components/schemas/serviceRefType",
+                    X_F5XC_WIRE_NAME: "origin_sevice",
+                },
+            },
+        }
+        result = _extract_field_metadata(schema, components, prefix="", depth=0, max_depth=3)
+        assert result["origin_service"]["wireName"] == "origin_sevice"
+
+
+# =============================================================================
+# CROSS-SPEC INVARIANT OVER THE GENERATED SPECS
+# =============================================================================
+
+
+def _generated_wire_name_sites() -> list[tuple[str, str, str]]:
+    """Return ``(spec_file, json_path, wire_name)`` for every annotation found."""
+    sites: list[tuple[str, str, str]] = []
+    for path in sorted(API_DIR.glob("*.json")):
+        found: dict[str, str] = {}
+        _collect_wire_names(json.loads(path.read_text()), found)
+        sites.extend((path.name, json_path, value) for json_path, value in found.items())
+    return sites
+
+
+_SPECS_MISSING = not API_DIR.exists() or not any(API_DIR.glob("*.json"))
+_SITES: list[tuple[str, str, str]] = [] if _SPECS_MISSING else _generated_wire_name_sites()
+
+
+@pytest.mark.skipif(_SPECS_MISSING, reason="specs not generated; run `make pipeline` first")
+@pytest.mark.skipif(
+    not _SITES,
+    reason=(
+        "upstream api-specs does not carry x-f5xc-wire-name yet "
+        "(f5-sales-demo/api-specs#689 still draft) — 0 occurrences in "
+        "docs/specifications/api/. Skipped rather than passed vacuously; this "
+        "test becomes an enforced invariant the moment the annotation ships."
+    ),
+)
+class TestGeneratedSpecInvariants:
+    """Shape invariants over every ``x-f5xc-wire-name`` in the generated specs."""
+
+    def test_every_wire_name_is_a_non_empty_string(self) -> None:
+        bad = [site for site in _SITES if not isinstance(site[2], str) or not site[2]]
+        assert not bad, f"non-string / empty x-f5xc-wire-name values: {bad}"
+
+    def test_every_wire_name_sits_on_a_schema_property(self) -> None:
+        """The annotation is property-level: its parent must be a ``properties`` member."""
+        bad = [
+            site
+            for site in _SITES
+            if not re.search(r"\.properties\.[^.]+\.x-f5xc-wire-name$", site[1])
+        ]
+        assert not bad, f"x-f5xc-wire-name found outside a schema property: {bad}"
+
+    def test_wire_name_differs_from_presented_property_key(self) -> None:
+        """A wire name equal to its property key carries no information."""
+        redundant = [
+            site
+            for site in _SITES
+            if site[1].split(".")[-2] == site[2]  # parent property key
+        ]
+        assert not redundant, f"x-f5xc-wire-name identical to the property key: {redundant}"


### PR DESCRIPTION
## Summary

The buffer zone (`f5-sales-demo/api-specs#686`) now corrects F5's misspelled property *names*
while preserving the wire contract: the property is presented under the corrected name and the
original key is recorded on it as `x-f5xc-wire-name`.

```json
"blocked_service": { "x-f5xc-wire-name": "blocked_sevice", ... }
```

Downstream code generators must send the *recorded* key, because F5 accepts only the
misspelling — a `PUT` with `blocked_sevice` returns HTTP 200 and round-trips, while
`blocked_service` is silently ignored. Emitting the corrected name makes F5 discard the field,
which is exactly `f5-sales-demo/terraform-provider-xcsh#1257`.

This PR makes the annotation a first-class known extension here and proves it survives
enrichment, so it reaches the consumer (`f5-sales-demo/terraform-provider-xcsh#1323`) intact.

## Related Issue

Closes #1084

## Changes

Registered `x-f5xc-wire-name` across the same chain `x-f5xc-action` used:

- `scripts/utils/extension_constants.py` — `X_F5XC_WIRE_NAME` constant in the property-level
  group, plus `VALID_X_F5XC_EXTENSIONS` membership.
- `docs/en/extensions/catalog.md` — a `### x-f5xc-wire-name` section following the documented
  entry schema, in the **Upstream pass-through** class (`Pass-through from upstream: yes`,
  `Injected by: upstream (f5-sales-demo/api-specs)`) because this repo never produces it.
  The 12 translated catalogs carry the same entry with a translated `Purpose` and a refreshed
  `i18n.sourceHash`, matching the precedent in c895c6b3.
- `config/extension_registry.yaml` — a `property_level` entry: value = the original wire key,
  `consumers: [terraform]` (code generators that build API requests), with a note spelling out
  the failure mode.

**Enricher audit** (issue scope item 3). Every enricher that rebuilds property dictionaries
iterates `obj.items()` exhaustively, so unknown/known extensions pass through untouched. Two
places do reshape property dicts, both verified safe and now covered by tests:

- `scripts/pipeline.py::_remove_ref_siblings` — the one allowlist over property dicts in the
  spec pipeline. It keeps only `x-*` keys plus `default` on a `$ref` sibling, so the annotation
  survives (and lands on the `allOf` wrapper).
- `scripts/utils/schema_fixer.py::_apply_property_renames` — moves the whole property dict, so
  an annotation travels with a renamed property.

Also checked and safe: `_merge_schema_union` is union-add-only; `constraint_reconciler` pops
only mapped `x-discovered-*` keys; `branding`/`grammar`/`acronyms` only rewrite values of
`target_fields` (`description`, `summary`, `title`, `x-displayname`), never the annotation;
`contract_diff` treats any `x-*` terminal as additive.

**One real strip found and fixed.** `scripts/compile_catalog.py::_ENRICHMENT_KEYS` is an
allowlist projected into `release/api-catalog.json`, which `xcsh` uses to build API requests —
it dropped the annotation. The wire name is now projected as `wireName`, and a property whose
only enrichment is a wire name now reaches the catalog.

**Tests** — `tests/test_wire_name_extension.py` (15 tests):

- `TestRegistration` (6) — constant value, valid-set membership, `is_valid_extension`,
  `validate_no_invalid_extensions` clean, catalog entry present, registry entry shape.
- `TestSurvivesPipeline` (4) — `x-f5xc-wire-name` values byte-identical after
  `normalize_spec()` + `enrich_spec()`; the inline-property and `$ref`-sibling shapes; the
  `SchemaFixer` rename path.
- `TestCatalogProjection` (2) — wire name projected into the compiled catalog from an inline
  property and from a `$ref` wrapper.
- `TestGeneratedSpecInvariants` (3) — shape invariants over `docs/specifications/api/*.json`
  (non-empty string, property-level placement, differs from the presented key). **Skipped with
  an explicit reason today** because upstream carries 0 occurrences (`api-specs#689` is still
  draft) — deliberately not a vacuous pass; these become enforced the moment the annotation
  ships.

Generated specs are intentionally **not** regenerated: none of these changes alter pipeline
output (`extension_registry.yaml` is documentation-only, no enricher reads it; `compile_catalog`
writes `release/api-catalog.json`, which is gitignored). The `contract-diff` CI job regenerates
the pipeline in-CI anyway.

## Verification evidence

Failing-first, then passing.

Red baseline for the registration tests (constant + valid-set added, catalog/registry not yet):

```
$ .venv/bin/python -m pytest tests/test_wire_name_extension.py tests/test_extension_catalog.py -q
FAILED tests/test_wire_name_extension.py::TestRegistration::test_has_catalog_entry
   AssertionError: assert 'x-f5xc-wire-name' in {...}
FAILED tests/test_wire_name_extension.py::TestRegistration::test_registered_in_extension_registry
   KeyError: 'x-f5xc-wire-name'
FAILED tests/test_extension_catalog.py::test_every_valid_extension_has_a_catalog_entry
   AssertionError: Missing catalog entries: ['x-f5xc-wire-name']
3 failed, 11 passed, 5 skipped
```

Red baseline for the catalog-projection strip (before the `compile_catalog` fix):

```
$ .venv/bin/python -m pytest tests/test_wire_name_extension.py::TestCatalogProjection -q
FAILED ...::test_wire_name_is_projected_from_an_inline_property
FAILED ...::test_wire_name_is_projected_from_a_ref_wrapper - KeyError: 'origin_service'
2 failed
```

Green after the fixes, including the extension-parity suites:

```
$ .venv/bin/python -m pytest tests/test_wire_name_extension.py tests/test_extension_catalog.py \
    tests/test_extension_naming.py tests/test_compile_catalog.py -q
141 passed, 5 skipped in 2.38s
```

Full suite, before vs after (delta is exactly the 15 new tests):

```
$ git stash -u && .venv/bin/python -m pytest -q --no-cov   # baseline
2171 passed, 6 skipped, 1 xfailed in 63.38s

$ .venv/bin/python -m pytest -q                            # with this change
2183 passed, 9 skipped, 1 xfailed in 70.15s
```

Local lint gate:

```
$ .venv/bin/ruff check .                                   -> All checks passed!
$ .venv/bin/ruff format --check scripts/ tests/            -> 192 files already formatted
$ .venv/bin/python -m pylint --rcfile=.python-lint scripts/compile_catalog.py \
    scripts/utils/extension_constants.py tests/test_wire_name_extension.py
                                                           -> 10.00/10
$ .venv/bin/mypy --ignore-missing-imports scripts/compile_catalog.py \
    scripts/utils/extension_constants.py                   -> clean
$ codespell <changed files>                                -> exit 0
$ markdownlint-cli2 --config .markdownlint.json docs/*/extensions/catalog.md
                                                           -> 0 issues in 0 files (13 files)
$ npx textlint -c .textlintrc docs/en/extensions/catalog.md -> clean
$ yamllint -c .yamllint.yaml config/extension_registry.yaml -> exit 0 (only the pre-existing
                                                               line-21 document-start warning)
$ .venv/bin/pre-commit run --files <changed>               -> all Passed / Skipped
$ .venv/bin/python -m scripts.verify_governance --base origin/main --head HEAD
                                                           -> ok: no governed files modified
```

Translation freshness (the `Translation Audit` gate) verified programmatically — all 12 locale
catalogs carry the new English `sourceHash` `5d455612b759`:

```
en: 5d455612b759
ar/de/es/fr/hi/it/ja/ko/pt-br/th/zh-cn/zh-tw  5d455612b759  OK
```

Note: `python -m scripts.validate_configs` fails on `origin/main` already
(`securemesh_site_v2` missing from `resource_metadata.yaml` / missing `example_yaml`) — a
pre-existing failure, unrelated to and unaffected by this change.

CI: watched to green — see the checks on this PR.

## Checklist

- [x] Linked to a GitHub issue (required — CI blocks merge without it)
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [x] Tests written first (TDD) and passing; the issue's acceptance criteria are met
- [x] Verified locally by running or exercising the change — evidence pasted above
- [x] CI watched to green (not just queued)
- [x] Follows project conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)