### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,7 @@ When it is restored it becomes a required, merge-gating check again: on a block,
 
 ## Worktrees
 
-- For non-trivial coding tasks, work in a git worktree (Claude Code: `EnterWorktree` or `claude --worktree`) to isolate changes from the main checkout and enable parallel sessions.
+- For non-trivial coding tasks, **the main session** works in a git worktree (Claude Code: `EnterWorktree` or `claude --worktree`) to isolate changes from the main checkout and enable parallel sessions. A subagent never creates one: spawned with `isolation: "worktree"` it already has one, and `EnterWorktree` refuses from a pinned cwd. Grant isolation at spawn, never from inside.
 - **Know where you are.** Before starting, run `git worktree list` and confirm the current directory belongs to the task at hand. Never begin new work in a worktree left over from a finished one — retire it and start fresh. A finished worktree looks unmerged (squash-merge) and its base is stale. Retiring has a required order and an ignored-file check first — see CONTRIBUTING.md.
 - New worktrees branch from `origin/<default-branch>` (`worktree.baseRef` is set to `fresh` in `.claude/settings.json`). The `.claude/worktrees/` directory is already gitignored.
 - `fresh` means "from the cached remote ref", not "freshly fetched" — it only re-fetches when `FETCH_HEAD` is over 24 hours old. A worktree created after an earlier same-day fetch is born behind whatever merged since, so fetch before you create one.


### PR DESCRIPTION
Closes #1134

Synced managed files from `f5-sales-demo/docs-control` canonical source:

- CLAUDE.md