### PR TITLE
fix(contract-diff): classify string.in enums and allOf-wrapped refs correctly

### DIFF
--- a/scripts/contract_diff.py
+++ b/scripts/contract_diff.py
@@ -148,6 +148,12 @@ def _flatten_allof_refs(obj: Any) -> Any:
     ``{"allOf": [{"$ref": "X"}], "x-foo": 1}`` becomes
     ``{"$ref": "X", "x-foo": 1}`` so that the contract diff sees
     allOf-wrapped refs as equivalent to direct refs.
+
+    Both forms mean the same thing in JSON Schema, and the wrapper appears on
+    *either* side: enrichment wraps a bare ``$ref`` so it can attach a sibling
+    ``description`` (OpenAPI 3.0 ignores siblings of ``$ref``), while a handful
+    of upstream properties already ship wrapped. So this normalization must be
+    applied to both specs — see ``run_contract_diff``.
     """
     if isinstance(obj, dict):
         allof = obj.get("allOf")
@@ -183,6 +189,11 @@ def run_contract_diff(
             set is suppressed (design spec 2026-04-22 §5).
     """
     known = known_drift or set()
+    # Normalize both sides: an allOf-wrapped $ref is semantically identical to a
+    # direct $ref, and either spec may use either form. Flattening only the
+    # output turned upstream-wrapped properties into a phantom `allOf` removal
+    # plus `$ref` add.
+    input_spec = _flatten_allof_refs(input_spec)
     output_spec = _flatten_allof_refs(output_spec)
     diff = DeepDiff(
         input_spec,

--- a/scripts/utils/additive_allowlist.py
+++ b/scripts/utils/additive_allowlist.py
@@ -92,6 +92,7 @@ def _is_terminal_additive(terminal: str, after: object) -> bool:
         terminal.startswith("x-")
         or terminal in _FREE_TEXT_KEYS
         or _is_constraint_add(terminal, after)
+        or _is_string_enum_add(terminal, after)
         or _is_schema_annotation_add(terminal, after)
         or _is_known_format_add(terminal, after)
     )
@@ -180,6 +181,30 @@ def _is_constraint_add(terminal: str, after: object) -> bool:
     if terminal in {"minLength", "maxLength", "minItems", "maxItems", "minimum", "maximum"}:
         return isinstance(after, int) and not isinstance(after, bool) and after >= 0
     return terminal == "pattern" and isinstance(after, str)
+
+
+def _is_string_enum_add(terminal: str, after: object) -> bool:
+    """Rule 9 — a native ``enum`` transcribed from an upstream ``string.in`` rule.
+
+    ``ConstraintEnricher._apply_string_in_enum`` copies the values of
+    ``ves.io.schema.rules.string.in`` onto the property's native JSON-Schema
+    ``enum`` so the provider's ``convert.go`` emits a ``OneOf`` validator. The
+    server already rejects any value outside that set, so publishing it as an
+    ``enum`` *documents* a constraint that was always enforced — it cannot
+    reject a request the upstream API would have accepted.
+
+    The rule is deliberately narrow so it does not become a blanket
+    "array-valued adds are additive" escape hatch: only a non-empty list whose
+    every member is a string qualifies, matching what ``string.in`` can produce
+    (it is applied only where ``type: string``). An empty ``enum`` permits
+    nothing and a non-string ``enum`` has no ``string.in`` provenance, so both
+    stay reportable.
+    """
+    if terminal != "enum":
+        return False
+    return (
+        isinstance(after, list) and bool(after) and all(isinstance(value, str) for value in after)
+    )
 
 
 def _is_schema_annotation_add(terminal: str, after: object) -> bool:

--- a/tests/test_additive_allowlist.py
+++ b/tests/test_additive_allowlist.py
@@ -297,3 +297,52 @@ def test_non_additive_dict_add_is_rejected():
     pointer = "root['components']['schemas']['Foo']['required']"
     after = ["bar", "baz"]
     assert not is_additive_change("dictionary_item_added", pointer, None, after)
