### PR TITLE
fix: authenticate governance exemptions

### DIFF
--- a/scripts/verify_governance.py
+++ b/scripts/verify_governance.py
@@ -27,23 +27,54 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
 
 DEFAULT_GOVERNANCE_JSON = Path(".claude/governance.json")
 
-# Branches created by the docs-control sync-managed-files workflow carry
-# the very files this check would otherwise reject. Exempt them by prefix;
-# the sync is the authorized upstream channel, so blocking it would self-
-# block every consumer every time docs-control updates a managed file.
-SYNC_BRANCH_PREFIXES = ("governance/sync-managed-files",)
+# Automation branches carry the governed files this check would otherwise
+# reject. Authorization requires an exact branch identity and same-repository
+# ownership proven by GitHub's pull-request event receipt.
+AUTHORIZED_AUTOMATION_BRANCH = re.compile(
+    r"(?:governance/sync-managed-files|"
+    r"sync/exact-caller-[0-9a-f]{12}-[1-9][0-9]*-[1-9][0-9]*)",
+)
 
 
-def _is_governance_sync_branch() -> bool:
-    """Return True when running on a PR from the managed-files sync bot."""
+def _is_authorized_automation_branch() -> bool:
+    """Return whether GitHub proves an exact, same-repository automation PR."""
     head_ref = os.environ.get("GITHUB_HEAD_REF", "")
-    return any(head_ref.startswith(prefix) for prefix in SYNC_BRANCH_PREFIXES)
+    repository = os.environ.get("GITHUB_REPOSITORY", "")
+    event_path = os.environ.get("GITHUB_EVENT_PATH", "")
+    if (
+        not head_ref
+        or not repository
+        or not event_path
+        or AUTHORIZED_AUTOMATION_BRANCH.fullmatch(head_ref) is None
+    ):
+        return False
+
+    try:
+        with Path(event_path).open(encoding="utf-8") as handle:
+            event = json.load(handle)
+    except (OSError, UnicodeError, ValueError):
+        return False
+
+    if not isinstance(event, dict):
+        return False
+    pull_request = event.get("pull_request")
+    if not isinstance(pull_request, dict):
+        return False
+    head = pull_request.get("head")
+    if not isinstance(head, dict):
+        return False
+    head_repo = head.get("repo")
+    if not isinstance(head_repo, dict):
+        return False
+    head_repository = head_repo.get("full_name")
+    return isinstance(head_repository, str) and head_repository == repository
 
 
 class GovernanceViolationError(RuntimeError):
@@ -113,9 +144,9 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
-    if _is_governance_sync_branch():
+    if _is_authorized_automation_branch():
         head_ref = os.environ.get("GITHUB_HEAD_REF", "")
-        print(f"ok: skipping governance check on sync branch {head_ref}")
+        print(f"ok: skipping governance check on authorized automation branch {head_ref}")
         return 0
 
     try:

--- a/tests/test_verify_governance.py
+++ b/tests/test_verify_governance.py
@@ -30,17 +30,38 @@ def _run(cmd: list[str], cwd: Path) -> None:
     subprocess.run(cmd, cwd=cwd, check=True, capture_output=True)
 
 
+def _set_pull_request_context(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    *,
+    head_ref: str,
+    head_repository: str = "example/managed",
+    base_repository: str = "example/managed",
+) -> None:
+    event_path = tmp_path / "event.json"
+    event_path.write_text(
+        json.dumps(
+            {
+                "pull_request": {
+                    "head": {"repo": {"full_name": head_repository}},
+                },
+            },
+        ),
+    )
+    monkeypatch.setenv("GITHUB_HEAD_REF", head_ref)
+    monkeypatch.setenv("GITHUB_REPOSITORY", base_repository)
+    monkeypatch.setenv("GITHUB_EVENT_PATH", str(event_path))
+
+
 @pytest.fixture(autouse=True)
 def _clear_sync_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Isolate tests from CI's GITHUB_HEAD_REF.
