### PR TITLE
fix: gate releases on generated output, not HEAD~1 commit history

### DIFF
--- a/.github/workflows/sync-and-enrich.yml
+++ b/.github/workflows/sync-and-enrich.yml
@@ -130,7 +130,7 @@ jobs:
       contents: write
     outputs:
       version: ${{ steps.version.outputs.new_version }}
-      has_changes: ${{ steps.version.outputs.has_changes }}
+      has_changes: ${{ steps.detect.outputs.has_changes }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -287,64 +287,22 @@ jobs:
           F5XC_API_URL: ${{ secrets.F5XC_API_URL }}
         run: python -m scripts.validate --dry-run
 
-      - name: Early exit for docs-only changes
-        id: docs_check
-        run: |
-          echo "Checking for documentation-only changes..."
-
-          # Check if ALL changes are docs-only using git pathspec exclusion
-          if git diff --quiet HEAD~1 HEAD -- . ':!CLAUDE.md' ':!README.md' ':!docs/**/*.md' ':!LICENSE'; then
-            echo "📝 Documentation-only changes detected - skipping pipeline"
-            echo "has_changes=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          else
-            echo "✅ Non-documentation changes detected - proceeding with pipeline"
-          fi
-
-      - name: Detect changes and bump version
-        id: version
+      - name: Detect release-worthy changes
+        id: detect
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # Output-driven gate: compares the generated, tracked output in the
+        # working tree against HEAD. Lives in a script so it can be unit
+        # tested (tests/shell/test_detect_release_changes.py) — the inline
+        # block it replaces was untestable, which is how #1094 survived.
+        run: bash scripts/release/detect-release-changes.sh
+
+      - name: Bump version
+        id: version
+        if: steps.detect.outputs.has_changes == 'true'
+        env:
+          CHANGE_TYPE: ${{ steps.detect.outputs.change_type }}
         run: |
-          # Check if enriched specs exist (pipeline generated them)
-          if [ ! -f docs/specifications/api/index.json ]; then
-            echo "has_changes=false" >> "$GITHUB_OUTPUT"
-            echo "No enriched specs generated"
-            exit 0
-          fi
-
-          # Force release if no GitHub releases exist yet (fresh repo / migration)
-          RELEASE_COUNT=$(gh release list --limit 1 2>/dev/null | wc -l)
-          if [ "${RELEASE_COUNT:-0}" -eq 0 ]; then
-            echo "has_changes=true" >> "$GITHUB_OUTPUT"
-            CHANGE_TYPE="source"
-            echo "No releases found - forcing initial release"
-          else
-            # Compare with previous release or mark as changed for new runs
-            # Check for changes in source specs, pipeline config, or dependencies
-            if git diff --quiet HEAD~1 HEAD -- \
-              specs/original/ .github_release scripts/ config/ requirements.txt \
-              .github/workflows/sync-and-enrich.yml; then
-              echo "has_changes=false" >> "$GITHUB_OUTPUT"
-              echo "No changes in: specs, pipeline scripts, configs, or workflow"
-              exit 0
-            fi
-
-            echo "has_changes=true" >> "$GITHUB_OUTPUT"
-
-            # Determine change type for semantic versioning (as bash variable for use in this script)
-            if git diff --quiet HEAD~1 HEAD -- specs/original/ .github_release; then
-              CHANGE_TYPE="pipeline"
-              echo "Pipeline/config/workflow changes detected"
-            else
-              CHANGE_TYPE="source"
-              echo "Source spec changes detected"
-            fi
-          fi
-
-          # Output change type for downstream steps
-          echo "change_type=$CHANGE_TYPE" >> "$GITHUB_OUTPUT"
-
           # Get current version from git tags (eliminates race conditions from file-based versioning)
           CURRENT_VERSION=$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || echo "0.0.0")
 
@@ -402,7 +360,7 @@ jobs:
           echo "::notice::Version: $CURRENT_VERSION -> $NEW_VERSION ($BUMP_TYPE)"
 
       - name: Update version in specs
-        if: steps.version.outputs.has_changes == 'true'
+        if: steps.detect.outputs.has_changes == 'true'
         env:
           VERSION: ${{ steps.version.outputs.new_version }}
         run: |
@@ -423,7 +381,7 @@ jobs:
           echo "Updated all specs to version $VERSION"
 
       - name: Verify version consistency
-        if: steps.version.outputs.has_changes == 'true'
+        if: steps.detect.outputs.has_changes == 'true'
         env:
           EXPECTED_VERSION: ${{ steps.version.outputs.new_version }}
         run: |
@@ -437,7 +395,7 @@ jobs:
           echo "Version consistent: $INDEX_VERSION"
 
       - name: Align catalog version with release
-        if: steps.version.outputs.has_changes == 'true'
+        if: steps.detect.outputs.has_changes == 'true'
         env:
           VERSION: ${{ steps.version.outputs.new_version }}
         run: |
@@ -464,7 +422,7 @@ jobs:
           fi
 
       - name: Generate changelog
-        if: steps.version.outputs.has_changes == 'true'
+        if: steps.detect.outputs.has_changes == 'true'
         env:
           VERSION: ${{ steps.version.outputs.new_version }}
           BUMP_TYPE: ${{ steps.version.outputs.bump_type }}
@@ -564,7 +522,7 @@ jobs:
           } > CHANGELOG.md
 
       - name: Upload docs artifact for deployment
