### PR TITLE
fix: bind Pages to exact release commit

### DIFF
--- a/.github/workflows/github-pages-deploy.yml
+++ b/.github/workflows/github-pages-deploy.yml
@@ -1,17 +1,16 @@
 ---
 name: GitHub Pages Deploy
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'docs/**'
-  workflow_dispatch:
+  # Publication owns ordering: GitHub Pages must never advance before the tag
+  # and all five release assets have been byte-verified.
+  workflow_call:
+    inputs:
+      target-commit:
+        description: 'Exact reconciled release commit to build'
+        required: true
+        type: string
 
-permissions:
-  contents: read
-  packages: read
-  pages: write
-  id-token: write
+permissions: {}
 
 concurrency:
   group: pages
@@ -22,4 +21,12 @@ concurrency:
 
 jobs:
   docs:
-    uses: f5-sales-demo/docs-control/.github/workflows/github-pages-deploy.yml@main
+    uses: f5-sales-demo/docs-control/.github/workflows/github-pages-deploy.yml@456fed72b588919317fc10a99c2afe9ad0efe115
+    permissions:
+      contents: read # read documentation sources at the verified content ref
+      packages: read # pull the pinned fleet documentation builder image
+      pages: write # publish the verified Pages artifact
+      id-token: write # authenticate the Pages deployment
+    with:
+      content-ref: ${{ inputs.target-commit }}
+      builder-image: ghcr.io/f5-sales-demo/docs-builder@sha256:905d2398fec15c05e828c881ab0e8b782368c30d70d97a978dc383935d7d0163


### PR DESCRIPTION
Closes #1245

## What changed

- replace independent docs push/manual deployment triggers with a reusable `workflow_call`
- require one `target-commit` input and forward it unchanged as `content-ref`
- pin the shared docs-control workflow to reviewed commit `456fed72b588919317fc10a99c2afe9ad0efe115`
- pin the documentation builder image by digest
- scope Pages/package/content permissions to the reusable-workflow job

The diff is exactly one governed file: `.github/workflows/github-pages-deploy.yml` (18 insertions, 11 deletions). There is deliberately no legacy trigger or mutable fallback: release reconciliation must own publication order and fail closed.

## Governed rollout

This PR uses the authorized `governance/sync-managed-files` branch prefix. It depends on f5-sales-demo/docs-control#950 and pins that PR's immutable reviewed head commit, as its measured rollout note explicitly permits for api-specs-enriched.

This supersedes only the stale Pages-caller portion of #1243. That earlier generated PR predates the exact `content-ref` contract, still calls mutable `@main`, bundles nine unrelated managed-file changes, and has failing checks; its other managed-file drift is not part of this PR.

## Measured verification

- pre-commit suite: all applicable hooks passed (governance, repository hooks/hygiene, YAML, Actions lint/security, Checkov, gitleaks, spelling, EditorConfig)
- `actionlint .github/workflows/github-pages-deploy.yml`: passed
- `zizmor` 1.28.0: zero findings
- strict YAML caller contract: passed (one required input, immutable workflow SHA, immutable builder digest)
- `git diff --check origin/main..HEAD`: passed
- governance positive control: authorized prefix skipped as designed
- governance negative control: the same one-file commit is rejected without the prefix
- `tests/test_verify_governance.py`: 8 passed
- branch freshness immediately before push: 0 commits behind `origin/main`