+
+
+# Rule 9 — native `enum` transcribed from an upstream `string.in` rule
+
+
+def test_added_string_enum_is_additive():
+    """Creating the `enum` key from an upstream `string.in` rule is additive.
+
+    `ConstraintEnricher._apply_string_in_enum` copies the values of
+    `ves.io.schema.rules.string.in` onto the property's native `enum`. The
+    server already rejects anything outside that set, so transcribing it
+    documents an existing constraint rather than adding a new one.
+    """
+    pointer = (
+        "root['components']['schemas']['routeRouteRedirect']"
+        "['properties']['proto_redirect']['enum']"
+    )
+    assert is_additive_change(
+        "dictionary_item_added",
+        pointer,
+        None,
+        ["incoming-proto", "http", "https"],
+    )
+
+
+def test_added_empty_enum_is_not_additive():
+    """An empty `enum` permits nothing — that narrows the contract to zero."""
+    pointer = "root['components']['schemas']['Foo']['properties']['bar']['enum']"
+    assert not is_additive_change("dictionary_item_added", pointer, None, [])
+
+
+def test_added_non_string_enum_is_not_additive():
+    """Only all-string enums come from `string.in`; anything else is unproven."""
+    pointer = "root['components']['schemas']['Foo']['properties']['bar']['enum']"
+    assert not is_additive_change("dictionary_item_added", pointer, None, [1, 2, 3])
+    assert not is_additive_change("dictionary_item_added", pointer, None, [{"a": "b"}])
+
+
+def test_added_non_list_enum_is_not_additive():
+    """A scalar `enum` value is malformed, not additive."""
+    pointer = "root['components']['schemas']['Foo']['properties']['bar']['enum']"
+    assert not is_additive_change("dictionary_item_added", pointer, None, "http")
+
+
+def test_enum_rule_does_not_widen_other_array_valued_adds():
+    """Guard against blanket widening: other array-valued adds stay breaking."""
+    for terminal in ("required", "oneOf", "anyOf", "allOf"):
+        pointer = f"root['components']['schemas']['Foo']['{terminal}']"
+        assert not is_additive_change("dictionary_item_added", pointer, None, ["bar"])

--- a/tests/test_contract_diff.py
+++ b/tests/test_contract_diff.py
@@ -283,3 +283,101 @@ def test_allof_wrapped_ref_is_not_a_violation() -> None:
     }
     violations = run_contract_diff(input_spec, output_spec)
     assert violations == []
+
+
+def test_upstream_allof_wrapped_ref_is_not_a_violation() -> None:
+    """Reverse direction: upstream wraps the $ref, enrichment adds a sibling.
+
+    A handful of upstream properties are emitted as
+    ``{"allOf": [{"$ref": X}]}`` rather than ``{"$ref": X}``. Enrichment keeps
+    the wrapper and attaches a description. Normalising only the output side
+    turned those sites into a bogus ``allOf`` removal plus ``$ref`` add.
+    """
+    input_spec = {
+        "components": {
+            "schemas": {
+                "originPoolAdvancedOptions": {
+                    "properties": {
+                        "disable_lb_source_ip_persistence": {
+                            "allOf": [{"$ref": "#/components/schemas/ioschemaEmpty"}],
+                        },
+                    },
+                },
+            },
+        },
+    }
+    output_spec = {
+        "components": {
+            "schemas": {
+                "originPoolAdvancedOptions": {
+                    "properties": {
+                        "disable_lb_source_ip_persistence": {
+                            "allOf": [{"$ref": "#/components/schemas/ioschemaEmpty"}],
+                            "description": "IP address configuration",
+                        },
+                    },
+                },
+            },
+        },
+    }
+    assert run_contract_diff(input_spec, output_spec) == []
+
+
+def test_dropped_ref_under_upstream_allof_is_still_a_violation() -> None:
+    """Normalising both sides must not hide a reference the output lost."""
+    input_spec = {
+        "components": {
+            "schemas": {
+                "Foo": {
+                    "properties": {
+                        "bar": {"allOf": [{"$ref": "#/components/schemas/Bar"}]},
+                    },
+                },
+            },
+        },
+    }
+    output_spec = {
+        "components": {
+            "schemas": {
+                "Foo": {
+                    "properties": {
+                        "bar": {"description": "no longer references Bar"},
+                    },
+                },
+            },
+        },
+    }
+    violations = run_contract_diff(input_spec, output_spec)
+    assert [v.rule_category for v in violations] == ["removal"]
+
+
+def test_multi_member_allof_is_not_flattened() -> None:
+    """Only a single-member allOf is a $ref wrapper; dropping a member breaks."""
+    input_spec = {
+        "components": {
+            "schemas": {
+                "Foo": {
+                    "properties": {
+                        "bar": {
+                            "allOf": [
+                                {"$ref": "#/components/schemas/Bar"},
+                                {"$ref": "#/components/schemas/Baz"},
+                            ],
+                        },
+                    },
+                },
+            },
+        },
+    }
+    output_spec = {
+        "components": {
+            "schemas": {
+                "Foo": {
+                    "properties": {
+                        "bar": {"allOf": [{"$ref": "#/components/schemas/Bar"}]},
+                    },
+                },
+            },
+        },
+    }
+    assert run_contract_diff(input_spec, output_spec) != []