+    """Isolate tests from GitHub's pull-request identity environment.
 
-    `scripts.verify_governance.main` short-circuits when the env var
-    matches the sync-branch prefix. CI on the docs-control sync PR
-    sets GITHUB_HEAD_REF=governance/sync-managed-files, which would
-    make every `main()` test here return 0 regardless of the scenario
-    under test.
+    Authorized automation tests install a complete synthetic event receipt.
+    Every other test must exercise the verifier without CI state leaking in.
     """
-    monkeypatch.delenv("GITHUB_HEAD_REF", raising=False)
+    for variable in ("GITHUB_EVENT_PATH", "GITHUB_HEAD_REF", "GITHUB_REPOSITORY"):
+        monkeypatch.delenv(variable, raising=False)
 
 
 @pytest.fixture
@@ -197,3 +218,208 @@ class TestMain:
         assert rc == 2
         captured = capsys.readouterr()
         assert "error:" in captured.err
+
+    @pytest.mark.parametrize(
+        "head_ref",
+        [
+            "governance/sync-managed-files",
+            "sync/exact-caller-0123456789ab-123-4",
+        ],
+    )
+    def test_same_repository_automation_branch_is_authorized(
+        self,
+        repo: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        head_ref: str,
+    ) -> None:
+        (repo / "biome.json").write_text('{"x": 1}\n')
+        _run(["git", "add", "."], repo)
+        _run(["git", "commit", "-q", "-m", "authorized governance update"], repo)
+        _set_pull_request_context(monkeypatch, tmp_path, head_ref=head_ref)
+        monkeypatch.chdir(repo)
+
+        rc = main(
+            [
+                "--base",
+                "main",
+                "--head",
+                "feature",
+                "--governance-json",
+                str(repo / "governance.json"),
+            ],
+        )
+
+        assert rc == 0
+
+    @pytest.mark.parametrize(
+        "head_ref",
+        [
+            "governance/sync-managed-files",
+            "sync/exact-caller-0123456789ab-123-4",
+        ],
+    )
+    def test_same_ref_fork_is_not_authorized(
+        self,
+        repo: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        head_ref: str,
+    ) -> None:
+        (repo / "biome.json").write_text('{"x": 1}\n')
+        _run(["git", "add", "."], repo)
+        _run(["git", "commit", "-q", "-m", "hostile fork update"], repo)
+        _set_pull_request_context(
+            monkeypatch,
+            tmp_path,
+            head_ref=head_ref,
+            head_repository="example/fork",
+        )
+        monkeypatch.chdir(repo)
+
+        rc = main(
+            [
+                "--base",
+                "main",
+                "--head",
+                "feature",
+                "--governance-json",
+                str(repo / "governance.json"),
+            ],
+        )
+
+        assert rc == 1
+
+    @pytest.mark.parametrize(
+        "head_ref",
+        [
+            "governance/sync-managed-files-lookalike",
+            "sync/exact-caller-0123456789ab-0-1",
+            "sync/exact-caller-0123456789ab-1-0",
+            "sync/exact-caller-0123456789ab-1-1-extra",
+        ],
+    )
+    def test_lookalike_automation_branch_is_not_authorized(
+        self,
+        repo: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        head_ref: str,
+    ) -> None:
+        (repo / "biome.json").write_text('{"x": 1}\n')
+        _run(["git", "add", "."], repo)
+        _run(["git", "commit", "-q", "-m", "lookalike update"], repo)
+        _set_pull_request_context(monkeypatch, tmp_path, head_ref=head_ref)
+        monkeypatch.chdir(repo)
+
+        rc = main(
+            [
+                "--base",
+                "main",
+                "--head",
+                "feature",
+                "--governance-json",
+                str(repo / "governance.json"),
+            ],
+        )
+
+        assert rc == 1
+
+    def test_missing_event_receipt_is_not_authorized(
+        self,
+        repo: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        (repo / "biome.json").write_text('{"x": 1}\n')
+        _run(["git", "add", "."], repo)
+        _run(["git", "commit", "-q", "-m", "unmeasured update"], repo)
+        monkeypatch.setenv("GITHUB_HEAD_REF", "governance/sync-managed-files")
+        monkeypatch.setenv("GITHUB_REPOSITORY", "example/managed")
+        monkeypatch.chdir(repo)
+
+        rc = main(
+            [
+                "--base",
+                "main",
+                "--head",
+                "feature",
+                "--governance-json",
+                str(repo / "governance.json"),
+            ],
+        )
+
+        assert rc == 1
+
+    @pytest.mark.parametrize("missing_variable", ["GITHUB_HEAD_REF", "GITHUB_REPOSITORY"])
+    def test_incomplete_environment_is_not_authorized(
+        self,
+        repo: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        missing_variable: str,
+    ) -> None:
+        (repo / "biome.json").write_text('{"x": 1}\n')
+        _run(["git", "add", "."], repo)
+        _run(["git", "commit", "-q", "-m", "incomplete identity"], repo)
+        _set_pull_request_context(
+            monkeypatch,
+            tmp_path,
+            head_ref="governance/sync-managed-files",
+        )
+        monkeypatch.delenv(missing_variable)
+        monkeypatch.chdir(repo)
+
+        rc = main(
+            [
+                "--base",
+                "main",
+                "--head",
+                "feature",
+                "--governance-json",
+                str(repo / "governance.json"),
+            ],
+        )
+
+        assert rc == 1
+
+    @pytest.mark.parametrize(
+        "event_content",
+        [
+            "not JSON",
+            "[]",
+            "{}",
+            '{"pull_request": []}',
+            '{"pull_request": {"head": []}}',
+            '{"pull_request": {"head": {"repo": []}}}',
+            '{"pull_request": {"head": {"repo": {"full_name": 7}}}}',
+        ],
+    )
+    def test_malformed_event_receipt_is_not_authorized(
+        self,
+        repo: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        event_content: str,
+    ) -> None:
+        (repo / "biome.json").write_text('{"x": 1}\n')
+        _run(["git", "add", "."], repo)
+        _run(["git", "commit", "-q", "-m", "malformed identity"], repo)
+        event_path = tmp_path / "event.json"
+        event_path.write_text(event_content)
+        monkeypatch.setenv("GITHUB_HEAD_REF", "governance/sync-managed-files")
+        monkeypatch.setenv("GITHUB_REPOSITORY", "example/managed")
+        monkeypatch.setenv("GITHUB_EVENT_PATH", str(event_path))
+        monkeypatch.chdir(repo)
+
+        rc = main(
+            [
+                "--base",
+                "main",
+                "--head",
+                "feature",
+                "--governance-json",
+                str(repo / "governance.json"),
+            ],
+        )
+
+        assert rc == 1


### PR DESCRIPTION
## Summary

- require exact automation branch identities instead of prefix matching
- authenticate pull-request ownership from the GitHub event receipt against `GITHUB_REPOSITORY`
- fail closed on missing, malformed, forked, suffixed, or zero-valued identities
- authorize the exact managed-sync and exact-caller branch shapes

## Verification

- focused verifier suite: 26 passed; verifier 100% coverage
- complete seeded suite: 2,289 passed, 6 skipped, 1 expected xfail
- Ruff: all 201 Python files clean and formatted
- MyPy: all 111 source files clean
- Pylint: changed files 10.00/10
- applicable commit hooks and staged secrets detection passed
- changed-file PII enforcement: 0 findings
- independent read-only adversarial audit: clear

No documentation or translation file is changed. Broader pre-existing inventories are tracked separately in #1232, #1257, #1258, and #1259.

Closes #1256