### PR TITLE
feat: consume upstream api-specs releases via repository_dispatch

### DIFF
--- a/.github/workflows/sync-and-enrich.yml
+++ b/.github/workflows/sync-and-enrich.yml
@@ -1,8 +1,15 @@
 name: Sync and Enrich API Specs
 
 on:
+  # Primary path: f5-sales-demo/api-specs sends this the moment a spec release
+  # publishes, so a correction is consumed in minutes instead of waiting for the
+  # cron below. See f5-sales-demo/api-specs#693.
+  repository_dispatch:
+    types: [upstream-specs-released]
   schedule:
-    # Run daily at 6 AM UTC
+    # Safety net, not the primary path: catches an upstream release whose
+    # dispatch never arrived (token expiry, an api-specs run that died after
+    # publishing, a hand-cut release).
     - cron: '0 6 * * *'
   push:
     branches:
@@ -59,16 +66,35 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements.txt
 
+      - name: Log upstream release trigger
+        if: github.event_name == 'repository_dispatch'
+        env:
+          # client_payload is attacker-influenceable in principle, so it is read
+          # through the environment and never interpolated into this run: body.
+          # It is logged only -- nothing downstream branches on it.
+          UPSTREAM_TAG: ${{ github.event.client_payload.release_tag }}
+          UPSTREAM_SOURCE: ${{ github.event.client_payload.trigger_source }}
+        run: |
+          echo "::notice::Triggered by upstream release ${UPSTREAM_TAG:-unknown} from ${UPSTREAM_SOURCE:-unknown}"
+
       - name: Check for GitHub Release updates
         id: check
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
-          # Force download on push/dispatch events, check-only on schedule
-          if [ "${{ github.event_name }}" = "push" ] || \
-            [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          # Force download on push, manual dispatch and upstream release
+          # dispatch; check-only on schedule.
+          #
+          # repository_dispatch must force: it only ever arrives because
+          # api-specs just published a release, and taking the --check-only
+          # ETag short-circuit here would let the trigger fire and change
+          # nothing -- automation that looks wired up and is not.
+          if [ "$EVENT_NAME" = "push" ] || \
+            [ "$EVENT_NAME" = "workflow_dispatch" ] || \
+            [ "$EVENT_NAME" = "repository_dispatch" ]; then
             echo "updated=true" >> "$GITHUB_OUTPUT"
-            echo "Push/dispatch event - forcing download"
+            echo "Event '$EVENT_NAME' - forcing download"
           else
             # Run check-only and capture exit code
             # Exit code 1 = updates available (success for our purposes)


### PR DESCRIPTION
Closes #1089

Consumer half of f5-sales-demo/api-specs#693. Producer half: f5-sales-demo/api-specs#694.

## Problem

`sync-and-enrich.yml` only started on the `0 6 * * *` cron, a `push` to `main`, or a human running `workflow_dispatch`. Nothing told this repository when its upstream, `f5-sales-demo/api-specs`, published a spec release — so a correction sat unconsumed for up to 24 hours. On 2026-07-24 the run for `v2026.07.24-1` had to be started by hand with `gh workflow run`.

Every other hop in the chain already self-triggers. This was the last human-in-the-loop link.

## Change

Two parts, and the second is the one that matters.

**1. Accept the event.** `repository_dispatch: types: [upstream-specs-released]` alongside the existing triggers. `api-specs` sends it the moment a release publishes successfully.

**2. Force-download on that path.** `check-updates` previously forced a download only on `push` and `workflow_dispatch`, and otherwise ran `python -m scripts.download --check-only` and short-circuited on an unchanged ETag. Leaving `repository_dispatch` on that path would have fired a run that consumed nothing — automation that looks wired up and is not. The condition now covers `repository_dispatch`, which is only ever delivered because a release just published:

```bash
if [ "$EVENT_NAME" = "push" ] || \
  [ "$EVENT_NAME" = "workflow_dispatch" ] || \
  [ "$EVENT_NAME" = "repository_dispatch" ]; then
  echo "updated=true" >> "$GITHUB_OUTPUT"
```

`updated=true` is what gates the `sync-and-enrich` job, whose download step already runs `scripts.download --force` — so this is the whole of the force-download path.

The daily cron stays as a **safety net**, not the primary path: it still catches a release whose dispatch never arrived (token expiry, an `api-specs` run that died after publishing, a hand-cut release).

## Security

`client_payload` is attacker-influenceable in principle, and this repository's own `workflow-security-audit.yml` exists to catch exactly that class of bug. No `github.event.*` value reaches a `run:` body: the new trigger-log step reads `release_tag` and `trigger_source` through step-level `env:` and references the quoted shell variables, and nothing downstream branches on the payload.

The same treatment is applied to the two pre-existing `${{ github.event_name }}` expansions in the `check-updates` shell body. With an externally-triggerable event now reaching this workflow, that step should read the environment rather than the template. Side effect: zizmor's finding count on the file drops from 17 to 15.

No permission changes — `check-updates` continues to run under the workflow-level `contents: read`.

## Verification

| Check | Result |
| --- | --- |
| `actionlint .github/workflows/*.yml` | exit 0 |
| `yamllint .github/workflows/sync-and-enrich.yml` | exit 0 |
| `codespell` on the changed file | exit 0 |
| `zizmor --config zizmor.yaml --min-severity medium .github/workflows/` (the audit gate) | `No findings to report`, exit 0 |
| `zizmor` on the changed file | 15 findings, 14 suppressed, **1 low** — down from 17/16/1 on `main` |
| `pre-commit` (full, including the ~13 min enrichment pipeline) | see below |

The one remaining low finding is a pre-existing `adhoc-packages` at `sync-and-enrich.yml:235` (`npm install -g @stoplight/spectral-cli`, no lockfile) — unrelated to this change and unchanged by it. The pre-commit `zizmor` hook runs with no severity floor and therefore already fails on `main` for that same finding; `zizmor.yaml` and `.pre-commit-config.yaml` are both governance-managed by docs-control and are not editable here. CI's `Lint Code Base` does not run zizmor at all; the gate is `Workflow Security Audit`, which uses `--min-severity medium` and passes.

Note for future workflow-only changes here: `scripts/hooks/pre-commit-pipeline.sh` lists `.github/workflows/sync-and-enrich.yml` in its staged-inputs regex, so editing *this* workflow does trigger the full ~13 minute enrichment run even though no pipeline input changed.