### PR DESCRIPTION
## Problem

`Contract-diff gate` has been red on `main` with **96 violations**
(78 `constraint-change`, 9 `removal`, 9 `shape-change`).

Every one of the 96 is a defect in the gate's own classification, not contract drift.
Triage below; evidence reproduced locally against `specs/original` at upstream
`api-specs v2026.07.24-2` and the enriched output at `ecbfaac7`.

## Triage

### 78 `constraint-change` — false positive (enum theory confirmed)

All 78 are `dictionary_item_added` on a terminal `enum` key, `before: not present`,
`after:` a non-empty list of strings (394 members, all `str`).

`ConstraintEnricher._apply_string_in_enum` copies the values of an upstream
`ves.io.schema.rules.string.in` validation rule onto the property's native
JSON-Schema `enum`. **77 of 78 trace to a `string.in` rule at the exact same
pointer with exactly the emitted values**; the 78th
(`discovered_serviceAwsPortInfo.protocol`) only failed to trace because the
schema is new in `v2026.07.24-2` and the trace was run against a
`v2026.07.10-1` checkout. Examples:

| Site | upstream `x-ves-validation-rules` | emitted `enum` |
| --- | --- | --- |
| `routeRouteRedirect.proto_redirect` | `string.in: [\"incoming-proto\",\"http\",\"https\"]` | `["incoming-proto","http","https"]` |
| `bigip_iruleCreateSpecType.source` | `string.in: [\"AI\",\"Human\",\"Mix\"]` | `["AI","Human","Mix"]` |

The server already rejects anything outside that set, so the `enum` documents a
constraint that was always enforced — it cannot reject a request the upstream API
would have accepted. Issue #1086 option 1 holds.

### 18 `removal` + `shape-change` — false positive (asymmetric normalization)

These are not 18 sites, they are **9 sites reported twice**: `allOf` removed and
`$ref` added at the same pointer.

```text
root[...]['origin_poolOriginPoolAdvancedOptions']['properties']['disable_lb_source_ip_persistence']['allOf']
  before: [{'$ref': '#/components/schemas/ioschemaEmpty'}]   after: not present
root[...]['origin_poolOriginPoolAdvancedOptions']['properties']['disable_lb_source_ip_persistence']['$ref']
  before: not present   after: '#/components/schemas/ioschemaEmpty'
```

`run_contract_diff` applied `_flatten_allof_refs` to the **output spec only**.
Enrichment wraps a bare `$ref` in `allOf` so it can attach a sibling `description`
(OpenAPI 3.0 ignores siblings of `$ref`) — 23891 output properties are wrapped that
way against 13955 direct `$ref` in the input, which is what the one-sided flatten
was written for. But **exactly 9 upstream properties already ship wrapped**, and for
those the flatten runs the wrong way:

| Upstream `allOf`-wrapped property | `$ref` target |
| --- | --- |
| `clusterGetSpecType.{disable,enable}_lb_source_ip_persistence` | `ioschemaEmpty` |
| `origin_poolOriginPoolAdvancedOptions.{disable,enable}_lb_source_ip_persistence` | `ioschemaEmpty` |
| `namespaceHTTPLoadbalancerResultType.public_advertisement_enabled` | `ioschemaEmpty` |
| `namespace{TCP,UDP}LoadbalancerResultType.public_advertisement` | `ioschemaEmpty` |
| `schemasite{Get,Replace}SpecType.volterra_software_override` | `siteSiteSoftwareOverrideType` |

Nine upstream sites, nine `removal` + nine `shape-change`. The output still carries
the same `$ref` at every one of them — nothing was removed.

(These nine are the correctly-spelled replacements for the `*_persistance` /
`public_advertisment` / `volterra_software_overide` typos upstream fixed in this
window, which is why they are the newest — and only — `allOf`-wrapped properties.)

### Real and expected / real and alarming — none in this gate

Upstream really did remove content across the 16-day freeze (`v2026.07.10-1` →
`v2026.07.24-2`): **307 schemas and 74 properties**, including
`schemaSecretType.secret_encoding_type` (plus `vault_secret_info`,
`wingman_secret_info`, `blindfold_secret_info_internal`), the whole `apm*` family,
`viewsudp_loadbalancer*.enable_per_packet_load_balancing`,
`viewssecuremesh_site_v2*.log_receiver`, `schemacloud_connect*.aws_tgw_site`, and
`tenant_configuration*.{basic_configuration,brute_force_detection_settings}`.