-        if: steps.version.outputs.has_changes == 'true'
+        if: steps.detect.outputs.has_changes == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: docs-site
@@ -572,7 +530,7 @@ jobs:
           retention-days: 1
 
       - name: Biome-format generated JSON for release PR
-        if: steps.version.outputs.has_changes == 'true'
+        if: steps.detect.outputs.has_changes == 'true'
         run: |
           # Re-run biome format on all generated output as a single batch.
           # json_writer.py already formats per-file during the pipeline, but
@@ -585,7 +543,7 @@ jobs:
           biome format --write docs/specifications/api/ docs/api-reference/ || true
 
       - name: Commit and tag release
-        if: steps.version.outputs.has_changes == 'true'
+        if: steps.detect.outputs.has_changes == 'true'
         env:
           GH_TOKEN: ${{ secrets.VERSION_BUMP_PAT }}
           VERSION: ${{ steps.version.outputs.new_version }}
@@ -673,7 +631,7 @@ jobs:
           fi
 
       - name: Create release package
-        if: steps.version.outputs.has_changes == 'true'
+        if: steps.detect.outputs.has_changes == 'true'
         env:
           VERSION: ${{ steps.version.outputs.new_version }}
         run: |
@@ -743,7 +701,7 @@ jobs:
           echo "::notice::Package created: ${ZIP_NAME}"
 
       - name: Create release
-        if: steps.version.outputs.has_changes == 'true'
+        if: steps.detect.outputs.has_changes == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ steps.version.outputs.new_version }}

--- a/scripts/release/detect-release-changes.sh
+++ b/scripts/release/detect-release-changes.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+#
+# Decide whether a sync-and-enrich run has anything to release, and classify
+# the change for semantic versioning.
+#
+# Writes to $GITHUB_OUTPUT:
+#   has_changes   true|false  Whether the run should publish a release.
+#   change_type   source|pipeline
+#                 `source`   a new upstream api-specs release is in play.
+#                 `pipeline` output moved without a new upstream release.
+#                 Omitted when the pipeline produced no output at all.
+#
+# Environment:
+#   GITHUB_OUTPUT      Required. Step output file appended to.
+#   DETECT_RELEASE_GH  Override the `gh` command (tests inject a fake).
+#
+# Why this is output-driven
+# -------------------------
+# The retired inline version asked "did the *previous commit* change the
+# inputs?" with `git diff HEAD~1 HEAD -- specs/original/ .github_release
+# scripts/ config/ requirements.txt <this workflow>`. That could never see an
+# upstream release (#1094):
+#
+#   * `specs/original/` is gitignored and has zero tracked files, so a diff on
+#     it is structurally silent.
+#   * `.github_release` is tracked, but the download step rewrites it in the
+#     WORKING TREE, which a comparison of two committed revisions cannot see.
+#
+# So the gate only ever fired when this repo's own previous commit touched
+# code, and every release in the history was a code merge. The only correct
+# question is "does what we just generated differ from what is committed?",
+# which is what this script asks. Being output-driven, it needs no
+# per-trigger special-casing: a code change that alters output releases, and
+# one that does not has nothing to release.
+
+set -euo pipefail
+
+OUTPUT_DIR="docs/specifications/api"
+INDEX_FILE="${OUTPUT_DIR}/index.json"
+UPSTREAM_STATE=".github_release"
+
+# Every path used as a change signal, guarded below. Both match a .gitignore
+# pattern and are tracked only because the release commit force-adds them, so
+# the invariant that matters is trackedness, not .gitignore membership.
+SIGNAL_PATHS=("$OUTPUT_DIR" "$UPSTREAM_STATE")
+
+# Volatile generator metadata: every pipeline run stamps a fresh wall clock
+# into these top-level keys (`timestamp` in index.json via
+# scripts/pipeline.py create_spec_index, `generated_at` in the
+# namespace-profile and validation reports). They carry no content, so a diff
+# made only of them must not publish an otherwise empty release.
+VOLATILE_FILTER='del(.timestamp, .generated_at)'
+
+GH_CMD="${DETECT_RELEASE_GH:-gh}"
+
+: "${GITHUB_OUTPUT:?GITHUB_OUTPUT must point at the step output file}"
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+emit() {
+  printf '%s\n' "$@" >>"$GITHUB_OUTPUT"
+}
+
+# Canonicalise one generated artifact into $1, dropping volatile metadata.
+# Input arrives on stdin. Anything jq cannot parse is compared byte-for-byte
+# instead, so a non-JSON artifact is never silently treated as unchanged.
+normalize_to() {
+  local dest="$1"
+  local raw="${WORK_DIR}/raw"
+  cat >"$raw"
+  if ! jq -S "$VOLATILE_FILTER" "$raw" >"$dest" 2>/dev/null; then
+    cp "$raw" "$dest"
+  fi
+}
+
+# A signal path with no tracked files cannot ever produce a diff. That was
+# defect (1) of #1094 and it failed silently for months; make it loud.
+for path in "${SIGNAL_PATHS[@]}"; do
+  if [ -z "$(git ls-files -- "$path")" ]; then
+    echo "::error::Change signal '${path}' has no files tracked in git," \
+      "so a diff on it can never report a change (see #1094)." >&2
+    exit 1
+  fi
+done
+
+if [ ! -f "$INDEX_FILE" ]; then
+  emit "has_changes=false"
+  echo "No enriched specs generated (${INDEX_FILE} is missing)"
+  exit 0
+fi
+
+# Fresh repo / migration: nothing published yet, so publish.
+RELEASE_COUNT="$("$GH_CMD" release list --limit 1 2>/dev/null | wc -l | tr -d ' ')"
+if [ "${RELEASE_COUNT:-0}" -eq 0 ]; then
+  emit "has_changes=true" "change_type=source"
+  echo "No releases found - forcing initial release"
+  exit 0
+fi
+
+# --- Is a new upstream api-specs release in play? --------------------------
+# Classify on the release IDENTITY, not on the bytes of .github_release: the
+# download step rewrites `downloaded_at` on every forced download, so a byte
+# comparison would report `source` on every run and never `pipeline`.
+COMMITTED_TAG="$({ git show "HEAD:${UPSTREAM_STATE}" 2>/dev/null || true; } | jq -r '.tag_name // ""' 2>/dev/null || true)"
+CURRENT_TAG=""
+if [ -f "$UPSTREAM_STATE" ]; then
+  CURRENT_TAG="$(jq -r '.tag_name // ""' "$UPSTREAM_STATE" 2>/dev/null || true)"
+fi
+
+SOURCE_CHANGED=false
+if [ "$CURRENT_TAG" != "$COMMITTED_TAG" ]; then
+  SOURCE_CHANGED=true
+  echo "Upstream release changed: '${COMMITTED_TAG:-none}' -> '${CURRENT_TAG:-none}'"
+fi
+
+# --- Did the generated output move? ---------------------------------------
+OUTPUT_CHANGED=false
+while IFS= read -r file; do
+  [ -n "$file" ] || continue
+  if [ ! -f "$file" ]; then
+    echo "Generated output changed: ${file} was removed"
+    OUTPUT_CHANGED=true
+    break
+  fi
+  { git show "HEAD:${file}" 2>/dev/null || true; } | normalize_to "${WORK_DIR}/committed"
+  normalize_to "${WORK_DIR}/current" <"$file"
+  if ! cmp -s "${WORK_DIR}/committed" "${WORK_DIR}/current"; then
+    echo "Generated output changed: ${file}"
+    OUTPUT_CHANGED=true
+    break
+  fi
+done < <(git diff --name-only HEAD -- "$OUTPUT_DIR")
+
+if [ "$SOURCE_CHANGED" = false ] && [ "$OUTPUT_CHANGED" = false ]; then
+  emit "has_changes=false"
+  echo "No release: generated output matches HEAD and upstream release is unchanged"
+  exit 0
+fi
+
+if [ "$SOURCE_CHANGED" = true ]; then
+  CHANGE_TYPE="source"
+  echo "Source spec changes detected"
+else
+  CHANGE_TYPE="pipeline"
+  echo "Pipeline/config/workflow changes detected"
+fi
+
+emit "has_changes=true" "change_type=${CHANGE_TYPE}"

