### PR TITLE
fix(release): stamp metadata versions correctly

### DIFF
--- a/.github/workflows/sync-and-enrich.yml
+++ b/.github/workflows/sync-and-enrich.yml
@@ -371,17 +371,12 @@ jobs:
         run: |
           echo "Updating specs to version: $VERSION"
 
-          # Update index.json
-          jq --arg v "$VERSION" '.version = $v' docs/specifications/api/index.json > /tmp/index.json
-          mv /tmp/index.json docs/specifications/api/index.json
-
-          # Update all domain specs info.version
-          for spec in docs/specifications/api/*.json; do
-            if [ "$(basename "$spec")" != "index.json" ]; then
-              jq --arg v "$VERSION" '.info.version = $v' "$spec" > /tmp/spec.json
-              mv /tmp/spec.json "$spec"
-            fi
-          done
+          # OpenAPI documents use info.version; auxiliary build artifacts use a
+          # top-level version; self-describing $schema artifacts keep their own
+          # format version. Keep this aligned with the contract-diff gate.
+          python -m scripts.stamp_release_version \
+            docs/specifications/api \
+            --version "$VERSION"
 
           echo "Updated all specs to version $VERSION"
 

--- a/docs/specifications/api/minimal-export-defaults.json
+++ b/docs/specifications/api/minimal-export-defaults.json
@@ -5220,8 +5220,5 @@
       "serverDefaultFields": []
     }
   },
-  "version": "2.1.202",
-  "info": {
-    "version": "2.1.203"
-  }
+  "version": "2.1.203"
 }

--- a/docs/specifications/api/namespace_profiles.json
+++ b/docs/specifications/api/namespace_profiles.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.1.202",
+  "version": "2.1.203",
   "generated_at": "2026-07-31T08:50:55+00:00",
   "source": "api-specs-enriched/config/namespace_profile.yaml",
   "default": {
@@ -5517,8 +5517,5 @@
       "tpm_category",
       "usb_policy"
     ]
-  },
-  "info": {
-    "version": "2.1.203"
   }
 }

--- a/docs/specifications/api/validation.json
+++ b/docs/specifications/api/validation.json
@@ -1209,8 +1209,5 @@
     "oneof_defaults_exported": 0,
     "ui_vs_server_defaults_exported": 1,
     "warnings": []
-  },
-  "info": {
-    "version": "2.1.203"
   }
 }

--- a/scripts/stamp_release_version.py
+++ b/scripts/stamp_release_version.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+"""Stamp generated artifacts with the repository release version."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def stamp_document(document: Any, version: str) -> bool:
+    """Apply a build version to a generated document in place.
+
+    OpenAPI documents carry their build identity in ``info.version``. Auxiliary
+    build artifacts carry it in a top-level ``version`` field. Self-describing
+    ``$schema`` artifacts have their own format version and must not be changed.
+    """
+    if not isinstance(document, dict) or "$schema" in document:
+        return False
+
+    info = document.get("info")
+    is_openapi = "openapi" in document or "swagger" in document
+    if is_openapi and isinstance(info, dict):
+        if info.get("version") == version:
+            return False
+        info["version"] = version
+        return True
+
+    if "version" in document:
+        if document["version"] == version:
+            return False
+        document["version"] = version
+        return True
+
+    return False
+
+
+def stamp_directory(directory: Path, version: str) -> int:
+    """Stamp all supported JSON artifacts in *directory*."""
+    changed = 0
+    for path in sorted(directory.glob("*.json")):
+        document = json.loads(path.read_text())
+        if not stamp_document(document, version):
+            continue
+        path.write_text(json.dumps(document, indent=2, ensure_ascii=False) + "\n")
+        changed += 1
+    return changed
+
+
+def main() -> None:
+    """Run the release-version stamper."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("directory", type=Path, help="Directory containing generated JSON")
+    parser.add_argument("--version", required=True, help="Release version to apply")
+    args = parser.parse_args()
+
+    changed = stamp_directory(args.directory, args.version)
+    print(f"Stamped {changed} generated artifact(s) with version {args.version}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_stamp_release_version.py
+++ b/tests/test_stamp_release_version.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+"""Tests for release-version stamping."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from scripts.stamp_release_version import stamp_directory, stamp_document
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_stamp_document_uses_openapi_info_version() -> None:
+    document = {"openapi": "3.0.3", "info": {"title": "Example", "version": "1.0.0"}}
+
+    assert stamp_document(document, "2.0.0") is True
+    assert document == {
+        "openapi": "3.0.3",
+        "info": {"title": "Example", "version": "2.0.0"},
+    }
+
+
+def test_stamp_document_uses_top_level_artifact_version() -> None:
+    document = {"version": "1.0.0", "resources": {}}
+
+    assert stamp_document(document, "2.0.0") is True
+    assert document == {"version": "2.0.0", "resources": {}}
+    assert "info" not in document
+
+
+def test_stamp_document_preserves_self_describing_schema() -> None:
+    document = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "version": "2.1.0",
+    }
+
+    assert stamp_document(document, "9.9.9") is False
+    assert document["version"] == "2.1.0"
+    assert "info" not in document
+
+
+def test_stamp_document_does_not_treat_arbitrary_info_as_openapi() -> None:
+    document = {"info": {"version": "format-v1"}, "resources": {}}
+
+    assert stamp_document(document, "2.0.0") is False
+    assert document["info"] == {"version": "format-v1"}
+
+
+def test_stamp_directory_updates_only_build_version_artifacts(tmp_path: Path) -> None:
+    fixtures = {
+        "domain.json": {"openapi": "3.0.3", "info": {"version": "1.0.0"}},
+        "index.json": {"version": "1.0.0"},
+        "validation.json": {"$schema": "example", "version": "2.1.0"},
+        "unversioned.json": {"resources": {}},
+    }
+    for name, document in fixtures.items():
+        (tmp_path / name).write_text(json.dumps(document))
+
+    assert stamp_directory(tmp_path, "2.0.0") == 2
+    assert json.loads((tmp_path / "domain.json").read_text())["info"]["version"] == "2.0.0"
+    assert json.loads((tmp_path / "index.json").read_text())["version"] == "2.0.0"
+    assert json.loads((tmp_path / "validation.json").read_text()) == fixtures["validation.json"]
+    assert json.loads((tmp_path / "unversioned.json").read_text()) == fixtures["unversioned.json"]


### PR DESCRIPTION
## Summary

- stamp OpenAPI documents through `info.version`
- stamp auxiliary build artifacts through top-level `version`
- preserve self-describing `$schema` format versions
- correct the three metadata artifacts corrupted by the v2.1.203 release stamp
- add focused regression coverage

## Verification

- 2,275 passed, 2 skipped, 1 expected xfail
- Ruff and mypy focused checks passed
- changed-file pre-commit suite passed, including Actions lint/security, Biome, and secrets detection
- clean pipeline rebuild reproduced only the three corrected artifacts

Closes #1186