**None of that is visible to this gate, by construction.** The gate diffs
`specs/original` → enriched output for the *same* upstream release; it never
compares upstream release N-1 to N. That blindness is a separate gap (filed
separately), not something this PR should paper over — and it means no known-drift
baseline entry is warranted here. All 96 reported violations are gate defects, so
green is the correct outcome.

## Fix

Root-cause only. No threshold, no per-violation allowlist entry, no known-drift
seeding, no gate relaxation.

1. `scripts/utils/additive_allowlist.py` — new Rule 9 `_is_string_enum_add`,
   wired into `_is_terminal_additive`. Deliberately narrow: only a **non-empty list
   whose every member is a string** qualifies, matching what `string.in` can produce
   (it is applied only where `type: string`). An empty `enum` permits nothing and a
   non-string `enum` has no `string.in` provenance, so both stay reportable, and
   this does not become a blanket "array-valued adds are additive" escape hatch.
2. `scripts/contract_diff.py` — apply `_flatten_allof_refs` to **both** specs.
   `{"allOf": [{"$ref": X}]}` and `{"$ref": X}` are the same thing in JSON Schema
   and either side may use either form.

## TDD evidence

RED first, on `tests/test_additive_allowlist.py` + `tests/test_contract_diff.py`:

```text
FAILED tests/test_additive_allowlist.py::test_added_string_enum_is_additive
FAILED tests/test_contract_diff.py::test_upstream_allof_wrapped_ref_is_not_a_violation
========================= 2 failed, 56 passed =========================
```

GREEN after the fix: `59 passed`. Full suite: **2211 passed, 6 skipped, 1 xfailed**
(2203 on `main` + the 8 new tests, no regression).

### Non-vacuity by mutation

| Mutation | Tests | Real gate |
| --- | --- | --- |
| Drop `_is_string_enum_add` from `_is_terminal_additive` | `test_added_string_enum_is_additive` FAILS | 96 → **78** (`constraint-change` only) |
| Revert `_flatten_allof_refs` to output-only | `test_upstream_allof_wrapped_ref_is_not_a_violation` FAILS | 96 → **18** (9 `removal` + 9 `shape-change`) |
| Relax Rule 9 to bare `return terminal == "enum"` | `test_added_empty_enum_is_not_additive`, `test_added_non_string_enum_is_not_additive`, `test_added_non_list_enum_is_not_additive` all FAIL | — |

Each half of the fix is individually load-bearing and accounts for exactly its
bucket; the guards on Rule 9 are not decorative.

Guard tests that must keep failing the gate: `test_dropped_ref_under_upstream_allof_is_still_a_violation`
(output loses the reference → still `removal`), `test_multi_member_allof_is_not_flattened`
(dropping a second `allOf` member → still reported), and
`test_enum_rule_does_not_widen_other_array_valued_adds` (`required`/`oneOf`/`anyOf`/`allOf`
array adds stay breaking).

## Gate result

Against `specs/original` @ `v2026.07.24-2` and `docs/specifications/api` @ `ecbfaac7`:

```text
before: 96 violations (78 constraint-change, 9 removal, 9 shape-change), exit 1
after:   0 violations, exit 0
```

The 96 violations reproduced locally are byte-identical to the CI artifact from run
`30187362455` (same change_type / pointer / before / after for all 96).

## Linters run locally

`ruff check` (all pass), `ruff format --check` (193 files formatted),
`mypy` (no issues), `pylint --rcfile=.python-lint` (10.00/10), `codespell`,
`yamllint`, `actionlint`, `zizmor`, `shellcheck`, `shfmt -d`, full `pytest`.
`pre-commit run --files <the 4 changed files>` passes every hook.

The `local-hooks` hook was skipped: staging `scripts/**` triggers its ~13-minute
enrichment pipeline, which regenerates `docs/specifications/api` with fresh
`x-f5xc-constraints.validatedAt` timestamps and auto-stages them. `scripts/pipeline.py`
imports neither `contract_diff` nor `additive_allowlist`, so this change cannot affect
enrichment output. Its constituent checks (`ruff check`, `ruff format`, `mypy`) were run
manually and are listed above.

Closes #1086

🤖 Generated with [Claude Code](https://claude.com/claude-code)
