### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/.claude/governance.json
+++ b/.claude/governance.json
@@ -7,7 +7,7 @@
     "api-specs-enriched": [".ruff.toml", ".python-lint", ".mypy.ini", ".github/workflows/github-pages-deploy.yml"],
     "vscode-xcsh": [".ruff.toml", ".python-lint", ".mypy.ini", ".isort.cfg", "README.md"],
     "i18n-core": [".ruff.toml", ".python-lint", ".mypy.ini", ".isort.cfg"],
-    "console": [".ruff.toml", ".python-lint", ".mypy.ini", ".isort.cfg"],
+    "console": [".ruff.toml", ".mypy.ini", ".isort.cfg"],
     "xcsh-chrome-extension": [".ruff.toml", ".python-lint", ".mypy.ini", ".isort.cfg"]
   },
   "protected_files": [
@@ -21,6 +21,7 @@
     ".github/workflows/workflow-security-audit.yml",
     ".github/workflows/semgrep.yml",
     ".github/workflows/translation-audit.yml",
+    ".github/workflows/antigravity-translate.yml",
     ".github/PULL_REQUEST_TEMPLATE.md",
     ".github/ISSUE_TEMPLATE/bug_report.md",
     ".github/ISSUE_TEMPLATE/feature_request.md",
@@ -32,6 +33,7 @@
     "AGENTS.md",
     ".agents/skills/demo-components/SKILL.md",
     ".agents/skills/demo-components/agents/openai.yaml",
+    ".agents/skills/i18n-translate/SKILL.md",
     "STYLE_GUIDE.md",
     "README.md",
     ".editorconfig",

--- a/.github/workflows/translation-audit.yml
+++ b/.github/workflows/translation-audit.yml
@@ -1,7 +1,7 @@
 ---
 # Managed by docs-control. Verifies that translations stay fresh when
-# English docs change. Generation happens in pre-commit (docs-translate
-# --staged); this gate only audits sourceHash freshness (no API calls).
+# English docs change. Generation happens via Antigravity (antigravity-translate.yml);
+# this gate only audits sourceHash freshness (no API calls).
 name: Translation Audit
 
 on:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -251,30 +251,20 @@ problems while they are still cheap to fix — in a spec or a plan, before any c
 The two layers are complementary: the local layer catches issues before the pull request exists and
 costs nothing when it is wrong, while CI remains the gate that decides whether a change merges.
 
-## Translations (suspended)
+## Translations (Antigravity `agy` Automated Translation)
 
-> **Suspended during development.** Translation generation calls a model API once per locale per
-> changed English file — twelve calls for every edit under `docs/en/`. That cost is not justified
-> while the documentation is still churning, so generation is off and the freshness audit no longer
-> gates merges. Translations will be regenerated as a deliberate effort before go-live.
+Language translation for the `f5-sales-demo` ecosystem across 12 target locales (`fr`, `es`, `de`, `pt-br`, `ja`, `ko`, `zh-cn`, `zh-tw`, `ar`, `it`, `hi`, `th`) is powered by **Antigravity (`agy`)** running as an automated GitHub Actions runner workflow (`antigravity-translate.yml`).
 
-How the three parts fit together, because only one of them costs anything:
+How the translation pipeline operates:
 
-| Part | Where | Cost |
-| ---- | ----- | ---- |
-| Generation | the `docs-translate` pre-commit hook, on `docs/en/**/*.md[x]` | the entire spend |
-| Freshness audit | `.github/workflows/translation-audit.yml` — compares each translation's `i18n.sourceHash` against the SHA-256 of its English source | none; it performs no translation |
-| Required context | `audit / Translation freshness` in branch protection | none; it made the audit blocking |
+| Part | Where | How it Works |
+| ---- | ----- | ------------ |
+| Automated Translation | `.github/workflows/antigravity-translate.yml` — invokes `agy` on GitHub Action runner | Triggers on PRs modifying `docs/en/**/*.md[x]`. Uses Gemini 3.6 Flash (High) and `.agents/skills/i18n-translate/SKILL.md` to translate missing/stale files, update `i18n.sourceHash`, and auto-commit back to the PR branch. |
+| Freshness Audit | `.github/workflows/translation-audit.yml` — compares each translation's `i18n.sourceHash` against English source SHA-256 | Verifies that all 12 localized docs exist and match current English hashes. |
+| Required Context | `audit / Translation freshness` in branch protection | Ensures no PR merges with stale or missing translations. |
 
-What this means for you now:
+### Restoring translations and activating Antigravity `agy` translator
 
-- **Existing translations under `docs/<locale>/` stay in place and will drift out of date.** That is
-  expected. Do not regenerate them individually, and do not treat the drift as a defect to fix.
-- Editing `docs/en/` no longer requires a matching translation update.
-- Both the generation hook and the audit are gated on the `TRANSLATIONS_ENABLED` variable. Unset means
-  off, so nothing spends money by accident.
-
-### Restoring translations
 
 Order matters, and getting it wrong deadlocks every open pull request — the same trap the suspended
 reviewer left behind.

--- a/scripts/lint-mdx-prose.sh
+++ b/scripts/lint-mdx-prose.sh
@@ -77,6 +77,10 @@ main() {
   local -a files=()
   local f
   for f in "${candidates[@]:-}"; do
+    # Skip non-English translation folders to align with Super-Linter's FILTER_REGEX_EXCLUDE posture
+    if [[ "$f" =~ ^docs/(fr|es|de|ja|pt-br|ko|zh-cn|zh-tw|ar|it|hi|th)/ ]]; then
+      continue
+    fi
     case "$f" in
     *.mdx) [ -f "$f" ] && files+=("$f") ;;
     *.md) [ "$textlint_only" -eq 1 ] && [ -f "$f" ] && files+=("$f") ;;


### PR DESCRIPTION
Closes #1268

Synced managed files from `f5-sales-demo/docs-control` canonical source:

- .github/workflows/translation-audit.yml
- CONTRIBUTING.md
- scripts/lint-mdx-prose.sh
- .claude/governance.json