--- a/scripts/release/detect-release-changes.sh
+++ b/scripts/release/detect-release-changes.sh
@@ -45,12 +45,22 @@ UPSTREAM_STATE=".github_release"
 # the invariant that matters is trackedness, not .gitignore membership.
 SIGNAL_PATHS=("$OUTPUT_DIR" "$UPSTREAM_STATE")
 
-# Volatile generator metadata: every pipeline run stamps a fresh wall clock
-# into these top-level keys (`timestamp` in index.json via
-# scripts/pipeline.py create_spec_index, `generated_at` in the
-# namespace-profile and validation reports). They carry no content, so a diff
-# made only of them must not publish an otherwise empty release.
-VOLATILE_FILTER='del(.timestamp, .generated_at)'
+# Fields that move without the content moving, stripped before comparing:
+#
+#   timestamp, generated_at  A fresh wall clock on every pipeline run
+#                            (scripts/pipeline.py create_spec_index, plus the
+#                            namespace-profile and validation report writers).
+#   version, info.version    Version STAMPS, assigned by the release process
+#                            itself in `Update version in specs` — after this
+#                            gate has already run. Treating them as a change
+#                            signal is circular: the pipeline writes the
+#                            previous tag, the committed files carry the tag
+#                            they shipped as, so a cache-restored tree always
+#                            looks "changed" and every run would publish a
+#                            content-free patch release.
+#
+# A diff made only of these must not publish an otherwise empty release.
+VOLATILE_FILTER='del(.timestamp, .generated_at, .version, .info.version)'
 
 GH_CMD="${DETECT_RELEASE_GH:-gh}"
 

--- a/tests/shell/test_detect_release_changes.py
+++ b/tests/shell/test_detect_release_changes.py
@@ -207,12 +207,14 @@ def _run(repo: Path, fake_gh: Path) -> tuple[subprocess.CompletedProcess[str], d
 def test_worktree_output_change_is_detected(tmp_path: Path) -> None:
     repo = _setup_repo(tmp_path)
     # What the enrichment pipeline just produced: renamed property, new
-    # annotation -- exactly the api-specs v2026.07.24-2 wire-name change.
+    # annotation -- exactly the api-specs v2026.07.24-2 wire-name change. The
+    # version stamp moves too (the pipeline writes the previous tag), which
+    # must not mask the real content change.
     (repo / f"{_OUTPUT_DIR}/network.json").write_text(
         json.dumps(
             {
                 "openapi": "3.0.3",
-                "info": {"version": "2.1.0"},
+                "info": {"version": "2.0.9"},
                 "blocked_service": {"x-f5xc-wire-name": "blocked_sevice"},
             },
             indent=2,
@@ -294,6 +296,34 @@ def test_volatile_generator_timestamps_alone_are_not_a_change(tmp_path: Path) ->
     """
     repo = _setup_repo(tmp_path)
     (repo / _INDEX).write_text(_index_json(timestamp="2026-07-25T23:59:59.999999+00:00"))
+
+    proc, outputs = _run(repo, _write_fake_gh(tmp_path, release_lines=1))
+
+    assert proc.returncode == 0, proc.stderr
+    assert outputs["has_changes"] == "false", proc.stdout
+
+
+def test_version_stamp_alone_is_not_a_change(tmp_path: Path) -> None:
+    """The release process assigns `version` *after* this gate runs.
+
+    The pipeline writes the previous tag and the committed files carry the tag
+    they shipped as, so a cache-restored tree always differs by exactly one
+    bump. Counting that would make every run publish a content-free release.
+    """
+    repo = _setup_repo(tmp_path)
+    (repo / _INDEX).write_text(_index_json(version="2.0.9"))
+
+    proc, outputs = _run(repo, _write_fake_gh(tmp_path, release_lines=1))
+
+    assert proc.returncode == 0, proc.stderr
+    assert outputs["has_changes"] == "false", proc.stdout
+
+
+def test_domain_spec_info_version_stamp_alone_is_not_a_change(tmp_path: Path) -> None:
+    repo = _setup_repo(tmp_path)
+    (repo / f"{_OUTPUT_DIR}/network.json").write_text(
+        json.dumps({"openapi": "3.0.3", "info": {"version": "2.0.9"}}, indent=2) + "\n"
+    )
 
     proc, outputs = _run(repo, _write_fake_gh(tmp_path, release_lines=1))
 

--- a/tests/shell/test_detect_release_changes.py
+++ b/tests/shell/test_detect_release_changes.py
@@ -1,0 +1,457 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+"""Tests for scripts/release/detect-release-changes.sh.
+
+Covers the release gate that decides whether a sync-and-enrich run publishes
+an enriched release. The previous implementation lived inline in
+`.github/workflows/sync-and-enrich.yml` and asked "did the *previous commit*
+change the inputs?" via `git diff HEAD~1 HEAD -- specs/original/ ...`. Two
+independent defects made an upstream release incapable of ever producing an
+enriched release (api-specs-enriched#1094):
+
+1. `specs/original/` is gitignored with zero tracked files, so a diff on it
+   can never report anything.
+2. `.github_release` is tracked, but the download step rewrites it in the
+   *working tree*, which a `HEAD~1 HEAD` comparison of two committed
+   revisions cannot see.
+
+The replacement asks the only correct question -- "does what we just
+generated differ from what is committed?" -- and lives in a script so these
+tests can pin it. Fixtures are throwaway git repos; the real repository's git
+state is never mutated.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT_RELATIVE = "scripts/release/detect-release-changes.sh"
+_SCRIPT = _PROJECT_ROOT / _SCRIPT_RELATIVE
+_WORKFLOW = _PROJECT_ROOT / ".github/workflows/sync-and-enrich.yml"
+
+_OUTPUT_DIR = "docs/specifications/api"
+_INDEX = f"{_OUTPUT_DIR}/index.json"
+_UPSTREAM_STATE = ".github_release"
+
+# The paths the detector is allowed to treat as a change signal. Every one of
+# them must have at least one file tracked in the real repository, otherwise
+# `git diff` on it is structurally silent -- defect (1) above.
+_SIGNAL_PATHS = (_OUTPUT_DIR, _UPSTREAM_STATE)
+
+# `.gitignore` matches both signal paths; they are tracked only because the
+# release commit force-adds them. Fixtures reproduce that exact shape so the
+# tests exercise reality rather than a friendlier variant.
+_FIXTURE_GITIGNORE = f"{_OUTPUT_DIR}/\n{_UPSTREAM_STATE}\nspecs/\n"
+
+
+def _git(cwd: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+
+
+def _index_json(*, version: str = "2.1.0", timestamp: str = "2026-01-01T00:00:00+00:00") -> str:
+    return (
+        json.dumps(
+            {
+                "version": version,
+                "timestamp": timestamp,
+                "specifications": [{"domain": "network", "file": "network.json"}],
+            },
+            indent=2,
+        )
+        + "\n"
+    )
+
+
+def _release_state(
+    *, tag: str = "v2026.01.01-1", downloaded_at: str = "2026-01-01T00:00:00Z"
+) -> str:
+    return (
+        json.dumps(
+            {
+                "version": tag.lstrip("v"),
+                "tag_name": tag,
+                "published_at": "2026-01-01T00:00:00Z",
+                "asset_name": f"api-specs-{tag}.zip",
+                "asset_size": 12345,
+                "downloaded_at": downloaded_at,
+            },
+            indent=2,
+        )
+        + "\n"
+    )
+
+
+def _write_fake_gh(tmp_path: Path, *, release_lines: int) -> Path:
+    """Fake `gh` implementing only `gh release list --limit 1`.
+
+    `release_lines=0` reproduces a repository with no releases yet, which the
+    detector must treat as "force an initial release".
+    """
+    payload = "".join(f"v1.0.{i}\tLatest\tv1.0.{i}\t2026-01-01\n" for i in range(release_lines))
+    listing = tmp_path / "fake_gh_releases"
+    listing.write_text(payload)
+
+    fake_gh = tmp_path / "fake_gh.sh"
+    fake_gh.write_text(
+        f"""#!/usr/bin/env bash
+set -e
+if [ "$1" = "release" ] && [ "$2" = "list" ]; then
+  cat {listing.as_posix()!r}
+  exit 0
+fi
+echo "fake gh: unsupported invocation: $*" >&2
+exit 1
+"""
+    )
+    fake_gh.chmod(fake_gh.stat().st_mode | stat.S_IEXEC)
+    return fake_gh
+
+
+def _setup_repo(
+    tmp_path: Path,
+    *,
+    with_gitignore: bool = True,
+    track_output: bool = True,
+) -> Path:
+    """Build a throwaway repo shaped like the runner's checkout.
+
+    Two commits: a base commit holding the generated output, then a commit
+    that touches only `README.md`. That second commit is what makes the old
+    `HEAD~1 HEAD` comparison silent -- the previous commit changed nothing the
+    old check looked at, even though the working tree may hold brand-new
+    generated output.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    _git(repo, "config", "user.email", "t@t.t")
+    _git(repo, "config", "user.name", "t")
+
+    (repo / _OUTPUT_DIR).mkdir(parents=True)
+    (repo / _INDEX).write_text(_index_json())
+    (repo / f"{_OUTPUT_DIR}/openapi.json").write_text(
+        json.dumps({"openapi": "3.0.3", "paths": {"/a": {}}}, indent=2) + "\n"
+    )
+    (repo / f"{_OUTPUT_DIR}/network.json").write_text(
+        json.dumps({"openapi": "3.0.3", "info": {"version": "2.1.0"}}, indent=2) + "\n"
+    )
+    (repo / _UPSTREAM_STATE).write_text(_release_state())
+    (repo / "README.md").write_text("base\n")
+    (repo / "specs" / "original").mkdir(parents=True)
+    (repo / "specs" / "original" / "raw.json").write_text("{}\n")
+
+    base_files = ["README.md"]
+    if with_gitignore:
+        (repo / ".gitignore").write_text(_FIXTURE_GITIGNORE)
+        base_files.append(".gitignore")
+
+    _git(repo, "add", *base_files)
+    if track_output:
+        _git(repo, "add", "-f", _OUTPUT_DIR, _UPSTREAM_STATE)
+    _git(repo, "commit", "-q", "-m", "init")
+
+    # A follow-up commit that touches nothing the detector cares about.
+    (repo / "README.md").write_text("second commit\n")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "-q", "-m", "docs: unrelated")
+    return repo
+
+
+def _run(repo: Path, fake_gh: Path) -> tuple[subprocess.CompletedProcess[str], dict[str, str]]:
+    """Run the detector inside ``repo`` and parse its ``$GITHUB_OUTPUT``."""
+    script_copy = repo / _SCRIPT_RELATIVE
+    script_copy.parent.mkdir(parents=True, exist_ok=True)
+    script_copy.write_text(_SCRIPT.read_text())
+    script_copy.chmod(script_copy.stat().st_mode | stat.S_IEXEC)
+
+    output_file = repo / "github_output"
+    output_file.write_text("")
+    env = {
+        **os.environ,
+        "GITHUB_OUTPUT": str(output_file),
+        "DETECT_RELEASE_GH": str(fake_gh),
+    }
+    proc = subprocess.run(
+        ["bash", _SCRIPT_RELATIVE],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    outputs = {}
+    for line in output_file.read_text().splitlines():
+        if "=" in line:
+            key, _, value = line.partition("=")
+            outputs[key] = value
+    return proc, outputs
+
+
+# ---------------------------------------------------------------------------
+# AC1 -- a working-tree output change is detected even though HEAD~1..HEAD
+#        touched nothing the old check looked at.
+# ---------------------------------------------------------------------------
+
+
+def test_worktree_output_change_is_detected(tmp_path: Path) -> None:
+    repo = _setup_repo(tmp_path)
+    # What the enrichment pipeline just produced: renamed property, new
+    # annotation -- exactly the api-specs v2026.07.24-2 wire-name change.
+    (repo / f"{_OUTPUT_DIR}/network.json").write_text(
+        json.dumps(
+            {
+                "openapi": "3.0.3",
+                "info": {"version": "2.1.0"},
+                "blocked_service": {"x-f5xc-wire-name": "blocked_sevice"},
+            },
+            indent=2,
+        )
+        + "\n"
+    )
+
+    proc, outputs = _run(repo, _write_fake_gh(tmp_path, release_lines=1))
+
+    assert proc.returncode == 0, proc.stderr
+    assert outputs["has_changes"] == "true", proc.stdout
+    assert outputs["change_type"] == "pipeline", proc.stdout
+
+
+def test_legacy_head_tilde_comparison_is_blind_to_that_change(tmp_path: Path) -> None:
+    """Pin the defect the fix removes.
+
+    In the very fixture where `test_worktree_output_change_is_detected`
+    demands `has_changes=true`, the retired `HEAD~1 HEAD` comparison reports
+    no change at all. This test exists so a regression back to input-guessing
+    across commit history is caught as a behavioural difference, not just a
+    diff review.
+    """
+    repo = _setup_repo(tmp_path)
+    (repo / f"{_OUTPUT_DIR}/network.json").write_text('{"changed": true}\n')
+
+    legacy = subprocess.run(
+        [
+            "git",
+            "diff",
+            "--quiet",
+            "HEAD~1",
+            "HEAD",
+            "--",
+            "specs/original/",
+            ".github_release",
+            "scripts/",
+            "config/",
+            "requirements.txt",
+            ".github/workflows/sync-and-enrich.yml",
+        ],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert legacy.returncode == 0, "expected the legacy check to see nothing"
+
+    current = subprocess.run(
+        ["git", "diff", "--quiet", "HEAD", "--", _OUTPUT_DIR, _UPSTREAM_STATE],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert current.returncode == 1, "expected the output-driven check to see the change"
+
+
+# ---------------------------------------------------------------------------
+# AC2 -- nothing changed means no release.
+# ---------------------------------------------------------------------------
+
+
+def test_identical_worktree_reports_no_changes(tmp_path: Path) -> None:
+    repo = _setup_repo(tmp_path)
+
+    proc, outputs = _run(repo, _write_fake_gh(tmp_path, release_lines=1))
+
+    assert proc.returncode == 0, proc.stderr
+    assert outputs["has_changes"] == "false", proc.stdout
+
+
+def test_volatile_generator_timestamps_alone_are_not_a_change(tmp_path: Path) -> None:
+    """`index.json` carries a wall-clock `timestamp` from every pipeline run.
+
+    Treating that as a content change would publish a release for every run
+    that regenerates byte-identical specs -- the "empty release" the gate
+    exists to prevent.
+    """
+    repo = _setup_repo(tmp_path)
+    (repo / _INDEX).write_text(_index_json(timestamp="2026-07-25T23:59:59.999999+00:00"))
+
+    proc, outputs = _run(repo, _write_fake_gh(tmp_path, release_lines=1))
+
+    assert proc.returncode == 0, proc.stderr
+    assert outputs["has_changes"] == "false", proc.stdout
+
+
+def test_real_content_change_in_index_is_still_a_change(tmp_path: Path) -> None:
+    """Normalising the volatile timestamp must not blind the detector."""
+    repo = _setup_repo(tmp_path)
+    payload = json.loads((repo / _INDEX).read_text())
+    payload["timestamp"] = "2026-07-25T23:59:59.999999+00:00"
+    payload["specifications"].append({"domain": "new_domain", "file": "new_domain.json"})
+    (repo / _INDEX).write_text(json.dumps(payload, indent=2) + "\n")
+
+    proc, outputs = _run(repo, _write_fake_gh(tmp_path, release_lines=1))
+
+    assert proc.returncode == 0, proc.stderr
+    assert outputs["has_changes"] == "true", proc.stdout
+
+
+# ---------------------------------------------------------------------------
+# AC3 -- change_type classification.
+# ---------------------------------------------------------------------------
+
+
+def test_new_upstream_release_tag_reports_source(tmp_path: Path) -> None:
+    repo = _setup_repo(tmp_path)
+    (repo / _UPSTREAM_STATE).write_text(
+        _release_state(tag="v2026.07.24-2", downloaded_at="2026-07-25T01:37:00Z")
+    )
+
+    proc, outputs = _run(repo, _write_fake_gh(tmp_path, release_lines=1))
+
+    assert proc.returncode == 0, proc.stderr
+    assert outputs["has_changes"] == "true", proc.stdout
+    assert outputs["change_type"] == "source", proc.stdout
+
+
+def test_redownloaded_same_tag_is_not_a_source_change(tmp_path: Path) -> None:
+    """`.github_release` always differs after a download -- `downloaded_at`.
+
+    Classifying on the file's bytes would therefore report `source` on every
+    run and never `pipeline`. The upstream release *identity* is the signal.
+    """
+    repo = _setup_repo(tmp_path)
+    (repo / _UPSTREAM_STATE).write_text(
+        _release_state(tag="v2026.01.01-1", downloaded_at="2026-07-25T01:37:00Z")
+    )
+    (repo / f"{_OUTPUT_DIR}/network.json").write_text('{"changed": true}\n')
+
+    proc, outputs = _run(repo, _write_fake_gh(tmp_path, release_lines=1))
+
+    assert proc.returncode == 0, proc.stderr
+    assert outputs["has_changes"] == "true", proc.stdout
+    assert outputs["change_type"] == "pipeline", proc.stdout
+
+
+def test_new_upstream_tag_alone_releases_even_without_output_change(tmp_path: Path) -> None:
+    repo = _setup_repo(tmp_path)
+    (repo / _UPSTREAM_STATE).write_text(_release_state(tag="v2026.07.24-2"))
+
+    proc, outputs = _run(repo, _write_fake_gh(tmp_path, release_lines=1))
+
+    assert proc.returncode == 0, proc.stderr
+    assert outputs["has_changes"] == "true", proc.stdout
+    assert outputs["change_type"] == "source", proc.stdout
+
+
+# ---------------------------------------------------------------------------
+# Preserved early paths.
+# ---------------------------------------------------------------------------
+
+
+def test_missing_generated_index_reports_no_changes(tmp_path: Path) -> None:
+    repo = _setup_repo(tmp_path)
+    (repo / _INDEX).unlink()
+
+    proc, outputs = _run(repo, _write_fake_gh(tmp_path, release_lines=1))
+
+    assert proc.returncode == 0, proc.stderr
+    assert outputs["has_changes"] == "false", proc.stdout
+
+
+def test_no_existing_releases_forces_a_source_release(tmp_path: Path) -> None:
+    repo = _setup_repo(tmp_path)
+
+    proc, outputs = _run(repo, _write_fake_gh(tmp_path, release_lines=0))
+
+    assert proc.returncode == 0, proc.stderr
+    assert outputs["has_changes"] == "true", proc.stdout
+    assert outputs["change_type"] == "source", proc.stdout
+
+
+# ---------------------------------------------------------------------------
+# AC4 -- a path with no tracked files can never be a change signal.
+# ---------------------------------------------------------------------------
+
+
+def test_untracked_signal_path_fails_loudly(tmp_path: Path) -> None:
+    """The shape of defect (1), turned into a hard failure.
+
+    `specs/original/` was silently useless as a signal because it has zero
+    tracked files. Any future signal path in that state must break the run
+    instead of quietly reporting "no changes".
+    """
+    repo = _setup_repo(tmp_path, track_output=False)
+
+    proc, outputs = _run(repo, _write_fake_gh(tmp_path, release_lines=1))
+
+    assert proc.returncode != 0, proc.stdout
+    assert _OUTPUT_DIR in proc.stderr + proc.stdout
+    assert "has_changes" not in outputs
+
+
+def test_gitignored_but_tracked_signal_path_is_accepted(tmp_path: Path) -> None:
+    """Both signal paths match `.gitignore` yet are force-added by the release
+    commit. Trackedness, not `.gitignore` membership, is the invariant."""
+    repo = _setup_repo(tmp_path, with_gitignore=True, track_output=True)
+    assert (
+        subprocess.run(
+            ["git", "check-ignore", "-q", "--no-index", _OUTPUT_DIR],
+            cwd=repo,
+            check=False,
+        ).returncode
+        == 0
+    ), "fixture must keep the signal path gitignored"
+
+    proc, outputs = _run(repo, _write_fake_gh(tmp_path, release_lines=1))
+
+    assert proc.returncode == 0, proc.stderr
+    assert outputs["has_changes"] == "false", proc.stdout
+
+
+def test_real_repo_signal_paths_have_tracked_files() -> None:
+    for path in _SIGNAL_PATHS:
+        tracked = _git(_PROJECT_ROOT, "ls-files", "--", path).split()
+        assert tracked, f"{path} has no tracked files, so it cannot signal a change"
+
+
+def test_detector_never_uses_a_zero_tracked_path_or_commit_history() -> None:
+    """Assert on executable lines only.
+
+    The script's header documents the retired `HEAD~1 HEAD` comparison and the
+    `specs/original/` pathspec on purpose, so comments are stripped before the
+    guard runs -- otherwise the guard would forbid explaining the bug.
+    """
+    code = [
+        line
+        for line in _SCRIPT.read_text().splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+    body = "\n".join(code)
+    assert "specs/original" not in body, "specs/original has zero tracked files"
+    assert "HEAD~1" not in body, "the release gate must not compare two committed revisions"
+
+
+def test_workflow_delegates_to_the_detector() -> None:
+    body = _WORKFLOW.read_text()
+    assert _SCRIPT_RELATIVE in body, "the workflow must call the detector script"
+    assert "HEAD~1 HEAD" not in body, "no step may gate on a HEAD~1..HEAD comparison"


### PR DESCRIPTION
Closes #1094

## Problem

An upstream `api-specs` release could **never** produce an `api-specs-enriched` release. `Detect changes and bump version` gated on:

```bash
git diff --quiet HEAD~1 HEAD -- \
  specs/original/ .github_release scripts/ config/ requirements.txt \
  .github/workflows/sync-and-enrich.yml
```

Two independent dead signals:

1. `specs/original/` is gitignored (`.gitignore:153` → `specs/`) with **0 tracked files** — a diff on it is structurally incapable of reporting anything.
2. `.github_release` **is** tracked, but the download step rewrites it in the **working tree**; `HEAD~1 HEAD` compares two *committed* revisions and cannot see that.

So the gate only ever fired when this repo's own previous commit touched code — matching the release history exactly (v2.1.188, v2.1.191, v2.1.192 were all code merges). Run `30183197820` downloaded `api-specs-v2026.07.24-2`, re-enriched against it (cache missed), then reported `No changes` and skipped the version bump, the release, and `Notify Downstream Repositories`.

## Fix

`scripts/release/detect-release-changes.sh` — an output-driven gate, extracted from inline YAML so it is unit-testable (the inline block being untestable is why this survived).

- **`has_changes`** compares the generated, **tracked** output in the working tree against `HEAD` (`git diff HEAD --`, never `HEAD~1 HEAD`). Output-driven, so it is correct for `repository_dispatch`, `push`, `schedule` and `workflow_dispatch` with no per-trigger special-casing.
- **`change_type`** keys on the upstream release **identity** (`.tag_name` in `.github_release`) rather than the file's bytes. Discovered while building this: `scripts/utils/github_release.py` rewrites `downloaded_at` on every forced download, so a byte comparison of `.github_release` would classify **every** run as `source` and never `pipeline`. Identity is the signal the issue's "(new upstream)" intends.
- **Volatile metadata normalised out** before comparing, so the gate is purely content-driven:
  - `timestamp` / `generated_at` — a fresh wall clock on every pipeline run (`scripts/pipeline.py` `create_spec_index`, plus the namespace-profile and validation report writers). Verified by scanning all 43 tracked output files; these are the only volatile top-level clock keys.
  - `version` / `info.version` — version **stamps**, assigned by `Update version in specs` *after* this gate runs. Using them as a signal is circular: the pipeline stamps the previous tag while the committed files carry the tag they shipped as, so any tree restored from the enriched-output cache differs by exactly one bump. Left in, every cache-hit run would publish a content-free patch release and dispatch all four downstream repos for it. The AC1 test moves a version stamp *alongside* a real content change, so the normalisation cannot mask a genuine release.
- **Guard so defect (1) cannot return:** a signal path with no tracked files now fails the run loudly instead of silently reporting "no changes". Note both signal paths *match* a `.gitignore` pattern and are tracked only because the release commit force-adds them, so the invariant that matters is **trackedness**, not `.gitignore` membership.
- Removed the dead `Early exit for docs-only changes` step: its `has_changes` output was consumed by nothing, it ran *after* the whole pipeline it claimed to skip, and it carried the same `HEAD~1 HEAD` defect.
- Downstream steps and the job output now read `steps.detect.outputs.has_changes` directly instead of a re-emitted copy.

## Tests — `tests/shell/test_detect_release_changes.py` (17 tests)

Written failing-first; fixtures are throwaway git repos in `tmp_path`, shaped like the runner's checkout (two commits, second touching only `README.md`, signal paths gitignored-but-force-added). The real repo's git state is never mutated.

RED before the script existed: **13 failed, 2 passed**. GREEN after: **17 passed**.

Coverage maps to the acceptance criteria:

| AC | Test |
| --- | --- |
| 1 — worktree output change with an untouched `HEAD~1..HEAD` | `test_worktree_output_change_is_detected`, plus `test_legacy_head_tilde_comparison_is_blind_to_that_change` which pins that the retired comparison sees nothing in the very same fixture |
| 2 — no difference → no release | `test_identical_worktree_reports_no_changes`, `test_volatile_generator_timestamps_alone_are_not_a_change`, `test_version_stamp_alone_is_not_a_change`, `test_domain_spec_info_version_stamp_alone_is_not_a_change`, `test_real_content_change_in_index_is_still_a_change` |
| 3 — `source` vs `pipeline` | `test_new_upstream_release_tag_reports_source`, `test_redownloaded_same_tag_is_not_a_source_change`, `test_new_upstream_tag_alone_releases_even_without_output_change` |
| 4 — no gitignored/zero-tracked path as a change signal | `test_untracked_signal_path_fails_loudly`, `test_gitignored_but_tracked_signal_path_is_accepted`, `test_real_repo_signal_paths_have_tracked_files`, `test_detector_never_uses_a_zero_tracked_path_or_commit_history` |
| preserved early paths | `test_missing_generated_index_reports_no_changes`, `test_no_existing_releases_forces_a_source_release` |
| wiring | `test_workflow_delegates_to_the_detector` (asserts no step gates on `HEAD~1 HEAD`) |

### Non-vacuity (mutation runs)

Each mutation of the script fails exactly the test that guards it:

| Mutation | Failing test |
| --- | --- |
| output diff reverted to `HEAD~1 HEAD` | `test_worktree_output_change_is_detected` (+3) |
| volatile-key normalisation removed | `test_volatile_generator_timestamps_alone_are_not_a_change` |
| tracked-path guard removed | `test_untracked_signal_path_fails_loudly` |
| `change_type` classified on `.github_release` bytes | `test_redownloaded_same_tag_is_not_a_source_change` |
| always release | `test_identical_worktree_reports_no_changes` (+2) |
| signal path pointed back at `specs/original` | 12 of 15 |
| version stamps left in the signal | `test_version_stamp_alone_is_not_a_change`, `test_domain_spec_info_version_stamp_alone_is_not_a_change` |
| everything normalised away (`{}`) | `test_worktree_output_change_is_detected` (+2) |

### Behaviour against the real working tree

- clean tree → `has_changes=false` (0.9 s)
- `index.json` timestamp bumped alone → `has_changes=false`
- `index.json` timestamp **and** version stamp bumped together → `has_changes=false`
- one real property rename inside the 30 MB `openapi.json` → `has_changes=true`, `change_type=pipeline` (3.2 s)

## Linters run locally

`ruff check`, `ruff format --check`, `mypy`, `pylint` (10.00/10), `shellcheck`, `shfmt -d`, `codespell`, `yamllint`, `actionlint`, `zizmor`, `check-repo-hygiene.sh`, and `pre-commit` on the changed files. Full `tests/shell` + `tests/test_github_release.py`: 49 passed.

Two notes, both pre-existing and unrelated to this change:

- zizmor reports one **low** `adhoc-packages` finding at `sync-and-enrich.yml:235` (`npm install -g @stoplight/spectral-cli`). Byte-identical on `origin/main` (`zizmor` exits 12 on both), and this repo's authoritative gate — `workflow-security-audit.yml` — runs `--min-severity medium`, which exits 0. Not introduced here and deliberately non-gating per that workflow's own comment.
- The `.pre-commit-config.yaml` `zizmor` hook has **no** `--min-severity`, so it is stricter than the CI policy it mirrors and fails on `main` for anyone editing a workflow. That file is governance-managed; worth a docs-control issue rather than a local edit.
