### PR TITLE
fix: clean Markdown lint violations

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,9 +1,11 @@
 # API Specs Enriched — Repo-Specific Instructions
 
 ## Project Overview
+
 Python-based OpenAPI enrichment pipeline for F5 Distributed Cloud. Downloads pre-validated specs from f5-sales-demo/api-specs, enriches them with descriptions, metadata, and branding, then publishes developer-friendly documentation.
 
 ## Key Commands
+
 - `make install` — production setup
 - `make dev-install` — dev setup with testing tools
 - `make download` — download specs from upstream (api-specs)
@@ -13,6 +15,7 @@ Python-based OpenAPI enrichment pipeline for F5 Distributed Cloud. Downloads pre
 - `make all` — full pipeline: download → enrich → release
 
 ## Directory Structure
+
 - `scripts/` — Python pipeline scripts
 - `config/` — 40 configuration files (enrichment, descriptions, metadata, etc.)
 - `specs/original/` — Downloaded source specs (from api-specs releases)
@@ -23,11 +26,13 @@ Python-based OpenAPI enrichment pipeline for F5 Distributed Cloud. Downloads pre
 - `examples/` — Example constraint outputs
 
 ## Upstream/Downstream
+
 - **Upstream**: f5-sales-demo/api-specs (pre-validated OpenAPI specs)
 - **Downstream**: f5-sales-demo/xcsh, f5-sales-demo/vscode-xcsh
 
 ## Environment Variables
-```
-F5XC_API_URL=https://f5-amer-ent.console.ves.volterra.io
+
+```bash
+F5XC_API_URL=https://${XC_TENANT}.console.ves.volterra.io
 F5XC_API_TOKEN=<your-api-token>
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,15 +3,18 @@
 ## Version 2.1.211 (2026-08-02)
 
 ### Version Information
+
 - **Full Version**: 2.1.211
 - **Upstream Timestamp**: unknown
 - **Upstream ETag**: unknown
 - **Enriched Version**: 2.1.211
 
 ### Release Type
+
 - **patch** release
 
 ### Changes
+
 - Updated API specifications from F5 Distributed Cloud
 - Applied enrichment pipeline:
   - Acronym normalization (100+ terms)
@@ -25,18 +28,21 @@
 - Merged specifications by domain
 
 ### Statistics
+
 - Original specs: 284
 - Domains: 38
 - Total paths: 1676
 - Total schemas: 8540
 
 ### API Discovery Enrichment
+
 - Discovery timestamp: 2025-12-20T19:39:20.211392+00:00
 - Endpoints explored: 300 / 1000
 - Applied x-discovered-* extensions from live API exploration
 - See \`reports/constraint-analysis.md\` for detailed comparison
 
 ### Output Structure
+
 \`\`\`text
 docs/specifications/api/
 ├── [domain].json        # Domain-specific specs
@@ -45,9 +51,10 @@ docs/specifications/api/
 \`\`\`
 
 ### Download
+
 - ZIP Package: F5xc-api-(unknown-2.1.211).zip
 
 ### Source
+
 - Source: F5 Distributed Cloud OpenAPI specifications
 - Upstream: unknown (ETag: unknown)
-

--- a/docs/api-reference/admin_console_and_ui-api.mdx
+++ b/docs/api-reference/admin_console_and_ui-api.mdx
@@ -28,7 +28,7 @@ Namespace-scoped visual elements with versioning. Custom widget deployment and c
 ## Endpoints
 
 | Method | Path | Description |
-|--------|------|-------------|
+| --- | --- | --- |
 | GET | `/api/web/custom/namespaces/system/dashboards/&#123;dashboard_id&#125;/current_layout` | GET Current Default Dashboard Layout. |
 | GET | `/api/web/custom/namespaces/system/dashboards/&#123;dashboard_id&#125;/layouts` | List Dashboard Layouts. |
 | POST | `/api/web/custom/namespaces/system/dashboards/&#123;dashboard_id&#125;/layouts` | Create Dashboard Layout. |

--- a/docs/api-reference/ai_services-api.mdx
+++ b/docs/api-reference/ai_services-api.mdx
@@ -12,7 +12,6 @@ Natural language processing with quality signals and anomaly monitoring. Token a
 - **Paths**: 11 | **Schemas**: 66
 - **Tier**: Advanced
 
-
 ## Use Cases
 
 - Access AI-powered features
@@ -28,7 +27,7 @@ Natural language processing with quality signals and anomaly monitoring. Token a
 ## Endpoints
 
 | Method | Path | Description |
-|--------|------|-------------|
+| --- | --- | --- |
 | POST | `/api/gen-ai/namespaces/&#123;namespace&#125;/eval_query` | Eval AI Assistant Query. |
 | POST | `/api/gen-ai/namespaces/&#123;namespace&#125;/eval_query_feedback` | Eval Feedback of AI Assistant Query. |
 | POST | `/api/gen-ai/namespaces/&#123;namespace&#125;/query` | AI Assistant Query. |

--- a/docs/api-reference/api-api.mdx
+++ b/docs/api-reference/api-api.mdx
@@ -29,7 +29,7 @@ Resource cataloging with automatic classification and security profiling. Organi
 ## Endpoints
 
 | Method | Path | Description |
-|--------|------|-------------|
+| --- | --- | --- |
 | POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/api_crawlers` | Create API Crawler. |
 | PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/api_crawlers/&#123;metadata.name&#125;` | Replace API crawler. |
 | GET | `/api/config/namespaces/&#123;namespace&#125;/api_crawlers` | List API Crawler. |

--- a/docs/api-reference/authentication-api.mdx
+++ b/docs/api-reference/authentication-api.mdx
@@ -30,7 +30,7 @@ Identity management with provider integration, access policies, and credential l
 ## Endpoints
 
 | Method | Path | Description |
-|--------|------|-------------|
+| --- | --- | --- |
 | POST | `/api/web/namespaces/system/bulk_revoke/api_credentials` | Bulk Revoke API credentials. |
 | POST | `/api/web/namespaces/system/bulk_revoke/service_credentials` | Bulk Revoke service credential. |
 | POST | `/api/web/namespaces/&#123;namespace&#125;/activate/api_credentials` | Activate API credential. |

--- a/docs/api-reference/bigip-api.mdx
+++ b/docs/api-reference/bigip-api.mdx
@@ -28,7 +28,7 @@ Legacy device orchestration with iRule scripts and data group synchronization. V
 ## Endpoints
 
 | Method | Path | Description |
-|--------|------|-------------|
+| --- | --- | --- |
 | POST | `/api/bigipconnector/namespaces/&#123;metadata.namespace&#125;/bigip_irules` | Specification. |
 | PUT | `/api/bigipconnector/namespaces/&#123;metadata.namespace&#125;/bigip_irules/&#123;metadata.name&#125;` | Specification. |
 | GET | `/api/bigipconnector/namespaces/&#123;namespace&#125;/bigip_irules` | List BIG-IP iRule as a Service. |

--- a/docs/api-reference/billing_and_usage-api.mdx
+++ b/docs/api-reference/billing_and_usage-api.mdx
@@ -29,7 +29,7 @@ Plan transitions, invoicing, and resource consumption. Namespace-level quota lim
 ## Endpoints
 
 | Method | Path | Description |
-|--------|------|-------------|
+| --- | --- | --- |
 | POST | `/api/data/namespaces/system/billing/usage_details` | Telemetry Data Metrics. |
 | POST | `/api/data/namespaces/system/billing/usage_summary` | Billing Usage Summary. |
 | GET | `/api/web/namespaces/&#123;namespace&#125;/usage/invoice_pdf` | GetInvoicePdf. |

--- a/docs/api-reference/blindfold-api.mdx
+++ b/docs/api-reference/blindfold-api.mdx
@@ -28,7 +28,7 @@ Encryption key management with policy-based access controls. Audit logging and s
 ## Endpoints
 
 | Method | Path | Description |
-|--------|------|-------------|
+| --- | --- | --- |
 | GET | `/api/secret_management/get_public_key` | Public Key. |
 | GET | `/api/secret_management/namespaces/&#123;namespace&#125;/secret_policys/&#123;name&#125;/get_policy_document` | Policy Document. |
 | POST | `/api/secret_management/namespaces/system/voltshare/decrypt_secret` | DecryptSecret. |

--- a/docs/api-reference/bot_and_threat_defense-api.mdx
+++ b/docs/api-reference/bot_and_threat_defense-api.mdx
@@ -28,7 +28,7 @@ Threat classification with behavioral analysis and signature matching. Automated
 ## Endpoints
 
 | Method | Path | Description |
-|--------|------|-------------|
+| --- | --- | --- |
 | POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/bot_defense_app_infrastructures` | Create Bot Defense App Infrastructure. |
 | PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/bot_defense_app_infrastructures/&#123;metadata.name&#125;` | Replace Bot Defense App Infrastructure. |
 | GET | `/api/config/namespaces/&#123;namespace&#125;/bot_defense_app_infrastructures` | List Bot Defense App Infrastructure. |

--- a/docs/api-reference/cdn-api.mdx
+++ b/docs/api-reference/cdn-api.mdx
@@ -28,7 +28,7 @@ Global distribution with cache rules and purge operations. Performance monitorin
 ## Endpoints
 
 | Method | Path | Description |
-|--------|------|-------------|
+| --- | --- | --- |
 | POST | `/api/config/namespaces/&#123;namespace&#125;/cdn_loadbalancers/&#123;name&#125;/block_client/suggestion` | Suggest block client rule. |
 | POST | `/api/config/namespaces/&#123;namespace&#125;/cdn_loadbalancers/&#123;name&#125;/ddos_mitigation/suggestion` | Suggest CDN DDoS Mitigation rule. |
 | POST | `/api/config/namespaces/&#123;namespace&#125;/cdn_loadbalancers/&#123;name&#125;/trust_client/suggestion` | Suggest trust client rule. |

--- a/docs/api-reference/ce_management-api.mdx
+++ b/docs/api-reference/ce_management-api.mdx
@@ -29,7 +29,7 @@ Token-based provisioning with image downloads and pre-upgrade validation. Fleet 
 ## Endpoints
 
 | Method | Path | Description |
-|--------|------|-------------|
+| --- | --- | --- |
 | POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/fleets` | Create Fleet. |
 | PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/fleets/&#123;metadata.name&#125;` | Replace Fleet. |
 | GET | `/api/config/namespaces/&#123;namespace&#125;/fleets` | List Fleet. |

--- a/docs/api-reference/certificates-api.mdx
+++ b/docs/api-reference/certificates-api.mdx
@@ -29,7 +29,7 @@ Certificate chains and trusted CA bundles. Revocation list management and manife
 ## Endpoints
 
 | Method | Path | Description |
-|--------|------|-------------|
+| --- | --- | --- |
 | POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/crls` | Create CRL. |
 | PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/crls/&#123;metadata.name&#125;` | Replace CRL. |
 | GET | `/api/config/namespaces/&#123;namespace&#125;/crls` | List CRL |

--- a/docs/api-reference/cloud_infrastructure-api.mdx
+++ b/docs/api-reference/cloud_infrastructure-api.mdx
@@ -30,7 +30,7 @@ Multi-cloud provider connections with gateway peering and network path configura
 ## Endpoints
 
 | Method | Path | Description |
-|--------|------|-------------|
+| --- | --- | --- |
 | GET | `/api/config/namespaces/&#123;namespace&#125;/certified_hardwares` | List Certified Hardware. |
 | GET | `/api/config/namespaces/&#123;namespace&#125;/certified_hardwares/&#123;name&#125;` | GET Certified Hardware. |
 | POST | `/api/sync-cloud-data/namespaces/system/cloud_connect_reapply_vpc_attachment` | ReApplyVPCAttachment. |

--- a/docs/api-reference/container_services-api.mdx
+++ b/docs/api-reference/container_services-api.mdx
@@ -29,7 +29,7 @@ Pod orchestration without full cluster complexity. Edge site execution, quota en
 ## Endpoints
 
 | Method | Path | Description |
-|--------|------|-------------|
+| --- | --- | --- |
 | POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/virtual_k8ss` | Create Virtual Kubernetes. |
 | PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/virtual_k8ss/&#123;metadata.name&#125;` | Replace Virtual Kubernetes. |
 | GET | `/api/config/namespaces/&#123;namespace&#125;/virtual_k8ss` | List Virtual Kubernetes. |

--- a/docs/api-reference/data_and_privacy_security-api.mdx
+++ b/docs/api-reference/data_and_privacy_security-api.mdx
@@ -28,7 +28,7 @@ Sensitive data policies with custom classification rules. LMA region configurati
 ## Endpoints
 
 | Method | Path | Description |
-|--------|------|-------------|
+| --- | --- | --- |
 | POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/data_types` | Create Data Type. |
 | PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/data_types/&#123;metadata.name&#125;` | Replace Data Type. |
 | GET | `/api/config/namespaces/&#123;namespace&#125;/data_types` | List Data Type. |

--- a/docs/api-reference/data_intelligence-api.mdx
+++ b/docs/api-reference/data_intelligence-api.mdx
@@ -27,7 +27,7 @@ Classification rules, resource policies, and insight generation for data analysi
 ## Endpoints
 
 | Method | Path | Description |
-|--------|------|-------------|
+| --- | --- | --- |
 | POST | `/api/data-intelligence/namespaces/&#123;metadata.namespace&#125;/receivers` | Create Data Delivery. |
 | PUT | `/api/data-intelligence/namespaces/&#123;metadata.namespace&#125;/receivers/&#123;metadata.name&#125;` | Replace Data Delivery. |
 | GET | `/api/data-intelligence/namespaces/&#123;namespace&#125;/receivers` | List Data Delivery. |

--- a/docs/api-reference/ddos-api.mdx
+++ b/docs/api-reference/ddos-api.mdx
@@ -27,7 +27,7 @@ Deny lists, firewall rule groups, and tunnel-based safeguards. Rate limiting and
 ## Endpoints
 
 | Method | Path | Description |
-|--------|------|-------------|
+| --- | --- | --- |
 | GET | `/api/infraprotect/namespaces/system/infraprotect/access` | Customer access. |
 | GET | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect/alert/&#123;alert_id&#125;` | DDoS Alert. |
 | PUT | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect/alert/&#123;alert_id&#125;/to_event` | Link Alert to Event. |

--- a/docs/api-reference/dns-api.mdx
+++ b/docs/api-reference/dns-api.mdx
@@ -29,7 +29,7 @@ Name resolution with zone transfers and health checks. Record types and delegati
 ## Endpoints
 
 | Method | Path | Description |
-|--------|------|-------------|
+| --- | --- | --- |
 | POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/dns_compliance_checkss` | Create DNS Compliance Checks. |
 | PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/dns_compliance_checkss/&#123;metadata.name&#125;` | Replace DNS Compliance Checks. |
 | GET | `/api/config/namespaces/&#123;namespace&#125;/dns_compliance_checkss` | List Configure DNS Compliance Checks. |

--- a/docs/api-reference/index.mdx
+++ b/docs/api-reference/index.mdx
@@ -11,7 +11,7 @@ import { CardGrid, LinkCard } from '@astrojs/starlight/components';
 Explore the F5 Distributed Cloud API documentation. Each domain includes
 endpoint details, request and response schemas, and code examples.
 
-### Security
+## Security
 
 <CardGrid>
   <LinkCard title="🔐 Api" description="Interface definitions, schema validation, and grouping. — 45 paths, 274 schemas, advanced" href="./api/" />
@@ -26,7 +26,7 @@ endpoint details, request and response schemas, and code examples.
   <LinkCard title="⚠️ Threat Campaign" description="Attack detection, tracking, and mitigation rules. — 1 paths, 112 schemas, moderate" href="./threat_campaign/" />
 </CardGrid>
 
-### Networking
+## Networking
 
 <CardGrid>
   <LinkCard title="🚀 Cdn" description="Content delivery and edge caching networks. — 29 paths, 501 schemas, advanced" href="./cdn/" />
@@ -36,7 +36,7 @@ endpoint details, request and response schemas, and code examples.
   <LinkCard title="⚖️ Virtual" description="HTTP, TCP, UDP load balancing with origin pools. — 133 paths, 808 schemas, advanced" href="./virtual/" />
 </CardGrid>
 
-### Infrastructure
+## Infrastructure
 
 <CardGrid>
   <LinkCard title="🔧 Ce Management" description="Network interfaces, fleets, and site registration. — 29 paths, 234 schemas, advanced" href="./ce_management/" />
@@ -47,7 +47,7 @@ endpoint details, request and response schemas, and code examples.
   <LinkCard title="🌍 Sites" description="Cloud and edge node deployments. — 133 paths, 938 schemas, advanced" href="./sites/" />
 </CardGrid>
 
-### Platform
+## Platform
 
 <CardGrid>
   <LinkCard title="🖥️ Admin Console And Ui" description="Static UI components and console assets. — 6 paths, 24 schemas, simple" href="./admin_console_and_ui/" />
@@ -62,7 +62,7 @@ endpoint details, request and response schemas, and code examples.
   <LinkCard title="🖥️ Vpm And Node Management" description="Node lifecycle, fleet grouping, and orchestration. — 1 paths, 2 schemas, simple" href="./vpm_and_node_management/" />
 </CardGrid>
 
-### Operations
+## Operations
 
 <CardGrid>
   <LinkCard title="🧠 Data Intelligence" description="Classification, insights, and policy management. — 15 paths, 72 schemas, simple" href="./data_intelligence/" />
@@ -72,13 +72,13 @@ endpoint details, request and response schemas, and code examples.
   <LinkCard title="📉 Telemetry And Insights" description="Metrics collection, analysis, and visualization. — 27 paths, 184 schemas, moderate" href="./telemetry_and_insights/" />
 </CardGrid>
 
-### AI
+## AI
 
 <CardGrid>
   <LinkCard title="🤖 Ai Services (Preview)" description="AI assistant queries and feedback collection. — 11 paths, 66 schemas, simple" href="./ai_services/" />
 </CardGrid>
 
-### Other
+## Other
 
 <CardGrid>
   <LinkCard title="📁 Other" description="Other — 4 paths, 38 schemas, simple" href="./other/" />

--- a/docs/api-reference/managed_kubernetes-api.mdx
+++ b/docs/api-reference/managed_kubernetes-api.mdx
@@ -29,7 +29,7 @@ Kubernetes role bindings and admission policies. Registry integration for EKS, A
 ## Endpoints
 
 | Method | Path | Description |
-|--------|------|-------------|
+| --- | --- | --- |
 | POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/container_registrys` | Create Container Registry. |
 | PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/container_registrys/&#123;metadata.name&#125;` | Replace Container Registry. |
 | GET | `/api/config/namespaces/&#123;namespace&#125;/container_registrys` | List Container Registry. |

--- a/docs/api-reference/marketplace-api.mdx
+++ b/docs/api-reference/marketplace-api.mdx
@@ -28,7 +28,7 @@ Third-party GRE and IPSec tunnel provisioning with DPD timers. Shared resource a
 ## Endpoints
 
 | Method | Path | Description |
-|--------|------|-------------|
+| --- | --- | --- |
 | GET | `/api/web/custom/namespaces/shared/addon_services/&#123;name&#125;` | GET Addon Service Details. |
 | GET | `/api/web/namespaces/system/addon_services/&#123;addon_service&#125;/activation-status` | Addon Service Activation Status. |
 | GET | `/api/web/namespaces/system/addon_services/&#123;addon_service&#125;/all-activation-status` | All Addon Service Activation Status. |

--- a/docs/api-reference/network-api.mdx
+++ b/docs/api-reference/network-api.mdx
@@ -31,7 +31,7 @@ Border gateway protocol with ASN management and autonomous system relationships.
 ## Endpoints
 
 | Method | Path | Description |
-|--------|------|-------------|
+| --- | --- | --- |
 | POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/address_allocators` | Create Address Allocator. |
 | GET | `/api/config/namespaces/&#123;namespace&#125;/address_allocators` | List Address Allocator. |
 | GET | `/api/config/namespaces/&#123;namespace&#125;/address_allocators/&#123;name&#125;` | GET Address Allocator. |

--- a/docs/api-reference/network_security-api.mdx
+++ b/docs/api-reference/network_security-api.mdx
@@ -30,7 +30,7 @@ Firewall rules with routing decisions based on source, destination, or protocol.
 ## Endpoints
 
 | Method | Path | Description |
-|--------|------|-------------|
+| --- | --- | --- |
 | POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/forward_proxy_policys` | Create Forward Proxy Policy. |
 | PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/forward_proxy_policys/&#123;metadata.name&#125;` | Replace Forward Proxy Policy. |
 | POST | `/api/data/namespaces/&#123;namespace&#125;/forward_proxy_policy/hits` | Forward Proxy Policy Hits. |

--- a/docs/api-reference/nginx_one-api.mdx
+++ b/docs/api-reference/nginx_one-api.mdx
@@ -27,7 +27,7 @@ Instance discovery, WAF integration, and service mesh connectivity. Subscription
 ## Endpoints
 
 | Method | Path | Description |
-|--------|------|-------------|
+| --- | --- | --- |
 | GET | `/api/config/namespaces/&#123;namespace&#125;/nginx_csgs` | List NGINX One CSG Object configuration. |
 | GET | `/api/config/namespaces/&#123;namespace&#125;/nginx_csgs/&#123;name&#125;` | GET Request. |
 | GET | `/api/config/namespaces/&#123;namespace&#125;/nginx_instances` | List NGINX One Instance Object configuration. |

--- a/docs/api-reference/object_storage-api.mdx
+++ b/docs/api-reference/object_storage-api.mdx
@@ -27,7 +27,7 @@ Versioned library distribution for mobile app integrators. Presigned URLs enable
 ## Endpoints
 
 | Method | Path | Description |
-|--------|------|-------------|
+| --- | --- | --- |
 | GET | `/api/object_store/namespaces/&#123;namespace&#125;/stored_objects/mobile-app-shield` | GET List Of Mobile App Shields. |
 | GET | `/api/object_store/namespaces/&#123;namespace&#125;/stored_objects/mobile-app-shield/&#123;name&#125;/&#123;version&#125;` | GET Mobile App Shield. |
 | GET | `/api/object_store/namespaces/&#123;namespace&#125;/stored_objects/mobile-integrator` | GET List Of Mobile Integrators. |

--- a/docs/api-reference/observability-api.mdx
+++ b/docs/api-reference/observability-api.mdx
@@ -28,7 +28,7 @@ HTTP availability probes with latency measurement. Certificate expiration alerts
 ## Endpoints
 
 | Method | Path | Description |
-|--------|------|-------------|
+| --- | --- | --- |
 | GET | `/api/data/namespaces/system/all_ns_alerts` | GET Alerts. |
 | GET | `/api/data/namespaces/&#123;namespace&#125;/alerts` | GET Alerts. |
 | GET | `/api/data/namespaces/&#123;namespace&#125;/alerts/history` | GET Alerts History. |

--- a/docs/api-reference/other-api.mdx
+++ b/docs/api-reference/other-api.mdx
@@ -12,15 +12,10 @@ F5 Distributed Cloud Other
 - **Paths**: 4 | **Schemas**: 38
 - **Tier**: Standard
 
-
-
-
-
-
 ## Endpoints
 
 | Method | Path | Description |
-|--------|------|-------------|
+| --- | --- | --- |
 | POST | `/api/discovery/namespaces/&#123;namespace&#125;/suggest-values` | Suggest Values. |
 | GET | `/api/web/namespaces/system/customer_data` | GET customer data. |
 | PUT | `/api/web/namespaces/system/customer_data` | Update customer data. |

--- a/docs/api-reference/rate_limiting-api.mdx
+++ b/docs/api-reference/rate_limiting-api.mdx
@@ -28,7 +28,7 @@ Time-based quota enforcement with configurable windows in hours, minutes, or sec
 ## Endpoints
 
 | Method | Path | Description |
-|--------|------|-------------|
+| --- | --- | --- |
 | POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/policers` | Create Policer. |
 | PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/policers/&#123;metadata.name&#125;` | Replace Policer. |
 | GET | `/api/config/namespaces/&#123;namespace&#125;/policers` | List Policer. |

--- a/docs/api-reference/secops_and_incident_response-api.mdx
+++ b/docs/api-reference/secops_and_incident_response-api.mdx
@@ -28,7 +28,7 @@ Malicious user mitigation with threat level classification. Automated response a
 ## Endpoints
 
 | Method | Path | Description |
-|--------|------|-------------|
+| --- | --- | --- |
 | POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/malicious_user_mitigations` | Create Malicious User Mitigation. |
 | PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/malicious_user_mitigations/&#123;metadata.name&#125;` | Replace Malicious User Mitigation. |
 | GET | `/api/config/namespaces/&#123;namespace&#125;/malicious_user_mitigations` | List Malicious User Mitigation. |

--- a/docs/api-reference/service_mesh-api.mdx
+++ b/docs/api-reference/service_mesh-api.mdx
@@ -29,7 +29,7 @@ Application type definitions with discovery and learned schema analysis. Traffic
 ## Endpoints
 
 | Method | Path | Description |
-|--------|------|-------------|
+| --- | --- | --- |
 | POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/app_settings` | Create App Setting. |
 | PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/app_settings/&#123;metadata.name&#125;` | Replace App Setting. |
 | GET | `/api/config/namespaces/&#123;namespace&#125;/app_settings` | List App Setting. |

--- a/docs/api-reference/shape-api.mdx
+++ b/docs/api-reference/shape-api.mdx
@@ -28,7 +28,7 @@ Threat recognition with behavioral analysis and device fingerprinting. Mobile SD
 ## Endpoints
 
 | Method | Path | Description |
-|--------|------|-------------|
+| --- | --- | --- |
 | POST | `/api/shape/dip/namespaces/system/app_provision` | Application Provision. |
 | DELETE | `/api/shape/dip/namespaces/system/application` | DELETE Application. |
 | POST | `/api/shape/dip/namespaces/system/application` | Update Application. |

--- a/docs/api-reference/sites-api.mdx
+++ b/docs/api-reference/sites-api.mdx
@@ -31,7 +31,7 @@ AWS, Azure, GCP VPC integration with transit gateways. Label-based selection for
 ## Endpoints
 
 | Method | Path | Description |
-|--------|------|-------------|
+| --- | --- | --- |
 | POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/aws_tgw_sites` | Create AWS TGW site. |
 | PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/aws_tgw_sites/&#123;metadata.name&#125;` | Replace AWS TGW site. |
 | POST | `/api/config/namespaces/&#123;namespace&#125;/aws_tgw_site/&#123;name&#125;/set_tgw_info` | Configure TGW Information. |

--- a/docs/api-reference/statistics-api.mdx
+++ b/docs/api-reference/statistics-api.mdx
@@ -30,7 +30,7 @@ Alerting policies with receiver integrations. Log aggregation, topology views, a
 ## Endpoints
 
 | Method | Path | Description |
-|--------|------|-------------|
+| --- | --- | --- |
 | POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/alert_policys` | Create Alert Policy. |
 | PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/alert_policys/&#123;metadata.name&#125;` | Replace Alert Policy. |
 | POST | `/api/alert/namespaces/&#123;namespace&#125;/alert_policy/match` | GET Alert Policy Match. |

--- a/docs/api-reference/support-api.mdx
+++ b/docs/api-reference/support-api.mdx
@@ -28,7 +28,7 @@ Issue lifecycle with comments, severity changes, and resolution tracking. Packet
 ## Endpoints
 
 | Method | Path | Description |
-|--------|------|-------------|
+| --- | --- | --- |
 | POST | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/ver/resync_crl` | Resync CRL. |
 | POST | `/api/web/namespaces/system/child_tenant/support_tickets` | List of support tickets created for a child tenant. |
 | POST | `/api/web/namespaces/system/customer_support/tax_exempt_request` | Tax exemption verification request. |
@@ -68,7 +68,7 @@ Issue lifecycle with comments, severity changes, and resolution tracking. Packet
 | POST | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/ver/list_tcpdump` | List Tcpdump. |
 | POST | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/ver/stop_tcpdump` | Stop Tcpdump. |
 | POST | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/ver/tcpdump` | Tcpdump |
-| POST | `/api/web/namespaces/shared/ticket_tracking_systems/jira_projects_issue_types` | JIRA Projects & Issue Types. |
+| POST | `/api/web/namespaces/shared/ticket_tracking_systems/jira_projects_issue_types` | Jira Projects & Issue Types. |
 | POST | `/api/web/namespaces/shared/ticket_tracking_systems/validate_ticket_tracking_system` | Validate Ticket Tracking System. |
 | POST | `/api/web/namespaces/&#123;metadata.namespace&#125;/ticket_tracking_systems` | Create Ticket Tracking System. |
 | PUT | `/api/web/namespaces/&#123;metadata.namespace&#125;/ticket_tracking_systems/&#123;metadata.name&#125;` | Replace Ticket Tracking System. |
@@ -81,11 +81,11 @@ Issue lifecycle with comments, severity changes, and resolution tracking. Packet
 | GET | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/vpm/usb/&#123;node&#125;/rules` | List USB Enablement Rules. |
 | POST | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/vpm/usb/&#123;node&#125;/rules/add` | Add USB Enablement Rules. |
 | POST | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/vpm/usb/&#123;node&#125;/rules/delete` | DELETE USB Enablement Rules. |
-| GET | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/vpm/wifi/&#123;node&#125;/config` | GET WIFI configuration. |
-| POST | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/vpm/wifi/&#123;node&#125;/config` | Update WIFI configuration. |
+| GET | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/vpm/wifi/&#123;node&#125;/config` | GET Wi-Fi configuration. |
+| POST | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/vpm/wifi/&#123;node&#125;/config` | Update Wi-Fi configuration. |
 | POST | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/vpm/wifi/&#123;node&#125;/disconnect` | Disconnect. |
-| GET | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/vpm/wifi/&#123;node&#125;/info` | Show WIFI info. |
-| GET | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/vpm/wifi/&#123;node&#125;/list` | List WIFI networks. |
+| GET | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/vpm/wifi/&#123;node&#125;/info` | Show Wi-Fi info. |
+| GET | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/vpm/wifi/&#123;node&#125;/list` | List Wi-Fi networks. |
 
 ## Links
 

--- a/docs/api-reference/telemetry_and_insights-api.mdx
+++ b/docs/api-reference/telemetry_and_insights-api.mdx
@@ -27,7 +27,7 @@ Collection endpoints, metrics storage, and insight generation for observability 
 ## Endpoints
 
 | Method | Path | Description |
-|--------|------|-------------|
+| --- | --- | --- |
 | POST | `/api/data/namespaces/&#123;namespace&#125;/graph/connectivity` | Connectivity Graph Query. |
 | POST | `/api/data/namespaces/&#123;namespace&#125;/graph/connectivity/edge` | Connectivity Edge Query. |
 | POST | `/api/data/namespaces/&#123;namespace&#125;/graph/connectivity/node` | Connectivity Node Query. |

--- a/docs/api-reference/tenant_and_identity-api.mdx
+++ b/docs/api-reference/tenant_and_identity-api.mdx
@@ -29,7 +29,7 @@ Account view configurations and admin alert channels. One-time password resets, 
 ## Endpoints
 
 | Method | Path | Description |
-|--------|------|-------------|
+| --- | --- | --- |
 | GET | `/api/web/namespaces/system/allowed_tenants/support-tenant/access` | GET Support Tenant Access. |
 | POST | `/api/web/namespaces/system/allowed_tenants/support-tenant/access` | Update Support Tenant Access. |
 | POST | `/api/web/namespaces/&#123;metadata.namespace&#125;/allowed_tenants` | Create Allowed Tenant. |

--- a/docs/api-reference/threat_campaign-api.mdx
+++ b/docs/api-reference/threat_campaign-api.mdx
@@ -26,7 +26,7 @@ Detection policies, attack tracking, and automated mitigation rule generation fo
 ## Endpoints
 
 | Method | Path | Description |
-|--------|------|-------------|
+| --- | --- | --- |
 | GET | `/api/waf/threat_campaign/&#123;id&#125;` | GET Threat Campaign by ID. |
 
 ## Links

--- a/docs/api-reference/users-api.mdx
+++ b/docs/api-reference/users-api.mdx
@@ -29,7 +29,7 @@ Site enrollment credentials with automatic expiration. Taxonomy keys define allo
 ## Endpoints
 
 | Method | Path | Description |
-|--------|------|-------------|
+| --- | --- | --- |
 | GET | `/api/config/namespaces/system/implicit_labels` | GET Implicit Labels. |
 | POST | `/api/config/namespaces/&#123;namespace&#125;/known_label/create` | Create |
 | POST | `/api/config/namespaces/&#123;namespace&#125;/known_label/delete` | DELETE |

--- a/docs/api-reference/virtual-api.mdx
+++ b/docs/api-reference/virtual-api.mdx
@@ -37,7 +37,7 @@ Traffic distribution across regions with routing rules. Health checks and failov
 ## Endpoints
 
 | Method | Path | Description |
-|--------|------|-------------|
+| --- | --- | --- |
 | POST | `/api/data/namespaces/system/app_firewall/all_ns_metrics` | MetricsAllNamespaces. |
 | POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/app_firewalls` | Create Application Firewall. |
 | PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/app_firewalls/&#123;metadata.name&#125;` | Replace Application Firewall. |
@@ -163,7 +163,7 @@ Traffic distribution across regions with routing rules. Health checks and failov
 | POST | `/api/ml/data/namespaces/&#123;namespace&#125;/virtual_hosts/&#123;name&#125;/api_endpoint` | GET API Endpoint. |
 | GET | `/api/ml/data/namespaces/&#123;namespace&#125;/virtual_hosts/&#123;name&#125;/api_endpoint/learnt_schema` | GET GET Learnt Schema per API endpoint. |
 | GET | `/api/ml/data/namespaces/&#123;namespace&#125;/virtual_hosts/&#123;name&#125;/api_endpoint/pdf` | GET API Endpoint PDF. |
-| GET | `/api/ml/data/namespaces/&#123;namespace&#125;/virtual_hosts/&#123;name&#125;/api_endpoint/sources_openapi_schema` | GET relevant source OpenApi schema per API endpoint. |
+| GET | `/api/ml/data/namespaces/&#123;namespace&#125;/virtual_hosts/&#123;name&#125;/api_endpoint/sources_openapi_schema` | GET relevant source OpenAPI schema per API endpoint. |
 | POST | `/api/ml/data/namespaces/&#123;namespace&#125;/virtual_hosts/&#123;name&#125;/api_endpoint/unmerge_sources_openapi_schema` | Unmerge Source from API Endpoint. |
 | GET | `/api/ml/data/namespaces/&#123;namespace&#125;/virtual_hosts/&#123;name&#125;/api_endpoints` | GET API Endpoints. |
 | GET | `/api/ml/data/namespaces/&#123;namespace&#125;/virtual_hosts/&#123;name&#125;/api_endpoints/stats` | GET API Endpoints Stats for Virtual Host. |

--- a/docs/api-reference/vpm_and_node_management-api.mdx
+++ b/docs/api-reference/vpm_and_node_management-api.mdx
@@ -27,7 +27,7 @@ Lifecycle control, fleet configuration, and deployment policies for distributed 
 ## Endpoints
 
 | Method | Path | Description |
-|--------|------|-------------|
+| --- | --- | --- |
 | GET | `/api/data/namespaces/system/upgrade_status` | Upgrade Status. |
 
 ## Links

--- a/docs/en/Enhancements/healthcheck-enhancements.mdx
+++ b/docs/en/Enhancements/healthcheck-enhancements.mdx
@@ -23,45 +23,45 @@ Additionally, the nested schema `healthcheckHttpHealthCheck` contains enrichment
 
 Fields marked with `x-f5xc-server-default: true` have their `default` value applied by the F5 XC API server when omitted from requests.
 
-### Top-Level Fields
+### Server-applied top-level fields
 
-| Field | Default Value | Type | Description |
-|-------|---------------|------|-------------|
-| `jitter` | `0` | integer | Absolute jitter value for timing randomization |
-| `jitter_percent` | `0` | integer | Percentage-based jitter for timing randomization |
+| Field            | Default Value | Type    | Description                                      |
+| ---------------- | ------------- | ------- | ------------------------------------------------ |
+| `jitter`         | `0`           | integer | Absolute jitter value for timing randomization   |
+| `jitter_percent` | `0`           | integer | Percentage-based jitter for timing randomization |
 
-### healthcheckHttpHealthCheck Schema
+### Server-applied healthcheckHttpHealthCheck schema
 
-| Field | Default Value | Type | Description |
-|-------|---------------|------|-------------|
-| `use_origin_server_name` | `{}` | object | Origin server name for Host header |
-| `headers` | `{}` | object | Custom headers |
-| `request_headers_to_remove` | `[]` | array | Headers to strip from requests |
-| `use_http2` | `false` | boolean | HTTP/2 support |
-| `expected_status_codes` | `[]` | array | Accepted status codes (empty = 200-299) |
+| Field                       | Default Value | Type    | Description                             |
+| --------------------------- | ------------- | ------- | --------------------------------------- |
+| `use_origin_server_name`    | `{}`          | object  | Origin server name for Host header      |
+| `headers`                   | `{}`          | object  | Custom headers                          |
+| `request_headers_to_remove` | `[]`          | array   | Headers to strip from requests          |
+| `use_http2`                 | `false`       | boolean | HTTP/2 support                          |
+| `expected_status_codes`     | `[]`          | array   | Accepted status codes (empty = 200-299) |
 
 ## Recommended Values
 
 Fields marked with `x-f5xc-recommended-value` indicate values that the F5 XC web console pre-populates when creating new resources.
 
-### Top-Level Fields
+### Recommended top-level fields
 
-| Field | Recommended Value | Type | Description |
-|-------|-------------------|------|-------------|
-| `timeout` | `3` | integer | Health check timeout in seconds |
-| `interval` | `15` | integer | Interval between health checks in seconds |
-| `unhealthy_threshold` | `1` | integer | Consecutive failures before marking unhealthy |
-| `healthy_threshold` | `3` | integer | Consecutive successes before marking healthy |
-| `jitter_percent` | `30` | integer | Jitter percentage for production use |
+| Field                 | Recommended Value | Type    | Description                                   |
+| --------------------- | ----------------- | ------- | --------------------------------------------- |
+| `timeout`             | `3`               | integer | Health check timeout in seconds               |
+| `interval`            | `15`              | integer | Interval between health checks in seconds     |
+| `unhealthy_threshold` | `1`               | integer | Consecutive failures before marking unhealthy |
+| `healthy_threshold`   | `3`               | integer | Consecutive successes before marking healthy  |
+| `jitter_percent`      | `30`              | integer | Jitter percentage for production use          |
 
-### healthcheckHttpHealthCheck Schema
+### Recommended healthcheckHttpHealthCheck schema
 
-| Field | Recommended Value | Type | Description |
-|-------|-------------------|------|-------------|
-| `path` | `"/"` | string | Health check endpoint path |
-| `use_http2` | `false` | boolean | HTTP/2 support setting |
-| `expected_status_codes` | `["200"]` | array | Status codes indicating healthy origin |
-| `use_origin_server_name` | `{}` | object | Origin server name for Host header |
+| Field                    | Recommended Value | Type    | Description                            |
+| ------------------------ | ----------------- | ------- | -------------------------------------- |
+| `path`                   | `"/"`             | string  | Health check endpoint path             |
+| `use_http2`              | `false`           | boolean | HTTP/2 support setting                 |
+| `expected_status_codes`  | `["200"]`         | array   | Status codes indicating healthy origin |
+| `use_origin_server_name` | `{}`              | object  | Origin server name for Host header     |
 
 ## OneOf Variant Recommendations
 
@@ -69,25 +69,25 @@ Schemas containing mutually exclusive field groups (OneOf) include `x-f5xc-recom
 
 ### Top-Level OneOf Groups
 
-| Schema | OneOf Group | Recommended Variant | Description |
-|--------|-------------|---------------------|-------------|
-| `healthcheckCreateSpecType` | `health_check` | `http_health_check` | HTTP health check type |
+| Schema                       | OneOf Group    | Recommended Variant | Description            |
+| ---------------------------- | -------------- | ------------------- | ---------------------- |
+| `healthcheckCreateSpecType`  | `health_check` | `http_health_check` | HTTP health check type |
 | `healthcheckReplaceSpecType` | `health_check` | `http_health_check` | HTTP health check type |
 
 ### healthcheckHttpHealthCheck OneOf Groups
 
-| Schema | OneOf Group | Recommended Variant | Description |
-|--------|-------------|---------------------|-------------|
+| Schema                       | OneOf Group          | Recommended Variant      | Description                           |
+| ---------------------------- | -------------------- | ------------------------ | ------------------------------------- |
 | `healthcheckHttpHealthCheck` | `host_header_choice` | `use_origin_server_name` | Host header for health check requests |
 
 #### Host Header Choice
 
 The `host_header_choice` OneOf group controls how the Host header is specified in health check HTTP requests.
 
-| Variant | Type | Description |
-|---------|------|-------------|
+| Variant                  | Type             | Description                                                                                        |
+| ------------------------ | ---------------- | -------------------------------------------------------------------------------------------------- |
 | `use_origin_server_name` | `object` (empty) | Use the origin server name as the Host header. This is the default selection in the F5 XC console. |
-| `host_header` | `string` | Specify a custom Host header value for health check requests. |
+| `host_header`            | `string`         | Specify a custom Host header value for health check requests.                                      |
 
 **API Schema Reference**: `x-ves-oneof-field-host_header_choice: ["host_header", "use_origin_server_name"]`
 
@@ -132,14 +132,15 @@ healthcheckCreateSpecType:
   x-f5xc-recommended-oneof-variant:
     health_check: "http_health_check"
 ```
+
 ## Data Access
 
 ### OpenAPI Specifications
 
-| File | Content |
-|------|---------|
+| File                                   | Content                                                                                                           |
+| -------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
 | `docs/specifications/api/virtual.json` | `healthcheckHttpHealthCheck`, `healthcheckCreateSpecType`, `healthcheckReplaceSpecType`, `healthcheckGetSpecType` |
-| `docs/specifications/api/openapi.json` | Merged specification with all schemas |
+| `docs/specifications/api/openapi.json` | Merged specification with all schemas                                                                             |
 
 ### validation.json Structure
 
@@ -159,12 +160,12 @@ defaults.resources.healthcheck
 
 ## Changelog
 
-| Version | Date | Changes |
-|---------|------|---------|
-| 2.1.4 | 2026-01-19 | Added `host_header_choice` OneOf group documentation for HTTP health check request parameters |
-| 2.1.3 | 2026-01-18 | Consolidated global extension docs to DEVELOPMENT.md; resource-specific data only |
-| 2.1.2 | 2026-01-18 | Rewritten as pure API reference; removed downstream examples and prescriptive language |
-| 2.1.1 | 2026-01-18 | Added nested recommended values, OneOf recommended variants, `x-f5xc-recommended-oneof-variant` extension |
-| 2.1.0 | 2026-01-18 | Added unified defaults structure in validation.json |
-| 2.0.30 | 2026-01-16 | Added nested defaults for `$ref` schemas |
-| 2.0.29 | 2026-01-17 | Initial healthcheck defaults |
+| Version | Date       | Changes                                                                                                   |
+| ------- | ---------- | --------------------------------------------------------------------------------------------------------- |
+| 2.1.4   | 2026-01-19 | Added `host_header_choice` OneOf group documentation for HTTP health check request parameters             |
+| 2.1.3   | 2026-01-18 | Consolidated global extension docs to DEVELOPMENT.md; resource-specific data only                         |
+| 2.1.2   | 2026-01-18 | Rewritten as pure API reference; removed downstream examples and prescriptive language                    |
+| 2.1.1   | 2026-01-18 | Added nested recommended values, OneOf recommended variants, `x-f5xc-recommended-oneof-variant` extension |
+| 2.1.0   | 2026-01-18 | Added unified defaults structure in validation.json                                                       |
+| 2.0.30  | 2026-01-16 | Added nested defaults for `$ref` schemas                                                                  |
+| 2.0.29  | 2026-01-17 | Initial healthcheck defaults                                                                              |

--- a/docs/en/Enhancements/http-loadbalancer-enhancements.mdx
+++ b/docs/en/Enhancements/http-loadbalancer-enhancements.mdx
@@ -23,24 +23,25 @@ The `x-f5xc-minimum-configuration` extension provides comprehensive CLI metadata
 
 ### Required Fields
 
-| Field | Constraint | Description |
-|-------|-----------|-------------|
-| `metadata.name` | DNS label format: `[a-z0-9]([-a-z0-9]*[a-z0-9])?` | Resource name |
-| `metadata.namespace` | DNS label format | Namespace |
-| `spec.domains` | Array, min_items: 1 | Domains to serve |
+| Field                | Constraint                                        | Description      |
+| -------------------- | ------------------------------------------------- | ---------------- |
+| `metadata.name`      | DNS label format: `[a-z0-9]([-a-z0-9]*[a-z0-9])?` | Resource name    |
+| `metadata.namespace` | DNS label format                                  | Namespace        |
+| `spec.domains`       | Array, min_items: 1                               | Domains to serve |
 
 ### Load Balancer Type (OneOf Required)
 
 One of the following load balancer types must be specified:
 
-| Variant | Description |
-|---------|-------------|
-| `spec.http` | HTTP only |
-| `spec.https` | HTTPS with manual certificate |
+| Variant                | Description                      |
+| ---------------------- | -------------------------------- |
+| `spec.http`            | HTTP only                        |
+| `spec.https`           | HTTPS with manual certificate    |
 | `spec.https_auto_cert` | HTTPS with automatic certificate |
-| `spec.http_https` | Both HTTP and HTTPS |
+| `spec.http_https`      | Both HTTP and HTTPS              |
 
 **Note**: The load balancer type OneOf group is referred to as:
+
 - `lb_type` in configuration files (short form in `config/minimum_configs.yaml`)
 - `loadbalancer_type` in OpenAPI spec native extensions (native field name)
 
@@ -58,10 +59,12 @@ One of the following load balancer types must be specified:
     "domains": ["example.com"],
     "https_auto_cert": {
       "port": 443,
-      "tls_config": {"default_security": {}}
+      "tls_config": { "default_security": {} }
     },
     "advertise_on_public_default_vip": {},
-    "routes": [{"prefix": "/", "origin_pool": {"pool_name": "backend-pool"}}]
+    "routes": [
+      { "prefix": "/", "origin_pool": { "pool_name": "backend-pool" } }
+    ]
   }
 }
 ```
@@ -74,61 +77,61 @@ Fields marked with `x-f5xc-server-default: true` have their `default` value appl
 
 When `https_auto_cert` is specified, the server applies these defaults for omitted fields:
 
-| Field | Default Value | Type | Description |
-|-------|---------------|------|-------------|
-| `port` | `443` | integer | HTTPS listening port |
-| `http_redirect` | `false` | boolean | HTTP to HTTPS redirect |
-| `add_hsts` | `false` | boolean | HTTP Strict Transport Security header |
-| `tls_config.default_security` | `{}` | object | TLS 1.2+ with strong ciphers |
-| `no_mtls` | `{}` | object | Mutual TLS disabled |
-| `default_header` | `{}` | object | Default server name header handling |
-| `enable_path_normalize` | `{}` | object | Path normalization enabled |
-| `default_loadbalancer` | `{}` | object | Default load balancer settings |
-| `header_transformation_type.legacy_header_transformation` | `{}` | object | Legacy header transformation |
-| `connection_idle_timeout` | `120000` | integer | Connection idle timeout in milliseconds (2 minutes) |
-| `http_protocol_options.http_protocol_enable_v1_v2` | `{}` | object | HTTP/1.1 and HTTP/2 enabled |
-| `coalescing_options.default_coalescing` | `{}` | object | Default HTTP/2 connection coalescing |
+| Field                                                     | Default Value | Type    | Description                                         |
+| --------------------------------------------------------- | ------------- | ------- | --------------------------------------------------- |
+| `port`                                                    | `443`         | integer | HTTPS listening port                                |
+| `http_redirect`                                           | `false`       | boolean | HTTP to HTTPS redirect                              |
+| `add_hsts`                                                | `false`       | boolean | HTTP Strict Transport Security header               |
+| `tls_config.default_security`                             | `{}`          | object  | TLS 1.2+ with strong ciphers                        |
+| `no_mtls`                                                 | `{}`          | object  | Mutual TLS disabled                                 |
+| `default_header`                                          | `{}`          | object  | Default server name header handling                 |
+| `enable_path_normalize`                                   | `{}`          | object  | Path normalization enabled                          |
+| `default_loadbalancer`                                    | `{}`          | object  | Default load balancer settings                      |
+| `header_transformation_type.legacy_header_transformation` | `{}`          | object  | Legacy header transformation                        |
+| `connection_idle_timeout`                                 | `120000`      | integer | Connection idle timeout in milliseconds (2 minutes) |
+| `http_protocol_options.http_protocol_enable_v1_v2`        | `{}`          | object  | HTTP/1.1 and HTTP/2 enabled                         |
+| `coalescing_options.default_coalescing`                   | `{}`          | object  | Default HTTP/2 connection coalescing                |
 
 ### Security Feature Defaults
 
 All security features default to disabled when omitted:
 
-| Field | Default Value | Description |
-|-------|---------------|-------------|
-| `disable_waf` | `{}` | Web Application Firewall disabled |
-| `disable_bot_defense` | `{}` | Bot defense disabled |
-| `disable_rate_limit` | `{}` | Rate limiting disabled |
-| `disable_api_discovery` | `{}` | API discovery disabled |
-| `disable_api_testing` | `{}` | API testing disabled |
-| `disable_api_definition` | `{}` | API definition disabled |
-| `disable_malware_protection` | `{}` | Malware protection disabled |
-| `disable_client_side_defense` | `{}` | Client-side defense disabled |
-| `disable_ip_reputation` | `{}` | IP reputation disabled |
-| `disable_threat_mesh` | `{}` | Threat mesh disabled |
-| `disable_malicious_user_detection` | `{}` | Malicious user detection disabled |
+| Field                              | Default Value | Description                       |
+| ---------------------------------- | ------------- | --------------------------------- |
+| `disable_waf`                      | `{}`          | Web Application Firewall disabled |
+| `disable_bot_defense`              | `{}`          | Bot defense disabled              |
+| `disable_rate_limit`               | `{}`          | Rate limiting disabled            |
+| `disable_api_discovery`            | `{}`          | API discovery disabled            |
+| `disable_api_testing`              | `{}`          | API testing disabled              |
+| `disable_api_definition`           | `{}`          | API definition disabled           |
+| `disable_malware_protection`       | `{}`          | Malware protection disabled       |
+| `disable_client_side_defense`      | `{}`          | Client-side defense disabled      |
+| `disable_ip_reputation`            | `{}`          | IP reputation disabled            |
+| `disable_threat_mesh`              | `{}`          | Threat mesh disabled              |
+| `disable_malicious_user_detection` | `{}`          | Malicious user detection disabled |
 
 ### DDoS and Access Control Defaults
 
-| Field | Default Value | Description |
-|-------|---------------|-------------|
-| `l7_ddos_protection.mitigation_block` | `{}` | Block DDoS traffic (default mitigation action) |
-| `l7_ddos_protection.default_rps_threshold` | `{}` | Use default RPS threshold |
-| `l7_ddos_protection.clientside_action_none` | `{}` | No client-side DDoS validation |
-| `l7_ddos_protection.ddos_policy_none` | `{}` | No DDoS policy reference |
-| `no_challenge` | `{}` | No client challenge |
-| `user_id_client_ip` | `{}` | Identify users by client IP |
-| `disable_trust_client_ip_headers` | `{}` | Do not trust client IP headers |
+| Field                                       | Default Value | Description                                    |
+| ------------------------------------------- | ------------- | ---------------------------------------------- |
+| `l7_ddos_protection.mitigation_block`       | `{}`          | Block DDoS traffic (default mitigation action) |
+| `l7_ddos_protection.default_rps_threshold`  | `{}`          | Use default RPS threshold                      |
+| `l7_ddos_protection.clientside_action_none` | `{}`          | No client-side DDoS validation                 |
+| `l7_ddos_protection.ddos_policy_none`       | `{}`          | No DDoS policy reference                       |
+| `no_challenge`                              | `{}`          | No client challenge                            |
+| `user_id_client_ip`                         | `{}`          | Identify users by client IP                    |
+| `disable_trust_client_ip_headers`           | `{}`          | Do not trust client IP headers                 |
 
 ### Other Server-Applied Defaults
 
-| Field | Default Value | Type | Description |
-|-------|---------------|------|-------------|
-| `advertise_on_public_default_vip` | `{}` | object | Advertise on public default VIP |
-| `round_robin` | `{}` | object | Round-robin load balancing algorithm |
-| `add_location` | `true` | boolean | Add location header to responses |
-| `system_default_timeouts` | `{}` | object | Use system default timeouts |
-| `service_policies_from_namespace` | `{}` | object | Inherit service policies from namespace |
-| `default_sensitive_data_policy` | `{}` | object | Use default sensitive data policy |
+| Field                             | Default Value | Type    | Description                             |
+| --------------------------------- | ------------- | ------- | --------------------------------------- |
+| `advertise_on_public_default_vip` | `{}`          | object  | Advertise on public default VIP         |
+| `round_robin`                     | `{}`          | object  | Round-robin load balancing algorithm    |
+| `add_location`                    | `true`        | boolean | Add location header to responses        |
+| `system_default_timeouts`         | `{}`          | object  | Use system default timeouts             |
+| `service_policies_from_namespace` | `{}`          | object  | Inherit service policies from namespace |
+| `default_sensitive_data_policy`   | `{}`          | object  | Use default sensitive data policy       |
 
 ## Mutually Exclusive Field Groups
 
@@ -136,72 +139,72 @@ Fields marked with `x-f5xc-conflicts-with` indicate OneOf patterns. Only one fie
 
 ### Core Configuration Groups
 
-| Group Name | Fields | Description |
-|-----------|--------|-------------|
-| `lb_type` | `http`, `https`, `https_auto_cert`, `http_https` | Load balancer protocol type |
-| `advertising` | `advertise_on_public_default_vip`, `advertise_on_public`, `advertise_custom`, `do_not_advertise` | How to advertise the load balancer |
-| `load_balancing_algorithm` | `round_robin`, `least_request`, `ring_hash`, `random` | Traffic distribution algorithm |
+| Group Name                 | Fields                                                                                           | Description                        |
+| -------------------------- | ------------------------------------------------------------------------------------------------ | ---------------------------------- |
+| `lb_type`                  | `http`, `https`, `https_auto_cert`, `http_https`                                                 | Load balancer protocol type        |
+| `advertising`              | `advertise_on_public_default_vip`, `advertise_on_public`, `advertise_custom`, `do_not_advertise` | How to advertise the load balancer |
+| `load_balancing_algorithm` | `round_robin`, `least_request`, `ring_hash`, `random`                                            | Traffic distribution algorithm     |
 
 ### HTTPS Configuration Groups (10 groups)
 
 #### TLS Configuration
 
-| Group Name | Fields | Description |
-|-----------|--------|-------------|
-| `tls_config` | `default_security`, `medium_security`, `low_security`, `custom_security` | TLS security level |
-| `mtls` | `no_mtls`, `use_mtls` | Mutual TLS enabled or disabled |
+| Group Name   | Fields                                                                   | Description                    |
+| ------------ | ------------------------------------------------------------------------ | ------------------------------ |
+| `tls_config` | `default_security`, `medium_security`, `low_security`, `custom_security` | TLS security level             |
+| `mtls`       | `no_mtls`, `use_mtls`                                                    | Mutual TLS enabled or disabled |
 
 #### Protocol and Headers
 
-| Group Name | Fields | Description |
-|-----------|--------|-------------|
-| `http_protocol` | `http_protocol_enable_v1_only`, `http_protocol_enable_v1_v2`, `http_protocol_enable_v2_only` | HTTP protocol versions |
+| Group Name              | Fields                                                                                                | Description                     |
+| ----------------------- | ----------------------------------------------------------------------------------------------------- | ------------------------------- |
+| `http_protocol`         | `http_protocol_enable_v1_only`, `http_protocol_enable_v1_v2`, `http_protocol_enable_v2_only`          | HTTP protocol versions          |
 | `header_transformation` | `legacy_header_transformation`, `proper_header_transformation`, `preserve_case_header_transformation` | HTTP header transformation type |
-| `server_name_header` | `default_header`, `append_server_name_header`, `pass_through_server_name_header` | Server name header handling |
+| `server_name_header`    | `default_header`, `append_server_name_header`, `pass_through_server_name_header`                      | Server name header handling     |
 
 #### Connection Management
 
-| Group Name | Fields | Description |
-|-----------|--------|-------------|
-| `path_normalize` | `enable_path_normalize`, `disable_path_normalize` | Path normalization enabled or disabled |
-| `loadbalancer_choice` | `non_default_loadbalancer`, `default_loadbalancer` | Default or non-default load balancer |
-| `coalescing` | `default_coalescing`, `disable_coalescing`, `enable_for_same_origin` | HTTP/2 connection coalescing options |
+| Group Name            | Fields                                                               | Description                            |
+| --------------------- | -------------------------------------------------------------------- | -------------------------------------- |
+| `path_normalize`      | `enable_path_normalize`, `disable_path_normalize`                    | Path normalization enabled or disabled |
+| `loadbalancer_choice` | `non_default_loadbalancer`, `default_loadbalancer`                   | Default or non-default load balancer   |
+| `coalescing`          | `default_coalescing`, `disable_coalescing`, `enable_for_same_origin` | HTTP/2 connection coalescing options   |
 
 ### Security Feature Groups (11 groups)
 
-| Group Name | Fields | Description |
-|-----------|--------|-------------|
-| `waf` | `disable_waf`, `enable_waf` | Web Application Firewall |
-| `bot_defense` | `disable_bot_defense`, `enable_bot_defense` | Bot detection and mitigation |
-| `rate_limit` | `disable_rate_limit`, `enable_rate_limit` | Rate limiting |
-| `api_discovery` | `disable_api_discovery`, `enable_api_discovery` | API discovery |
-| `api_testing` | `disable_api_testing`, `enable_api_testing` | API testing |
-| `api_definition` | `disable_api_definition`, `enable_api_definition` | API definition |
-| `malware_protection` | `disable_malware_protection`, `enable_malware_protection` | Malware protection |
-| `client_side_defense` | `disable_client_side_defense`, `enable_client_side_defense` | Client-side defense |
-| `ip_reputation` | `disable_ip_reputation`, `enable_ip_reputation` | IP reputation |
-| `threat_mesh` | `disable_threat_mesh`, `enable_threat_mesh` | Threat mesh |
-| `malicious_user_detection` | `disable_malicious_user_detection`, `enable_malicious_user_detection` | Malicious user detection |
+| Group Name                 | Fields                                                                | Description                  |
+| -------------------------- | --------------------------------------------------------------------- | ---------------------------- |
+| `waf`                      | `disable_waf`, `enable_waf`                                           | Web Application Firewall     |
+| `bot_defense`              | `disable_bot_defense`, `enable_bot_defense`                           | Bot detection and mitigation |
+| `rate_limit`               | `disable_rate_limit`, `enable_rate_limit`                             | Rate limiting                |
+| `api_discovery`            | `disable_api_discovery`, `enable_api_discovery`                       | API discovery                |
+| `api_testing`              | `disable_api_testing`, `enable_api_testing`                           | API testing                  |
+| `api_definition`           | `disable_api_definition`, `enable_api_definition`                     | API definition               |
+| `malware_protection`       | `disable_malware_protection`, `enable_malware_protection`             | Malware protection           |
+| `client_side_defense`      | `disable_client_side_defense`, `enable_client_side_defense`           | Client-side defense          |
+| `ip_reputation`            | `disable_ip_reputation`, `enable_ip_reputation`                       | IP reputation                |
+| `threat_mesh`              | `disable_threat_mesh`, `enable_threat_mesh`                           | Threat mesh                  |
+| `malicious_user_detection` | `disable_malicious_user_detection`, `enable_malicious_user_detection` | Malicious user detection     |
 
 ### DDoS Protection Groups (4 groups)
 
-| Group Name | Fields | Description |
-|-----------|--------|-------------|
-| `ddos_mitigation` | `mitigation_block`, `mitigation_challenge`, `mitigation_none` | DDoS mitigation action |
-| `ddos_rps_threshold` | `default_rps_threshold`, `custom_rps_threshold` | Requests per second threshold |
+| Group Name               | Fields                                                                                | Description                        |
+| ------------------------ | ------------------------------------------------------------------------------------- | ---------------------------------- |
+| `ddos_mitigation`        | `mitigation_block`, `mitigation_challenge`, `mitigation_none`                         | DDoS mitigation action             |
+| `ddos_rps_threshold`     | `default_rps_threshold`, `custom_rps_threshold`                                       | Requests per second threshold      |
 | `ddos_clientside_action` | `clientside_action_none`, `clientside_action_javascript`, `clientside_action_captcha` | Client-side DDoS validation action |
-| `ddos_policy` | `ddos_policy_none`, `ddos_policy_ref` | DDoS policy reference or none |
+| `ddos_policy`            | `ddos_policy_none`, `ddos_policy_ref`                                                 | DDoS policy reference or none      |
 
 ### Other Settings Groups (6 groups)
 
-| Group Name | Fields | Description |
-|-----------|--------|-------------|
-| `challenge` | `no_challenge`, `js_challenge`, `captcha_challenge` | Client challenge type for bot detection |
-| `user_identification` | `user_id_client_ip`, `user_identification` | User identification method |
-| `client_ip_headers` | `disable_trust_client_ip_headers`, `enable_trust_client_ip_headers` | Trust client IP headers or not |
-| `timeouts` | `system_default_timeouts`, `custom_timeouts` | Use system default or custom timeouts |
-| `service_policies_source` | `service_policies_from_namespace`, `active_service_policies` | Service policies from namespace or active list |
-| `sensitive_data_policy` | `default_sensitive_data_policy`, `custom_sensitive_data_policy` | Use default or custom sensitive data policy |
+| Group Name                | Fields                                                              | Description                                    |
+| ------------------------- | ------------------------------------------------------------------- | ---------------------------------------------- |
+| `challenge`               | `no_challenge`, `js_challenge`, `captcha_challenge`                 | Client challenge type for bot detection        |
+| `user_identification`     | `user_id_client_ip`, `user_identification`                          | User identification method                     |
+| `client_ip_headers`       | `disable_trust_client_ip_headers`, `enable_trust_client_ip_headers` | Trust client IP headers or not                 |
+| `timeouts`                | `system_default_timeouts`, `custom_timeouts`                        | Use system default or custom timeouts          |
+| `service_policies_source` | `service_policies_from_namespace`, `active_service_policies`        | Service policies from namespace or active list |
+| `sensitive_data_policy`   | `default_sensitive_data_policy`, `custom_sensitive_data_policy`     | Use default or custom sensitive data policy    |
 
 ## OneOf Variant Recommendations (Future Extension)
 
@@ -212,6 +215,7 @@ Unlike healthcheck, which includes `x-f5xc-recommended-oneof-variant` to indicat
 ### Comparison with Healthcheck
 
 **Healthcheck** (implemented):
+
 ```yaml
 viewshealthcheckCreateSpecType:
   x-f5xc-recommended-oneof-variant:
@@ -219,23 +223,26 @@ viewshealthcheckCreateSpecType:
 ```
 
 **HTTP LoadBalancer** (not yet implemented):
+
 ```yaml
 viewshttp_loadbalancerCreateSpecType:
-  x-f5xc-recommended-oneof-variant: null  # Would indicate recommended lb_type variant
+  x-f5xc-recommended-oneof-variant: null # Would indicate recommended lb_type variant
 ```
 
 ### Future Implementation
 
 To add this extension for http_loadbalancer:
+
 1. Observe F5 XC console default selections (e.g., which lb_type is preselected in the UI)
 2. Add configuration to `config/discovered_defaults.yaml`
 3. Re-run enrichment pipeline to apply extension
 
 **Expected structure when added**:
+
 ```yaml
 viewshttp_loadbalancerCreateSpecType:
   x-f5xc-recommended-oneof-variant:
-    loadbalancer_type: "https_auto_cert"  # Example - requires verification
+    loadbalancer_type: "https_auto_cert" # Example - requires verification
 ```
 
 This extension would enable downstream tools to preselect the most commonly used variant when presenting configuration options to users.
@@ -246,35 +253,35 @@ Fields marked with `x-f5xc-constraints` include validation constraints discovere
 
 ### Array Constraints
 
-| Field | minItems | maxItems | uniqueItems |
-|-------|----------|----------|-------------|
-| `spec.domains` | 1 | - | false |
-| `spec.routes` | 1 | 256 | false |
-| `spec.blocked_clients` | 1 | 128 | true |
-| `spec.trusted_clients` | 1 | 128 | true |
-| `spec.data_guard_rules` | 1 | 256 | true |
+| Field                   | minItems | maxItems | uniqueItems |
+| ----------------------- | -------- | -------- | ----------- |
+| `spec.domains`          | 1        | -        | false       |
+| `spec.routes`           | 1        | 256      | false       |
+| `spec.blocked_clients`  | 1        | 128      | true        |
+| `spec.trusted_clients`  | 1        | 128      | true        |
+| `spec.data_guard_rules` | 1        | 256      | true        |
 
 ### Integer Constraints
 
-| Field | Minimum | Maximum | Default | Description |
-|-------|---------|---------|---------|-------------|
-| `spec.https_auto_cert.port` | 1 | 65535 | 443 | HTTPS port number |
-| `spec.https_auto_cert.connection_idle_timeout` | 1000 | 3600000 | 120000 | Connection idle timeout (milliseconds, 1s to 1h) |
+| Field                                          | Minimum | Maximum | Default | Description                                      |
+| ---------------------------------------------- | ------- | ------- | ------- | ------------------------------------------------ |
+| `spec.https_auto_cert.port`                    | 1       | 65535   | 443     | HTTPS port number                                |
+| `spec.https_auto_cert.connection_idle_timeout` | 1000    | 3600000 | 120000  | Connection idle timeout (milliseconds, 1s to 1h) |
 
 ### Enum Constraints
 
-| Field | Values | Default | Description |
-|-------|--------|---------|-------------|
-| `spec.https_auto_cert.tls_config` | `default_security`, `medium_security`, `low_security`, `custom_security` | `default_security` | TLS security level |
-| `spec.https_auto_cert.header_transformation_type` | `legacy_header_transformation`, `proper_header_transformation`, `preserve_case_header_transformation` | `legacy_header_transformation` | HTTP header transformation |
-| `spec.https_auto_cert.http_protocol_options` | `http_protocol_enable_v1_only`, `http_protocol_enable_v1_v2`, `http_protocol_enable_v2_only` | `http_protocol_enable_v1_v2` | HTTP protocol versions |
-| `spec.https_auto_cert.coalescing_options` | `default_coalescing`, `disable_coalescing`, `enable_for_same_origin` | `default_coalescing` | HTTP/2 connection coalescing |
-| `spec.load_balancing_algorithm` | `round_robin`, `least_request`, `ring_hash`, `random` | `round_robin` | Load balancing algorithm |
-| `spec.l7_ddos_protection.mitigation` | `mitigation_block`, `mitigation_challenge`, `mitigation_none` | `mitigation_block` | Layer 7 DDoS mitigation action |
-| `spec.l7_ddos_protection.rps_threshold` | `default_rps_threshold`, `custom_rps_threshold` | `default_rps_threshold` | RPS threshold for DDoS detection |
-| `spec.l7_ddos_protection.clientside_action` | `clientside_action_none`, `clientside_action_javascript`, `clientside_action_captcha` | `clientside_action_none` | Client-side DDoS validation |
-| `spec.challenge` | `no_challenge`, `js_challenge`, `captcha_challenge` | `no_challenge` | Client challenge type |
-| `spec.advertising` | `advertise_on_public_default_vip`, `advertise_on_public`, `advertise_custom`, `do_not_advertise` | `advertise_on_public_default_vip` | Load balancer advertising |
+| Field                                             | Values                                                                                                | Default                           | Description                      |
+| ------------------------------------------------- | ----------------------------------------------------------------------------------------------------- | --------------------------------- | -------------------------------- |
+| `spec.https_auto_cert.tls_config`                 | `default_security`, `medium_security`, `low_security`, `custom_security`                              | `default_security`                | TLS security level               |
+| `spec.https_auto_cert.header_transformation_type` | `legacy_header_transformation`, `proper_header_transformation`, `preserve_case_header_transformation` | `legacy_header_transformation`    | HTTP header transformation       |
+| `spec.https_auto_cert.http_protocol_options`      | `http_protocol_enable_v1_only`, `http_protocol_enable_v1_v2`, `http_protocol_enable_v2_only`          | `http_protocol_enable_v1_v2`      | HTTP protocol versions           |
+| `spec.https_auto_cert.coalescing_options`         | `default_coalescing`, `disable_coalescing`, `enable_for_same_origin`                                  | `default_coalescing`              | HTTP/2 connection coalescing     |
+| `spec.load_balancing_algorithm`                   | `round_robin`, `least_request`, `ring_hash`, `random`                                                 | `round_robin`                     | Load balancing algorithm         |
+| `spec.l7_ddos_protection.mitigation`              | `mitigation_block`, `mitigation_challenge`, `mitigation_none`                                         | `mitigation_block`                | Layer 7 DDoS mitigation action   |
+| `spec.l7_ddos_protection.rps_threshold`           | `default_rps_threshold`, `custom_rps_threshold`                                                       | `default_rps_threshold`           | RPS threshold for DDoS detection |
+| `spec.l7_ddos_protection.clientside_action`       | `clientside_action_none`, `clientside_action_javascript`, `clientside_action_captcha`                 | `clientside_action_none`          | Client-side DDoS validation      |
+| `spec.challenge`                                  | `no_challenge`, `js_challenge`, `captcha_challenge`                                                   | `no_challenge`                    | Client challenge type            |
+| `spec.advertising`                                | `advertise_on_public_default_vip`, `advertise_on_public`, `advertise_custom`, `do_not_advertise`      | `advertise_on_public_default_vip` | Load balancer advertising        |
 
 ## Guided Workflow Integration
 
@@ -284,13 +291,13 @@ The enrichment pipeline adds `x-f5xc-guided-workflows` metadata at the spec leve
 
 A 5-step workflow for creating a fully configured HTTP load balancer with backend origin pool (defined in `config/guided_workflows.yaml`):
 
-| Step | Action | Resource | Required Fields | Optional |
-|------|--------|----------|-----------------|----------|
-| 1 | Create Origin Pool | `origin_pool` | `name`, `origin_servers`, `port` | No |
-| 2 | Configure Health Check | `healthcheck` | `name`, `http_health_check` | Yes |
-| 3 | Attach Health Check | - | - | Yes |
-| 4 | Create HTTP Load Balancer | `http_loadbalancer` | `name`, `domains`, `http.port` | No |
-| 5 | Verify Deployment | - | - | No |
+| Step | Action                    | Resource            | Required Fields                  | Optional |
+| ---- | ------------------------- | ------------------- | -------------------------------- | -------- |
+| 1    | Create Origin Pool        | `origin_pool`       | `name`, `origin_servers`, `port` | No       |
+| 2    | Configure Health Check    | `healthcheck`       | `name`, `http_health_check`      | Yes      |
+| 3    | Attach Health Check       | -                   | -                                | Yes      |
+| 4    | Create HTTP Load Balancer | `http_loadbalancer` | `name`, `domains`, `http.port`   | No       |
+| 5    | Verify Deployment         | -                   | -                                | No       |
 
 **Prerequisites**: Valid namespace in target tenant, backend application reachable via IP or DNS, SSL certificate (optional for HTTPS).
 
@@ -298,15 +305,15 @@ A 5-step workflow for creating a fully configured HTTP load balancer with backen
 
 A 7-step workflow for creating HTTPS load balancer with SSL/TLS termination:
 
-| Step | Action | Resource | Required Fields | Optional |
-|------|--------|----------|-----------------|----------|
-| 1 | Upload SSL Certificate | `certificate` | `name`, `certificate_chain`, `private_key` | No |
-| 2 | Create Origin Pool | `origin_pool` | `name`, `origin_servers` | No |
-| 3 | Configure Health Check | `healthcheck` | - | Yes |
-| 4 | Configure WAF Policy | `app_firewall` | - | Yes |
-| 5 | Create HTTPS Load Balancer | `http_loadbalancer` | `name`, `domains`, `https.tls_parameters` | No |
-| 6 | Attach WAF Policy | - | - | Yes |
-| 7 | Verify HTTPS Deployment | - | - | No |
+| Step | Action                     | Resource            | Required Fields                            | Optional |
+| ---- | -------------------------- | ------------------- | ------------------------------------------ | -------- |
+| 1    | Upload SSL Certificate     | `certificate`       | `name`, `certificate_chain`, `private_key` | No       |
+| 2    | Create Origin Pool         | `origin_pool`       | `name`, `origin_servers`                   | No       |
+| 3    | Configure Health Check     | `healthcheck`       | -                                          | Yes      |
+| 4    | Configure WAF Policy       | `app_firewall`      | -                                          | Yes      |
+| 5    | Create HTTPS Load Balancer | `http_loadbalancer` | `name`, `domains`, `https.tls_parameters`  | No       |
+| 6    | Attach WAF Policy          | -                   | -                                          | Yes      |
+| 7    | Verify HTTPS Deployment    | -                   | -                                          | No       |
 
 **Prerequisites**: Valid namespace in target tenant, SSL certificate and private key, backend application reachable.
 
@@ -339,11 +346,12 @@ viewshttp_loadbalancerCreateSpecType:
 **Type**: `object`
 
 Provides comprehensive metadata for creating minimal viable configurations. Includes:
+
 - Description
 - Required fields with constraints
 - Mutually exclusive groups
 - Example configurations (YAML, JSON)
-- curl command examples
+- cURL command examples
 
 ```yaml
 viewshttp_loadbalancerCreateSpecType:
@@ -356,7 +364,8 @@ viewshttp_loadbalancerCreateSpecType:
       - "spec.domains"
     mutually_exclusive_groups:
       - name: "lb_type"
-        fields: ["spec.http", "spec.https", "spec.https_auto_cert", "spec.http_https"]
+        fields:
+          ["spec.http", "spec.https", "spec.https_auto_cert", "spec.http_https"]
         reason: "Choose exactly one load balancer type"
     example_yaml: |
       ...
@@ -431,6 +440,7 @@ port:
 **Type**: `string`
 
 Provides alternative description lengths for different use cases:
+
 - `x-f5xc-description-short`: 60 characters max (CLI columns, badges)
 - `x-f5xc-description-medium`: 150 characters max (tooltips, summaries)
 
@@ -478,19 +488,19 @@ metadata.uid:
 
 ### OpenAPI Specifications
 
-| File | Content |
-|------|---------|
+| File                                   | Content                                        |
+| -------------------------------------- | ---------------------------------------------- |
 | `docs/specifications/api/virtual.json` | All http_loadbalancer schemas with enrichments |
-| `docs/specifications/api/openapi.json` | Merged specification with all schemas |
+| `docs/specifications/api/openapi.json` | Merged specification with all schemas          |
 
 ### Configuration Files
 
-| File | Purpose |
-|------|---------|
-| `config/minimum_configs.yaml` | Source of minimum configuration metadata |
-| `config/constraint_patterns.yaml` | Constraint pattern definitions |
-| `config/guided_workflows.yaml` | Guided workflow step definitions |
-| `config/domain_descriptions.yaml` | Domain-level description metadata |
+| File                              | Purpose                                  |
+| --------------------------------- | ---------------------------------------- |
+| `config/minimum_configs.yaml`     | Source of minimum configuration metadata |
+| `config/constraint_patterns.yaml` | Constraint pattern definitions           |
+| `config/guided_workflows.yaml`    | Guided workflow step definitions         |
+| `config/domain_descriptions.yaml` | Domain-level description metadata        |
 
 ### Schemas Enriched
 
@@ -507,7 +517,7 @@ metadata.uid:
 
 ## Changelog
 
-| Version | Date | Changes |
-|---------|------|---------|
-| 2.0.46 | 2026-04-18 | Added server-applied defaults, guided workflow integration, and expanded minimum config section |
-| 2.0.45 | 2026-01-20 | Initial http_loadbalancer enrichments documentation |
+| Version | Date       | Changes                                                                                         |
+| ------- | ---------- | ----------------------------------------------------------------------------------------------- |
+| 2.0.46  | 2026-04-18 | Added server-applied defaults, guided workflow integration, and expanded minimum config section |
+| 2.0.45  | 2026-01-20 | Initial http_loadbalancer enrichments documentation                                             |

--- a/docs/en/Enhancements/originpool-enhancements.mdx
+++ b/docs/en/Enhancements/originpool-enhancements.mdx
@@ -19,12 +19,12 @@ All schemas matching `origin_pool.*SpecType` receive enrichments:
 
 ## Required Fields
 
-| Field | Required For | Notes |
-|-------|--------------|-------|
-| `metadata.name` | All operations | 1-63 chars, lowercase alphanumeric, pattern: `^[a-z0-9]([-a-z0-9]*[a-z0-9])?$` |
-| `metadata.namespace` | All operations | Namespace identifier |
-| `spec.origin_servers` | Create | Minimum 1 item |
-| `spec.port` | Create | 1-65535, no server default |
+| Field                 | Required For   | Notes                                                                          |
+| --------------------- | -------------- | ------------------------------------------------------------------------------ |
+| `metadata.name`       | All operations | 1-63 chars, lowercase alphanumeric, pattern: `^[a-z0-9]([-a-z0-9]*[a-z0-9])?$` |
+| `metadata.namespace`  | All operations | Namespace identifier                                                           |
+| `spec.origin_servers` | Create         | Minimum 1 item                                                                 |
+| `spec.port`           | Create         | 1-65535, no server default                                                     |
 
 ## Minimum Viable Configuration
 
@@ -53,123 +53,123 @@ Fields marked with `x-f5xc-server-default: true` have their `default` value appl
 
 ### Top-Level Fields
 
-| Field | Default Value | Type | Description |
-|-------|---------------|------|-------------|
-| `no_tls` | `{}` | object | TLS to origin disabled |
-| `healthcheck` | `[]` | array | No health checks configured |
-| `loadbalancer_algorithm` | `ROUND_ROBIN` | enum | Round-robin load balancing |
-| `endpoint_selection` | `DISTRIBUTED` | enum | Use all endpoints (local + remote) |
+| Field                    | Default Value | Type   | Description                        |
+| ------------------------ | ------------- | ------ | ---------------------------------- |
+| `no_tls`                 | `{}`          | object | TLS to origin disabled             |
+| `healthcheck`            | `[]`          | array  | No health checks configured        |
+| `loadbalancer_algorithm` | `ROUND_ROBIN` | enum   | Round-robin load balancing         |
+| `endpoint_selection`     | `DISTRIBUTED` | enum   | Use all endpoints (local + remote) |
 
 ### advanced_options Defaults
 
 When `advanced_options` is not specified, the server behaves as if these values were set:
 
-| Field | Default Value | Type | Description |
-|-------|---------------|------|-------------|
-| `connection_timeout` | `2000` | integer | Connection timeout in milliseconds |
-| `http_idle_timeout` | `300000` | integer | HTTP idle timeout in milliseconds (5 min) |
-| `same_as_endpoint_port` | `{}` | object | Health check uses endpoint port |
-| `default_circuit_breaker` | `{}` | object | Default circuit breaker settings |
-| `disable_outlier_detection` | `{}` | object | Outlier detection disabled |
-| `no_panic_threshold` | `{}` | object | No panic threshold |
-| `disable_subsets` | `{}` | object | Subset load balancing disabled |
-| `auto_http_config` | `{}` | object | Automatic HTTP protocol negotiation |
-| `disable_proxy_protocol` | `{}` | object | Proxy protocol disabled |
-| `disable_lb_source_ip_persistance` | `{}` | object | LB source IP persistence disabled |
+| Field                              | Default Value | Type    | Description                               |
+| ---------------------------------- | ------------- | ------- | ----------------------------------------- |
+| `connection_timeout`               | `2000`        | integer | Connection timeout in milliseconds        |
+| `http_idle_timeout`                | `300000`      | integer | HTTP idle timeout in milliseconds (5 min) |
+| `same_as_endpoint_port`            | `{}`          | object  | Health check uses endpoint port           |
+| `default_circuit_breaker`          | `{}`          | object  | Default circuit breaker settings          |
+| `disable_outlier_detection`        | `{}`          | object  | Outlier detection disabled                |
+| `no_panic_threshold`               | `{}`          | object  | No panic threshold                        |
+| `disable_subsets`                  | `{}`          | object  | Subset load balancing disabled            |
+| `auto_http_config`                 | `{}`          | object  | Automatic HTTP protocol negotiation       |
+| `disable_proxy_protocol`           | `{}`          | object  | Proxy protocol disabled                   |
+| `disable_lb_source_ip_persistance` | `{}`          | object  | LB source IP persistence disabled         |
 
 ### Nested Object Defaults
 
-| Path | Default Value | Description |
-|------|---------------|-------------|
-| `origin_servers[].labels` | `{}` | Empty labels object |
-| `origin_servers[].public_name.refresh_interval` | `0` | Use system default DNS refresh |
+| Path                                            | Default Value | Description                    |
+| ----------------------------------------------- | ------------- | ------------------------------ |
+| `origin_servers[].labels`                       | `{}`          | Empty labels object            |
+| `origin_servers[].public_name.refresh_interval` | `0`           | Use system default DNS refresh |
 
 ## UI vs Server Default Discrepancies
 
 The F5 XC web UI preselects different values than what the API applies when fields are omitted.
 
-| Field | UI Preselected | Server Applied | Note |
-|-------|-----------------|----------------|------|
-| `loadbalancer_algorithm` | `LB_OVERRIDE` | `ROUND_ROBIN` | UI-created and API-created resources differ when field is omitted |
+| Field                    | UI Preselected | Server Applied | Note                                                              |
+| ------------------------ | -------------- | -------------- | ----------------------------------------------------------------- |
+| `loadbalancer_algorithm` | `LB_OVERRIDE`  | `ROUND_ROBIN`  | UI-created and API-created resources differ when field is omitted |
 
 ## Enum Values
 
 ### loadbalancer_algorithm
 
-| Value | Description | Notes |
-|-------|-------------|-------|
-| `ROUND_ROBIN` | Each healthy endpoint selected in round-robin order | Server default |
-| `LEAST_REQUEST` | Endpoint with fewest active requests selected | |
-| `RING_HASH` | Consistent hashing using ring hash of endpoint names | |
-| `RANDOM` | Random healthy endpoint selection | |
-| `LB_OVERRIDE` | Hash policy inherited from parent load balancer | UI default |
+| Value           | Description                                          | Notes          |
+| --------------- | ---------------------------------------------------- | -------------- |
+| `ROUND_ROBIN`   | Each healthy endpoint selected in round-robin order  | Server default |
+| `LEAST_REQUEST` | Endpoint with fewest active requests selected        |                |
+| `RING_HASH`     | Consistent hashing using ring hash of endpoint names |                |
+| `RANDOM`        | Random healthy endpoint selection                    |                |
+| `LB_OVERRIDE`   | Hash policy inherited from parent load balancer      | UI default     |
 
 ### endpoint_selection
 
-| Value | Description | Notes |
-|-------|-------------|-------|
-| `DISTRIBUTED` | Consider both remote and local endpoints | Server default |
-| `LOCAL_ONLY` | Only local endpoints used | |
-| `LOCAL_PREFERRED` | Prefer local, fall back to remote if unavailable | |
+| Value             | Description                                      | Notes          |
+| ----------------- | ------------------------------------------------ | -------------- |
+| `DISTRIBUTED`     | Consider both remote and local endpoints         | Server default |
+| `LOCAL_ONLY`      | Only local endpoints used                        |                |
+| `LOCAL_PREFERRED` | Prefer local, fall back to remote if unavailable |                |
 
 ## OneOf Field Groups
 
 Mutually exclusive field groups. Only ONE field from each group can be specified:
 
-| Group | Fields | Server Default |
-|-------|--------|----------------|
-| Port Configuration | `port`, `automatic_port`, `lb_port` | `port` (explicit) |
-| TLS to Origin | `no_tls`, `use_tls` | `no_tls` |
-| Health Check Port | `same_as_endpoint_port`, `health_check_port` | `same_as_endpoint_port` |
-| Circuit Breaker | `default_circuit_breaker`, `disable_circuit_breaker`, `circuit_breaker` | `default_circuit_breaker` |
-| Outlier Detection | `disable_outlier_detection`, `outlier_detection` | `disable_outlier_detection` |
-| Panic Threshold | `no_panic_threshold`, `panic_threshold` | `no_panic_threshold` |
-| Subset LB | `disable_subsets`, `enable_subsets` | `disable_subsets` |
-| HTTP Protocol | `auto_http_config`, `http1_config`, `http2_options` | `auto_http_config` |
-| Proxy Protocol | `disable_proxy_protocol`, `proxy_protocol_v1`, `proxy_protocol_v2` | `disable_proxy_protocol` |
-| LB Source IP | `disable_lb_source_ip_persistance`, `enable_lb_source_ip_persistance` | `disable_lb_source_ip_persistance` |
-| Connection Pool | `enable_conn_pool_reuse`, `disable_conn_pool_reuse` | `enable_conn_pool_reuse` |
+| Group              | Fields                                                                  | Server Default                     |
+| ------------------ | ----------------------------------------------------------------------- | ---------------------------------- |
+| Port Configuration | `port`, `automatic_port`, `lb_port`                                     | `port` (explicit)                  |
+| TLS to Origin      | `no_tls`, `use_tls`                                                     | `no_tls`                           |
+| Health Check Port  | `same_as_endpoint_port`, `health_check_port`                            | `same_as_endpoint_port`            |
+| Circuit Breaker    | `default_circuit_breaker`, `disable_circuit_breaker`, `circuit_breaker` | `default_circuit_breaker`          |
+| Outlier Detection  | `disable_outlier_detection`, `outlier_detection`                        | `disable_outlier_detection`        |
+| Panic Threshold    | `no_panic_threshold`, `panic_threshold`                                 | `no_panic_threshold`               |
+| Subset LB          | `disable_subsets`, `enable_subsets`                                     | `disable_subsets`                  |
+| HTTP Protocol      | `auto_http_config`, `http1_config`, `http2_options`                     | `auto_http_config`                 |
+| Proxy Protocol     | `disable_proxy_protocol`, `proxy_protocol_v1`, `proxy_protocol_v2`      | `disable_proxy_protocol`           |
+| LB Source IP       | `disable_lb_source_ip_persistance`, `enable_lb_source_ip_persistance`   | `disable_lb_source_ip_persistance` |
+| Connection Pool    | `enable_conn_pool_reuse`, `disable_conn_pool_reuse`                     | `enable_conn_pool_reuse`           |
 
 ## Field Constraints
 
-| Field | Type | Constraint |
-|-------|------|------------|
-| `spec.port` | integer | 1-65535 |
-| `spec.advanced_options.connection_timeout` | integer | 0-1,800,000 ms |
-| `spec.advanced_options.http_idle_timeout` | integer | 0-600,000 ms |
-| `spec.advanced_options.panic_threshold` | integer | 0-100 (percentage) |
-| `metadata.name` | string | 1-63 chars, pattern: `^[a-z0-9]([-a-z0-9]*[a-z0-9])?$` |
+| Field                                      | Type    | Constraint                                             |
+| ------------------------------------------ | ------- | ------------------------------------------------------ |
+| `spec.port`                                | integer | 1-65535                                                |
+| `spec.advanced_options.connection_timeout` | integer | 0-1,800,000 ms                                         |
+| `spec.advanced_options.http_idle_timeout`  | integer | 0-600,000 ms                                           |
+| `spec.advanced_options.panic_threshold`    | integer | 0-100 (percentage)                                     |
+| `metadata.name`                            | string  | 1-63 chars, pattern: `^[a-z0-9]([-a-z0-9]*[a-z0-9])?$` |
 
 ## UI Configuration Options
 
 The F5 XC web console presents 15 configuration options for origin pools:
 
-| # | UI Label | API Field Path | Type | Server Default |
-|---|----------|----------------|------|----------------|
-| 1 | Origin Server Port | `spec.[port\|automatic_port\|lb_port]` | OneOf | `port` (explicit) |
-| 2 | Connection Pool Reuse | `spec.[enable_conn_pool_reuse\|disable_conn_pool_reuse]` | OneOf | `enable_conn_pool_reuse` |
-| 3 | Health Check Port | `spec.advanced_options.[same_as_endpoint_port\|health_check_port]` | OneOf | `same_as_endpoint_port` |
-| 4 | LoadBalancer Algorithm | `spec.loadbalancer_algorithm` | enum | `ROUND_ROBIN` |
-| 5 | Endpoint Selection | `spec.endpoint_selection` | enum | `DISTRIBUTED` |
-| 6 | TLS to Origin | `spec.[no_tls\|use_tls]` | OneOf | `no_tls` |
-| 7 | Connection Timeout | `spec.advanced_options.connection_timeout` | integer | 2000 ms |
-| 8 | HTTP Idle Timeout | `spec.advanced_options.http_idle_timeout` | integer | 300000 ms |
-| 9 | Circuit Breaker | `spec.advanced_options.[default_circuit_breaker\|disable_circuit_breaker\|circuit_breaker]` | OneOf | `default_circuit_breaker` |
-| 10 | Outlier Detection | `spec.advanced_options.[disable_outlier_detection\|outlier_detection]` | OneOf | `disable_outlier_detection` |
-| 11 | Panic Threshold | `spec.advanced_options.[no_panic_threshold\|panic_threshold]` | OneOf | `no_panic_threshold` |
-| 12 | Subset Load Balancing | `spec.advanced_options.[disable_subsets\|enable_subsets]` | OneOf | `disable_subsets` |
-| 13 | HTTP Protocol | `spec.advanced_options.[auto_http_config\|http1_config\|http2_options]` | OneOf | `auto_http_config` |
-| 14 | Proxy Protocol | `spec.advanced_options.[disable_proxy_protocol\|proxy_protocol_v1\|proxy_protocol_v2]` | OneOf | `disable_proxy_protocol` |
-| 15 | LB Source IP Persistence | `spec.advanced_options.[disable_lb_source_ip_persistance\|enable_lb_source_ip_persistance]` | OneOf | `disable_lb_source_ip_persistance` |
+| #   | UI Label                 | API Field Path                                                                              | Type    | Server Default                     |
+| --- | ------------------------ | ------------------------------------------------------------------------------------------- | ------- | ---------------------------------- |
+| 1   | Origin Server Port       | `spec.[port\|automatic_port\|lb_port]`                                                      | OneOf   | `port` (explicit)                  |
+| 2   | Connection Pool Reuse    | `spec.[enable_conn_pool_reuse\|disable_conn_pool_reuse]`                                    | OneOf   | `enable_conn_pool_reuse`           |
+| 3   | Health Check Port        | `spec.advanced_options.[same_as_endpoint_port\|health_check_port]`                          | OneOf   | `same_as_endpoint_port`            |
+| 4   | LoadBalancer Algorithm   | `spec.loadbalancer_algorithm`                                                               | enum    | `ROUND_ROBIN`                      |
+| 5   | Endpoint Selection       | `spec.endpoint_selection`                                                                   | enum    | `DISTRIBUTED`                      |
+| 6   | TLS to Origin            | `spec.[no_tls\|use_tls]`                                                                    | OneOf   | `no_tls`                           |
+| 7   | Connection Timeout       | `spec.advanced_options.connection_timeout`                                                  | integer | 2000 ms                            |
+| 8   | HTTP Idle Timeout        | `spec.advanced_options.http_idle_timeout`                                                   | integer | 300000 ms                          |
+| 9   | Circuit Breaker          | `spec.advanced_options.[default_circuit_breaker\|disable_circuit_breaker\|circuit_breaker]` | OneOf   | `default_circuit_breaker`          |
+| 10  | Outlier Detection        | `spec.advanced_options.[disable_outlier_detection\|outlier_detection]`                      | OneOf   | `disable_outlier_detection`        |
+| 11  | Panic Threshold          | `spec.advanced_options.[no_panic_threshold\|panic_threshold]`                               | OneOf   | `no_panic_threshold`               |
+| 12  | Subset Load Balancing    | `spec.advanced_options.[disable_subsets\|enable_subsets]`                                   | OneOf   | `disable_subsets`                  |
+| 13  | HTTP Protocol            | `spec.advanced_options.[auto_http_config\|http1_config\|http2_options]`                     | OneOf   | `auto_http_config`                 |
+| 14  | Proxy Protocol           | `spec.advanced_options.[disable_proxy_protocol\|proxy_protocol_v1\|proxy_protocol_v2]`      | OneOf   | `disable_proxy_protocol`           |
+| 15  | LB Source IP Persistence | `spec.advanced_options.[disable_lb_source_ip_persistance\|enable_lb_source_ip_persistance]` | OneOf   | `disable_lb_source_ip_persistance` |
 
 ## Data Access
 
 ### OpenAPI Specifications
 
-| File | Content |
-|------|---------|
+| File                                   | Content                                                                             |
+| -------------------------------------- | ----------------------------------------------------------------------------------- |
 | `docs/specifications/api/virtual.json` | `origin_poolCreateSpecType`, `origin_poolReplaceSpecType`, `origin_poolGetSpecType` |
-| `docs/specifications/api/openapi.json` | Merged specification with all schemas |
+| `docs/specifications/api/openapi.json` | Merged specification with all schemas                                               |
 
 ### validation.json Structure
 
@@ -188,10 +188,10 @@ Origin servers can be specified using different type variants. The type determin
 
 ### Implemented Types
 
-| Type | Description | Required Fields | Status |
-|------|-------------|-----------------|--------|
-| `public_name` | Origin server with public DNS name | `dns_name` | ✅ Complete |
-| `public_ip` | Origin server with public IP address | `ip` (IPv4) | ✅ Complete |
+| Type          | Description                          | Required Fields | Status      |
+| ------------- | ------------------------------------ | --------------- | ----------- |
+| `public_name` | Origin server with public DNS name   | `dns_name`      | ✅ Complete |
+| `public_ip`   | Origin server with public IP address | `ip` (IPv4)     | ✅ Complete |
 
 ### Example: public_name
 
@@ -225,12 +225,12 @@ Origin servers can be specified using different type variants. The type determin
 
 The following origin server types require "site" resource logic development before implementation:
 
-| Type | Description | Required Fields | Status |
-|------|-------------|-----------------|--------|
-| `private_ip` | Origin server with private/public IP and site info | `ip`, `site_locator`, `network_choice`, `snat_pool` | 🔲 Pending site logic |
-| `private_name` | Origin server with DNS name and site info | `dns_name`, `site_locator`, `network_choice`, `snat_pool` | 🔲 Pending site logic |
-| `k8s_service` | Kubernetes service with site info | `service_name`, `site_locator`, `network_choice` | 🔲 Pending site logic |
-| `consul_service` | HashiCorp Consul service with site info | `service_name`, `site_locator`, `network_choice` | 🔲 Pending site logic |
+| Type             | Description                                        | Required Fields                                           | Status                |
+| ---------------- | -------------------------------------------------- | --------------------------------------------------------- | --------------------- |
+| `private_ip`     | Origin server with private/public IP and site info | `ip`, `site_locator`, `network_choice`, `snat_pool`       | 🔲 Pending site logic |
+| `private_name`   | Origin server with DNS name and site info          | `dns_name`, `site_locator`, `network_choice`, `snat_pool` | 🔲 Pending site logic |
+| `k8s_service`    | Kubernetes service with site info                  | `service_name`, `site_locator`, `network_choice`          | 🔲 Pending site logic |
+| `consul_service` | HashiCorp Consul service with site info            | `service_name`, `site_locator`, `network_choice`          | 🔲 Pending site logic |
 
 ### Implementation Requirements
 
@@ -254,9 +254,9 @@ Before these types can be fully documented:
 
 ## Changelog
 
-| Version | Date | Changes |
-|---------|------|---------|
-| 2.1.2 | 2026-01-18 | Added origin server types section with public_name/public_ip; TODO markers for site-dependent types |
-| 2.1.1 | 2026-01-18 | Rewritten as pure API reference; removed downstream code examples |
-| 2.1.0 | 2026-01-18 | Updated to unified defaults structure in validation.json |
-| 2.0.33 | 2026-01-17 | Initial origin pool enhancements documentation |
+| Version | Date       | Changes                                                                                             |
+| ------- | ---------- | --------------------------------------------------------------------------------------------------- |
+| 2.1.2   | 2026-01-18 | Added origin server types section with public_name/public_ip; TODO markers for site-dependent types |
+| 2.1.1   | 2026-01-18 | Rewritten as pure API reference; removed downstream code examples                                   |
+| 2.1.0   | 2026-01-18 | Updated to unified defaults structure in validation.json                                            |
+| 2.0.33  | 2026-01-17 | Initial origin pool enhancements documentation                                                      |

--- a/docs/en/api-reference/admin_console_and_ui-api.mdx
+++ b/docs/en/api-reference/admin_console_and_ui-api.mdx
@@ -2,7 +2,7 @@
 title: "🖥️ Admin Console And Ui API"
 description: "Static UI components and console assets."
 sidebar:
-    hidden: true
+  hidden: true
 ---
 
 Namespace-scoped visual elements with versioning. Custom widget deployment and catalog management for portal surfaces.
@@ -27,10 +27,10 @@ Namespace-scoped visual elements with versioning. Custom widget deployment and c
 
 ## Endpoints
 
-| Method | Path | Description |
-|--------|------|-------------|
-| GET | `/api/web/namespaces/&#123;namespace&#125;/static_components` | List UI Static Component. |
-| GET | `/api/web/namespaces/&#123;namespace&#125;/static_components/&#123;name&#125;` | GET UI static component. |
+| Method | Path                                                                           | Description               |
+| ------ | ------------------------------------------------------------------------------ | ------------------------- |
+| GET    | `/api/web/namespaces/&#123;namespace&#125;/static_components`                  | List UI Static Component. |
+| GET    | `/api/web/namespaces/&#123;namespace&#125;/static_components/&#123;name&#125;` | GET UI static component.  |
 
 ## Links
 

--- a/docs/en/api-reference/ai_services-api.mdx
+++ b/docs/en/api-reference/ai_services-api.mdx
@@ -2,7 +2,7 @@
 title: "🤖 Ai Services API"
 description: "AI assistant queries and feedback collection."
 sidebar:
-    hidden: true
+  hidden: true
 ---
 
 Natural language processing with quality signals and anomaly monitoring. Token authentication for data stream subscriptions.
@@ -11,7 +11,6 @@ Natural language processing with quality signals and anomaly monitoring. Token a
 - **Complexity**: simple
 - **Paths**: 11 | **Schemas**: 66
 - **Tier**: Advanced
-
 
 ## Use Cases
 
@@ -27,19 +26,19 @@ Natural language processing with quality signals and anomaly monitoring. Token a
 
 ## Endpoints
 
-| Method | Path | Description |
-|--------|------|-------------|
-| POST | `/api/gen-ai/namespaces/&#123;namespace&#125;/eval_query` | Eval AI Assistant Query. |
-| POST | `/api/gen-ai/namespaces/&#123;namespace&#125;/eval_query_feedback` | Eval Feedback of AI Assistant Query. |
-| POST | `/api/gen-ai/namespaces/&#123;namespace&#125;/query` | AI Assistant Query. |
-| POST | `/api/gen-ai/namespaces/&#123;namespace&#125;/query_feedback` | Feedback of AI Assistant Query. |
-| POST | `/api/ai_data/bfdp/namespaces/system/bfdp/enable_feature` | Enable feature. |
-| POST | `/api/ai_data/bfdp/namespaces/system/bfdp/refresh_token` | Refresh Token. |
-| POST | `/api/ai_data/bfdp/namespaces/system/bfdp/gettoken` | Subscribe to BFDP pipeline. |
-| POST | `/api/ai_data/bfdp/namespaces/system/bfdp/subscribe` | Subscribe to BFDP pipeline. |
-| POST | `/api/ai_data/bfdp/namespaces/system/bfdp/unsubscribe` | Unsubscribe to BFDP pipeline. |
-| POST | `/api/gia/gia/allocateip` | Allocate IP through Global IP Allocator. |
-| DELETE | `/api/gia/gia/deallocateip` | Deallocate IP through Global IP Allocator. |
+| Method | Path                                                               | Description                                |
+| ------ | ------------------------------------------------------------------ | ------------------------------------------ |
+| POST   | `/api/gen-ai/namespaces/&#123;namespace&#125;/eval_query`          | Eval AI Assistant Query.                   |
+| POST   | `/api/gen-ai/namespaces/&#123;namespace&#125;/eval_query_feedback` | Eval Feedback of AI Assistant Query.       |
+| POST   | `/api/gen-ai/namespaces/&#123;namespace&#125;/query`               | AI Assistant Query.                        |
+| POST   | `/api/gen-ai/namespaces/&#123;namespace&#125;/query_feedback`      | Feedback of AI Assistant Query.            |
+| POST   | `/api/ai_data/bfdp/namespaces/system/bfdp/enable_feature`          | Enable feature.                            |
+| POST   | `/api/ai_data/bfdp/namespaces/system/bfdp/refresh_token`           | Refresh Token.                             |
+| POST   | `/api/ai_data/bfdp/namespaces/system/bfdp/gettoken`                | Subscribe to BFDP pipeline.                |
+| POST   | `/api/ai_data/bfdp/namespaces/system/bfdp/subscribe`               | Subscribe to BFDP pipeline.                |
+| POST   | `/api/ai_data/bfdp/namespaces/system/bfdp/unsubscribe`             | Unsubscribe to BFDP pipeline.              |
+| POST   | `/api/gia/gia/allocateip`                                          | Allocate IP through Global IP Allocator.   |
+| DELETE | `/api/gia/gia/deallocateip`                                        | Deallocate IP through Global IP Allocator. |
 
 ## Links
 

--- a/docs/en/api-reference/api-api.mdx
+++ b/docs/en/api-reference/api-api.mdx
@@ -2,7 +2,7 @@
 title: "🔐 Api API"
 description: "Interface definitions, schema validation, and grouping."
 sidebar:
-    hidden: true
+  hidden: true
 ---
 
 Resource cataloging with automatic classification and security profiling. Organizational hierarchies segment access by function or protection policy.
@@ -28,60 +28,60 @@ Resource cataloging with automatic classification and security profiling. Organi
 
 ## Endpoints
 
-| Method | Path | Description |
-|--------|------|-------------|
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/api_crawlers` | Create API Crawler. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/api_crawlers/&#123;metadata.name&#125;` | Replace API crawler. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/api_crawlers` | List API Crawler. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/api_crawlers/&#123;name&#125;` | GET API crawler. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/api_crawlers/&#123;name&#125;` | DELETE API Crawler. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/api_definitions` | Create API Definition. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/api_definitions/&#123;metadata.name&#125;` | Replace API Definition. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/api_definitions` | List API Definition. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/api_definitions/&#123;name&#125;` | GET API Definition. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/api_definitions/&#123;name&#125;` | DELETE API Definition. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/api_definitions/&#123;name&#125;/loadbalancers` | GET Referencing Loadbalancers. |
-| POST | `/api/config/namespaces/&#123;namespace&#125;/api_definitions/&#123;name&#125;/mark_as_non_api` | Mark As Non-API. |
-| POST | `/api/config/namespaces/&#123;namespace&#125;/api_definitions/&#123;name&#125;/move_to_inventory` | Move To API Inventory. |
-| POST | `/api/config/namespaces/&#123;namespace&#125;/api_definitions/&#123;name&#125;/remove_from_inventory` | Remove From API Inventory. |
-| POST | `/api/config/namespaces/&#123;namespace&#125;/api_definitions/&#123;name&#125;/unmark_as_non_api` | Unmark As Non-API. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/api_definitions_without_shared` | List Available API Definitions. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/api_discoverys` | Create API Discovery. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/api_discoverys/&#123;metadata.name&#125;` | Replace API Discovery. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/api_discoverys` | List API Discovery. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/api_discoverys/&#123;name&#125;` | GET API Discovery. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/api_discoverys/&#123;name&#125;` | DELETE API Discovery. |
-| GET | `/api/web/namespaces/&#123;namespace&#125;/api_groups` | List API Group. |
-| GET | `/api/web/namespaces/&#123;namespace&#125;/api_groups/&#123;name&#125;` | GET API Group. |
-| GET | `/api/web/namespaces/&#123;namespace&#125;/api_group_elements` | List API Group Element. |
-| GET | `/api/web/namespaces/&#123;namespace&#125;/api_group_elements/&#123;name&#125;` | GET API Group Element. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/api_testings` | Create API Testing. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/api_testings/&#123;metadata.name&#125;` | Replace API testing. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/api_testings` | List API Testing. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/api_testings/&#123;name&#125;` | GET API testing. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/api_testings/&#123;name&#125;` | DELETE API Testing. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/app_api_groups` | Create API Group. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/app_api_groups/&#123;metadata.name&#125;` | Replace API Group. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/app_api_groups` | List App API Group. |
-| POST | `/api/ml/data/namespaces/&#123;namespace&#125;/app_api_groups/evaluate` | Evaluate API Group. |
-| POST | `/api/ml/data/namespaces/&#123;namespace&#125;/app_api_groups/stats` | Evaluate API Group. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/app_api_groups/&#123;name&#125;` | GET API Group. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/app_api_groups/&#123;name&#125;` | DELETE App API Group. |
-| POST | `/api/config/namespaces/&#123;namespace&#125;/api_sec/rule_suggestion/api_endpoint_protection` | Suggest API endpoint protection rule. |
-| POST | `/api/config/namespaces/&#123;namespace&#125;/api_sec/rule_suggestion/data_exposure` | Suggest sensitive data rule. |
-| POST | `/api/config/namespaces/&#123;namespace&#125;/api_sec/rule_suggestion/oas_validation` | Suggest Open API specification validation rule. |
-| POST | `/api/config/namespaces/&#123;namespace&#125;/api_sec/rule_suggestion/rate_limit` | Suggest rate limit rule. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/code_base_integrations` | CREATE Code Base Integration. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/code_base_integrations/&#123;metadata.name&#125;` | Replace Code Base Integration. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/code_base_integrations` | List Code Base Integration. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/code_base_integrations/&#123;name&#125;` | GET Code Base Integration. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/code_base_integrations/&#123;name&#125;` | DELETE Code Base Integration. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/discoverys` | Create Discovery. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/discoverys/&#123;metadata.name&#125;` | Replace Discovery. |
-| POST | `/api/config/namespaces/&#123;namespace&#125;/discovery/&#123;name&#125;/download_certificates` | Download Certificates. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/discoverys` | List Discovery. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/discoverys/&#123;name&#125;` | GET Discovery. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/discoverys/&#123;name&#125;` | DELETE Discovery. |
+| Method | Path                                                                                                     | Description                                     |
+| ------ | -------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/api_crawlers`                                     | Create API Crawler.                             |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/api_crawlers/&#123;metadata.name&#125;`           | Replace API crawler.                            |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/api_crawlers`                                              | List API Crawler.                               |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/api_crawlers/&#123;name&#125;`                             | GET API crawler.                                |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/api_crawlers/&#123;name&#125;`                             | DELETE API Crawler.                             |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/api_definitions`                                  | Create API Definition.                          |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/api_definitions/&#123;metadata.name&#125;`        | Replace API Definition.                         |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/api_definitions`                                           | List API Definition.                            |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/api_definitions/&#123;name&#125;`                          | GET API Definition.                             |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/api_definitions/&#123;name&#125;`                          | DELETE API Definition.                          |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/api_definitions/&#123;name&#125;/loadbalancers`            | GET Referencing Loadbalancers.                  |
+| POST   | `/api/config/namespaces/&#123;namespace&#125;/api_definitions/&#123;name&#125;/mark_as_non_api`          | Mark As Non-API.                                |
+| POST   | `/api/config/namespaces/&#123;namespace&#125;/api_definitions/&#123;name&#125;/move_to_inventory`        | Move To API Inventory.                          |
+| POST   | `/api/config/namespaces/&#123;namespace&#125;/api_definitions/&#123;name&#125;/remove_from_inventory`    | Remove From API Inventory.                      |
+| POST   | `/api/config/namespaces/&#123;namespace&#125;/api_definitions/&#123;name&#125;/unmark_as_non_api`        | Unmark As Non-API.                              |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/api_definitions_without_shared`                            | List Available API Definitions.                 |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/api_discoverys`                                   | Create API Discovery.                           |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/api_discoverys/&#123;metadata.name&#125;`         | Replace API Discovery.                          |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/api_discoverys`                                            | List API Discovery.                             |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/api_discoverys/&#123;name&#125;`                           | GET API Discovery.                              |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/api_discoverys/&#123;name&#125;`                           | DELETE API Discovery.                           |
+| GET    | `/api/web/namespaces/&#123;namespace&#125;/api_groups`                                                   | List API Group.                                 |
+| GET    | `/api/web/namespaces/&#123;namespace&#125;/api_groups/&#123;name&#125;`                                  | GET API Group.                                  |
+| GET    | `/api/web/namespaces/&#123;namespace&#125;/api_group_elements`                                           | List API Group Element.                         |
+| GET    | `/api/web/namespaces/&#123;namespace&#125;/api_group_elements/&#123;name&#125;`                          | GET API Group Element.                          |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/api_testings`                                     | Create API Testing.                             |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/api_testings/&#123;metadata.name&#125;`           | Replace API testing.                            |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/api_testings`                                              | List API Testing.                               |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/api_testings/&#123;name&#125;`                             | GET API testing.                                |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/api_testings/&#123;name&#125;`                             | DELETE API Testing.                             |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/app_api_groups`                                   | Create API Group.                               |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/app_api_groups/&#123;metadata.name&#125;`         | Replace API Group.                              |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/app_api_groups`                                            | List App API Group.                             |
+| POST   | `/api/ml/data/namespaces/&#123;namespace&#125;/app_api_groups/evaluate`                                  | Evaluate API Group.                             |
+| POST   | `/api/ml/data/namespaces/&#123;namespace&#125;/app_api_groups/stats`                                     | Evaluate API Group.                             |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/app_api_groups/&#123;name&#125;`                           | GET API Group.                                  |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/app_api_groups/&#123;name&#125;`                           | DELETE App API Group.                           |
+| POST   | `/api/config/namespaces/&#123;namespace&#125;/api_sec/rule_suggestion/api_endpoint_protection`           | Suggest API endpoint protection rule.           |
+| POST   | `/api/config/namespaces/&#123;namespace&#125;/api_sec/rule_suggestion/data_exposure`                     | Suggest sensitive data rule.                    |
+| POST   | `/api/config/namespaces/&#123;namespace&#125;/api_sec/rule_suggestion/oas_validation`                    | Suggest Open API specification validation rule. |
+| POST   | `/api/config/namespaces/&#123;namespace&#125;/api_sec/rule_suggestion/rate_limit`                        | Suggest rate limit rule.                        |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/code_base_integrations`                           | CREATE Code Base Integration.                   |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/code_base_integrations/&#123;metadata.name&#125;` | Replace Code Base Integration.                  |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/code_base_integrations`                                    | List Code Base Integration.                     |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/code_base_integrations/&#123;name&#125;`                   | GET Code Base Integration.                      |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/code_base_integrations/&#123;name&#125;`                   | DELETE Code Base Integration.                   |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/discoverys`                                       | Create Discovery.                               |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/discoverys/&#123;metadata.name&#125;`             | Replace Discovery.                              |
+| POST   | `/api/config/namespaces/&#123;namespace&#125;/discovery/&#123;name&#125;/download_certificates`          | Download Certificates.                          |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/discoverys`                                                | List Discovery.                                 |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/discoverys/&#123;name&#125;`                               | GET Discovery.                                  |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/discoverys/&#123;name&#125;`                               | DELETE Discovery.                               |
 
 ## Links
 

--- a/docs/en/api-reference/authentication-api.mdx
+++ b/docs/en/api-reference/authentication-api.mdx
@@ -2,7 +2,7 @@
 title: "🔑 Authentication API"
 description: "Identity provider and access policy configuration."
 sidebar:
-    hidden: true
+  hidden: true
 ---
 
 Identity management with provider integration, access policies, and credential lifecycle control.
@@ -29,26 +29,26 @@ Identity management with provider integration, access policies, and credential l
 
 ## Endpoints
 
-| Method | Path | Description |
-|--------|------|-------------|
-| POST | `/api/web/namespaces/system/bulk_revoke/api_credentials` | Bulk Revoke API credentials. |
-| POST | `/api/web/namespaces/system/bulk_revoke/service_credentials` | Bulk Revoke service credential. |
-| POST | `/api/web/namespaces/&#123;namespace&#125;/activate/api_credentials` | Activate API credential. |
-| POST | `/api/web/namespaces/&#123;namespace&#125;/activate/service_credentials` | Activate API service credential. |
-| GET | `/api/web/namespaces/&#123;namespace&#125;/api_credentials` | List API Credentials. |
-| POST | `/api/web/namespaces/&#123;namespace&#125;/api_credentials` | Create API Credentials. |
-| GET | `/api/web/namespaces/&#123;namespace&#125;/api_credentials/&#123;name&#125;` | GET API Credentials. |
-| POST | `/api/web/namespaces/&#123;namespace&#125;/renew/api_credentials` | Renew API credential. |
-| POST | `/api/web/namespaces/&#123;namespace&#125;/renew/service_credentials` | Renew API service credential. |
-| POST | `/api/web/namespaces/&#123;namespace&#125;/revoke/api_credentials` | Revoke API credential. |
-| POST | `/api/web/namespaces/&#123;namespace&#125;/revoke/scim_token` | Revoke SCIM API credential. |
-| POST | `/api/web/namespaces/&#123;namespace&#125;/revoke/service_credentials` | Revoke Service credential. |
-| GET | `/api/web/namespaces/&#123;namespace&#125;/scim_token` | GET Scim Token. |
-| POST | `/api/web/namespaces/&#123;namespace&#125;/scim_token` | Create/RE-create SCIM API token. |
-| GET | `/api/web/namespaces/&#123;namespace&#125;/service_credentials` | List service credentials. |
-| POST | `/api/web/namespaces/&#123;namespace&#125;/service_credentials` | Create service credentials. |
-| GET | `/api/web/namespaces/&#123;namespace&#125;/service_credentials/&#123;name&#125;` | GET Service Credential. |
-| PUT | `/api/web/namespaces/&#123;namespace&#125;/service_credentials/&#123;name&#125;` | Replace service credentials. |
+| Method | Path                                                                             | Description                      |
+| ------ | -------------------------------------------------------------------------------- | -------------------------------- |
+| POST   | `/api/web/namespaces/system/bulk_revoke/api_credentials`                         | Bulk Revoke API credentials.     |
+| POST   | `/api/web/namespaces/system/bulk_revoke/service_credentials`                     | Bulk Revoke service credential.  |
+| POST   | `/api/web/namespaces/&#123;namespace&#125;/activate/api_credentials`             | Activate API credential.         |
+| POST   | `/api/web/namespaces/&#123;namespace&#125;/activate/service_credentials`         | Activate API service credential. |
+| GET    | `/api/web/namespaces/&#123;namespace&#125;/api_credentials`                      | List API Credentials.            |
+| POST   | `/api/web/namespaces/&#123;namespace&#125;/api_credentials`                      | Create API Credentials.          |
+| GET    | `/api/web/namespaces/&#123;namespace&#125;/api_credentials/&#123;name&#125;`     | GET API Credentials.             |
+| POST   | `/api/web/namespaces/&#123;namespace&#125;/renew/api_credentials`                | Renew API credential.            |
+| POST   | `/api/web/namespaces/&#123;namespace&#125;/renew/service_credentials`            | Renew API service credential.    |
+| POST   | `/api/web/namespaces/&#123;namespace&#125;/revoke/api_credentials`               | Revoke API credential.           |
+| POST   | `/api/web/namespaces/&#123;namespace&#125;/revoke/scim_token`                    | Revoke SCIM API credential.      |
+| POST   | `/api/web/namespaces/&#123;namespace&#125;/revoke/service_credentials`           | Revoke Service credential.       |
+| GET    | `/api/web/namespaces/&#123;namespace&#125;/scim_token`                           | GET Scim Token.                  |
+| POST   | `/api/web/namespaces/&#123;namespace&#125;/scim_token`                           | Create/RE-create SCIM API token. |
+| GET    | `/api/web/namespaces/&#123;namespace&#125;/service_credentials`                  | List service credentials.        |
+| POST   | `/api/web/namespaces/&#123;namespace&#125;/service_credentials`                  | Create service credentials.      |
+| GET    | `/api/web/namespaces/&#123;namespace&#125;/service_credentials/&#123;name&#125;` | GET Service Credential.          |
+| PUT    | `/api/web/namespaces/&#123;namespace&#125;/service_credentials/&#123;name&#125;` | Replace service credentials.     |
 
 ## Links
 

--- a/docs/en/api-reference/bigip-api.mdx
+++ b/docs/en/api-reference/bigip-api.mdx
@@ -2,7 +2,7 @@
 title: "🏢 Bigip API"
 description: "iRules, data groups, and APM integration."
 sidebar:
-    hidden: true
+  hidden: true
 ---
 
 Legacy device orchestration with iRule scripts and data group synchronization. Virtual server bindings and metrics collection.
@@ -27,43 +27,43 @@ Legacy device orchestration with iRule scripts and data group synchronization. V
 
 ## Endpoints
 
-| Method | Path | Description |
-|--------|------|-------------|
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/apms` | Create APM Service. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/apms/&#123;metadata.name&#125;` | Replace APM Service. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/apms` | List BIG-IP APM as a Service. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/apms/&#123;name&#125;` | GET APM Service. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/apms/&#123;name&#125;` | DELETE BIG-IP APM as a Service. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/bigip/apm/metrics` | Metrics |
-| POST | `/api/bigipconnector/namespaces/&#123;metadata.namespace&#125;/bigip_irules` | Specification. |
-| PUT | `/api/bigipconnector/namespaces/&#123;metadata.namespace&#125;/bigip_irules/&#123;metadata.name&#125;` | Specification. |
-| GET | `/api/bigipconnector/namespaces/&#123;namespace&#125;/bigip_irules` | List BIG-IP iRule as a Service. |
-| GET | `/api/bigipconnector/namespaces/&#123;namespace&#125;/bigip_irules/&#123;name&#125;` | Specification. |
-| DELETE | `/api/bigipconnector/namespaces/&#123;namespace&#125;/bigip_irules/&#123;name&#125;` | DELETE BIG-IP iRule as a Service. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/bigip_virtual_servers/&#123;metadata.name&#125;` | Replace BIG-IP virtual server. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/bigip_virtual_servers` | List BIG-IP virtual server. |
-| POST | `/api/config/namespaces/&#123;namespace&#125;/bigip_virtual_servers/get_security_config` | GET Security Config for BIG-IP Load Balancer. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/bigip_virtual_servers/&#123;name&#125;` | GET BIG-IP virtual server. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/application_profiless` | Create Application Profiles. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/application_profiless/&#123;metadata.name&#125;` | Replace Application Profiles. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/application_profiless` | List Configure Application Profiles. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/application_profiless/&#123;name&#125;` | GET Application Profiles. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/application_profiless/&#123;name&#125;` | DELETE Configure Application Profiles. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/bigip_http_proxies` | Create BIG-IP HTTP Proxy. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/bigip_http_proxies/&#123;metadata.name&#125;` | Replace BIG-IP HTTP Proxy. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/bigip_http_proxies` | List Configure BIG-IP HTTP Proxy. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/bigip_http_proxies/&#123;name&#125;` | GET BIG-IP HTTP Proxy. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/bigip_http_proxies/&#123;name&#125;` | DELETE Configure BIG-IP HTTP Proxy. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/irules` | Create iRule. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/irules/&#123;metadata.name&#125;` | Replace iRule. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/irules` | List Configure iRule. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/irules/&#123;name&#125;` | GET iRule |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/irules/&#123;name&#125;` | DELETE Configure iRule. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/data_groups` | Create Data group. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/data_groups/&#123;metadata.name&#125;` | Replace Data Group. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/data_groups` | List Data Group. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/data_groups/&#123;name&#125;` | GET Data Group. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/data_groups/&#123;name&#125;` | DELETE Data Group. |
+| Method | Path                                                                                                    | Description                                   |
+| ------ | ------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/apms`                                            | Create APM Service.                           |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/apms/&#123;metadata.name&#125;`                  | Replace APM Service.                          |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/apms`                                                     | List BIG-IP APM as a Service.                 |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/apms/&#123;name&#125;`                                    | GET APM Service.                              |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/apms/&#123;name&#125;`                                    | DELETE BIG-IP APM as a Service.               |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/bigip/apm/metrics`                                          | Metrics                                       |
+| POST   | `/api/bigipconnector/namespaces/&#123;metadata.namespace&#125;/bigip_irules`                            | Specification.                                |
+| PUT    | `/api/bigipconnector/namespaces/&#123;metadata.namespace&#125;/bigip_irules/&#123;metadata.name&#125;`  | Specification.                                |
+| GET    | `/api/bigipconnector/namespaces/&#123;namespace&#125;/bigip_irules`                                     | List BIG-IP iRule as a Service.               |
+| GET    | `/api/bigipconnector/namespaces/&#123;namespace&#125;/bigip_irules/&#123;name&#125;`                    | Specification.                                |
+| DELETE | `/api/bigipconnector/namespaces/&#123;namespace&#125;/bigip_irules/&#123;name&#125;`                    | DELETE BIG-IP iRule as a Service.             |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/bigip_virtual_servers/&#123;metadata.name&#125;` | Replace BIG-IP virtual server.                |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/bigip_virtual_servers`                                    | List BIG-IP virtual server.                   |
+| POST   | `/api/config/namespaces/&#123;namespace&#125;/bigip_virtual_servers/get_security_config`                | GET Security Config for BIG-IP Load Balancer. |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/bigip_virtual_servers/&#123;name&#125;`                   | GET BIG-IP virtual server.                    |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/application_profiless`                           | Create Application Profiles.                  |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/application_profiless/&#123;metadata.name&#125;` | Replace Application Profiles.                 |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/application_profiless`                                    | List Configure Application Profiles.          |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/application_profiless/&#123;name&#125;`                   | GET Application Profiles.                     |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/application_profiless/&#123;name&#125;`                   | DELETE Configure Application Profiles.        |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/bigip_http_proxies`                              | Create BIG-IP HTTP Proxy.                     |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/bigip_http_proxies/&#123;metadata.name&#125;`    | Replace BIG-IP HTTP Proxy.                    |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/bigip_http_proxies`                                       | List Configure BIG-IP HTTP Proxy.             |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/bigip_http_proxies/&#123;name&#125;`                      | GET BIG-IP HTTP Proxy.                        |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/bigip_http_proxies/&#123;name&#125;`                      | DELETE Configure BIG-IP HTTP Proxy.           |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/irules`                                          | Create iRule.                                 |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/irules/&#123;metadata.name&#125;`                | Replace iRule.                                |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/irules`                                                   | List Configure iRule.                         |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/irules/&#123;name&#125;`                                  | GET iRule                                     |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/irules/&#123;name&#125;`                                  | DELETE Configure iRule.                       |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/data_groups`                                     | Create Data group.                            |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/data_groups/&#123;metadata.name&#125;`           | Replace Data Group.                           |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/data_groups`                                              | List Data Group.                              |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/data_groups/&#123;name&#125;`                             | GET Data Group.                               |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/data_groups/&#123;name&#125;`                             | DELETE Data Group.                            |
 
 ## Links
 

--- a/docs/en/api-reference/billing_and_usage-api.mdx
+++ b/docs/en/api-reference/billing_and_usage-api.mdx
@@ -2,7 +2,7 @@
 title: "💳 Billing And Usage API"
 description: "Subscription plans, payment methods, and quotas."
 sidebar:
-    hidden: true
+  hidden: true
 ---
 
 Plan transitions, invoicing, and resource consumption. Namespace-level quota limits and usage tracking.
@@ -28,34 +28,34 @@ Plan transitions, invoicing, and resource consumption. Namespace-level quota lim
 
 ## Endpoints
 
-| Method | Path | Description |
-|--------|------|-------------|
-| POST | `/api/data/namespaces/system/billing/usage_summary` | Billing Usage Summary. |
-| GET | `/api/web/namespaces/&#123;namespace&#125;/usage/invoice_pdf` | GetInvoicePdf. |
-| GET | `/api/web/namespaces/&#123;namespace&#125;/usage/invoices/custom_list` | List invoices. |
-| POST | `/api/web/namespaces/&#123;namespace&#125;/billing/payment_method/&#123;name&#125;/primary` | Make credit card primary. |
-| POST | `/api/web/namespaces/&#123;namespace&#125;/billing/payment_method/&#123;name&#125;/secondary` | Make payment method secondary. |
-| POST | `/api/web/namespaces/&#123;namespace&#125;/billing/payment_method/&#123;name&#125;/swap-primary` | Make payment method secondary. |
-| POST | `/api/web/namespaces/&#123;namespace&#125;/billing/payment_methods` | Create payment method specification. |
-| DELETE | `/api/web/namespaces/&#123;namespace&#125;/billing/payment_methods/&#123;name&#125;` | DELETE the specified payment method. |
-| GET | `/no_auth/namespaces/system/billing/plan_transition` | GetPlanTransition. |
-| POST | `/api/web/namespaces/&#123;namespace&#125;/billing/plan_transition` | InitiatePlanTransition. |
-| POST | `/api/web/namespaces/&#123;metadata.namespace&#125;/quotas` | Create Quota. |
-| PUT | `/api/web/namespaces/&#123;metadata.namespace&#125;/quotas/&#123;metadata.name&#125;` | Replace Quota. |
-| GET | `/api/web/namespaces/&#123;namespace&#125;/quota/limits` | Custom GET Quota Limits. |
-| GET | `/api/web/namespaces/&#123;namespace&#125;/quota/usage` | GET Quota Usage. |
-| GET | `/api/web/namespaces/&#123;namespace&#125;/quotas` | List Quota. |
-| GET | `/api/web/namespaces/&#123;namespace&#125;/quotas/&#123;name&#125;` | GET Quota |
-| DELETE | `/api/web/namespaces/&#123;namespace&#125;/quotas/&#123;name&#125;` | DELETE Quota. |
-| GET | `/api/web/namespaces/&#123;namespace&#125;/subscriptions/custom_list` | List Subscriptions. |
-| POST | `/api/web/namespaces/system/addon/subscribe` | Subscribe to XC addon services. |
-| POST | `/api/web/namespaces/system/addon/unsubscribe` | Unsubscribe to XC addon services. |
-| POST | `/api/web/namespaces/&#123;namespace&#125;/current_usage` | List current usage details. |
-| POST | `/api/web/namespaces/&#123;namespace&#125;/hourly_usage_details` | List hourly usage details. |
-| POST | `/api/web/namespaces/&#123;namespace&#125;/monthly_usage` | List monthly usage details. |
-| POST | `/api/web/namespaces/&#123;namespace&#125;/usage_details` | List usage details. |
-| GET | `/api/web/namespaces/system/usage_plans/current` | GET current usage plan. |
-| GET | `/api/web/namespaces/system/usage_plans/custom_list` | List Usage Plans. |
+| Method | Path                                                                                             | Description                          |
+| ------ | ------------------------------------------------------------------------------------------------ | ------------------------------------ |
+| POST   | `/api/data/namespaces/system/billing/usage_summary`                                              | Billing Usage Summary.               |
+| GET    | `/api/web/namespaces/&#123;namespace&#125;/usage/invoice_pdf`                                    | GetInvoicePdf.                       |
+| GET    | `/api/web/namespaces/&#123;namespace&#125;/usage/invoices/custom_list`                           | List invoices.                       |
+| POST   | `/api/web/namespaces/&#123;namespace&#125;/billing/payment_method/&#123;name&#125;/primary`      | Make credit card primary.            |
+| POST   | `/api/web/namespaces/&#123;namespace&#125;/billing/payment_method/&#123;name&#125;/secondary`    | Make payment method secondary.       |
+| POST   | `/api/web/namespaces/&#123;namespace&#125;/billing/payment_method/&#123;name&#125;/swap-primary` | Make payment method secondary.       |
+| POST   | `/api/web/namespaces/&#123;namespace&#125;/billing/payment_methods`                              | Create payment method specification. |
+| DELETE | `/api/web/namespaces/&#123;namespace&#125;/billing/payment_methods/&#123;name&#125;`             | DELETE the specified payment method. |
+| GET    | `/no_auth/namespaces/system/billing/plan_transition`                                             | GetPlanTransition.                   |
+| POST   | `/api/web/namespaces/&#123;namespace&#125;/billing/plan_transition`                              | InitiatePlanTransition.              |
+| POST   | `/api/web/namespaces/&#123;metadata.namespace&#125;/quotas`                                      | Create Quota.                        |
+| PUT    | `/api/web/namespaces/&#123;metadata.namespace&#125;/quotas/&#123;metadata.name&#125;`            | Replace Quota.                       |
+| GET    | `/api/web/namespaces/&#123;namespace&#125;/quota/limits`                                         | Custom GET Quota Limits.             |
+| GET    | `/api/web/namespaces/&#123;namespace&#125;/quota/usage`                                          | GET Quota Usage.                     |
+| GET    | `/api/web/namespaces/&#123;namespace&#125;/quotas`                                               | List Quota.                          |
+| GET    | `/api/web/namespaces/&#123;namespace&#125;/quotas/&#123;name&#125;`                              | GET Quota                            |
+| DELETE | `/api/web/namespaces/&#123;namespace&#125;/quotas/&#123;name&#125;`                              | DELETE Quota.                        |
+| GET    | `/api/web/namespaces/&#123;namespace&#125;/subscriptions/custom_list`                            | List Subscriptions.                  |
+| POST   | `/api/web/namespaces/system/addon/subscribe`                                                     | Subscribe to XC addon services.      |
+| POST   | `/api/web/namespaces/system/addon/unsubscribe`                                                   | Unsubscribe to XC addon services.    |
+| POST   | `/api/web/namespaces/&#123;namespace&#125;/current_usage`                                        | List current usage details.          |
+| POST   | `/api/web/namespaces/&#123;namespace&#125;/hourly_usage_details`                                 | List hourly usage details.           |
+| POST   | `/api/web/namespaces/&#123;namespace&#125;/monthly_usage`                                        | List monthly usage details.          |
+| POST   | `/api/web/namespaces/&#123;namespace&#125;/usage_details`                                        | List usage details.                  |
+| GET    | `/api/web/namespaces/system/usage_plans/current`                                                 | GET current usage plan.              |
+| GET    | `/api/web/namespaces/system/usage_plans/custom_list`                                             | List Usage Plans.                    |
 
 ## Links
 

--- a/docs/en/api-reference/blindfold-api.mdx
+++ b/docs/en/api-reference/blindfold-api.mdx
@@ -2,7 +2,7 @@
 title: "🔏 Blindfold API"
 description: "Secret encryption, key policies, and audit trails."
 sidebar:
-    hidden: true
+  hidden: true
 ---
 
 Encryption key management with policy-based access controls. Audit logging and secure data protection.
@@ -27,40 +27,40 @@ Encryption key management with policy-based access controls. Audit logging and s
 
 ## Endpoints
 
-| Method | Path | Description |
-|--------|------|-------------|
-| GET | `/api/secret_management/get_public_key` | Public Key. |
-| GET | `/api/secret_management/namespaces/&#123;namespace&#125;/secret_policys/&#123;name&#125;/get_policy_document` | Policy Document. |
-| POST | `/api/secret_management/namespaces/system/voltshare/decrypt_secret` | DecryptSecret. |
-| POST | `/api/secret_management/namespaces/system/voltshare/process_policy_information` | ProcessPolicyInformation. |
-| POST | `/api/secret_management/namespaces/&#123;namespace&#125;/voltshare/access_count` | VoltShare Access Count Query. |
-| POST | `/api/secret_management/namespaces/&#123;namespace&#125;/voltshare/audit_logs` | Audit Log Query. |
-| POST | `/api/secret_management/namespaces/&#123;namespace&#125;/voltshare/audit_logs/aggregation` | Audit Log Aggregation Query. |
-| GET | `/api/secret_management/namespaces/&#123;namespace&#125;/voltshare/audit_logs/scroll` | Audit Log Scroll Query. |
-| POST | `/api/secret_management/namespaces/&#123;namespace&#125;/voltshare/audit_logs/scroll` | Audit Log Scroll Query. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/secret_management_accesss` | Create Secret Management Access. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/secret_management_accesss/&#123;metadata.name&#125;` | Replace Secret Management Access. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/secret_management_accesss` | List Secret Management Access. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/secret_management_accesss/&#123;name&#125;` | GET Secret Management Access. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/secret_management_accesss/&#123;name&#125;` | DELETE Secret Management Access. |
-| POST | `/api/secret_management/namespaces/&#123;metadata.namespace&#125;/secret_policys` | Create Secret Policy. |
-| PUT | `/api/secret_management/namespaces/&#123;metadata.namespace&#125;/secret_policys/&#123;metadata.name&#125;` | Replace Secret Policy. |
-| GET | `/api/secret_management/namespaces/&#123;namespace&#125;/secret_policy/list_policy/&#123;policy_state&#125;` | List secret policy. |
-| POST | `/api/secret_management/namespaces/&#123;namespace&#125;/secret_policy/&#123;name&#125;/recover` | Recover secret policy with given policy name. |
-| POST | `/api/secret_management/namespaces/&#123;namespace&#125;/secret_policy/&#123;name&#125;/softdelete` | DELETE secret policy with given policy name. |
-| GET | `/api/secret_management/namespaces/&#123;namespace&#125;/secret_policys` | List Secret Policy. |
-| GET | `/api/secret_management/namespaces/&#123;namespace&#125;/secret_policys/&#123;name&#125;` | GET Secret Policy. |
-| DELETE | `/api/secret_management/namespaces/&#123;namespace&#125;/secret_policys/&#123;name&#125;` | DELETE Secret Policy. |
-| POST | `/api/secret_management/namespaces/&#123;metadata.namespace&#125;/secret_policy_rules` | Create Secret Policy Rule. |
-| PUT | `/api/secret_management/namespaces/&#123;metadata.namespace&#125;/secret_policy_rules/&#123;metadata.name&#125;` | Replace Secret Policy Rule. |
-| GET | `/api/secret_management/namespaces/&#123;namespace&#125;/secret_policy_rules` | List Secret Policy Rule. |
-| GET | `/api/secret_management/namespaces/&#123;namespace&#125;/secret_policy_rules/&#123;name&#125;` | GET Secret Policy Rule. |
-| DELETE | `/api/secret_management/namespaces/&#123;namespace&#125;/secret_policy_rules/&#123;name&#125;` | DELETE Secret Policy Rule. |
-| POST | `/api/secret_management/namespaces/&#123;metadata.namespace&#125;/voltshare_admin_policys` | Create VoltShare Admin Policy. |
-| PUT | `/api/secret_management/namespaces/&#123;metadata.namespace&#125;/voltshare_admin_policys/&#123;metadata.name&#125;` | Replace VoltShare Admin Policy. |
-| GET | `/api/secret_management/namespaces/&#123;namespace&#125;/voltshare_admin_policys` | List VoltShare Admin Policy. |
-| GET | `/api/secret_management/namespaces/&#123;namespace&#125;/voltshare_admin_policys/&#123;name&#125;` | GET VoltShare Admin Policy. |
-| DELETE | `/api/secret_management/namespaces/&#123;namespace&#125;/voltshare_admin_policys/&#123;name&#125;` | DELETE VoltShare Admin Policy. |
+| Method | Path                                                                                                                 | Description                                   |
+| ------ | -------------------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
+| GET    | `/api/secret_management/get_public_key`                                                                              | Public Key.                                   |
+| GET    | `/api/secret_management/namespaces/&#123;namespace&#125;/secret_policys/&#123;name&#125;/get_policy_document`        | Policy Document.                              |
+| POST   | `/api/secret_management/namespaces/system/voltshare/decrypt_secret`                                                  | DecryptSecret.                                |
+| POST   | `/api/secret_management/namespaces/system/voltshare/process_policy_information`                                      | ProcessPolicyInformation.                     |
+| POST   | `/api/secret_management/namespaces/&#123;namespace&#125;/voltshare/access_count`                                     | VoltShare Access Count Query.                 |
+| POST   | `/api/secret_management/namespaces/&#123;namespace&#125;/voltshare/audit_logs`                                       | Audit Log Query.                              |
+| POST   | `/api/secret_management/namespaces/&#123;namespace&#125;/voltshare/audit_logs/aggregation`                           | Audit Log Aggregation Query.                  |
+| GET    | `/api/secret_management/namespaces/&#123;namespace&#125;/voltshare/audit_logs/scroll`                                | Audit Log Scroll Query.                       |
+| POST   | `/api/secret_management/namespaces/&#123;namespace&#125;/voltshare/audit_logs/scroll`                                | Audit Log Scroll Query.                       |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/secret_management_accesss`                                    | Create Secret Management Access.              |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/secret_management_accesss/&#123;metadata.name&#125;`          | Replace Secret Management Access.             |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/secret_management_accesss`                                             | List Secret Management Access.                |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/secret_management_accesss/&#123;name&#125;`                            | GET Secret Management Access.                 |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/secret_management_accesss/&#123;name&#125;`                            | DELETE Secret Management Access.              |
+| POST   | `/api/secret_management/namespaces/&#123;metadata.namespace&#125;/secret_policys`                                    | Create Secret Policy.                         |
+| PUT    | `/api/secret_management/namespaces/&#123;metadata.namespace&#125;/secret_policys/&#123;metadata.name&#125;`          | Replace Secret Policy.                        |
+| GET    | `/api/secret_management/namespaces/&#123;namespace&#125;/secret_policy/list_policy/&#123;policy_state&#125;`         | List secret policy.                           |
+| POST   | `/api/secret_management/namespaces/&#123;namespace&#125;/secret_policy/&#123;name&#125;/recover`                     | Recover secret policy with given policy name. |
+| POST   | `/api/secret_management/namespaces/&#123;namespace&#125;/secret_policy/&#123;name&#125;/softdelete`                  | DELETE secret policy with given policy name.  |
+| GET    | `/api/secret_management/namespaces/&#123;namespace&#125;/secret_policys`                                             | List Secret Policy.                           |
+| GET    | `/api/secret_management/namespaces/&#123;namespace&#125;/secret_policys/&#123;name&#125;`                            | GET Secret Policy.                            |
+| DELETE | `/api/secret_management/namespaces/&#123;namespace&#125;/secret_policys/&#123;name&#125;`                            | DELETE Secret Policy.                         |
+| POST   | `/api/secret_management/namespaces/&#123;metadata.namespace&#125;/secret_policy_rules`                               | Create Secret Policy Rule.                    |
+| PUT    | `/api/secret_management/namespaces/&#123;metadata.namespace&#125;/secret_policy_rules/&#123;metadata.name&#125;`     | Replace Secret Policy Rule.                   |
+| GET    | `/api/secret_management/namespaces/&#123;namespace&#125;/secret_policy_rules`                                        | List Secret Policy Rule.                      |
+| GET    | `/api/secret_management/namespaces/&#123;namespace&#125;/secret_policy_rules/&#123;name&#125;`                       | GET Secret Policy Rule.                       |
+| DELETE | `/api/secret_management/namespaces/&#123;namespace&#125;/secret_policy_rules/&#123;name&#125;`                       | DELETE Secret Policy Rule.                    |
+| POST   | `/api/secret_management/namespaces/&#123;metadata.namespace&#125;/voltshare_admin_policys`                           | Create VoltShare Admin Policy.                |
+| PUT    | `/api/secret_management/namespaces/&#123;metadata.namespace&#125;/voltshare_admin_policys/&#123;metadata.name&#125;` | Replace VoltShare Admin Policy.               |
+| GET    | `/api/secret_management/namespaces/&#123;namespace&#125;/voltshare_admin_policys`                                    | List VoltShare Admin Policy.                  |
+| GET    | `/api/secret_management/namespaces/&#123;namespace&#125;/voltshare_admin_policys/&#123;name&#125;`                   | GET VoltShare Admin Policy.                   |
+| DELETE | `/api/secret_management/namespaces/&#123;namespace&#125;/voltshare_admin_policys/&#123;name&#125;`                   | DELETE VoltShare Admin Policy.                |
 
 ## Links
 

--- a/docs/en/api-reference/bot_and_threat_defense-api.mdx
+++ b/docs/en/api-reference/bot_and_threat_defense-api.mdx
@@ -2,7 +2,7 @@
 title: "🦠 Bot And Threat Defense API"
 description: "Bot detection, threat categories, and defense instances."
 sidebar:
-    hidden: true
+  hidden: true
 ---
 
 Threat classification with behavioral analysis and signature matching. Automated blocking for malicious traffic patterns.
@@ -27,28 +27,28 @@ Threat classification with behavioral analysis and signature matching. Automated
 
 ## Endpoints
 
-| Method | Path | Description |
-|--------|------|-------------|
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/bot_defense_app_infrastructures` | Create Bot Defense App Infrastructure. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/bot_defense_app_infrastructures/&#123;metadata.name&#125;` | Replace Bot Defense App Infrastructure. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/bot_defense_app_infrastructures` | List Bot Defense App Infrastructure. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/bot_defense_app_infrastructures/&#123;name&#125;` | Bot Defense App Infrastructure. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/bot_defense_app_infrastructures/&#123;name&#125;` | DELETE Bot Defense App Infrastructure. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/shape_bot_defense_instances` | List Shape Bot Defense Instance. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/shape_bot_defense_instances/&#123;name&#125;` | GET Virtual Host. |
-| POST | `/api/tpm/namespaces/&#123;metadata.namespace&#125;/tpm_api_keys` | Create TPM API Key. |
-| PUT | `/api/tpm/namespaces/&#123;metadata.namespace&#125;/tpm_api_keys/&#123;metadata.name&#125;` | Replace TPM API Key. |
-| GET | `/api/tpm/namespaces/&#123;namespace&#125;/tpm_api_keys` | List TPM API Key. |
-| GET | `/api/tpm/namespaces/&#123;namespace&#125;/tpm_api_keys/&#123;name&#125;` | GET TPM API Key. |
-| POST | `/api/tpm/namespaces/&#123;metadata.namespace&#125;/tpm_categorys` | Create TPM Category. |
-| PUT | `/api/tpm/namespaces/&#123;metadata.namespace&#125;/tpm_categorys/&#123;metadata.name&#125;` | Replace TPM Category. |
-| GET | `/api/tpm/namespaces/&#123;namespace&#125;/tpm_categorys` | List TPM Category. |
-| GET | `/api/tpm/namespaces/&#123;namespace&#125;/tpm_categorys/&#123;name&#125;` | GET TPM Category. |
-| POST | `/api/tpm/namespaces/&#123;metadata.namespace&#125;/tpm_managers` | Create TPM Manager. |
-| GET | `/api/tpm/namespaces/&#123;namespace&#125;/tpm_managers` | List TPM Manager. |
-| GET | `/api/tpm/namespaces/&#123;namespace&#125;/tpm_managers/&#123;name&#125;` | GET TPM Manager. |
-| POST | `/api/tpm/tpm/preauth` | Preauth |
-| POST | `/api/tpm/tpm/provision` | Provision |
+| Method | Path                                                                                                              | Description                             |
+| ------ | ----------------------------------------------------------------------------------------------------------------- | --------------------------------------- |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/bot_defense_app_infrastructures`                           | Create Bot Defense App Infrastructure.  |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/bot_defense_app_infrastructures/&#123;metadata.name&#125;` | Replace Bot Defense App Infrastructure. |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/bot_defense_app_infrastructures`                                    | List Bot Defense App Infrastructure.    |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/bot_defense_app_infrastructures/&#123;name&#125;`                   | Bot Defense App Infrastructure.         |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/bot_defense_app_infrastructures/&#123;name&#125;`                   | DELETE Bot Defense App Infrastructure.  |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/shape_bot_defense_instances`                                        | List Shape Bot Defense Instance.        |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/shape_bot_defense_instances/&#123;name&#125;`                       | GET Virtual Host.                       |
+| POST   | `/api/tpm/namespaces/&#123;metadata.namespace&#125;/tpm_api_keys`                                                 | Create TPM API Key.                     |
+| PUT    | `/api/tpm/namespaces/&#123;metadata.namespace&#125;/tpm_api_keys/&#123;metadata.name&#125;`                       | Replace TPM API Key.                    |
+| GET    | `/api/tpm/namespaces/&#123;namespace&#125;/tpm_api_keys`                                                          | List TPM API Key.                       |
+| GET    | `/api/tpm/namespaces/&#123;namespace&#125;/tpm_api_keys/&#123;name&#125;`                                         | GET TPM API Key.                        |
+| POST   | `/api/tpm/namespaces/&#123;metadata.namespace&#125;/tpm_categorys`                                                | Create TPM Category.                    |
+| PUT    | `/api/tpm/namespaces/&#123;metadata.namespace&#125;/tpm_categorys/&#123;metadata.name&#125;`                      | Replace TPM Category.                   |
+| GET    | `/api/tpm/namespaces/&#123;namespace&#125;/tpm_categorys`                                                         | List TPM Category.                      |
+| GET    | `/api/tpm/namespaces/&#123;namespace&#125;/tpm_categorys/&#123;name&#125;`                                        | GET TPM Category.                       |
+| POST   | `/api/tpm/namespaces/&#123;metadata.namespace&#125;/tpm_managers`                                                 | Create TPM Manager.                     |
+| GET    | `/api/tpm/namespaces/&#123;namespace&#125;/tpm_managers`                                                          | List TPM Manager.                       |
+| GET    | `/api/tpm/namespaces/&#123;namespace&#125;/tpm_managers/&#123;name&#125;`                                         | GET TPM Manager.                        |
+| POST   | `/api/tpm/tpm/preauth`                                                                                            | Preauth                                 |
+| POST   | `/api/tpm/tpm/provision`                                                                                          | Provision                               |
 
 ## Links
 

--- a/docs/en/api-reference/cdn-api.mdx
+++ b/docs/en/api-reference/cdn-api.mdx
@@ -2,7 +2,7 @@
 title: "🚀 Cdn API"
 description: "Content delivery and edge caching networks."
 sidebar:
-    hidden: true
+  hidden: true
 ---
 
 Global distribution with cache rules and purge operations. Performance monitoring and analytics.
@@ -27,40 +27,40 @@ Global distribution with cache rules and purge operations. Performance monitorin
 
 ## Endpoints
 
-| Method | Path | Description |
-|--------|------|-------------|
-| POST | `/api/config/namespaces/&#123;namespace&#125;/cdn_loadbalancers/&#123;name&#125;/block_client/suggestion` | Suggest block client rule. |
-| POST | `/api/config/namespaces/&#123;namespace&#125;/cdn_loadbalancers/&#123;name&#125;/ddos_mitigation/suggestion` | Suggest CDN DDoS Mitigation rule. |
-| POST | `/api/config/namespaces/&#123;namespace&#125;/cdn_loadbalancers/&#123;name&#125;/trust_client/suggestion` | Suggest trust client rule. |
-| POST | `/api/config/namespaces/&#123;namespace&#125;/cdn_loadbalancers/&#123;name&#125;/waf_exclusion/suggestion` | Suggest WAF Exclusion Rule. |
-| POST | `/api/cdn/namespaces/system/lilac-cdn/addon/subscribe` | Subscribe to CDN Loadbalancer. |
-| POST | `/api/cdn/namespaces/system/lilac-cdn/addon/unsubscribe` | Unsubscribe to CDN Loadbalancer. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/cdn_loadbalancers` | Create CDN Loadbalancer. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/cdn_loadbalancers/&#123;metadata.name&#125;` | Replace CDN Loadbalancer. |
-| POST | `/api/cdn/namespaces/&#123;namespace&#125;/cdn_loadbalancer/access_logs` | GET CDN Access Logs. |
-| POST | `/api/cdn/namespaces/&#123;namespace&#125;/cdn_loadbalancer/access_logs/aggregation` | CDN Access Log Aggregation Query. |
-| POST | `/api/cdn/namespaces/&#123;namespace&#125;/cdn_loadbalancer/get-service-operation-status` | GET Service Operation Status. |
-| POST | `/api/cdn/namespaces/&#123;namespace&#125;/cdn_loadbalancer/list-service-operations-status` | List of CDN Operation Commands. |
-| POST | `/api/cdn/namespaces/&#123;namespace&#125;/cdn_loadbalancer/metrics` | GET CDN Metrics. |
-| POST | `/api/cdn/namespaces/&#123;namespace&#125;/cdn_loadbalancer/&#123;name&#125;/cache-purge` | Purge CDN Cache. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/cdn_loadbalancers` | List CDN Loadbalancer. |
-| POST | `/api/config/namespaces/&#123;namespace&#125;/cdn_loadbalancers/get_security_config` | GET Security Config for CDN Load Balancer. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/cdn_loadbalancers/&#123;name&#125;` | GET CDN Loadbalancer. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/cdn_loadbalancers/&#123;name&#125;` | DELETE CDN Loadbalancer. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/cdn_loadbalancers/&#123;name&#125;/dos_automitigation_rules` | GET DoS Auto-Mitigation Rules for CDN Load Balancer. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/cdn_loadbalancers/&#123;name&#125;/dos_automitigation_rules/&#123;dos_automitigation_rule_name&#125;` | DELETE DoS Auto-Mitigation Rule for CDN Load Balancer. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/cdn_cache_rules` | Create CDN cache rule. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/cdn_cache_rules/&#123;metadata.name&#125;` | Replace CDN cache rule. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/cdn_cache_rules` | List CDN cache rule. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/cdn_cache_rules/&#123;name&#125;` | GET CDN cache rule. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/cdn_cache_rules/&#123;name&#125;` | DELETE CDN cache rule. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/cdn_purge_commands` | Create CDN Cache Purge Command. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/cdn_purge_commands` | List CDN cache purge command. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/cdn_purge_commands/&#123;name&#125;` | GET CDN Cache Purge Command. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/cdn_purge_commands/&#123;name&#125;` | DELETE CDN cache purge command. |
-| POST | `/api/cdn/namespaces/&#123;namespace&#125;/http_loadbalancer/get-service-operation-status` | GET Service Operation Status for HTTPLB when Caching Enabled. |
-| POST | `/api/cdn/namespaces/&#123;namespace&#125;/http_loadbalancer/list-service-operations-status` | List of HTTPLB Operation Commands when Caching Enabled. |
-| POST | `/api/cdn/namespaces/&#123;namespace&#125;/http_loadbalancer/&#123;name&#125;/cache-purge` | Purge the LB Cache. |
+| Method | Path                                                                                                                                                | Description                                                   |
+| ------ | --------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| POST   | `/api/config/namespaces/&#123;namespace&#125;/cdn_loadbalancers/&#123;name&#125;/block_client/suggestion`                                           | Suggest block client rule.                                    |
+| POST   | `/api/config/namespaces/&#123;namespace&#125;/cdn_loadbalancers/&#123;name&#125;/ddos_mitigation/suggestion`                                        | Suggest CDN DDoS Mitigation rule.                             |
+| POST   | `/api/config/namespaces/&#123;namespace&#125;/cdn_loadbalancers/&#123;name&#125;/trust_client/suggestion`                                           | Suggest trust client rule.                                    |
+| POST   | `/api/config/namespaces/&#123;namespace&#125;/cdn_loadbalancers/&#123;name&#125;/waf_exclusion/suggestion`                                          | Suggest WAF Exclusion Rule.                                   |
+| POST   | `/api/cdn/namespaces/system/lilac-cdn/addon/subscribe`                                                                                              | Subscribe to CDN Loadbalancer.                                |
+| POST   | `/api/cdn/namespaces/system/lilac-cdn/addon/unsubscribe`                                                                                            | Unsubscribe to CDN Loadbalancer.                              |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/cdn_loadbalancers`                                                                           | Create CDN Loadbalancer.                                      |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/cdn_loadbalancers/&#123;metadata.name&#125;`                                                 | Replace CDN Loadbalancer.                                     |
+| POST   | `/api/cdn/namespaces/&#123;namespace&#125;/cdn_loadbalancer/access_logs`                                                                            | GET CDN Access Logs.                                          |
+| POST   | `/api/cdn/namespaces/&#123;namespace&#125;/cdn_loadbalancer/access_logs/aggregation`                                                                | CDN Access Log Aggregation Query.                             |
+| POST   | `/api/cdn/namespaces/&#123;namespace&#125;/cdn_loadbalancer/get-service-operation-status`                                                           | GET Service Operation Status.                                 |
+| POST   | `/api/cdn/namespaces/&#123;namespace&#125;/cdn_loadbalancer/list-service-operations-status`                                                         | List of CDN Operation Commands.                               |
+| POST   | `/api/cdn/namespaces/&#123;namespace&#125;/cdn_loadbalancer/metrics`                                                                                | GET CDN Metrics.                                              |
+| POST   | `/api/cdn/namespaces/&#123;namespace&#125;/cdn_loadbalancer/&#123;name&#125;/cache-purge`                                                           | Purge CDN Cache.                                              |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/cdn_loadbalancers`                                                                                    | List CDN Loadbalancer.                                        |
+| POST   | `/api/config/namespaces/&#123;namespace&#125;/cdn_loadbalancers/get_security_config`                                                                | GET Security Config for CDN Load Balancer.                    |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/cdn_loadbalancers/&#123;name&#125;`                                                                   | GET CDN Loadbalancer.                                         |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/cdn_loadbalancers/&#123;name&#125;`                                                                   | DELETE CDN Loadbalancer.                                      |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/cdn_loadbalancers/&#123;name&#125;/dos_automitigation_rules`                                          | GET DoS Auto-Mitigation Rules for CDN Load Balancer.          |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/cdn_loadbalancers/&#123;name&#125;/dos_automitigation_rules/&#123;dos_automitigation_rule_name&#125;` | DELETE DoS Auto-Mitigation Rule for CDN Load Balancer.        |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/cdn_cache_rules`                                                                             | Create CDN cache rule.                                        |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/cdn_cache_rules/&#123;metadata.name&#125;`                                                   | Replace CDN cache rule.                                       |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/cdn_cache_rules`                                                                                      | List CDN cache rule.                                          |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/cdn_cache_rules/&#123;name&#125;`                                                                     | GET CDN cache rule.                                           |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/cdn_cache_rules/&#123;name&#125;`                                                                     | DELETE CDN cache rule.                                        |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/cdn_purge_commands`                                                                          | Create CDN Cache Purge Command.                               |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/cdn_purge_commands`                                                                                   | List CDN cache purge command.                                 |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/cdn_purge_commands/&#123;name&#125;`                                                                  | GET CDN Cache Purge Command.                                  |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/cdn_purge_commands/&#123;name&#125;`                                                                  | DELETE CDN cache purge command.                               |
+| POST   | `/api/cdn/namespaces/&#123;namespace&#125;/http_loadbalancer/get-service-operation-status`                                                          | GET Service Operation Status for HTTPLB when Caching Enabled. |
+| POST   | `/api/cdn/namespaces/&#123;namespace&#125;/http_loadbalancer/list-service-operations-status`                                                        | List of HTTPLB Operation Commands when Caching Enabled.       |
+| POST   | `/api/cdn/namespaces/&#123;namespace&#125;/http_loadbalancer/&#123;name&#125;/cache-purge`                                                          | Purge the LB Cache.                                           |
 
 ## Links
 

--- a/docs/en/api-reference/ce_management-api.mdx
+++ b/docs/en/api-reference/ce_management-api.mdx
@@ -2,7 +2,7 @@
 title: "🔧 Ce Management API"
 description: "Network interfaces, fleets, and site registration."
 sidebar:
-    hidden: true
+  hidden: true
 ---
 
 Token-based provisioning with image downloads and pre-upgrade validation. Fleet grouping enables bulk operations across distributed locations.
@@ -28,40 +28,40 @@ Token-based provisioning with image downloads and pre-upgrade validation. Fleet 
 
 ## Endpoints
 
-| Method | Path | Description |
-|--------|------|-------------|
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/fleets` | Create Fleet. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/fleets/&#123;metadata.name&#125;` | Replace Fleet. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/fleets` | List Fleet. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/fleets/&#123;name&#125;` | GET Fleet |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/fleets/&#123;name&#125;` | DELETE Fleet. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/module_management/settings` | Module Management Settings. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/network_interfaces` | Create Network Interface. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/network_interfaces/&#123;metadata.name&#125;` | Replace Network Interface. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/network_interfaces` | List Network Interface. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/network_interfaces/&#123;name&#125;` | GET Network Interface. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/network_interfaces/&#123;name&#125;` | DELETE Network Interface. |
-| POST | `/api/register/namespaces/system/get-image-download-url` | GET Image Download URL. |
-| POST | `/api/register/namespaces/system/get-registrations-by-token` | GET Registration UID by Site Token. |
-| POST | `/api/register/namespaces/system/suggest-values` | Suggest Values. |
-| POST | `/api/register/namespaces/&#123;metadata.namespace&#125;/registrations` | Create Registration. |
-| PUT | `/api/register/namespaces/&#123;metadata.namespace&#125;/registrations/&#123;metadata.name&#125;` | Replace Registration. |
-| POST | `/api/register/namespaces/&#123;namespace&#125;/listregistrationsbystate` | List Registrations By State. |
-| POST | `/api/register/namespaces/&#123;namespace&#125;/registration/&#123;name&#125;/approve` | Registration Approve. |
-| GET | `/api/register/namespaces/&#123;namespace&#125;/registrations` | List Registration. |
-| GET | `/api/register/namespaces/&#123;namespace&#125;/registrations/&#123;name&#125;` | GET Registration. |
-| DELETE | `/api/register/namespaces/&#123;namespace&#125;/registrations/&#123;name&#125;` | DELETE Registration. |
-| GET | `/api/register/namespaces/&#123;namespace&#125;/registrations_by_site/&#123;site_name&#125;` | List registrations by site. |
-| POST | `/api/register/registerBootstrap` | Registration Create. |
-| POST | `/api/register/requestConfig` | Registration Config. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/usb_policys` | Create USB policy. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/usb_policys/&#123;metadata.name&#125;` | Replace USB policy. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/usb_policys` | List USB policy. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/usb_policys/&#123;name&#125;` | GET USB policy. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/usb_policys/&#123;name&#125;` | DELETE USB policy. |
-| GET | `/api/maurice/namespaces/&#123;namespace&#125;/sites/&#123;name&#125;/pre_upgrade_check` | Pre upgrade check. |
-| GET | `/api/maurice/namespaces/&#123;namespace&#125;/sites/&#123;name&#125;/upgrade_status` | GET Upgrade Status. |
-| GET | `/api/maurice/upgradable_sw_versions` | GET Upgradable SW Versions. |
+| Method | Path                                                                                                 | Description                         |
+| ------ | ---------------------------------------------------------------------------------------------------- | ----------------------------------- |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/fleets`                                       | Create Fleet.                       |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/fleets/&#123;metadata.name&#125;`             | Replace Fleet.                      |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/fleets`                                                | List Fleet.                         |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/fleets/&#123;name&#125;`                               | GET Fleet                           |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/fleets/&#123;name&#125;`                               | DELETE Fleet.                       |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/module_management/settings`                            | Module Management Settings.         |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/network_interfaces`                           | Create Network Interface.           |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/network_interfaces/&#123;metadata.name&#125;` | Replace Network Interface.          |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/network_interfaces`                                    | List Network Interface.             |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/network_interfaces/&#123;name&#125;`                   | GET Network Interface.              |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/network_interfaces/&#123;name&#125;`                   | DELETE Network Interface.           |
+| POST   | `/api/register/namespaces/system/get-image-download-url`                                             | GET Image Download URL.             |
+| POST   | `/api/register/namespaces/system/get-registrations-by-token`                                         | GET Registration UID by Site Token. |
+| POST   | `/api/register/namespaces/system/suggest-values`                                                     | Suggest Values.                     |
+| POST   | `/api/register/namespaces/&#123;metadata.namespace&#125;/registrations`                              | Create Registration.                |
+| PUT    | `/api/register/namespaces/&#123;metadata.namespace&#125;/registrations/&#123;metadata.name&#125;`    | Replace Registration.               |
+| POST   | `/api/register/namespaces/&#123;namespace&#125;/listregistrationsbystate`                            | List Registrations By State.        |
+| POST   | `/api/register/namespaces/&#123;namespace&#125;/registration/&#123;name&#125;/approve`               | Registration Approve.               |
+| GET    | `/api/register/namespaces/&#123;namespace&#125;/registrations`                                       | List Registration.                  |
+| GET    | `/api/register/namespaces/&#123;namespace&#125;/registrations/&#123;name&#125;`                      | GET Registration.                   |
+| DELETE | `/api/register/namespaces/&#123;namespace&#125;/registrations/&#123;name&#125;`                      | DELETE Registration.                |
+| GET    | `/api/register/namespaces/&#123;namespace&#125;/registrations_by_site/&#123;site_name&#125;`         | List registrations by site.         |
+| POST   | `/api/register/registerBootstrap`                                                                    | Registration Create.                |
+| POST   | `/api/register/requestConfig`                                                                        | Registration Config.                |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/usb_policys`                                  | Create USB policy.                  |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/usb_policys/&#123;metadata.name&#125;`        | Replace USB policy.                 |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/usb_policys`                                           | List USB policy.                    |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/usb_policys/&#123;name&#125;`                          | GET USB policy.                     |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/usb_policys/&#123;name&#125;`                          | DELETE USB policy.                  |
+| GET    | `/api/maurice/namespaces/&#123;namespace&#125;/sites/&#123;name&#125;/pre_upgrade_check`             | Pre upgrade check.                  |
+| GET    | `/api/maurice/namespaces/&#123;namespace&#125;/sites/&#123;name&#125;/upgrade_status`                | GET Upgrade Status.                 |
+| GET    | `/api/maurice/upgradable_sw_versions`                                                                | GET Upgradable SW Versions.         |
 
 ## Links
 

--- a/docs/en/api-reference/certificates-api.mdx
+++ b/docs/en/api-reference/certificates-api.mdx
@@ -2,7 +2,7 @@
 title: "📜 Certificates API"
 description: "SSL/TLS chains, trusted CAs, and revocation lists."
 sidebar:
-    hidden: true
+  hidden: true
 ---
 
 Certificate chains and trusted CA bundles. Revocation list management and manifest configuration for PKI operations.
@@ -28,28 +28,28 @@ Certificate chains and trusted CA bundles. Revocation list management and manife
 
 ## Endpoints
 
-| Method | Path | Description |
-|--------|------|-------------|
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/crls` | Create CRL. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/crls/&#123;metadata.name&#125;` | Replace CRL. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/crls` | List CRL |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/crls/&#123;name&#125;` | GET CRL |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/crls/&#123;name&#125;` | DELETE CRL. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/certificates` | Create Certificate. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/certificates/&#123;metadata.name&#125;` | Replace Certificate. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/certificates` | List Certificate. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/certificates/&#123;name&#125;` | GET Certificate. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/certificates/&#123;name&#125;` | DELETE Certificate. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/certificate_chains` | Create Certificate Chain. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/certificate_chains/&#123;metadata.name&#125;` | Replace Certificate Chain. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/certificate_chains` | List Certificate Chain. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/certificate_chains/&#123;name&#125;` | GET Certificate Chain. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/certificate_chains/&#123;name&#125;` | DELETE Certificate Chain. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/trusted_ca_lists` | Create Root CA Certificate. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/trusted_ca_lists/&#123;metadata.name&#125;` | Replace Root CA Certificate. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/trusted_ca_lists` | List Root CA Certificate. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/trusted_ca_lists/&#123;name&#125;` | GET Root CA Certificate. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/trusted_ca_lists/&#123;name&#125;` | DELETE Root CA Certificate. |
+| Method | Path                                                                                                 | Description                  |
+| ------ | ---------------------------------------------------------------------------------------------------- | ---------------------------- |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/crls`                                         | Create CRL.                  |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/crls/&#123;metadata.name&#125;`               | Replace CRL.                 |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/crls`                                                  | List CRL                     |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/crls/&#123;name&#125;`                                 | GET CRL                      |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/crls/&#123;name&#125;`                                 | DELETE CRL.                  |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/certificates`                                 | Create Certificate.          |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/certificates/&#123;metadata.name&#125;`       | Replace Certificate.         |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/certificates`                                          | List Certificate.            |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/certificates/&#123;name&#125;`                         | GET Certificate.             |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/certificates/&#123;name&#125;`                         | DELETE Certificate.          |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/certificate_chains`                           | Create Certificate Chain.    |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/certificate_chains/&#123;metadata.name&#125;` | Replace Certificate Chain.   |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/certificate_chains`                                    | List Certificate Chain.      |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/certificate_chains/&#123;name&#125;`                   | GET Certificate Chain.       |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/certificate_chains/&#123;name&#125;`                   | DELETE Certificate Chain.    |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/trusted_ca_lists`                             | Create Root CA Certificate.  |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/trusted_ca_lists/&#123;metadata.name&#125;`   | Replace Root CA Certificate. |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/trusted_ca_lists`                                      | List Root CA Certificate.    |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/trusted_ca_lists/&#123;name&#125;`                     | GET Root CA Certificate.     |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/trusted_ca_lists/&#123;name&#125;`                     | DELETE Root CA Certificate.  |
 
 ## Links
 

--- a/docs/en/api-reference/cloud_infrastructure-api.mdx
+++ b/docs/en/api-reference/cloud_infrastructure-api.mdx
@@ -2,7 +2,7 @@
 title: "☁️ Cloud Infrastructure API"
 description: "AWS, Azure, GCP connectors and VPC attachments."
 sidebar:
-    hidden: true
+  hidden: true
 ---
 
 Multi-cloud provider connections with gateway peering and network path configuration. Credential vault integration and subnet enumeration.
@@ -29,43 +29,43 @@ Multi-cloud provider connections with gateway peering and network path configura
 
 ## Endpoints
 
-| Method | Path | Description |
-|--------|------|-------------|
-| GET | `/api/config/namespaces/&#123;namespace&#125;/certified_hardwares` | List Certified Hardware. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/certified_hardwares/&#123;name&#125;` | GET Certified Hardware. |
-| POST | `/api/sync-cloud-data/namespaces/system/cloud_connect_reapply_vpc_attachment` | ReApplyVPCAttachment. |
-| POST | `/api/data/namespaces/system/cloud_connects/metrics` | All Cloud Connect Metrics. |
-| POST | `/api/data/namespaces/system/cloud_connects/segment_metrics` | All Cloud Connect Segment Metrics. |
-| POST | `/api/data/namespaces/system/cloud_connects/&#123;name&#125;/metrics` | Cloud Connect Metrics. |
-| POST | `/api/sync-cloud-data/namespaces/system/discover_vpc` | Cloud Connect VPC Discovery. |
-| POST | `/api/config/namespaces/system/edge_credentials` | Cloud Credential. |
-| GET | `/api/config/namespaces/system/edge_list` | Edge List |
-| POST | `/api/data/namespaces/system/top/cloud_connects` | Top Cloud Connect. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/cloud_connects` | Create Cloud Connect. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/cloud_connects/&#123;metadata.name&#125;` | Replace Cloud Connect. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/cloud_connects` | List Cloud Connect. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/cloud_connects/&#123;name&#125;` | GET Cloud Connect. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/cloud_connects/&#123;name&#125;` | DELETE Cloud Connect. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/cloud_credentialss` | Create Cloud Credentials. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/cloud_credentialss/&#123;metadata.name&#125;` | Replace Cloud Credentials. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/cloud_credentialss` | List Cloud Credentials. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/cloud_credentialss/&#123;name&#125;` | GET Cloud Credentials. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/cloud_credentialss/&#123;name&#125;` | DELETE Cloud Credentials. |
-| POST | `/api/config/namespaces/system/cloud_elastic_ip/&#123;name&#125;/force-delete` | Force DELETE Cloud Elastic IP. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/cloud_elastic_ips` | Create Cloud Elastic IP. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/cloud_elastic_ips/&#123;metadata.name&#125;` | Replace Cloud Elastic IP. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/cloud_elastic_ips` | List Cloud Elastic IP. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/cloud_elastic_ips/&#123;name&#125;` | GET Cloud Elastic IP. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/cloud_elastic_ips/&#123;name&#125;` | DELETE Cloud Elastic IP. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/cloud_regions/&#123;metadata.name&#125;` | Replace Cloud Region. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/cloud_regions` | List Cloud Region. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/cloud_regions/&#123;name&#125;` | GET Cloud Region. |
-| POST | `/api/config/namespaces/system/cloud_links/&#123;name&#125;/reapply_config` | CloudLink |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/cloud_links` | Create CloudLink. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/cloud_links/&#123;metadata.name&#125;` | Replace CloudLink. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/cloud_links` | List CloudLink. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/cloud_links/&#123;name&#125;` | GET CloudLink. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/cloud_links/&#123;name&#125;` | DELETE CloudLink. |
+| Method | Path                                                                                                 | Description                        |
+| ------ | ---------------------------------------------------------------------------------------------------- | ---------------------------------- |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/certified_hardwares`                                   | List Certified Hardware.           |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/certified_hardwares/&#123;name&#125;`                  | GET Certified Hardware.            |
+| POST   | `/api/sync-cloud-data/namespaces/system/cloud_connect_reapply_vpc_attachment`                        | ReApplyVPCAttachment.              |
+| POST   | `/api/data/namespaces/system/cloud_connects/metrics`                                                 | All Cloud Connect Metrics.         |
+| POST   | `/api/data/namespaces/system/cloud_connects/segment_metrics`                                         | All Cloud Connect Segment Metrics. |
+| POST   | `/api/data/namespaces/system/cloud_connects/&#123;name&#125;/metrics`                                | Cloud Connect Metrics.             |
+| POST   | `/api/sync-cloud-data/namespaces/system/discover_vpc`                                                | Cloud Connect VPC Discovery.       |
+| POST   | `/api/config/namespaces/system/edge_credentials`                                                     | Cloud Credential.                  |
+| GET    | `/api/config/namespaces/system/edge_list`                                                            | Edge List                          |
+| POST   | `/api/data/namespaces/system/top/cloud_connects`                                                     | Top Cloud Connect.                 |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/cloud_connects`                               | Create Cloud Connect.              |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/cloud_connects/&#123;metadata.name&#125;`     | Replace Cloud Connect.             |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/cloud_connects`                                        | List Cloud Connect.                |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/cloud_connects/&#123;name&#125;`                       | GET Cloud Connect.                 |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/cloud_connects/&#123;name&#125;`                       | DELETE Cloud Connect.              |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/cloud_credentialss`                           | Create Cloud Credentials.          |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/cloud_credentialss/&#123;metadata.name&#125;` | Replace Cloud Credentials.         |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/cloud_credentialss`                                    | List Cloud Credentials.            |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/cloud_credentialss/&#123;name&#125;`                   | GET Cloud Credentials.             |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/cloud_credentialss/&#123;name&#125;`                   | DELETE Cloud Credentials.          |
+| POST   | `/api/config/namespaces/system/cloud_elastic_ip/&#123;name&#125;/force-delete`                       | Force DELETE Cloud Elastic IP.     |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/cloud_elastic_ips`                            | Create Cloud Elastic IP.           |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/cloud_elastic_ips/&#123;metadata.name&#125;`  | Replace Cloud Elastic IP.          |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/cloud_elastic_ips`                                     | List Cloud Elastic IP.             |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/cloud_elastic_ips/&#123;name&#125;`                    | GET Cloud Elastic IP.              |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/cloud_elastic_ips/&#123;name&#125;`                    | DELETE Cloud Elastic IP.           |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/cloud_regions/&#123;metadata.name&#125;`      | Replace Cloud Region.              |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/cloud_regions`                                         | List Cloud Region.                 |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/cloud_regions/&#123;name&#125;`                        | GET Cloud Region.                  |
+| POST   | `/api/config/namespaces/system/cloud_links/&#123;name&#125;/reapply_config`                          | CloudLink                          |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/cloud_links`                                  | Create CloudLink.                  |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/cloud_links/&#123;metadata.name&#125;`        | Replace CloudLink.                 |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/cloud_links`                                           | List CloudLink.                    |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/cloud_links/&#123;name&#125;`                          | GET CloudLink.                     |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/cloud_links/&#123;name&#125;`                          | DELETE CloudLink.                  |
 
 ## Links
 

--- a/docs/en/api-reference/container_services-api.mdx
+++ b/docs/en/api-reference/container_services-api.mdx
@@ -2,7 +2,7 @@
 title: "📦 Container Services API"
 description: "Containerized workloads and virtual Kubernetes clusters."
 sidebar:
-    hidden: true
+  hidden: true
 ---
 
 Pod orchestration without full cluster complexity. Edge site execution, quota enforcement, and standardized compute profiles for distributed apps.
@@ -28,24 +28,24 @@ Pod orchestration without full cluster complexity. Edge site execution, quota en
 
 ## Endpoints
 
-| Method | Path | Description |
-|--------|------|-------------|
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/virtual_k8ss` | Create Virtual Kubernetes. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/virtual_k8ss/&#123;metadata.name&#125;` | Replace Virtual Kubernetes. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/virtual_k8ss` | List Virtual Kubernetes. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/virtual_k8ss/&#123;name&#125;` | GET Virtual Kubernetes. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/virtual_k8ss/&#123;name&#125;` | DELETE Virtual Kubernetes. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/workloads` | Create Workload. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/workloads/&#123;metadata.name&#125;` | Replace Workload. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/workloads` | List Workload. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/workloads/usage` | Usage Metrics. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/workloads/&#123;name&#125;` | GET Workload. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/workloads/&#123;name&#125;` | DELETE Workload. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/workload_flavors` | Create Workload Flavor. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/workload_flavors/&#123;metadata.name&#125;` | Replace Flavor. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/workload_flavors` | List Workload Flavor. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/workload_flavors/&#123;name&#125;` | GET Workload Flavor. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/workload_flavors/&#123;name&#125;` | DELETE Workload Flavor. |
+| Method | Path                                                                                               | Description                 |
+| ------ | -------------------------------------------------------------------------------------------------- | --------------------------- |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/virtual_k8ss`                               | Create Virtual Kubernetes.  |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/virtual_k8ss/&#123;metadata.name&#125;`     | Replace Virtual Kubernetes. |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/virtual_k8ss`                                        | List Virtual Kubernetes.    |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/virtual_k8ss/&#123;name&#125;`                       | GET Virtual Kubernetes.     |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/virtual_k8ss/&#123;name&#125;`                       | DELETE Virtual Kubernetes.  |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/workloads`                                  | Create Workload.            |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/workloads/&#123;metadata.name&#125;`        | Replace Workload.           |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/workloads`                                           | List Workload.              |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/workloads/usage`                                       | Usage Metrics.              |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/workloads/&#123;name&#125;`                          | GET Workload.               |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/workloads/&#123;name&#125;`                          | DELETE Workload.            |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/workload_flavors`                           | Create Workload Flavor.     |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/workload_flavors/&#123;metadata.name&#125;` | Replace Flavor.             |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/workload_flavors`                                    | List Workload Flavor.       |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/workload_flavors/&#123;name&#125;`                   | GET Workload Flavor.        |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/workload_flavors/&#123;name&#125;`                   | DELETE Workload Flavor.     |
 
 ## Links
 

--- a/docs/en/api-reference/data_and_privacy_security-api.mdx
+++ b/docs/en/api-reference/data_and_privacy_security-api.mdx
@@ -2,7 +2,7 @@
 title: "🔐 Data And Privacy Security API"
 description: "PII detection, data types, and regional compliance."
 sidebar:
-    hidden: true
+  hidden: true
 ---
 
 Sensitive data policies with custom classification rules. LMA region configuration and geo-based compliance controls.
@@ -27,21 +27,21 @@ Sensitive data policies with custom classification rules. LMA region configurati
 
 ## Endpoints
 
-| Method | Path | Description |
-|--------|------|-------------|
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/data_types` | Create Data Type. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/data_types/&#123;metadata.name&#125;` | Replace Data Type. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/data_types` | List Data Type. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/data_types/&#123;name&#125;` | GET Data Type. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/data_types/&#123;name&#125;` | DELETE Data Type. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/geo_configs/&#123;name&#125;` | GET Geo Config. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/lma_regions` | List LMA Region. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/lma_regions/&#123;name&#125;` | GET LMA Region. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/sensitive_data_policys` | Create Sensitive Data Discovery. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/sensitive_data_policys/&#123;metadata.name&#125;` | Replace Sensitive Data Discovery. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/sensitive_data_policys` | List Sensitive Data Discovery. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/sensitive_data_policys/&#123;name&#125;` | GET Sensitive Data Discovery. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/sensitive_data_policys/&#123;name&#125;` | DELETE Sensitive Data Discovery. |
+| Method | Path                                                                                                     | Description                       |
+| ------ | -------------------------------------------------------------------------------------------------------- | --------------------------------- |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/data_types`                                       | Create Data Type.                 |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/data_types/&#123;metadata.name&#125;`             | Replace Data Type.                |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/data_types`                                                | List Data Type.                   |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/data_types/&#123;name&#125;`                               | GET Data Type.                    |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/data_types/&#123;name&#125;`                               | DELETE Data Type.                 |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/geo_configs/&#123;name&#125;`                              | GET Geo Config.                   |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/lma_regions`                                               | List LMA Region.                  |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/lma_regions/&#123;name&#125;`                              | GET LMA Region.                   |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/sensitive_data_policys`                           | Create Sensitive Data Discovery.  |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/sensitive_data_policys/&#123;metadata.name&#125;` | Replace Sensitive Data Discovery. |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/sensitive_data_policys`                                    | List Sensitive Data Discovery.    |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/sensitive_data_policys/&#123;name&#125;`                   | GET Sensitive Data Discovery.     |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/sensitive_data_policys/&#123;name&#125;`                   | DELETE Sensitive Data Discovery.  |
 
 ## Links
 

--- a/docs/en/api-reference/data_intelligence-api.mdx
+++ b/docs/en/api-reference/data_intelligence-api.mdx
@@ -2,7 +2,7 @@
 title: "🧠 Data Intelligence API"
 description: "Classification, insights, and policy management."
 sidebar:
-    hidden: true
+  hidden: true
 ---
 
 Classification rules, resource policies, and insight generation for data analysis workflows.
@@ -26,24 +26,24 @@ Classification rules, resource policies, and insight generation for data analysi
 
 ## Endpoints
 
-| Method | Path | Description |
-|--------|------|-------------|
-| POST | `/api/data-intelligence/namespaces/&#123;metadata.namespace&#125;/receivers` | Create Data Delivery. |
-| PUT | `/api/data-intelligence/namespaces/&#123;metadata.namespace&#125;/receivers/&#123;metadata.name&#125;` | Replace Data Delivery. |
-| GET | `/api/data-intelligence/namespaces/&#123;namespace&#125;/receivers` | List Data Delivery. |
-| GET | `/api/data-intelligence/namespaces/&#123;namespace&#125;/receivers/&#123;name&#125;` | GET Data Delivery. |
-| DELETE | `/api/data-intelligence/namespaces/&#123;namespace&#125;/receivers/&#123;name&#125;` | DELETE Data Delivery. |
-| GET | `/api/data-intelligence/namespaces/system/dataSets` | GET Data Sets. |
-| GET | `/api/data-intelligence/namespaces/system/datadictionary/&#123;dataset&#125;` | GET Data Dictionary. |
-| POST | `/api/data-intelligence/namespaces/system/init-request` | Enable Data Intelligence. |
-| GET | `/api/data-intelligence/namespaces/&#123;namespace&#125;/data-dictionary/datasets` | List DataSets. |
-| GET | `/api/data-intelligence/namespaces/&#123;namespace&#125;/di/flowlabels` | List FlowLabels. |
-| POST | `/api/data-intelligence/namespaces/&#123;namespace&#125;/di/summary` | Load Executive Summary. |
-| POST | `/api/data-intelligence/namespaces/&#123;namespace&#125;/receivers/&#123;id&#125;/status` | Update Status of Receiver. |
-| POST | `/api/data-intelligence/namespaces/&#123;namespace&#125;/receivers/&#123;id&#125;/test` | Test Receiver. |
-| POST | `/api/data-intelligence/namespaces/&#123;namespace&#125;/suggest-values` | Suggest Values. |
-| POST | `/api/data-intelligence/namespaces/system/data-intelligence/addon/subscribe` | Subscribe to Data Intelligence. |
-| POST | `/api/data-intelligence/namespaces/system/data-intelligence/addon/unsubscribe` | Unsubscribe to Client-Side Defense. |
+| Method | Path                                                                                                   | Description                         |
+| ------ | ------------------------------------------------------------------------------------------------------ | ----------------------------------- |
+| POST   | `/api/data-intelligence/namespaces/&#123;metadata.namespace&#125;/receivers`                           | Create Data Delivery.               |
+| PUT    | `/api/data-intelligence/namespaces/&#123;metadata.namespace&#125;/receivers/&#123;metadata.name&#125;` | Replace Data Delivery.              |
+| GET    | `/api/data-intelligence/namespaces/&#123;namespace&#125;/receivers`                                    | List Data Delivery.                 |
+| GET    | `/api/data-intelligence/namespaces/&#123;namespace&#125;/receivers/&#123;name&#125;`                   | GET Data Delivery.                  |
+| DELETE | `/api/data-intelligence/namespaces/&#123;namespace&#125;/receivers/&#123;name&#125;`                   | DELETE Data Delivery.               |
+| GET    | `/api/data-intelligence/namespaces/system/dataSets`                                                    | GET Data Sets.                      |
+| GET    | `/api/data-intelligence/namespaces/system/datadictionary/&#123;dataset&#125;`                          | GET Data Dictionary.                |
+| POST   | `/api/data-intelligence/namespaces/system/init-request`                                                | Enable Data Intelligence.           |
+| GET    | `/api/data-intelligence/namespaces/&#123;namespace&#125;/data-dictionary/datasets`                     | List DataSets.                      |
+| GET    | `/api/data-intelligence/namespaces/&#123;namespace&#125;/di/flowlabels`                                | List FlowLabels.                    |
+| POST   | `/api/data-intelligence/namespaces/&#123;namespace&#125;/di/summary`                                   | Load Executive Summary.             |
+| POST   | `/api/data-intelligence/namespaces/&#123;namespace&#125;/receivers/&#123;id&#125;/status`              | Update Status of Receiver.          |
+| POST   | `/api/data-intelligence/namespaces/&#123;namespace&#125;/receivers/&#123;id&#125;/test`                | Test Receiver.                      |
+| POST   | `/api/data-intelligence/namespaces/&#123;namespace&#125;/suggest-values`                               | Suggest Values.                     |
+| POST   | `/api/data-intelligence/namespaces/system/data-intelligence/addon/subscribe`                           | Subscribe to Data Intelligence.     |
+| POST   | `/api/data-intelligence/namespaces/system/data-intelligence/addon/unsubscribe`                         | Unsubscribe to Client-Side Defense. |
 
 ## Links
 

--- a/docs/en/api-reference/ddos-api.mdx
+++ b/docs/en/api-reference/ddos-api.mdx
@@ -2,7 +2,7 @@
 title: "🛑 Ddos API"
 description: "Volumetric attack mitigation and traffic scrubbing."
 sidebar:
-    hidden: true
+  hidden: true
 ---
 
 Deny lists, firewall rule groups, and tunnel-based safeguards. Rate limiting and pattern analysis for network perimeter security.
@@ -26,78 +26,78 @@ Deny lists, firewall rule groups, and tunnel-based safeguards. Rate limiting and
 
 ## Endpoints
 
-| Method | Path | Description |
-|--------|------|-------------|
-| GET | `/api/infraprotect/namespaces/system/infraprotect/access` | Customer access. |
-| GET | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect/alert/&#123;alert_id&#125;` | DDoS Alert. |
-| PUT | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect/alert/&#123;alert_id&#125;/to_event` | Link Alert to Event. |
-| POST | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect/alerts` | DDoS Alerts. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/infraprotect/bgp_peer_status` | BGP Peer Status. |
-| GET | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect/event/&#123;event_id&#125;` | Event details. |
-| PUT | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect/event/&#123;event_id&#125;` | Edit event. |
-| GET | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect/event/&#123;event_id&#125;/alerts` | Event alerts. |
-| GET | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect/event/&#123;event_id&#125;/attachments` | Event attachments. |
-| DELETE | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect/event/&#123;event_id&#125;/detail/&#123;event_detail_id&#125;` | DELETE event detail. |
-| PUT | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect/event/&#123;event_id&#125;/detail/&#123;event_detail_id&#125;` | Edit event detail. |
-| GET | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect/event/&#123;event_id&#125;/details` | List of event details. |
-| POST | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect/event/&#123;event_id&#125;/details` | Add Event Detail. |
-| GET | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect/event/&#123;event_id&#125;/mitigation_annotations` | Event mitigation annotation. |
-| POST | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect/events` | List of events. |
-| GET | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect/events_summary` | Simple events view. |
-| GET | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect/mitigation/&#123;mitigation_id&#125;` | Mitigation details. |
-| GET | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect/mitigation/&#123;mitigation_id&#125;/annotations` | Mitigation annotations. |
-| GET | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect/mitigation/&#123;mitigation_id&#125;/ips` | Mitigation IPs. |
-| POST | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect/mitigations` | List of mitigations. |
-| GET | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect/networks` | List networks. |
-| GET | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect/report/&#123;report_id&#125;` | Report details. |
-| POST | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect/reports` | List reports. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/infraprotect/transit_usage` | Transit Usage. |
-| POST | `/api/infraprotect/namespaces/&#123;namespace&#125;/suggest-values` | Suggest Values. |
-| POST | `/api/infraprotect/namespaces/&#123;metadata.namespace&#125;/infraprotect_asns` | Create DDoS transit ASN. |
-| PUT | `/api/infraprotect/namespaces/&#123;metadata.namespace&#125;/infraprotect_asns/&#123;metadata.name&#125;` | Replace DDoS transit ASN. |
-| GET | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect_asns` | List Infraprotect ASN. |
-| POST | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect_asns/update-asn-review-status` | Update ASN Review Status. |
-| GET | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect_asns/&#123;name&#125;` | GET Infraprotect ASN. |
-| DELETE | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect_asns/&#123;name&#125;` | DELETE Infraprotect ASN. |
-| POST | `/api/infraprotect/namespaces/&#123;metadata.namespace&#125;/infraprotect_asn_prefixs` | Create DDoS transit Prefix. |
-| PUT | `/api/infraprotect/namespaces/&#123;metadata.namespace&#125;/infraprotect_asn_prefixs/&#123;metadata.name&#125;` | Replace DDoS transit Prefix. |
-| POST | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect_asn_prefixes/update-asn-prefix-irr-override` | Update ASN Prefix IRR Override. |
-| POST | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect_asn_prefixes/update-asn-prefix-review-status` | Update ASN Prefix Review Status. |
-| GET | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect_asn_prefixs` | List Infraprotect ASN Prefix. |
-| GET | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect_asn_prefixs/&#123;name&#125;` | GET Infraprotect ASN Prefix. |
-| DELETE | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect_asn_prefixs/&#123;name&#125;` | DELETE Infraprotect ASN Prefix. |
-| POST | `/api/infraprotect/namespaces/&#123;metadata.namespace&#125;/infraprotect_deny_list_rules` | Create DDoS transit Deny List Rule. |
-| PUT | `/api/infraprotect/namespaces/&#123;metadata.namespace&#125;/infraprotect_deny_list_rules/&#123;metadata.name&#125;` | Replace DDoS transit Deny List Rule. |
-| GET | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect_deny_list_rules` | List Infraprotect Deny List Rule. |
-| GET | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect_deny_list_rules/&#123;name&#125;` | GET Infraprotect Deny List Rule. |
-| DELETE | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect_deny_list_rules/&#123;name&#125;` | DELETE Infraprotect Deny List Rule. |
-| POST | `/api/infraprotect/namespaces/&#123;metadata.namespace&#125;/infraprotect_firewall_rules` | Create DDoS transit Firewall Rule. |
-| PUT | `/api/infraprotect/namespaces/&#123;metadata.namespace&#125;/infraprotect_firewall_rules/&#123;metadata.name&#125;` | Replace DDoS transit Firewall Rule. |
-| GET | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect_firewall_rules` | List Infraprotect Firewall Rule. |
-| GET | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect_firewall_rules/&#123;name&#125;` | GET Infraprotect Firewall Rule. |
-| DELETE | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect_firewall_rules/&#123;name&#125;` | DELETE Infraprotect Firewall Rule. |
-| POST | `/api/infraprotect/namespaces/&#123;metadata.namespace&#125;/infraprotect_firewall_rule_groups` | Replace DDoS transit Firewall Rule Group. |
-| PUT | `/api/infraprotect/namespaces/&#123;metadata.namespace&#125;/infraprotect_firewall_rule_groups/&#123;metadata.name&#125;` | Replace DDoS transit Firewall Rule Group. |
-| GET | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect_firewall_rule_groups` | List Infraprotect Firewall Rule Group. |
-| GET | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect_firewall_rule_groups/&#123;name&#125;` | GET Infraprotect Firewall Rule Group. |
-| DELETE | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect_firewall_rule_groups/&#123;name&#125;` | DELETE Infraprotect Firewall Rule Group. |
-| GET | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect/mitigation/&#123;mitigation_id&#125;/countermeasures` | Mitigation Countermeasures. |
-| PUT | `/api/infraprotect/namespaces/&#123;metadata.namespace&#125;/infraprotect_firewall_rulesets/&#123;metadata.name&#125;` | Replace DDoS transit Firewall Ruleset. |
-| GET | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect_firewall_rulesets` | List Infraprotect Firewall Ruleset. |
-| GET | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect_firewall_rulesets/&#123;name&#125;` | GET Infraprotect Firewall Ruleset. |
-| GET | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect_informations/&#123;name&#125;` | GET Infraprotect Information. |
-| POST | `/api/infraprotect/namespaces/&#123;metadata.namespace&#125;/infraprotect_internet_prefix_advertisements` | Create DDoS transit Internet Prefix. |
-| PUT | `/api/infraprotect/namespaces/&#123;metadata.namespace&#125;/infraprotect_internet_prefix_advertisements/&#123;metadata.name&#125;` | Replace DDoS transit Internet Prefix. |
-| GET | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect_internet_prefix_advertisements` | List Infraprotect Internet Prefix Advertisement. |
-| POST | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect_internet_prefix_advertisements/update-advertisement-status` | Update Infraprotect Internet prefix advertisement. |
-| GET | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect_internet_prefix_advertisements/&#123;name&#125;` | GET Infraprotect Internet Prefix. |
-| DELETE | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect_internet_prefix_advertisements/&#123;name&#125;` | DELETE Infraprotect Internet Prefix Advertisement. |
-| POST | `/api/infraprotect/namespaces/&#123;metadata.namespace&#125;/infraprotect_tunnels` | Create DDoS Transit Tunnel. |
-| PUT | `/api/infraprotect/namespaces/&#123;metadata.namespace&#125;/infraprotect_tunnels/&#123;metadata.name&#125;` | Replace DDoS Transit Tunnel. |
-| GET | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect_tunnels` | List Tunnel. |
-| POST | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect_tunnels/update-tunnel-status` | Update Tunnel Status. |
-| GET | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect_tunnels/&#123;name&#125;` | GET Tunnel. |
-| DELETE | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect_tunnels/&#123;name&#125;` | DELETE Tunnel. |
+| Method | Path                                                                                                                                | Description                                        |
+| ------ | ----------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
+| GET    | `/api/infraprotect/namespaces/system/infraprotect/access`                                                                           | Customer access.                                   |
+| GET    | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect/alert/&#123;alert_id&#125;`                                        | DDoS Alert.                                        |
+| PUT    | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect/alert/&#123;alert_id&#125;/to_event`                               | Link Alert to Event.                               |
+| POST   | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect/alerts`                                                            | DDoS Alerts.                                       |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/infraprotect/bgp_peer_status`                                                           | BGP Peer Status.                                   |
+| GET    | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect/event/&#123;event_id&#125;`                                        | Event details.                                     |
+| PUT    | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect/event/&#123;event_id&#125;`                                        | Edit event.                                        |
+| GET    | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect/event/&#123;event_id&#125;/alerts`                                 | Event alerts.                                      |
+| GET    | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect/event/&#123;event_id&#125;/attachments`                            | Event attachments.                                 |
+| DELETE | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect/event/&#123;event_id&#125;/detail/&#123;event_detail_id&#125;`     | DELETE event detail.                               |
+| PUT    | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect/event/&#123;event_id&#125;/detail/&#123;event_detail_id&#125;`     | Edit event detail.                                 |
+| GET    | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect/event/&#123;event_id&#125;/details`                                | List of event details.                             |
+| POST   | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect/event/&#123;event_id&#125;/details`                                | Add Event Detail.                                  |
+| GET    | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect/event/&#123;event_id&#125;/mitigation_annotations`                 | Event mitigation annotation.                       |
+| POST   | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect/events`                                                            | List of events.                                    |
+| GET    | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect/events_summary`                                                    | Simple events view.                                |
+| GET    | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect/mitigation/&#123;mitigation_id&#125;`                              | Mitigation details.                                |
+| GET    | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect/mitigation/&#123;mitigation_id&#125;/annotations`                  | Mitigation annotations.                            |
+| GET    | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect/mitigation/&#123;mitigation_id&#125;/ips`                          | Mitigation IPs.                                    |
+| POST   | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect/mitigations`                                                       | List of mitigations.                               |
+| GET    | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect/networks`                                                          | List networks.                                     |
+| GET    | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect/report/&#123;report_id&#125;`                                      | Report details.                                    |
+| POST   | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect/reports`                                                           | List reports.                                      |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/infraprotect/transit_usage`                                                             | Transit Usage.                                     |
+| POST   | `/api/infraprotect/namespaces/&#123;namespace&#125;/suggest-values`                                                                 | Suggest Values.                                    |
+| POST   | `/api/infraprotect/namespaces/&#123;metadata.namespace&#125;/infraprotect_asns`                                                     | Create DDoS transit ASN.                           |
+| PUT    | `/api/infraprotect/namespaces/&#123;metadata.namespace&#125;/infraprotect_asns/&#123;metadata.name&#125;`                           | Replace DDoS transit ASN.                          |
+| GET    | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect_asns`                                                              | List Infraprotect ASN.                             |
+| POST   | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect_asns/update-asn-review-status`                                     | Update ASN Review Status.                          |
+| GET    | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect_asns/&#123;name&#125;`                                             | GET Infraprotect ASN.                              |
+| DELETE | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect_asns/&#123;name&#125;`                                             | DELETE Infraprotect ASN.                           |
+| POST   | `/api/infraprotect/namespaces/&#123;metadata.namespace&#125;/infraprotect_asn_prefixs`                                              | Create DDoS transit Prefix.                        |
+| PUT    | `/api/infraprotect/namespaces/&#123;metadata.namespace&#125;/infraprotect_asn_prefixs/&#123;metadata.name&#125;`                    | Replace DDoS transit Prefix.                       |
+| POST   | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect_asn_prefixes/update-asn-prefix-irr-override`                       | Update ASN Prefix IRR Override.                    |
+| POST   | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect_asn_prefixes/update-asn-prefix-review-status`                      | Update ASN Prefix Review Status.                   |
+| GET    | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect_asn_prefixs`                                                       | List Infraprotect ASN Prefix.                      |
+| GET    | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect_asn_prefixs/&#123;name&#125;`                                      | GET Infraprotect ASN Prefix.                       |
+| DELETE | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect_asn_prefixs/&#123;name&#125;`                                      | DELETE Infraprotect ASN Prefix.                    |
+| POST   | `/api/infraprotect/namespaces/&#123;metadata.namespace&#125;/infraprotect_deny_list_rules`                                          | Create DDoS transit Deny List Rule.                |
+| PUT    | `/api/infraprotect/namespaces/&#123;metadata.namespace&#125;/infraprotect_deny_list_rules/&#123;metadata.name&#125;`                | Replace DDoS transit Deny List Rule.               |
+| GET    | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect_deny_list_rules`                                                   | List Infraprotect Deny List Rule.                  |
+| GET    | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect_deny_list_rules/&#123;name&#125;`                                  | GET Infraprotect Deny List Rule.                   |
+| DELETE | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect_deny_list_rules/&#123;name&#125;`                                  | DELETE Infraprotect Deny List Rule.                |
+| POST   | `/api/infraprotect/namespaces/&#123;metadata.namespace&#125;/infraprotect_firewall_rules`                                           | Create DDoS transit Firewall Rule.                 |
+| PUT    | `/api/infraprotect/namespaces/&#123;metadata.namespace&#125;/infraprotect_firewall_rules/&#123;metadata.name&#125;`                 | Replace DDoS transit Firewall Rule.                |
+| GET    | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect_firewall_rules`                                                    | List Infraprotect Firewall Rule.                   |
+| GET    | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect_firewall_rules/&#123;name&#125;`                                   | GET Infraprotect Firewall Rule.                    |
+| DELETE | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect_firewall_rules/&#123;name&#125;`                                   | DELETE Infraprotect Firewall Rule.                 |
+| POST   | `/api/infraprotect/namespaces/&#123;metadata.namespace&#125;/infraprotect_firewall_rule_groups`                                     | Replace DDoS transit Firewall Rule Group.          |
+| PUT    | `/api/infraprotect/namespaces/&#123;metadata.namespace&#125;/infraprotect_firewall_rule_groups/&#123;metadata.name&#125;`           | Replace DDoS transit Firewall Rule Group.          |
+| GET    | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect_firewall_rule_groups`                                              | List Infraprotect Firewall Rule Group.             |
+| GET    | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect_firewall_rule_groups/&#123;name&#125;`                             | GET Infraprotect Firewall Rule Group.              |
+| DELETE | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect_firewall_rule_groups/&#123;name&#125;`                             | DELETE Infraprotect Firewall Rule Group.           |
+| GET    | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect/mitigation/&#123;mitigation_id&#125;/countermeasures`              | Mitigation Countermeasures.                        |
+| PUT    | `/api/infraprotect/namespaces/&#123;metadata.namespace&#125;/infraprotect_firewall_rulesets/&#123;metadata.name&#125;`              | Replace DDoS transit Firewall Ruleset.             |
+| GET    | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect_firewall_rulesets`                                                 | List Infraprotect Firewall Ruleset.                |
+| GET    | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect_firewall_rulesets/&#123;name&#125;`                                | GET Infraprotect Firewall Ruleset.                 |
+| GET    | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect_informations/&#123;name&#125;`                                     | GET Infraprotect Information.                      |
+| POST   | `/api/infraprotect/namespaces/&#123;metadata.namespace&#125;/infraprotect_internet_prefix_advertisements`                           | Create DDoS transit Internet Prefix.               |
+| PUT    | `/api/infraprotect/namespaces/&#123;metadata.namespace&#125;/infraprotect_internet_prefix_advertisements/&#123;metadata.name&#125;` | Replace DDoS transit Internet Prefix.              |
+| GET    | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect_internet_prefix_advertisements`                                    | List Infraprotect Internet Prefix Advertisement.   |
+| POST   | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect_internet_prefix_advertisements/update-advertisement-status`        | Update Infraprotect Internet prefix advertisement. |
+| GET    | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect_internet_prefix_advertisements/&#123;name&#125;`                   | GET Infraprotect Internet Prefix.                  |
+| DELETE | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect_internet_prefix_advertisements/&#123;name&#125;`                   | DELETE Infraprotect Internet Prefix Advertisement. |
+| POST   | `/api/infraprotect/namespaces/&#123;metadata.namespace&#125;/infraprotect_tunnels`                                                  | Create DDoS Transit Tunnel.                        |
+| PUT    | `/api/infraprotect/namespaces/&#123;metadata.namespace&#125;/infraprotect_tunnels/&#123;metadata.name&#125;`                        | Replace DDoS Transit Tunnel.                       |
+| GET    | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect_tunnels`                                                           | List Tunnel.                                       |
+| POST   | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect_tunnels/update-tunnel-status`                                      | Update Tunnel Status.                              |
+| GET    | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect_tunnels/&#123;name&#125;`                                          | GET Tunnel.                                        |
+| DELETE | `/api/infraprotect/namespaces/&#123;namespace&#125;/infraprotect_tunnels/&#123;name&#125;`                                          | DELETE Tunnel.                                     |
 
 ## Links
 

--- a/docs/en/api-reference/dns-api.mdx
+++ b/docs/en/api-reference/dns-api.mdx
@@ -2,7 +2,7 @@
 title: "🌐 Dns API"
 description: "Authoritative zones and record management."
 sidebar:
-    hidden: true
+  hidden: true
 ---
 
 Name resolution with zone transfers and health checks. Record types and delegation support.
@@ -28,66 +28,66 @@ Name resolution with zone transfers and health checks. Record types and delegati
 
 ## Endpoints
 
-| Method | Path | Description |
-|--------|------|-------------|
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/dns_compliance_checkss` | Create DNS Compliance Checks. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/dns_compliance_checkss/&#123;metadata.name&#125;` | Replace DNS Compliance Checks. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/dns_compliance_checkss` | List Configure DNS Compliance Checks. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/dns_compliance_checkss/&#123;name&#125;` | GET DNS Compliance Checks. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/dns_compliance_checkss/&#123;name&#125;` | DELETE Configure DNS Compliance Checks. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/dns_proxies` | Create DNS Proxy. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/dns_proxies/&#123;metadata.name&#125;` | Replace DNS Proxy. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/dns_proxies` | List Configure DNS Proxy. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/dns_proxies/&#123;name&#125;` | GET DNS Proxy. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/dns_proxies/&#123;name&#125;` | DELETE Configure DNS Proxy. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/dns_domains` | Create DNS Domain. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/dns_domains/&#123;metadata.name&#125;` | Replace DNS Domain. |
-| POST | `/api/config/namespaces/&#123;namespace&#125;/dns_domain/&#123;name&#125;/verify` | Verify DNS Domain. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/dns_domains` | List DNS Domain. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/dns_domains/&#123;name&#125;` | GET DNS Domain. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/dns_domains/&#123;name&#125;` | DELETE DNS Domain. |
-| POST | `/api/config/dns/namespaces/system/suggest-values` | Suggest Values. |
-| POST | `/api/config/dns/namespaces/&#123;metadata.namespace&#125;/dns_load_balancers` | Create DNS Load Balancer. |
-| PUT | `/api/config/dns/namespaces/&#123;metadata.namespace&#125;/dns_load_balancers/&#123;metadata.name&#125;` | Replace DNS Load Balancer. |
-| GET | `/api/config/dns/namespaces/&#123;namespace&#125;/dns_load_balancers` | List DNS Load Balancer. |
-| GET | `/api/data/namespaces/&#123;namespace&#125;/dns_load_balancers/health_status` | DNS Load Balancer Health Status List. |
-| GET | `/api/data/namespaces/&#123;namespace&#125;/dns_load_balancers/pool_members_health_status` | DNS Load Balancer Pool Members Health Status List. |
-| GET | `/api/data/namespaces/&#123;namespace&#125;/dns_load_balancers/&#123;dns_lb_name&#125;/dns_lb_pools/&#123;dns_lb_pool_name&#125;/health_status` | DNS Load Balancer Pool Health Status. |
-| GET | `/api/data/namespaces/&#123;namespace&#125;/dns_load_balancers/&#123;dns_lb_name&#125;/dns_lb_pools/&#123;dns_lb_pool_name&#125;/pool_members/&#123;pool_member_address&#125;/health_status_change_events` | DNS Load Balancer Pool Member Health Status Change Events. |
-| GET | `/api/config/dns/namespaces/&#123;namespace&#125;/dns_load_balancers/&#123;name&#125;` | GET DNS Load Balancer. |
-| DELETE | `/api/config/dns/namespaces/&#123;namespace&#125;/dns_load_balancers/&#123;name&#125;` | DELETE DNS Load Balancer. |
-| GET | `/api/data/namespaces/&#123;namespace&#125;/dns_load_balancers/&#123;name&#125;/health_status` | DNS Load Balancer Health Status. |
-| POST | `/api/config/dns/namespaces/&#123;metadata.namespace&#125;/dns_lb_health_checks` | Create DNS Load Balancer Health Check. |
-| PUT | `/api/config/dns/namespaces/&#123;metadata.namespace&#125;/dns_lb_health_checks/&#123;metadata.name&#125;` | Replace DNS Load Balancer Health Check. |
-| GET | `/api/config/dns/namespaces/&#123;namespace&#125;/dns_lb_health_checks` | List DNS Load Balancer Health Check. |
-| GET | `/api/config/dns/namespaces/&#123;namespace&#125;/dns_lb_health_checks/&#123;name&#125;` | GET DNS Load Balancer Health Check. |
-| DELETE | `/api/config/dns/namespaces/&#123;namespace&#125;/dns_lb_health_checks/&#123;name&#125;` | DELETE DNS Load Balancer Health Check. |
-| POST | `/api/config/dns/namespaces/&#123;metadata.namespace&#125;/dns_lb_pools` | Create DNS Load Balancer Pool. |
-| PUT | `/api/config/dns/namespaces/&#123;metadata.namespace&#125;/dns_lb_pools/&#123;metadata.name&#125;` | Replace DNS Load Balancer Pool. |
-| GET | `/api/config/dns/namespaces/&#123;namespace&#125;/dns_lb_pools` | List DNS Load Balancer Pool. |
-| GET | `/api/config/dns/namespaces/&#123;namespace&#125;/dns_lb_pools/&#123;name&#125;` | GET DNS Load Balancer Pool. |
-| DELETE | `/api/config/dns/namespaces/&#123;namespace&#125;/dns_lb_pools/&#123;name&#125;` | DELETE DNS Load Balancer Pool. |
-| POST | `/api/config/dns/namespaces/system/dns_zone/clone_from_dns_domain` | Clone from DNSDomain. |
-| POST | `/api/config/dns/namespaces/system/dns_zone/import` | Import F5 Cloud Services DNS Zone. |
-| POST | `/api/config/dns/namespaces/system/dns_zone/import_axfr` | Import DNS Zone. |
-| POST | `/api/config/dns/namespaces/system/dns_zone/import_bind_create` | Import BIND Files. |
-| POST | `/api/config/dns/namespaces/system/dns_zone/import_bind_validate` | Validate BIND Files. |
-| POST | `/api/config/dns/namespaces/&#123;metadata.namespace&#125;/dns_zones` | Create DNS Zone. |
-| PUT | `/api/config/dns/namespaces/&#123;metadata.namespace&#125;/dns_zones/&#123;metadata.name&#125;` | Replace DNS Zone. |
-| GET | `/api/config/dns/namespaces/&#123;namespace&#125;/dns_zone/&#123;dns_zone_name&#125;/local_zone_file` | GET Local Zone File. |
-| GET | `/api/config/dns/namespaces/&#123;namespace&#125;/dns_zone/&#123;dns_zone_name&#125;/remote_zone_file` | GET Remote Zone File. |
-| GET | `/api/config/dns/namespaces/&#123;namespace&#125;/dns_zone/&#123;dns_zone_name&#125;/zone_file/export` | Export Zone File. |
-| GET | `/api/config/dns/namespaces/&#123;namespace&#125;/dns_zones` | List DNS Zone. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/dns_zones/metrics` | DNS Zone Metrics. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/dns_zones/request_logs` | GET DNS Zone Request Logs. |
-| GET | `/api/config/dns/namespaces/&#123;namespace&#125;/dns_zones/&#123;name&#125;` | GET DNS Zone. |
-| DELETE | `/api/config/dns/namespaces/&#123;namespace&#125;/dns_zones/&#123;name&#125;` | DELETE DNS Zone. |
-| POST | `/api/config/dns/namespaces/system/dns_zones/&#123;dns_zone_name&#125;/rrsets/&#123;group_name&#125;` | Create |
-| GET | `/api/config/dns/namespaces/system/dns_zones/&#123;dns_zone_name&#125;/rrsets/&#123;group_name&#125;/&#123;record_name&#125;/&#123;type&#125;` | GET |
-| DELETE | `/api/config/dns/namespaces/system/dns_zones/&#123;dns_zone_name&#125;/rrsets/&#123;group_name&#125;/&#123;record_name&#125;/&#123;type&#125;` | DELETE |
-| PUT | `/api/config/dns/namespaces/system/dns_zones/&#123;dns_zone_name&#125;/rrsets/&#123;group_name&#125;/&#123;record_name&#125;/&#123;type&#125;` | Replace |
-| POST | `/api/config/dns/namespaces/system/dns_management/addon/subscribe` | Subscribe to DNS Management. |
-| POST | `/api/config/dns/namespaces/system/dns_management/addon/unsubscribe` | Unsubscribe to DNS Management. |
+| Method | Path                                                                                                                                                                                                       | Description                                                |
+| ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/dns_compliance_checkss`                                                                                                                             | Create DNS Compliance Checks.                              |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/dns_compliance_checkss/&#123;metadata.name&#125;`                                                                                                   | Replace DNS Compliance Checks.                             |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/dns_compliance_checkss`                                                                                                                                      | List Configure DNS Compliance Checks.                      |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/dns_compliance_checkss/&#123;name&#125;`                                                                                                                     | GET DNS Compliance Checks.                                 |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/dns_compliance_checkss/&#123;name&#125;`                                                                                                                     | DELETE Configure DNS Compliance Checks.                    |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/dns_proxies`                                                                                                                                        | Create DNS Proxy.                                          |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/dns_proxies/&#123;metadata.name&#125;`                                                                                                              | Replace DNS Proxy.                                         |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/dns_proxies`                                                                                                                                                 | List Configure DNS Proxy.                                  |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/dns_proxies/&#123;name&#125;`                                                                                                                                | GET DNS Proxy.                                             |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/dns_proxies/&#123;name&#125;`                                                                                                                                | DELETE Configure DNS Proxy.                                |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/dns_domains`                                                                                                                                        | Create DNS Domain.                                         |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/dns_domains/&#123;metadata.name&#125;`                                                                                                              | Replace DNS Domain.                                        |
+| POST   | `/api/config/namespaces/&#123;namespace&#125;/dns_domain/&#123;name&#125;/verify`                                                                                                                          | Verify DNS Domain.                                         |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/dns_domains`                                                                                                                                                 | List DNS Domain.                                           |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/dns_domains/&#123;name&#125;`                                                                                                                                | GET DNS Domain.                                            |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/dns_domains/&#123;name&#125;`                                                                                                                                | DELETE DNS Domain.                                         |
+| POST   | `/api/config/dns/namespaces/system/suggest-values`                                                                                                                                                         | Suggest Values.                                            |
+| POST   | `/api/config/dns/namespaces/&#123;metadata.namespace&#125;/dns_load_balancers`                                                                                                                             | Create DNS Load Balancer.                                  |
+| PUT    | `/api/config/dns/namespaces/&#123;metadata.namespace&#125;/dns_load_balancers/&#123;metadata.name&#125;`                                                                                                   | Replace DNS Load Balancer.                                 |
+| GET    | `/api/config/dns/namespaces/&#123;namespace&#125;/dns_load_balancers`                                                                                                                                      | List DNS Load Balancer.                                    |
+| GET    | `/api/data/namespaces/&#123;namespace&#125;/dns_load_balancers/health_status`                                                                                                                              | DNS Load Balancer Health Status List.                      |
+| GET    | `/api/data/namespaces/&#123;namespace&#125;/dns_load_balancers/pool_members_health_status`                                                                                                                 | DNS Load Balancer Pool Members Health Status List.         |
+| GET    | `/api/data/namespaces/&#123;namespace&#125;/dns_load_balancers/&#123;dns_lb_name&#125;/dns_lb_pools/&#123;dns_lb_pool_name&#125;/health_status`                                                            | DNS Load Balancer Pool Health Status.                      |
+| GET    | `/api/data/namespaces/&#123;namespace&#125;/dns_load_balancers/&#123;dns_lb_name&#125;/dns_lb_pools/&#123;dns_lb_pool_name&#125;/pool_members/&#123;pool_member_address&#125;/health_status_change_events` | DNS Load Balancer Pool Member Health Status Change Events. |
+| GET    | `/api/config/dns/namespaces/&#123;namespace&#125;/dns_load_balancers/&#123;name&#125;`                                                                                                                     | GET DNS Load Balancer.                                     |
+| DELETE | `/api/config/dns/namespaces/&#123;namespace&#125;/dns_load_balancers/&#123;name&#125;`                                                                                                                     | DELETE DNS Load Balancer.                                  |
+| GET    | `/api/data/namespaces/&#123;namespace&#125;/dns_load_balancers/&#123;name&#125;/health_status`                                                                                                             | DNS Load Balancer Health Status.                           |
+| POST   | `/api/config/dns/namespaces/&#123;metadata.namespace&#125;/dns_lb_health_checks`                                                                                                                           | Create DNS Load Balancer Health Check.                     |
+| PUT    | `/api/config/dns/namespaces/&#123;metadata.namespace&#125;/dns_lb_health_checks/&#123;metadata.name&#125;`                                                                                                 | Replace DNS Load Balancer Health Check.                    |
+| GET    | `/api/config/dns/namespaces/&#123;namespace&#125;/dns_lb_health_checks`                                                                                                                                    | List DNS Load Balancer Health Check.                       |
+| GET    | `/api/config/dns/namespaces/&#123;namespace&#125;/dns_lb_health_checks/&#123;name&#125;`                                                                                                                   | GET DNS Load Balancer Health Check.                        |
+| DELETE | `/api/config/dns/namespaces/&#123;namespace&#125;/dns_lb_health_checks/&#123;name&#125;`                                                                                                                   | DELETE DNS Load Balancer Health Check.                     |
+| POST   | `/api/config/dns/namespaces/&#123;metadata.namespace&#125;/dns_lb_pools`                                                                                                                                   | Create DNS Load Balancer Pool.                             |
+| PUT    | `/api/config/dns/namespaces/&#123;metadata.namespace&#125;/dns_lb_pools/&#123;metadata.name&#125;`                                                                                                         | Replace DNS Load Balancer Pool.                            |
+| GET    | `/api/config/dns/namespaces/&#123;namespace&#125;/dns_lb_pools`                                                                                                                                            | List DNS Load Balancer Pool.                               |
+| GET    | `/api/config/dns/namespaces/&#123;namespace&#125;/dns_lb_pools/&#123;name&#125;`                                                                                                                           | GET DNS Load Balancer Pool.                                |
+| DELETE | `/api/config/dns/namespaces/&#123;namespace&#125;/dns_lb_pools/&#123;name&#125;`                                                                                                                           | DELETE DNS Load Balancer Pool.                             |
+| POST   | `/api/config/dns/namespaces/system/dns_zone/clone_from_dns_domain`                                                                                                                                         | Clone from DNSDomain.                                      |
+| POST   | `/api/config/dns/namespaces/system/dns_zone/import`                                                                                                                                                        | Import F5 Cloud Services DNS Zone.                         |
+| POST   | `/api/config/dns/namespaces/system/dns_zone/import_axfr`                                                                                                                                                   | Import DNS Zone.                                           |
+| POST   | `/api/config/dns/namespaces/system/dns_zone/import_bind_create`                                                                                                                                            | Import BIND Files.                                         |
+| POST   | `/api/config/dns/namespaces/system/dns_zone/import_bind_validate`                                                                                                                                          | Validate BIND Files.                                       |
+| POST   | `/api/config/dns/namespaces/&#123;metadata.namespace&#125;/dns_zones`                                                                                                                                      | Create DNS Zone.                                           |
+| PUT    | `/api/config/dns/namespaces/&#123;metadata.namespace&#125;/dns_zones/&#123;metadata.name&#125;`                                                                                                            | Replace DNS Zone.                                          |
+| GET    | `/api/config/dns/namespaces/&#123;namespace&#125;/dns_zone/&#123;dns_zone_name&#125;/local_zone_file`                                                                                                      | GET Local Zone File.                                       |
+| GET    | `/api/config/dns/namespaces/&#123;namespace&#125;/dns_zone/&#123;dns_zone_name&#125;/remote_zone_file`                                                                                                     | GET Remote Zone File.                                      |
+| GET    | `/api/config/dns/namespaces/&#123;namespace&#125;/dns_zone/&#123;dns_zone_name&#125;/zone_file/export`                                                                                                     | Export Zone File.                                          |
+| GET    | `/api/config/dns/namespaces/&#123;namespace&#125;/dns_zones`                                                                                                                                               | List DNS Zone.                                             |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/dns_zones/metrics`                                                                                                                                             | DNS Zone Metrics.                                          |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/dns_zones/request_logs`                                                                                                                                        | GET DNS Zone Request Logs.                                 |
+| GET    | `/api/config/dns/namespaces/&#123;namespace&#125;/dns_zones/&#123;name&#125;`                                                                                                                              | GET DNS Zone.                                              |
+| DELETE | `/api/config/dns/namespaces/&#123;namespace&#125;/dns_zones/&#123;name&#125;`                                                                                                                              | DELETE DNS Zone.                                           |
+| POST   | `/api/config/dns/namespaces/system/dns_zones/&#123;dns_zone_name&#125;/rrsets/&#123;group_name&#125;`                                                                                                      | Create                                                     |
+| GET    | `/api/config/dns/namespaces/system/dns_zones/&#123;dns_zone_name&#125;/rrsets/&#123;group_name&#125;/&#123;record_name&#125;/&#123;type&#125;`                                                             | GET                                                        |
+| DELETE | `/api/config/dns/namespaces/system/dns_zones/&#123;dns_zone_name&#125;/rrsets/&#123;group_name&#125;/&#123;record_name&#125;/&#123;type&#125;`                                                             | DELETE                                                     |
+| PUT    | `/api/config/dns/namespaces/system/dns_zones/&#123;dns_zone_name&#125;/rrsets/&#123;group_name&#125;/&#123;record_name&#125;/&#123;type&#125;`                                                             | Replace                                                    |
+| POST   | `/api/config/dns/namespaces/system/dns_management/addon/subscribe`                                                                                                                                         | Subscribe to DNS Management.                               |
+| POST   | `/api/config/dns/namespaces/system/dns_management/addon/unsubscribe`                                                                                                                                       | Unsubscribe to DNS Management.                             |
 
 ## Links
 

--- a/docs/en/api-reference/index.mdx
+++ b/docs/en/api-reference/index.mdx
@@ -3,83 +3,235 @@ title: API Reference
 description: API documentation for F5 Distributed Cloud services
 tableOfContents: false
 sidebar:
-    order: 0
+  order: 0
 ---
 
-import { CardGrid, LinkCard } from '@astrojs/starlight/components';
+import { CardGrid, LinkCard } from "@astrojs/starlight/components";
 
 Explore the F5 Distributed Cloud API documentation. Each domain includes
 endpoint details, request and response schemas, and code examples.
 
-### Security
+## Security
 
 <CardGrid>
-  <LinkCard title="🔐 Api" description="Interface definitions, schema validation, and grouping. — 45 paths, 279 schemas, advanced" href="./api/" />
-  <LinkCard title="🔏 Blindfold" description="Secret encryption, key policies, and audit trails. — 27 paths, 163 schemas, moderate" href="./blindfold/" />
-  <LinkCard title="🦠 Bot And Threat Defense" description="Bot detection, threat categories, and defense instances. — 19 paths, 74 schemas, moderate" href="./bot_and_threat_defense/" />
-  <LinkCard title="📜 Certificates" description="SSL/TLS chains, trusted CAs, and revocation lists. — 16 paths, 74 schemas, moderate" href="./certificates/" />
-  <LinkCard title="🔐 Data And Privacy Security" description="PII detection, data types, and regional compliance. — 11 paths, 65 schemas, simple" href="./data_and_privacy_security/" />
-  <LinkCard title="🛑 Ddos" description="Volumetric attack mitigation and traffic scrubbing. — 60 paths, 246 schemas, advanced" href="./ddos/" />
-  <LinkCard title="🔒 Network Security" description="NAT policies, firewalls, and segment connections. — 62 paths, 386 schemas, advanced" href="./network_security/" />
-  <LinkCard title="🚨 Secops And Incident Response" description="Threat detection, user risk scoring, and automated blocking. — 4 paths, 32 schemas, simple" href="./secops_and_incident_response/" />
-  <LinkCard title="🎭 Shape" description="Bot defense, fraud prevention, and client integrity. — 271 paths, 813 schemas, advanced" href="./shape/" />
-  <LinkCard title="⚠️ Threat Campaign" description="Attack detection, tracking, and mitigation rules. — 1 paths, 161 schemas, moderate" href="./threat_campaign/" />
+  <LinkCard
+    title="🔐 Api"
+    description="Interface definitions, schema validation, and grouping. — 45 paths, 279 schemas, advanced"
+    href="./api/"
+  />
+  <LinkCard
+    title="🔏 Blindfold"
+    description="Secret encryption, key policies, and audit trails. — 27 paths, 163 schemas, moderate"
+    href="./blindfold/"
+  />
+  <LinkCard
+    title="🦠 Bot And Threat Defense"
+    description="Bot detection, threat categories, and defense instances. — 19 paths, 74 schemas, moderate"
+    href="./bot_and_threat_defense/"
+  />
+  <LinkCard
+    title="📜 Certificates"
+    description="SSL/TLS chains, trusted CAs, and revocation lists. — 16 paths, 74 schemas, moderate"
+    href="./certificates/"
+  />
+  <LinkCard
+    title="🔐 Data And Privacy Security"
+    description="PII detection, data types, and regional compliance. — 11 paths, 65 schemas, simple"
+    href="./data_and_privacy_security/"
+  />
+  <LinkCard
+    title="🛑 Ddos"
+    description="Volumetric attack mitigation and traffic scrubbing. — 60 paths, 246 schemas, advanced"
+    href="./ddos/"
+  />
+  <LinkCard
+    title="🔒 Network Security"
+    description="NAT policies, firewalls, and segment connections. — 62 paths, 386 schemas, advanced"
+    href="./network_security/"
+  />
+  <LinkCard
+    title="🚨 Secops And Incident Response"
+    description="Threat detection, user risk scoring, and automated blocking. — 4 paths, 32 schemas, simple"
+    href="./secops_and_incident_response/"
+  />
+  <LinkCard
+    title="🎭 Shape"
+    description="Bot defense, fraud prevention, and client integrity. — 271 paths, 813 schemas, advanced"
+    href="./shape/"
+  />
+  <LinkCard
+    title="⚠️ Threat Campaign"
+    description="Attack detection, tracking, and mitigation rules. — 1 paths, 161 schemas, moderate"
+    href="./threat_campaign/"
+  />
 </CardGrid>
 
-### Networking
+## Networking
 
 <CardGrid>
-  <LinkCard title="🚀 Cdn" description="Content delivery and edge caching networks. — 29 paths, 592 schemas, advanced" href="./cdn/" />
-  <LinkCard title="🌐 Dns" description="Authoritative zones and record management. — 49 paths, 285 schemas, advanced" href="./dns/" />
-  <LinkCard title="🔌 Network" description="BGP peering, IPsec tunnels, and segment policies. — 81 paths, 449 schemas, advanced" href="./network/" />
-  <LinkCard title="⏱️ Rate Limiting" description="Request throttling, quotas, and policer rules. — 12 paths, 70 schemas, simple" href="./rate_limiting/" />
-  <LinkCard title="⚖️ Virtual" description="HTTP, TCP, UDP load balancing with origin pools. — 133 paths, 903 schemas, advanced" href="./virtual/" />
+  <LinkCard
+    title="🚀 Cdn"
+    description="Content delivery and edge caching networks. — 29 paths, 592 schemas, advanced"
+    href="./cdn/"
+  />
+  <LinkCard
+    title="🌐 Dns"
+    description="Authoritative zones and record management. — 49 paths, 285 schemas, advanced"
+    href="./dns/"
+  />
+  <LinkCard
+    title="🔌 Network"
+    description="BGP peering, IPsec tunnels, and segment policies. — 81 paths, 449 schemas, advanced"
+    href="./network/"
+  />
+  <LinkCard
+    title="⏱️ Rate Limiting"
+    description="Request throttling, quotas, and policer rules. — 12 paths, 70 schemas, simple"
+    href="./rate_limiting/"
+  />
+  <LinkCard
+    title="⚖️ Virtual"
+    description="HTTP, TCP, UDP load balancing with origin pools. — 133 paths, 903 schemas, advanced"
+    href="./virtual/"
+  />
 </CardGrid>
 
-### Infrastructure
+## Infrastructure
 
 <CardGrid>
-  <LinkCard title="🔧 Ce Management" description="Network interfaces, fleets, and site registration. — 28 paths, 231 schemas, moderate" href="./ce_management/" />
-  <LinkCard title="☁️ Cloud Infrastructure" description="AWS, Azure, GCP connectors and VPC attachments. — 31 paths, 208 schemas, moderate" href="./cloud_infrastructure/" />
-  <LinkCard title="📦 Container Services" description="Containerized workloads and virtual Kubernetes clusters. — 13 paths, 159 schemas, moderate" href="./container_services/" />
-  <LinkCard title="⚙️ Managed Kubernetes" description="Cluster RBAC, pod security, and container registries. — 20 paths, 95 schemas, moderate" href="./managed_kubernetes/" />
-  <LinkCard title="🕸️ Service Mesh" description="Microservice routing and sidecar configuration. — 38 paths, 247 schemas, advanced" href="./service_mesh/" />
-  <LinkCard title="🌍 Sites" description="Cloud and edge node deployments. — 133 paths, 1015 schemas, advanced" href="./sites/" />
+  <LinkCard
+    title="🔧 Ce Management"
+    description="Network interfaces, fleets, and site registration. — 28 paths, 231 schemas, moderate"
+    href="./ce_management/"
+  />
+  <LinkCard
+    title="☁️ Cloud Infrastructure"
+    description="AWS, Azure, GCP connectors and VPC attachments. — 31 paths, 208 schemas, moderate"
+    href="./cloud_infrastructure/"
+  />
+  <LinkCard
+    title="📦 Container Services"
+    description="Containerized workloads and virtual Kubernetes clusters. — 13 paths, 159 schemas, moderate"
+    href="./container_services/"
+  />
+  <LinkCard
+    title="⚙️ Managed Kubernetes"
+    description="Cluster RBAC, pod security, and container registries. — 20 paths, 95 schemas, moderate"
+    href="./managed_kubernetes/"
+  />
+  <LinkCard
+    title="🕸️ Service Mesh"
+    description="Microservice routing and sidecar configuration. — 38 paths, 247 schemas, advanced"
+    href="./service_mesh/"
+  />
+  <LinkCard
+    title="🌍 Sites"
+    description="Cloud and edge node deployments. — 133 paths, 1015 schemas, advanced"
+    href="./sites/"
+  />
 </CardGrid>
 
-### Platform
+## Platform
 
 <CardGrid>
-  <LinkCard title="🖥️ Admin Console And Ui" description="Static UI components and console assets. — 2 paths, 14 schemas, simple" href="./admin_console_and_ui/" />
-  <LinkCard title="🔑 Authentication" description="Identity provider and access policy configuration. — 14 paths, 38 schemas, simple" href="./authentication/" />
-  <LinkCard title="🏢 Bigip" description="iRules, data groups, and APM integration. — 29 paths, 238 schemas, advanced" href="./bigip/" />
-  <LinkCard title="💳 Billing And Usage" description="Subscription plans, payment methods, and quotas. — 25 paths, 101 schemas, moderate" href="./billing_and_usage/" />
-  <LinkCard title="🏪 Marketplace" description="Add-on services, connectors, and TPM policies. — 36 paths, 183 schemas, moderate" href="./marketplace/" />
-  <LinkCard title="🟢 Nginx One" description="NGINX Plus instances and dataplane servers. — 13 paths, 59 schemas, simple" href="./nginx_one/" />
-  <LinkCard title="🗄️ Object Storage" description="Mobile SDK assets, versioned binaries, and app shield files. — 9 paths, 17 schemas, simple" href="./object_storage/" />
-  <LinkCard title="🪪 Tenant And Identity" description="User profiles, sessions, and OTP settings. — 183 paths, 511 schemas, advanced" href="./tenant_and_identity/" />
-  <LinkCard title="👥 Users" description="Account tokens, labels, and cloud-init config. — 13 paths, 50 schemas, simple" href="./users/" />
-  <LinkCard title="🖥️ Vpm And Node Management" description="Node lifecycle, fleet grouping, and orchestration. — 1 paths, 2 schemas, simple" href="./vpm_and_node_management/" />
+  <LinkCard
+    title="🖥️ Admin Console And Ui"
+    description="Static UI components and console assets. — 2 paths, 14 schemas, simple"
+    href="./admin_console_and_ui/"
+  />
+  <LinkCard
+    title="🔑 Authentication"
+    description="Identity provider and access policy configuration. — 14 paths, 38 schemas, simple"
+    href="./authentication/"
+  />
+  <LinkCard
+    title="🏢 Bigip"
+    description="iRules, data groups, and APM integration. — 29 paths, 238 schemas, advanced"
+    href="./bigip/"
+  />
+  <LinkCard
+    title="💳 Billing And Usage"
+    description="Subscription plans, payment methods, and quotas. — 25 paths, 101 schemas, moderate"
+    href="./billing_and_usage/"
+  />
+  <LinkCard
+    title="🏪 Marketplace"
+    description="Add-on services, connectors, and TPM policies. — 36 paths, 183 schemas, moderate"
+    href="./marketplace/"
+  />
+  <LinkCard
+    title="🟢 Nginx One"
+    description="NGINX Plus instances and dataplane servers. — 13 paths, 59 schemas, simple"
+    href="./nginx_one/"
+  />
+  <LinkCard
+    title="🗄️ Object Storage"
+    description="Mobile SDK assets, versioned binaries, and app shield files. — 9 paths, 17 schemas, simple"
+    href="./object_storage/"
+  />
+  <LinkCard
+    title="🪪 Tenant And Identity"
+    description="User profiles, sessions, and OTP settings. — 183 paths, 511 schemas, advanced"
+    href="./tenant_and_identity/"
+  />
+  <LinkCard
+    title="👥 Users"
+    description="Account tokens, labels, and cloud-init config. — 13 paths, 50 schemas, simple"
+    href="./users/"
+  />
+  <LinkCard
+    title="🖥️ Vpm And Node Management"
+    description="Node lifecycle, fleet grouping, and orchestration. — 1 paths, 2 schemas, simple"
+    href="./vpm_and_node_management/"
+  />
 </CardGrid>
 
-### Operations
+## Operations
 
 <CardGrid>
-  <LinkCard title="🧠 Data Intelligence" description="Classification, insights, and policy management. — 15 paths, 73 schemas, simple" href="./data_intelligence/" />
-  <LinkCard title="📊 Observability" description="Synthetic health checks and DNS resolution validation. — 56 paths, 196 schemas, moderate" href="./observability/" />
-  <LinkCard title="📈 Statistics" description="Alerts, logs, flow analytics, and reporting. — 77 paths, 575 schemas, advanced" href="./statistics/" />
-  <LinkCard title="🎫 Support" description="Tickets, escalations, and network diagnostics. — 53 paths, 167 schemas, moderate" href="./support/" />
-  <LinkCard title="📉 Telemetry And Insights" description="Metrics collection, analysis, and visualization. — 27 paths, 181 schemas, moderate" href="./telemetry_and_insights/" />
+  <LinkCard
+    title="🧠 Data Intelligence"
+    description="Classification, insights, and policy management. — 15 paths, 73 schemas, simple"
+    href="./data_intelligence/"
+  />
+  <LinkCard
+    title="📊 Observability"
+    description="Synthetic health checks and DNS resolution validation. — 56 paths, 196 schemas, moderate"
+    href="./observability/"
+  />
+  <LinkCard
+    title="📈 Statistics"
+    description="Alerts, logs, flow analytics, and reporting. — 77 paths, 575 schemas, advanced"
+    href="./statistics/"
+  />
+  <LinkCard
+    title="🎫 Support"
+    description="Tickets, escalations, and network diagnostics. — 53 paths, 167 schemas, moderate"
+    href="./support/"
+  />
+  <LinkCard
+    title="📉 Telemetry And Insights"
+    description="Metrics collection, analysis, and visualization. — 27 paths, 181 schemas, moderate"
+    href="./telemetry_and_insights/"
+  />
 </CardGrid>
 
-### AI
+## AI
 
 <CardGrid>
-  <LinkCard title="🤖 Ai Services (Preview)" description="AI assistant queries and feedback collection. — 11 paths, 66 schemas, simple" href="./ai_services/" />
+  <LinkCard
+    title="🤖 Ai Services (Preview)"
+    description="AI assistant queries and feedback collection. — 11 paths, 66 schemas, simple"
+    href="./ai_services/"
+  />
 </CardGrid>
 
 ### Other
 
 <CardGrid>
-  <LinkCard title="📁 Other" description="Other — 0 paths, 0 schemas, simple" href="./other/" />
+  <LinkCard
+    title="📁 Other"
+    description="Other — 0 paths, 0 schemas, simple"
+    href="./other/"
+  />
 </CardGrid>

--- a/docs/en/api-reference/managed_kubernetes-api.mdx
+++ b/docs/en/api-reference/managed_kubernetes-api.mdx
@@ -2,7 +2,7 @@
 title: "⚙️ Managed Kubernetes API"
 description: "Cluster RBAC, pod security, and container registries."
 sidebar:
-    hidden: true
+  hidden: true
 ---
 
 Kubernetes role bindings and admission policies. Registry integration for EKS, AKS, and GKE workloads.
@@ -28,33 +28,33 @@ Kubernetes role bindings and admission policies. Registry integration for EKS, A
 
 ## Endpoints
 
-| Method | Path | Description |
-|--------|------|-------------|
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/container_registrys` | Create Container Registry. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/container_registrys/&#123;metadata.name&#125;` | Replace Container Registry. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/container_registrys` | List Container Registry. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/container_registrys/&#123;name&#125;` | GET Container Registry. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/container_registrys/&#123;name&#125;` | DELETE Container Registry. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/k8s_cluster_roles` | Create Configuration Specification. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/k8s_cluster_roles/&#123;metadata.name&#125;` | Replace Configuration Specification. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/k8s_cluster_roles` | List K8s Cluster Role. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/k8s_cluster_roles/&#123;name&#125;` | GET Configuration Specification. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/k8s_cluster_roles/&#123;name&#125;` | DELETE K8s Cluster Role. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/k8s_cluster_role_bindings` | Create Configuration Specification. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/k8s_cluster_role_bindings/&#123;metadata.name&#125;` | Replace Configuration Specification. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/k8s_cluster_role_bindings` | List K8s Cluster Role Binding. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/k8s_cluster_role_bindings/&#123;name&#125;` | GET Configuration Specification. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/k8s_cluster_role_bindings/&#123;name&#125;` | DELETE K8s Cluster Role Binding. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/k8s_pod_security_admissions` | Create Configuration Specification. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/k8s_pod_security_admissions/&#123;metadata.name&#125;` | Replace Configuration Specification. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/k8s_pod_security_admissions` | List K8s Pod Security Admission. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/k8s_pod_security_admissions/&#123;name&#125;` | GET Configuration Specification. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/k8s_pod_security_admissions/&#123;name&#125;` | DELETE K8s Pod Security Admission. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/k8s_pod_security_policys` | Create Configuration Specification. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/k8s_pod_security_policys/&#123;metadata.name&#125;` | Replace Configuration Specification. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/k8s_pod_security_policys` | List K8s Pod Security Policy. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/k8s_pod_security_policys/&#123;name&#125;` | GET Configuration Specification. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/k8s_pod_security_policys/&#123;name&#125;` | DELETE K8s Pod Security Policy. |
+| Method | Path                                                                                                          | Description                          |
+| ------ | ------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/container_registrys`                                   | Create Container Registry.           |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/container_registrys/&#123;metadata.name&#125;`         | Replace Container Registry.          |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/container_registrys`                                            | List Container Registry.             |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/container_registrys/&#123;name&#125;`                           | GET Container Registry.              |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/container_registrys/&#123;name&#125;`                           | DELETE Container Registry.           |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/k8s_cluster_roles`                                     | Create Configuration Specification.  |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/k8s_cluster_roles/&#123;metadata.name&#125;`           | Replace Configuration Specification. |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/k8s_cluster_roles`                                              | List K8s Cluster Role.               |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/k8s_cluster_roles/&#123;name&#125;`                             | GET Configuration Specification.     |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/k8s_cluster_roles/&#123;name&#125;`                             | DELETE K8s Cluster Role.             |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/k8s_cluster_role_bindings`                             | Create Configuration Specification.  |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/k8s_cluster_role_bindings/&#123;metadata.name&#125;`   | Replace Configuration Specification. |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/k8s_cluster_role_bindings`                                      | List K8s Cluster Role Binding.       |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/k8s_cluster_role_bindings/&#123;name&#125;`                     | GET Configuration Specification.     |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/k8s_cluster_role_bindings/&#123;name&#125;`                     | DELETE K8s Cluster Role Binding.     |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/k8s_pod_security_admissions`                           | Create Configuration Specification.  |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/k8s_pod_security_admissions/&#123;metadata.name&#125;` | Replace Configuration Specification. |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/k8s_pod_security_admissions`                                    | List K8s Pod Security Admission.     |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/k8s_pod_security_admissions/&#123;name&#125;`                   | GET Configuration Specification.     |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/k8s_pod_security_admissions/&#123;name&#125;`                   | DELETE K8s Pod Security Admission.   |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/k8s_pod_security_policys`                              | Create Configuration Specification.  |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/k8s_pod_security_policys/&#123;metadata.name&#125;`    | Replace Configuration Specification. |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/k8s_pod_security_policys`                                       | List K8s Pod Security Policy.        |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/k8s_pod_security_policys/&#123;name&#125;`                      | GET Configuration Specification.     |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/k8s_pod_security_policys/&#123;name&#125;`                      | DELETE K8s Pod Security Policy.      |
 
 ## Links
 

--- a/docs/en/api-reference/marketplace-api.mdx
+++ b/docs/en/api-reference/marketplace-api.mdx
@@ -2,7 +2,7 @@
 title: "🏪 Marketplace API"
 description: "Add-on services, connectors, and TPM policies."
 sidebar:
-    hidden: true
+  hidden: true
 ---
 
 Third-party GRE and IPSec tunnel provisioning with DPD timers. Shared resource allocation across namespaces with tile placement controls.
@@ -27,47 +27,47 @@ Third-party GRE and IPSec tunnel provisioning with DPD timers. Shared resource a
 
 ## Endpoints
 
-| Method | Path | Description |
-|--------|------|-------------|
-| GET | `/api/web/custom/namespaces/shared/addon_services/&#123;name&#125;` | GET Addon Service Details. |
-| GET | `/api/web/namespaces/system/addon_services/&#123;addon_service&#125;/activation-status` | Addon Service Activation Status. |
-| GET | `/api/web/namespaces/system/addon_services/&#123;addon_service&#125;/all-activation-status` | All Addon Service Activation Status. |
-| GET | `/api/web/namespaces/&#123;namespace&#125;/addon_services` | List Addon Service. |
-| GET | `/api/web/namespaces/&#123;namespace&#125;/addon_services/&#123;name&#125;` | GET Addon Service. |
-| POST | `/api/web/namespaces/&#123;metadata.namespace&#125;/addon_subscriptions` | Create Addon Subscription. |
-| PUT | `/api/web/namespaces/&#123;metadata.namespace&#125;/addon_subscriptions/&#123;metadata.name&#125;` | Replace Addon Subscription. |
-| GET | `/api/web/namespaces/&#123;namespace&#125;/addon_subscriptions` | List Addon Subscrption. |
-| GET | `/api/web/namespaces/&#123;namespace&#125;/addon_subscriptions/&#123;name&#125;` | GET Addon Subscription. |
-| DELETE | `/api/web/namespaces/&#123;namespace&#125;/addon_subscriptions/&#123;name&#125;` | DELETE Addon Subscrption. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/cminstances` | Create Central Manager Instance. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/cminstances/&#123;metadata.name&#125;` | Replace Central Manager Instance. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/cminstances` | List Central Manager Instance. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/cminstances/&#123;name&#125;` | GET Central Manager Instance. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/cminstances/&#123;name&#125;` | DELETE Central Manager Instance. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/external_connectors` | Create external_connector configuration. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/external_connectors/&#123;metadata.name&#125;` | Replace external_connector configuration. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/external_connectors` | List External Connector Configuration. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/external_connectors/&#123;name&#125;` | GET external_connector configuration. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/external_connectors/&#123;name&#125;` | DELETE External Connector Configuration. |
-| GET | `/api/web/namespaces/&#123;namespace&#125;/navigation_tiles` | List Navigation Tile. |
-| GET | `/api/web/namespaces/&#123;namespace&#125;/navigation_tiles/&#123;name&#125;` | GET Navigation Tile. |
-| POST | `/no_auth/namespaces/system/aws/f5xc-saas/register` | Register New AWS Account. |
-| POST | `/no_auth/namespaces/system/aws/f5xc-saas/signup` | Signup AWS Account. |
-| GET | `/api/web/namespaces/&#123;namespace&#125;/plans` | List Plan |
-| GET | `/api/web/namespaces/&#123;namespace&#125;/plans/&#123;name&#125;` | GET Plan |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/third_party_applications/&#123;metadata.name&#125;` | Replace Third Party Applicationr. |
-| POST | `/api/config/namespaces/&#123;namespace&#125;/third_party_application/get_security_config` | GET Security Config for Third Party Application. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/third_party_applications` | List Third Party Application. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/third_party_applications/&#123;name&#125;` | GET Third Party Application. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/third_party_applications/&#123;name&#125;/generate_token` | Generate Token. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/view_internal/&#123;view_kind&#125;/&#123;view_name&#125;` | GET Internal object for view. |
-| POST | `/api/terraform/namespaces/&#123;namespace&#125;/terraform/&#123;view_kind&#125;/&#123;view_name&#125;/force-delete` | Force DELETE view. |
-| POST | `/api/terraform/namespaces/&#123;namespace&#125;/terraform/&#123;view_kind&#125;/&#123;view_name&#125;/run` | Run Terraform Action for view. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/terraform_parameters/&#123;view_kind&#125;/&#123;view_name&#125;` | GET Terraform Parameters for view. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/terraform_parameters/&#123;view_kind&#125;/&#123;view_name&#125;/status` | GET Status of Terraform for view. |
-| POST | `/no_auth/namespaces/system/f5xc-saas/signup` | Signup XC SaaS. |
-| GET | `/no_auth/namespaces/system/f5xc-saas/signup/registration_details` | GET Registration Details. |
-| POST | `/no_auth/namespaces/system/f5xc-saas/signup/send_email` | Send Signup Email. |
+| Method | Path                                                                                                                   | Description                                      |
+| ------ | ---------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| GET    | `/api/web/custom/namespaces/shared/addon_services/&#123;name&#125;`                                                    | GET Addon Service Details.                       |
+| GET    | `/api/web/namespaces/system/addon_services/&#123;addon_service&#125;/activation-status`                                | Addon Service Activation Status.                 |
+| GET    | `/api/web/namespaces/system/addon_services/&#123;addon_service&#125;/all-activation-status`                            | All Addon Service Activation Status.             |
+| GET    | `/api/web/namespaces/&#123;namespace&#125;/addon_services`                                                             | List Addon Service.                              |
+| GET    | `/api/web/namespaces/&#123;namespace&#125;/addon_services/&#123;name&#125;`                                            | GET Addon Service.                               |
+| POST   | `/api/web/namespaces/&#123;metadata.namespace&#125;/addon_subscriptions`                                               | Create Addon Subscription.                       |
+| PUT    | `/api/web/namespaces/&#123;metadata.namespace&#125;/addon_subscriptions/&#123;metadata.name&#125;`                     | Replace Addon Subscription.                      |
+| GET    | `/api/web/namespaces/&#123;namespace&#125;/addon_subscriptions`                                                        | List Addon Subscrption.                          |
+| GET    | `/api/web/namespaces/&#123;namespace&#125;/addon_subscriptions/&#123;name&#125;`                                       | GET Addon Subscription.                          |
+| DELETE | `/api/web/namespaces/&#123;namespace&#125;/addon_subscriptions/&#123;name&#125;`                                       | DELETE Addon Subscrption.                        |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/cminstances`                                                    | Create Central Manager Instance.                 |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/cminstances/&#123;metadata.name&#125;`                          | Replace Central Manager Instance.                |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/cminstances`                                                             | List Central Manager Instance.                   |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/cminstances/&#123;name&#125;`                                            | GET Central Manager Instance.                    |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/cminstances/&#123;name&#125;`                                            | DELETE Central Manager Instance.                 |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/external_connectors`                                            | Create external_connector configuration.         |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/external_connectors/&#123;metadata.name&#125;`                  | Replace external_connector configuration.        |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/external_connectors`                                                     | List External Connector Configuration.           |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/external_connectors/&#123;name&#125;`                                    | GET external_connector configuration.            |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/external_connectors/&#123;name&#125;`                                    | DELETE External Connector Configuration.         |
+| GET    | `/api/web/namespaces/&#123;namespace&#125;/navigation_tiles`                                                           | List Navigation Tile.                            |
+| GET    | `/api/web/namespaces/&#123;namespace&#125;/navigation_tiles/&#123;name&#125;`                                          | GET Navigation Tile.                             |
+| POST   | `/no_auth/namespaces/system/aws/f5xc-saas/register`                                                                    | Register New AWS Account.                        |
+| POST   | `/no_auth/namespaces/system/aws/f5xc-saas/signup`                                                                      | Signup AWS Account.                              |
+| GET    | `/api/web/namespaces/&#123;namespace&#125;/plans`                                                                      | List Plan                                        |
+| GET    | `/api/web/namespaces/&#123;namespace&#125;/plans/&#123;name&#125;`                                                     | GET Plan                                         |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/third_party_applications/&#123;metadata.name&#125;`             | Replace Third Party Applicationr.                |
+| POST   | `/api/config/namespaces/&#123;namespace&#125;/third_party_application/get_security_config`                             | GET Security Config for Third Party Application. |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/third_party_applications`                                                | List Third Party Application.                    |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/third_party_applications/&#123;name&#125;`                               | GET Third Party Application.                     |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/third_party_applications/&#123;name&#125;/generate_token`                | Generate Token.                                  |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/view_internal/&#123;view_kind&#125;/&#123;view_name&#125;`               | GET Internal object for view.                    |
+| POST   | `/api/terraform/namespaces/&#123;namespace&#125;/terraform/&#123;view_kind&#125;/&#123;view_name&#125;/force-delete`   | Force DELETE view.                               |
+| POST   | `/api/terraform/namespaces/&#123;namespace&#125;/terraform/&#123;view_kind&#125;/&#123;view_name&#125;/run`            | Run Terraform Action for view.                   |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/terraform_parameters/&#123;view_kind&#125;/&#123;view_name&#125;`        | GET Terraform Parameters for view.               |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/terraform_parameters/&#123;view_kind&#125;/&#123;view_name&#125;/status` | GET Status of Terraform for view.                |
+| POST   | `/no_auth/namespaces/system/f5xc-saas/signup`                                                                          | Signup XC SaaS.                                  |
+| GET    | `/no_auth/namespaces/system/f5xc-saas/signup/registration_details`                                                     | GET Registration Details.                        |
+| POST   | `/no_auth/namespaces/system/f5xc-saas/signup/send_email`                                                               | Send Signup Email.                               |
 
 ## Links
 

--- a/docs/en/api-reference/network-api.mdx
+++ b/docs/en/api-reference/network-api.mdx
@@ -2,7 +2,7 @@
 title: "🔌 Network API"
 description: "BGP peering, IPsec tunnels, and segment policies."
 sidebar:
-    hidden: true
+  hidden: true
 ---
 
 Border gateway protocol with ASN management and autonomous system relationships. Site-to-site VPN linking datacenters through encrypted channels.
@@ -30,107 +30,107 @@ Border gateway protocol with ASN management and autonomous system relationships.
 
 ## Endpoints
 
-| Method | Path | Description |
-|--------|------|-------------|
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/address_allocators` | Create Address Allocator. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/address_allocators` | List Address Allocator. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/address_allocators/&#123;name&#125;` | GET Address Allocator. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/address_allocators/&#123;name&#125;` | DELETE Address Allocator. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/advertise_policys` | Create Advertise Policy. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/advertise_policys/&#123;metadata.name&#125;` | Replace Advertise Policy. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/advertise_policys` | List Advertise Policy. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/advertise_policys/&#123;name&#125;` | GET Advertise Policy. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/advertise_policys/&#123;name&#125;` | DELETE Advertise Policy. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/bgps` | Create BGP. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/bgps/&#123;metadata.name&#125;` | Replace BGP. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/bgps` | List BGP |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/bgps/&#123;name&#125;` | GET BGP |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/bgps/&#123;name&#125;` | DELETE BGP. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/bgpstatus/&#123;view_name&#125;` | GET BGP Status for view. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/bgp_asn_sets` | Create BGP ASN Set. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/bgp_asn_sets/&#123;metadata.name&#125;` | Replace BGP ASN Set. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/bgp_asn_sets` | List BGP ASN Set. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/bgp_asn_sets/&#123;name&#125;` | GET BGP ASN Set. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/bgp_asn_sets/&#123;name&#125;` | DELETE BGP ASN Set. |
-| GET | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/ver/bgp_peers` | Show BGP Peer Info. |
-| GET | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/ver/bgp_routes` | Show BGP Routes. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/bgp_routing_policys` | Create BGP Routing Policy. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/bgp_routing_policys/&#123;metadata.name&#125;` | Replace BGP Routing Policy. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/bgp_routing_policys` | List BGP Routing Policy. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/bgp_routing_policys/&#123;name&#125;` | GET BGP Routing Policy. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/bgp_routing_policys/&#123;name&#125;` | DELETE BGP Routing Policy. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/dc_cluster_groups` | Create DC Cluster Group. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/dc_cluster_groups/&#123;metadata.name&#125;` | Replace DC Cluster Group. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/dc_cluster_groups` | List DC Cluster Group. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/dc_cluster_groups/metrics` | Metrics |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/dc_cluster_groups/&#123;name&#125;` | GET DC Cluster Group. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/dc_cluster_groups/&#123;name&#125;` | DELETE DC Cluster Group. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/forwarding_classs` | Create Forwarding Class. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/forwarding_classs/&#123;metadata.name&#125;` | Replace Forwarding Class. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/forwarding_classs` | List Forwarding Class. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/forwarding_classs/&#123;name&#125;` | GET Forwarding Class. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/forwarding_classs/&#123;name&#125;` | DELETE Forwarding Class. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/ike1s` | Create IKE Phase1 Profile. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/ike1s/&#123;metadata.name&#125;` | Replace IKE Phase1 Profile configuration. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/ike1s` | List IKE Phase 1 Profile. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/ike1s/&#123;name&#125;` | GET IKE Phase1 profile configuration. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/ike1s/&#123;name&#125;` | DELETE IKE Phase 1 Profile. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/ike_phase1_profiles` | Create IKE Phase1 Profile. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/ike_phase1_profiles/&#123;metadata.name&#125;` | Replace IKE Phase1 Profile configuration. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/ike_phase1_profiles` | List IKE Phase 1 Profile. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/ike_phase1_profiles/&#123;name&#125;` | GET IKE Phase1 profile configuration. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/ike_phase1_profiles/&#123;name&#125;` | DELETE IKE Phase 1 Profile. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/ike2s` | Create IKE Phase2 Profile. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/ike2s/&#123;metadata.name&#125;` | Replace IKE Phase2 Profile configuration. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/ike2s` | List IKE Phase 2 Profile. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/ike2s/&#123;name&#125;` | GET IKE Phase2 profile configuration. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/ike2s/&#123;name&#125;` | DELETE IKE Phase 2 Profile. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/ike_phase2_profiles` | Create IKE Phase2 Profile. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/ike_phase2_profiles/&#123;metadata.name&#125;` | Replace IKE Phase2 Profile configuration. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/ike_phase2_profiles` | List IKE Phase 2 Profile. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/ike_phase2_profiles/&#123;name&#125;` | GET IKE Phase2 profile configuration. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/ike_phase2_profiles/&#123;name&#125;` | DELETE IKE Phase 2 Profile. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/ip_prefix_sets` | Create IP Prefix Set. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/ip_prefix_sets/&#123;metadata.name&#125;` | Replace IP Prefix Set. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/ip_prefix_sets` | List IP Prefix Set. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/ip_prefix_sets/&#123;name&#125;` | GET IP Prefix Set. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/ip_prefix_sets/&#123;name&#125;` | DELETE IP Prefix Set. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/network_connectors` | Create Network Connector. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/network_connectors/&#123;metadata.name&#125;` | Replace Network Connector. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/network_connectors` | List Network Connector. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/network_connectors/&#123;name&#125;` | GET Network Connector. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/network_connectors/&#123;name&#125;` | DELETE Network Connector. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/public_ips/&#123;metadata.name&#125;` | Replace Public IP. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/public_ips` | List Public IP. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/public_ips/&#123;name&#125;` | GET Public IP. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/routes` | Create Route. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/routes/&#123;metadata.name&#125;` | Replace Route. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/routes` | List Route. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/routes/&#123;name&#125;` | GET Route |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/routes/&#123;name&#125;` | DELETE Route. |
-| POST | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/ver/routes` | Show Routes. |
-| POST | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/ver/simplified_routes` | Show Simplified Routes. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/srv6_network_slices` | Create SRv6 Network Slice. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/srv6_network_slices/&#123;metadata.name&#125;` | Replace SRv6 Network Slice. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/srv6_network_slices` | List SRv6 Network Slice. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/srv6_network_slices/&#123;name&#125;` | GET SRv6 Network Slice. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/srv6_network_slices/&#123;name&#125;` | DELETE SRv6 Network Slice. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/subnets` | Create Subnet. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/subnets/&#123;metadata.name&#125;` | Replace Subnet. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/subnets` | List Subnet. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/subnets/&#123;name&#125;` | GET Subnet. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/subnets/&#123;name&#125;` | DELETE Subnet. |
-| POST | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/ver/traceroute` | Traceroute. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/tunnels` | Create Tunnel. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/tunnels/&#123;metadata.name&#125;` | Replace Tunnel. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/tunnels` | List Tunnel. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/tunnels/&#123;name&#125;` | GET Tunnel. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/tunnels/&#123;name&#125;` | DELETE Tunnel. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/virtual_networks` | Create Virtual Network. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/virtual_networks/&#123;metadata.name&#125;` | Replace Virtual Network. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/virtual_networks` | List Virtual Network. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/virtual_networks/&#123;name&#125;` | GET Virtual Network. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/virtual_networks/&#123;name&#125;` | DELETE Virtual Network. |
+| Method | Path                                                                                                  | Description                               |
+| ------ | ----------------------------------------------------------------------------------------------------- | ----------------------------------------- |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/address_allocators`                            | Create Address Allocator.                 |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/address_allocators`                                     | List Address Allocator.                   |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/address_allocators/&#123;name&#125;`                    | GET Address Allocator.                    |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/address_allocators/&#123;name&#125;`                    | DELETE Address Allocator.                 |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/advertise_policys`                             | Create Advertise Policy.                  |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/advertise_policys/&#123;metadata.name&#125;`   | Replace Advertise Policy.                 |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/advertise_policys`                                      | List Advertise Policy.                    |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/advertise_policys/&#123;name&#125;`                     | GET Advertise Policy.                     |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/advertise_policys/&#123;name&#125;`                     | DELETE Advertise Policy.                  |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/bgps`                                          | Create BGP.                               |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/bgps/&#123;metadata.name&#125;`                | Replace BGP.                              |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/bgps`                                                   | List BGP                                  |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/bgps/&#123;name&#125;`                                  | GET BGP                                   |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/bgps/&#123;name&#125;`                                  | DELETE BGP.                               |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/bgpstatus/&#123;view_name&#125;`                        | GET BGP Status for view.                  |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/bgp_asn_sets`                                  | Create BGP ASN Set.                       |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/bgp_asn_sets/&#123;metadata.name&#125;`        | Replace BGP ASN Set.                      |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/bgp_asn_sets`                                           | List BGP ASN Set.                         |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/bgp_asn_sets/&#123;name&#125;`                          | GET BGP ASN Set.                          |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/bgp_asn_sets/&#123;name&#125;`                          | DELETE BGP ASN Set.                       |
+| GET    | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/ver/bgp_peers`                  | Show BGP Peer Info.                       |
+| GET    | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/ver/bgp_routes`                 | Show BGP Routes.                          |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/bgp_routing_policys`                           | Create BGP Routing Policy.                |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/bgp_routing_policys/&#123;metadata.name&#125;` | Replace BGP Routing Policy.               |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/bgp_routing_policys`                                    | List BGP Routing Policy.                  |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/bgp_routing_policys/&#123;name&#125;`                   | GET BGP Routing Policy.                   |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/bgp_routing_policys/&#123;name&#125;`                   | DELETE BGP Routing Policy.                |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/dc_cluster_groups`                             | Create DC Cluster Group.                  |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/dc_cluster_groups/&#123;metadata.name&#125;`   | Replace DC Cluster Group.                 |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/dc_cluster_groups`                                      | List DC Cluster Group.                    |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/dc_cluster_groups/metrics`                                | Metrics                                   |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/dc_cluster_groups/&#123;name&#125;`                     | GET DC Cluster Group.                     |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/dc_cluster_groups/&#123;name&#125;`                     | DELETE DC Cluster Group.                  |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/forwarding_classs`                             | Create Forwarding Class.                  |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/forwarding_classs/&#123;metadata.name&#125;`   | Replace Forwarding Class.                 |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/forwarding_classs`                                      | List Forwarding Class.                    |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/forwarding_classs/&#123;name&#125;`                     | GET Forwarding Class.                     |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/forwarding_classs/&#123;name&#125;`                     | DELETE Forwarding Class.                  |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/ike1s`                                         | Create IKE Phase1 Profile.                |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/ike1s/&#123;metadata.name&#125;`               | Replace IKE Phase1 Profile configuration. |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/ike1s`                                                  | List IKE Phase 1 Profile.                 |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/ike1s/&#123;name&#125;`                                 | GET IKE Phase1 profile configuration.     |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/ike1s/&#123;name&#125;`                                 | DELETE IKE Phase 1 Profile.               |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/ike_phase1_profiles`                           | Create IKE Phase1 Profile.                |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/ike_phase1_profiles/&#123;metadata.name&#125;` | Replace IKE Phase1 Profile configuration. |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/ike_phase1_profiles`                                    | List IKE Phase 1 Profile.                 |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/ike_phase1_profiles/&#123;name&#125;`                   | GET IKE Phase1 profile configuration.     |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/ike_phase1_profiles/&#123;name&#125;`                   | DELETE IKE Phase 1 Profile.               |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/ike2s`                                         | Create IKE Phase2 Profile.                |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/ike2s/&#123;metadata.name&#125;`               | Replace IKE Phase2 Profile configuration. |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/ike2s`                                                  | List IKE Phase 2 Profile.                 |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/ike2s/&#123;name&#125;`                                 | GET IKE Phase2 profile configuration.     |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/ike2s/&#123;name&#125;`                                 | DELETE IKE Phase 2 Profile.               |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/ike_phase2_profiles`                           | Create IKE Phase2 Profile.                |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/ike_phase2_profiles/&#123;metadata.name&#125;` | Replace IKE Phase2 Profile configuration. |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/ike_phase2_profiles`                                    | List IKE Phase 2 Profile.                 |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/ike_phase2_profiles/&#123;name&#125;`                   | GET IKE Phase2 profile configuration.     |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/ike_phase2_profiles/&#123;name&#125;`                   | DELETE IKE Phase 2 Profile.               |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/ip_prefix_sets`                                | Create IP Prefix Set.                     |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/ip_prefix_sets/&#123;metadata.name&#125;`      | Replace IP Prefix Set.                    |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/ip_prefix_sets`                                         | List IP Prefix Set.                       |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/ip_prefix_sets/&#123;name&#125;`                        | GET IP Prefix Set.                        |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/ip_prefix_sets/&#123;name&#125;`                        | DELETE IP Prefix Set.                     |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/network_connectors`                            | Create Network Connector.                 |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/network_connectors/&#123;metadata.name&#125;`  | Replace Network Connector.                |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/network_connectors`                                     | List Network Connector.                   |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/network_connectors/&#123;name&#125;`                    | GET Network Connector.                    |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/network_connectors/&#123;name&#125;`                    | DELETE Network Connector.                 |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/public_ips/&#123;metadata.name&#125;`          | Replace Public IP.                        |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/public_ips`                                             | List Public IP.                           |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/public_ips/&#123;name&#125;`                            | GET Public IP.                            |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/routes`                                        | Create Route.                             |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/routes/&#123;metadata.name&#125;`              | Replace Route.                            |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/routes`                                                 | List Route.                               |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/routes/&#123;name&#125;`                                | GET Route                                 |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/routes/&#123;name&#125;`                                | DELETE Route.                             |
+| POST   | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/ver/routes`                     | Show Routes.                              |
+| POST   | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/ver/simplified_routes`          | Show Simplified Routes.                   |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/srv6_network_slices`                           | Create SRv6 Network Slice.                |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/srv6_network_slices/&#123;metadata.name&#125;` | Replace SRv6 Network Slice.               |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/srv6_network_slices`                                    | List SRv6 Network Slice.                  |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/srv6_network_slices/&#123;name&#125;`                   | GET SRv6 Network Slice.                   |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/srv6_network_slices/&#123;name&#125;`                   | DELETE SRv6 Network Slice.                |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/subnets`                                       | Create Subnet.                            |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/subnets/&#123;metadata.name&#125;`             | Replace Subnet.                           |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/subnets`                                                | List Subnet.                              |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/subnets/&#123;name&#125;`                               | GET Subnet.                               |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/subnets/&#123;name&#125;`                               | DELETE Subnet.                            |
+| POST   | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/ver/traceroute`                 | Traceroute.                               |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/tunnels`                                       | Create Tunnel.                            |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/tunnels/&#123;metadata.name&#125;`             | Replace Tunnel.                           |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/tunnels`                                                | List Tunnel.                              |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/tunnels/&#123;name&#125;`                               | GET Tunnel.                               |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/tunnels/&#123;name&#125;`                               | DELETE Tunnel.                            |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/virtual_networks`                              | Create Virtual Network.                   |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/virtual_networks/&#123;metadata.name&#125;`    | Replace Virtual Network.                  |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/virtual_networks`                                       | List Virtual Network.                     |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/virtual_networks/&#123;name&#125;`                      | GET Virtual Network.                      |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/virtual_networks/&#123;name&#125;`                      | DELETE Virtual Network.                   |
 
 ## Links
 

--- a/docs/en/api-reference/network_security-api.mdx
+++ b/docs/en/api-reference/network_security-api.mdx
@@ -2,7 +2,7 @@
 title: "🔒 Network Security API"
 description: "NAT policies, firewalls, and segment connections."
 sidebar:
-    hidden: true
+  hidden: true
 ---
 
 Firewall rules with routing decisions based on source, destination, or protocol. Segmentation isolates workloads while outbound proxies govern access.
@@ -29,82 +29,82 @@ Firewall rules with routing decisions based on source, destination, or protocol.
 
 ## Endpoints
 
-| Method | Path | Description |
-|--------|------|-------------|
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/forward_proxy_policys` | Create Forward Proxy Policy. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/forward_proxy_policys/&#123;metadata.name&#125;` | Replace Forward Proxy Policy. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/forward_proxy_policy/hits` | Forward Proxy Policy Hits. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/forward_proxy_policys` | List Configure Forward Proxy Policy. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/forward_proxy_policys/&#123;name&#125;` | GET Forward Proxy Policy. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/forward_proxy_policys/&#123;name&#125;` | DELETE Configure Forward Proxy Policy. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/network_policy_views` | Create Network policy View. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/network_policy_views/&#123;metadata.name&#125;` | Replace Network policy View. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/network_policy_view/hits` | Network Policy Hits. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/network_policy_views` | List Configure Network policy View. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/network_policy_views/&#123;name&#125;` | GET Network policy View. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/network_policy_views/&#123;name&#125;` | DELETE Configure Network policy View. |
-| GET | `/api/bigipconnector/namespaces/&#123;namespace&#125;/uztna/applications/discovered` | List |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/fast_acls` | Create Fast ACL. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/fast_acls/&#123;metadata.name&#125;` | Replace Fast ACL. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/fast_acl/hits` | Fast ACL Hits. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/fast_acls` | List Fast ACL. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/fast_acls/&#123;name&#125;` | GET Fast ACL. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/fast_acls/&#123;name&#125;` | DELETE Fast ACL. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/fast_acl_rules` | Create Fast ACL Rule. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/fast_acl_rules/&#123;metadata.name&#125;` | Replace Fast ACL Rule. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/fast_acl_rules` | List Fast ACL Rule. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/fast_acl_rules/&#123;name&#125;` | GET Fast ACL Rule. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/fast_acl_rules/&#123;name&#125;` | DELETE Fast ACL Rule. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/filter_sets` | Create Specification. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/filter_sets/&#123;metadata.name&#125;` | Replace Specification. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/filter_sets` | List Filter Set. |
-| POST | `/api/config/namespaces/&#123;namespace&#125;/filter_sets/find` | Find Filter Sets for 1 or More Context Keys. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/filter_sets/&#123;name&#125;` | GET Specification. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/filter_sets/&#123;name&#125;` | DELETE Filter Set. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/nat_policys` | Create NAT Policy. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/nat_policys/&#123;metadata.name&#125;` | Replace NAT Policy. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/nat_policys` | List NAT Policy. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/nat_policys/&#123;name&#125;` | GET NAT Policy. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/nat_policys/&#123;name&#125;` | DELETE NAT Policy. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/network_firewalls` | Create Network Firewall. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/network_firewalls/&#123;metadata.name&#125;` | Replace Network Firewall. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/network_firewalls` | List Network Firewall. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/network_firewalls/&#123;name&#125;` | GET Network Firewall. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/network_firewalls/&#123;name&#125;` | DELETE Network Firewall. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/network_policys` | Create Network Policy. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/network_policys/&#123;metadata.name&#125;` | Replace Network Policy. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/network_policy/hits` | Network Policy Hits. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/network_policys` | List Network Policy. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/network_policys/&#123;name&#125;` | GET Network Policy. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/network_policys/&#123;name&#125;` | DELETE Network Policy. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/network_policy_rules` | Create Network Policy Rule. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/network_policy_rules/&#123;metadata.name&#125;` | Replace Network Policy Rule. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/network_policy_rules` | List Network Policy Rule. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/network_policy_rules/&#123;name&#125;` | GET Network Policy Rule. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/network_policy_rules/&#123;name&#125;` | DELETE Network Policy Rule. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/network_policy_sets` | List Network Policy Set. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/network_policy_sets/&#123;name&#125;` | GET Network Policy Set. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/policy_based_routings` | Create Policy based Routing. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/policy_based_routings/&#123;metadata.name&#125;` | Replace Policy based Routing. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/policy_based_routings` | List Policy based Routing. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/policy_based_routings/&#123;name&#125;` | GET Policy based Routing. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/policy_based_routings/&#123;name&#125;` | DELETE Policy based Routing. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/segments` | Create segment. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/segments/&#123;metadata.name&#125;` | Replace segment. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/segments` | List Segment. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/segments/graph` | Segment |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/segments/&#123;name&#125;` | GET segment. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/segments/&#123;name&#125;` | DELETE Segment. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/segment_connections/&#123;metadata.name&#125;` | Replace segment connector. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/segment_connections` | List Segment Connector. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/segment_connections/&#123;name&#125;` | GET segment connector. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/service_policys` | Create Service Policy. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/service_policys/&#123;metadata.name&#125;` | Replace Service Policy. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/service_policy/hits` | Service Policy Hits. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/service_policy/latency` | Service Policy Latency. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/service_policys` | List Service Policy. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/service_policys/&#123;name&#125;` | GET Service Policy. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/service_policys/&#123;name&#125;` | DELETE Service Policy. |
+| Method | Path                                                                                                    | Description                                  |
+| ------ | ------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/forward_proxy_policys`                           | Create Forward Proxy Policy.                 |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/forward_proxy_policys/&#123;metadata.name&#125;` | Replace Forward Proxy Policy.                |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/forward_proxy_policy/hits`                                  | Forward Proxy Policy Hits.                   |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/forward_proxy_policys`                                    | List Configure Forward Proxy Policy.         |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/forward_proxy_policys/&#123;name&#125;`                   | GET Forward Proxy Policy.                    |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/forward_proxy_policys/&#123;name&#125;`                   | DELETE Configure Forward Proxy Policy.       |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/network_policy_views`                            | Create Network policy View.                  |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/network_policy_views/&#123;metadata.name&#125;`  | Replace Network policy View.                 |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/network_policy_view/hits`                                   | Network Policy Hits.                         |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/network_policy_views`                                     | List Configure Network policy View.          |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/network_policy_views/&#123;name&#125;`                    | GET Network policy View.                     |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/network_policy_views/&#123;name&#125;`                    | DELETE Configure Network policy View.        |
+| GET    | `/api/bigipconnector/namespaces/&#123;namespace&#125;/uztna/applications/discovered`                    | List                                         |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/fast_acls`                                       | Create Fast ACL.                             |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/fast_acls/&#123;metadata.name&#125;`             | Replace Fast ACL.                            |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/fast_acl/hits`                                              | Fast ACL Hits.                               |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/fast_acls`                                                | List Fast ACL.                               |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/fast_acls/&#123;name&#125;`                               | GET Fast ACL.                                |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/fast_acls/&#123;name&#125;`                               | DELETE Fast ACL.                             |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/fast_acl_rules`                                  | Create Fast ACL Rule.                        |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/fast_acl_rules/&#123;metadata.name&#125;`        | Replace Fast ACL Rule.                       |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/fast_acl_rules`                                           | List Fast ACL Rule.                          |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/fast_acl_rules/&#123;name&#125;`                          | GET Fast ACL Rule.                           |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/fast_acl_rules/&#123;name&#125;`                          | DELETE Fast ACL Rule.                        |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/filter_sets`                                     | Create Specification.                        |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/filter_sets/&#123;metadata.name&#125;`           | Replace Specification.                       |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/filter_sets`                                              | List Filter Set.                             |
+| POST   | `/api/config/namespaces/&#123;namespace&#125;/filter_sets/find`                                         | Find Filter Sets for 1 or More Context Keys. |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/filter_sets/&#123;name&#125;`                             | GET Specification.                           |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/filter_sets/&#123;name&#125;`                             | DELETE Filter Set.                           |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/nat_policys`                                     | Create NAT Policy.                           |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/nat_policys/&#123;metadata.name&#125;`           | Replace NAT Policy.                          |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/nat_policys`                                              | List NAT Policy.                             |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/nat_policys/&#123;name&#125;`                             | GET NAT Policy.                              |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/nat_policys/&#123;name&#125;`                             | DELETE NAT Policy.                           |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/network_firewalls`                               | Create Network Firewall.                     |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/network_firewalls/&#123;metadata.name&#125;`     | Replace Network Firewall.                    |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/network_firewalls`                                        | List Network Firewall.                       |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/network_firewalls/&#123;name&#125;`                       | GET Network Firewall.                        |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/network_firewalls/&#123;name&#125;`                       | DELETE Network Firewall.                     |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/network_policys`                                 | Create Network Policy.                       |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/network_policys/&#123;metadata.name&#125;`       | Replace Network Policy.                      |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/network_policy/hits`                                        | Network Policy Hits.                         |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/network_policys`                                          | List Network Policy.                         |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/network_policys/&#123;name&#125;`                         | GET Network Policy.                          |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/network_policys/&#123;name&#125;`                         | DELETE Network Policy.                       |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/network_policy_rules`                            | Create Network Policy Rule.                  |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/network_policy_rules/&#123;metadata.name&#125;`  | Replace Network Policy Rule.                 |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/network_policy_rules`                                     | List Network Policy Rule.                    |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/network_policy_rules/&#123;name&#125;`                    | GET Network Policy Rule.                     |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/network_policy_rules/&#123;name&#125;`                    | DELETE Network Policy Rule.                  |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/network_policy_sets`                                      | List Network Policy Set.                     |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/network_policy_sets/&#123;name&#125;`                     | GET Network Policy Set.                      |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/policy_based_routings`                           | Create Policy based Routing.                 |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/policy_based_routings/&#123;metadata.name&#125;` | Replace Policy based Routing.                |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/policy_based_routings`                                    | List Policy based Routing.                   |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/policy_based_routings/&#123;name&#125;`                   | GET Policy based Routing.                    |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/policy_based_routings/&#123;name&#125;`                   | DELETE Policy based Routing.                 |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/segments`                                        | Create segment.                              |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/segments/&#123;metadata.name&#125;`              | Replace segment.                             |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/segments`                                                 | List Segment.                                |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/segments/graph`                                             | Segment                                      |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/segments/&#123;name&#125;`                                | GET segment.                                 |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/segments/&#123;name&#125;`                                | DELETE Segment.                              |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/segment_connections/&#123;metadata.name&#125;`   | Replace segment connector.                   |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/segment_connections`                                      | List Segment Connector.                      |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/segment_connections/&#123;name&#125;`                     | GET segment connector.                       |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/service_policys`                                 | Create Service Policy.                       |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/service_policys/&#123;metadata.name&#125;`       | Replace Service Policy.                      |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/service_policy/hits`                                        | Service Policy Hits.                         |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/service_policy/latency`                                     | Service Policy Latency.                      |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/service_policys`                                          | List Service Policy.                         |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/service_policys/&#123;name&#125;`                         | GET Service Policy.                          |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/service_policys/&#123;name&#125;`                         | DELETE Service Policy.                       |
 
 ## Links
 

--- a/docs/en/api-reference/nginx_one-api.mdx
+++ b/docs/en/api-reference/nginx_one-api.mdx
@@ -2,7 +2,7 @@
 title: "🟢 Nginx One API"
 description: "NGINX Plus instances and dataplane servers."
 sidebar:
-    hidden: true
+  hidden: true
 ---
 
 Instance discovery, WAF integration, and service mesh connectivity. Subscription lifecycle and configuration synchronization.
@@ -26,22 +26,22 @@ Instance discovery, WAF integration, and service mesh connectivity. Subscription
 
 ## Endpoints
 
-| Method | Path | Description |
-|--------|------|-------------|
-| GET | `/api/config/namespaces/&#123;namespace&#125;/nginx_csgs` | List NGINX One CSG Object configuration. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/nginx_csgs/&#123;name&#125;` | GET Request. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/nginx_instances` | List NGINX One Instance Object configuration. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/nginx_instances/&#123;name&#125;` | GET Request. |
-| POST | `/api/config/namespaces/&#123;namespace&#125;/nginx_dataplane_servers` | GET NGINX One Dataplane Servers. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/nginx_servers` | List NGINX One Server APIs. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/nginx_servers/&#123;name&#125;` | GET Request. |
-| POST | `/api/nginx/one/namespaces/system/n1/subscribe` | Subscribe to NGINX One. |
-| POST | `/api/nginx/one/namespaces/system/n1/unsubscribe` | Unsubscribe to NGINX One. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/nginx_service_discoverys` | Create NGINX Service Discovery. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/nginx_service_discoverys/&#123;metadata.name&#125;` | Replace NGINX Service Discovery. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/nginx_service_discoverys` | List NGINX Service Discovery. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/nginx_service_discoverys/&#123;name&#125;` | GET NGINX Service Discovery. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/nginx_service_discoverys/&#123;name&#125;` | DELETE NGINX Service Discovery. |
+| Method | Path                                                                                                       | Description                                   |
+| ------ | ---------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/nginx_csgs`                                                  | List NGINX One CSG Object configuration.      |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/nginx_csgs/&#123;name&#125;`                                 | GET Request.                                  |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/nginx_instances`                                             | List NGINX One Instance Object configuration. |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/nginx_instances/&#123;name&#125;`                            | GET Request.                                  |
+| POST   | `/api/config/namespaces/&#123;namespace&#125;/nginx_dataplane_servers`                                     | GET NGINX One Dataplane Servers.              |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/nginx_servers`                                               | List NGINX One Server APIs.                   |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/nginx_servers/&#123;name&#125;`                              | GET Request.                                  |
+| POST   | `/api/nginx/one/namespaces/system/n1/subscribe`                                                            | Subscribe to NGINX One.                       |
+| POST   | `/api/nginx/one/namespaces/system/n1/unsubscribe`                                                          | Unsubscribe to NGINX One.                     |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/nginx_service_discoverys`                           | Create NGINX Service Discovery.               |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/nginx_service_discoverys/&#123;metadata.name&#125;` | Replace NGINX Service Discovery.              |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/nginx_service_discoverys`                                    | List NGINX Service Discovery.                 |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/nginx_service_discoverys/&#123;name&#125;`                   | GET NGINX Service Discovery.                  |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/nginx_service_discoverys/&#123;name&#125;`                   | DELETE NGINX Service Discovery.               |
 
 ## Links
 

--- a/docs/en/api-reference/object_storage-api.mdx
+++ b/docs/en/api-reference/object_storage-api.mdx
@@ -2,7 +2,7 @@
 title: "🗄️ Object Storage API"
 description: "Mobile SDK assets, versioned binaries, and app shield files."
 sidebar:
-    hidden: true
+  hidden: true
 ---
 
 Versioned library distribution for mobile app integrators. Presigned URLs enable secure downloads with OS-specific builds for iOS and Android.
@@ -26,19 +26,19 @@ Versioned library distribution for mobile app integrators. Presigned URLs enable
 
 ## Endpoints
 
-| Method | Path | Description |
-|--------|------|-------------|
-| GET | `/api/object_store/namespaces/&#123;namespace&#125;/stored_objects/mobile-app-shield` | GET List Of Mobile App Shields. |
-| GET | `/api/object_store/namespaces/&#123;namespace&#125;/stored_objects/mobile-app-shield/&#123;name&#125;/&#123;version&#125;` | GET Mobile App Shield. |
-| GET | `/api/object_store/namespaces/&#123;namespace&#125;/stored_objects/mobile-integrator` | GET List Of Mobile Integrators. |
-| GET | `/api/object_store/namespaces/&#123;namespace&#125;/stored_objects/mobile-integrator/&#123;name&#125;/&#123;version&#125;` | GET Mobile Integrator. |
-| GET | `/api/object_store/namespaces/&#123;namespace&#125;/stored_objects/&#123;object_type&#125;` | GET List Of Stored Objects. |
-| DELETE | `/api/object_store/namespaces/&#123;namespace&#125;/stored_objects/&#123;object_type&#125;/&#123;name&#125;` | DELETE Stored Object(s) |
-| PUT | `/api/object_store/namespaces/&#123;namespace&#125;/stored_objects/&#123;object_type&#125;/&#123;name&#125;` | Create Stored Object. |
-| GET | `/api/object_store/namespaces/&#123;namespace&#125;/stored_objects/&#123;object_type&#125;/&#123;name&#125;/&#123;version&#125;` | GET Stored Object. |
-| DELETE | `/api/object_store/namespaces/&#123;namespace&#125;/stored_objects/&#123;object_type&#125;/&#123;name&#125;/&#123;version&#125;` | DELETE Stored Object(s) |
-| GET | `/api/object_store/namespaces/&#123;namespace&#125;/stored_objects/mobile-sdk-self-serve` | GET List Of Mobile SDKs self serve. |
-| GET | `/api/object_store/namespaces/&#123;namespace&#125;/stored_objects/mobile-sdk-self-serve/&#123;name&#125;/&#123;version&#125;` | GET Mobile SDK Self serve. |
+| Method | Path                                                                                                                             | Description                         |
+| ------ | -------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
+| GET    | `/api/object_store/namespaces/&#123;namespace&#125;/stored_objects/mobile-app-shield`                                            | GET List Of Mobile App Shields.     |
+| GET    | `/api/object_store/namespaces/&#123;namespace&#125;/stored_objects/mobile-app-shield/&#123;name&#125;/&#123;version&#125;`       | GET Mobile App Shield.              |
+| GET    | `/api/object_store/namespaces/&#123;namespace&#125;/stored_objects/mobile-integrator`                                            | GET List Of Mobile Integrators.     |
+| GET    | `/api/object_store/namespaces/&#123;namespace&#125;/stored_objects/mobile-integrator/&#123;name&#125;/&#123;version&#125;`       | GET Mobile Integrator.              |
+| GET    | `/api/object_store/namespaces/&#123;namespace&#125;/stored_objects/&#123;object_type&#125;`                                      | GET List Of Stored Objects.         |
+| DELETE | `/api/object_store/namespaces/&#123;namespace&#125;/stored_objects/&#123;object_type&#125;/&#123;name&#125;`                     | DELETE Stored Object(s)             |
+| PUT    | `/api/object_store/namespaces/&#123;namespace&#125;/stored_objects/&#123;object_type&#125;/&#123;name&#125;`                     | Create Stored Object.               |
+| GET    | `/api/object_store/namespaces/&#123;namespace&#125;/stored_objects/&#123;object_type&#125;/&#123;name&#125;/&#123;version&#125;` | GET Stored Object.                  |
+| DELETE | `/api/object_store/namespaces/&#123;namespace&#125;/stored_objects/&#123;object_type&#125;/&#123;name&#125;/&#123;version&#125;` | DELETE Stored Object(s)             |
+| GET    | `/api/object_store/namespaces/&#123;namespace&#125;/stored_objects/mobile-sdk-self-serve`                                        | GET List Of Mobile SDKs self serve. |
+| GET    | `/api/object_store/namespaces/&#123;namespace&#125;/stored_objects/mobile-sdk-self-serve/&#123;name&#125;/&#123;version&#125;`   | GET Mobile SDK Self serve.          |
 
 ## Links
 

--- a/docs/en/api-reference/observability-api.mdx
+++ b/docs/en/api-reference/observability-api.mdx
@@ -2,7 +2,7 @@
 title: "📊 Observability API"
 description: "Synthetic health checks and DNS resolution validation."
 sidebar:
-    hidden: true
+  hidden: true
 ---
 
 HTTP availability probes with latency measurement. Certificate expiration alerts and global status dashboards for infrastructure health.
@@ -27,75 +27,75 @@ HTTP availability probes with latency measurement. Certificate expiration alerts
 
 ## Endpoints
 
-| Method | Path | Description |
-|--------|------|-------------|
-| GET | `/api/data/namespaces/system/all_ns_alerts` | GET Alerts. |
-| GET | `/api/data/namespaces/&#123;namespace&#125;/alerts` | GET Alerts. |
-| GET | `/api/data/namespaces/&#123;namespace&#125;/alerts/history` | GET Alerts History. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/alerts/history/aggregation` | Alerts History Aggregation. |
-| GET | `/api/data/namespaces/&#123;namespace&#125;/alerts/history/scroll` | Alerts History Scroll. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/alerts/history/scroll` | Alerts History Scroll. |
-| POST | `/api/observability/synthetic_monitor/namespaces/&#123;metadata.namespace&#125;/v1_dns_monitors` | Create DNS Monitor. |
-| PUT | `/api/observability/synthetic_monitor/namespaces/&#123;metadata.namespace&#125;/v1_dns_monitors/&#123;metadata.name&#125;` | Replace DNS Monitor. |
-| GET | `/api/observability/synthetic_monitor/namespaces/&#123;namespace&#125;/filtered-dns-monitor-list` | GET Filtered DNS Monitor List. |
-| GET | `/api/observability/synthetic_monitor/namespaces/&#123;namespace&#125;/v1_dns_monitors` | List DNS Monitor. |
-| GET | `/api/observability/synthetic_monitor/namespaces/&#123;namespace&#125;/v1_dns_monitors/&#123;name&#125;` | GET DNS Monitor. |
-| DELETE | `/api/observability/synthetic_monitor/namespaces/&#123;namespace&#125;/v1_dns_monitors/&#123;name&#125;` | DELETE DNS Monitor. |
-| POST | `/api/observability/synthetic_monitor/namespaces/&#123;metadata.namespace&#125;/v1_http_monitors` | Create HTTP Monitor. |
-| PUT | `/api/observability/synthetic_monitor/namespaces/&#123;metadata.namespace&#125;/v1_http_monitors/&#123;metadata.name&#125;` | Update HTTP Monitor. |
-| GET | `/api/observability/synthetic_monitor/namespaces/&#123;namespace&#125;/filtered-http-monitor-list` | GET Filtered HTTP Monitor List. |
-| GET | `/api/observability/synthetic_monitor/namespaces/&#123;namespace&#125;/v1_http_monitors` | List HTTP Monitor. |
-| GET | `/api/observability/synthetic_monitor/namespaces/&#123;namespace&#125;/v1_http_monitors/&#123;name&#125;` | GET HTTP Monitor. |
-| DELETE | `/api/observability/synthetic_monitor/namespaces/&#123;namespace&#125;/v1_http_monitors/&#123;name&#125;` | DELETE HTTP Monitor. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/access_logs` | Access Log Query V2. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/access_logs/aggregation` | Access Log Aggregation Query. |
-| GET | `/api/data/namespaces/&#123;namespace&#125;/access_logs/scroll` | Access Log Scroll Query. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/access_logs/scroll` | Access Log Scroll Query. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/audit_logs` | Audit Log Query V2. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/audit_logs/aggregation` | Audit Log Aggregation Query. |
-| GET | `/api/data/namespaces/&#123;namespace&#125;/audit_logs/scroll` | Audit Log Scroll Query. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/audit_logs/scroll` | Audit Log Scroll Query. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/firewall_logs` | Firewall Logs Query. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/firewall_logs/aggregation` | Firewall Logs Aggregation Query. |
-| GET | `/api/data/namespaces/&#123;namespace&#125;/firewall_logs/scroll` | Firewall Logs Scroll Query. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/firewall_logs/scroll` | Firewall Logs Scroll Query. |
-| GET | `/api/data/namespaces/&#123;namespace&#125;/k8s_audit_logs/scroll` | K8s Audit Log Scroll Query. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/k8s_audit_logs/scroll` | K8s Audit Log Scroll Query. |
-| GET | `/api/data/namespaces/&#123;namespace&#125;/k8s_events/scroll` | K8s Events Scroll Query. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/k8s_events/scroll` | K8s Events Scroll Query. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/platform_events` | Platform event Query. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/platform_events/aggregation` | Platform event Aggregation Query. |
-| GET | `/api/data/namespaces/&#123;namespace&#125;/platform_events/scroll` | Platform event Scroll Query. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/platform_events/scroll` | Platform event Scroll Query. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/vk8s_audit_logs` | VK8s Audit Log Query. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/vk8s_audit_logs/aggregation` | VK8s Audit Log Aggregation Query. |
-| GET | `/api/data/namespaces/&#123;namespace&#125;/vk8s_audit_logs/scroll` | VK8s Audit Log Scroll Query. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/vk8s_audit_logs/scroll` | VK8s Audit Log Scroll Query. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/vk8s_events` | VK8s Events Query. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/vk8s_events/aggregation` | VK8s Events Aggregation Query. |
-| GET | `/api/data/namespaces/&#123;namespace&#125;/vk8s_events/scroll` | VK8s Events Scroll Query. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/vk8s_events/scroll` | VK8s Events Scroll Query. |
-| POST | `/api/observability/connector/namespaces/system/observability/subscribe` | Subscribe to Observability service. |
-| POST | `/api/observability/connector/namespaces/system/observability/unsubscribe` | Unsubscribe to Observability Synthetic Monitor. |
-| GET | `/api/observability/synthetic_monitor/namespaces/&#123;namespace&#125;/certificate-report-detail` | GET Certificate Report Detail. |
-| GET | `/api/observability/synthetic_monitor/namespaces/&#123;namespace&#125;/certificate-summary` | GET Certificate Summary. |
-| GET | `/api/observability/synthetic_monitor/namespaces/&#123;namespace&#125;/dns-monitor-summary` | GET DNS Monitor Summary. |
-| POST | `/api/observability/synthetic_monitor/namespaces/&#123;namespace&#125;/dns-monitors-health` | GET DNS Monitor Health. |
-| GET | `/api/observability/synthetic_monitor/namespaces/&#123;namespace&#125;/global-history` | GET Global History. |
-| GET | `/api/observability/synthetic_monitor/namespaces/&#123;namespace&#125;/global-summary` | GET Global Summary. |
-| GET | `/api/observability/synthetic_monitor/namespaces/&#123;namespace&#125;/health` | GET Synthetic Monitoring Health Check. |
-| GET | `/api/observability/synthetic_monitor/namespaces/&#123;namespace&#125;/http-monitor-detail` | GET HTTP Monitor Detail. |
-| GET | `/api/observability/synthetic_monitor/namespaces/&#123;namespace&#125;/http-monitor-summary` | GET HTTP Monitor Summary. |
-| POST | `/api/observability/synthetic_monitor/namespaces/&#123;namespace&#125;/http-monitors-health` | GET HTTP Monitor Health. |
-| POST | `/api/observability/synthetic_monitor/namespaces/&#123;namespace&#125;/metric-query` | GET Metric Query Data. |
-| GET | `/api/observability/synthetic_monitor/namespaces/&#123;namespace&#125;/monitor-events` | GET Monitor Events. |
-| GET | `/api/observability/synthetic_monitor/namespaces/&#123;namespace&#125;/monitor-history` | GET Monitor History. |
-| GET | `/api/observability/synthetic_monitor/namespaces/&#123;namespace&#125;/record-type-summary` | GET Record Type Summary. |
-| GET | `/api/observability/synthetic_monitor/namespaces/&#123;namespace&#125;/source-summary` | GET Source Summary. |
-| POST | `/api/observability/synthetic_monitor/namespaces/&#123;namespace&#125;/suggest-values` | Suggest Values. |
-| GET | `/api/observability/synthetic_monitor/namespaces/&#123;namespace&#125;/tls-report-detail` | GET TLS Report Detail. |
-| GET | `/api/observability/synthetic_monitor/namespaces/&#123;namespace&#125;/tls-report-summary` | GET TLS Report Summary. |
-| GET | `/api/observability/synthetic_monitor/namespaces/&#123;namespace&#125;/tls-summary` | GET TLS Summary. |
+| Method | Path                                                                                                                        | Description                                     |
+| ------ | --------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
+| GET    | `/api/data/namespaces/system/all_ns_alerts`                                                                                 | GET Alerts.                                     |
+| GET    | `/api/data/namespaces/&#123;namespace&#125;/alerts`                                                                         | GET Alerts.                                     |
+| GET    | `/api/data/namespaces/&#123;namespace&#125;/alerts/history`                                                                 | GET Alerts History.                             |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/alerts/history/aggregation`                                                     | Alerts History Aggregation.                     |
+| GET    | `/api/data/namespaces/&#123;namespace&#125;/alerts/history/scroll`                                                          | Alerts History Scroll.                          |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/alerts/history/scroll`                                                          | Alerts History Scroll.                          |
+| POST   | `/api/observability/synthetic_monitor/namespaces/&#123;metadata.namespace&#125;/v1_dns_monitors`                            | Create DNS Monitor.                             |
+| PUT    | `/api/observability/synthetic_monitor/namespaces/&#123;metadata.namespace&#125;/v1_dns_monitors/&#123;metadata.name&#125;`  | Replace DNS Monitor.                            |
+| GET    | `/api/observability/synthetic_monitor/namespaces/&#123;namespace&#125;/filtered-dns-monitor-list`                           | GET Filtered DNS Monitor List.                  |
+| GET    | `/api/observability/synthetic_monitor/namespaces/&#123;namespace&#125;/v1_dns_monitors`                                     | List DNS Monitor.                               |
+| GET    | `/api/observability/synthetic_monitor/namespaces/&#123;namespace&#125;/v1_dns_monitors/&#123;name&#125;`                    | GET DNS Monitor.                                |
+| DELETE | `/api/observability/synthetic_monitor/namespaces/&#123;namespace&#125;/v1_dns_monitors/&#123;name&#125;`                    | DELETE DNS Monitor.                             |
+| POST   | `/api/observability/synthetic_monitor/namespaces/&#123;metadata.namespace&#125;/v1_http_monitors`                           | Create HTTP Monitor.                            |
+| PUT    | `/api/observability/synthetic_monitor/namespaces/&#123;metadata.namespace&#125;/v1_http_monitors/&#123;metadata.name&#125;` | Update HTTP Monitor.                            |
+| GET    | `/api/observability/synthetic_monitor/namespaces/&#123;namespace&#125;/filtered-http-monitor-list`                          | GET Filtered HTTP Monitor List.                 |
+| GET    | `/api/observability/synthetic_monitor/namespaces/&#123;namespace&#125;/v1_http_monitors`                                    | List HTTP Monitor.                              |
+| GET    | `/api/observability/synthetic_monitor/namespaces/&#123;namespace&#125;/v1_http_monitors/&#123;name&#125;`                   | GET HTTP Monitor.                               |
+| DELETE | `/api/observability/synthetic_monitor/namespaces/&#123;namespace&#125;/v1_http_monitors/&#123;name&#125;`                   | DELETE HTTP Monitor.                            |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/access_logs`                                                                    | Access Log Query V2.                            |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/access_logs/aggregation`                                                        | Access Log Aggregation Query.                   |
+| GET    | `/api/data/namespaces/&#123;namespace&#125;/access_logs/scroll`                                                             | Access Log Scroll Query.                        |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/access_logs/scroll`                                                             | Access Log Scroll Query.                        |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/audit_logs`                                                                     | Audit Log Query V2.                             |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/audit_logs/aggregation`                                                         | Audit Log Aggregation Query.                    |
+| GET    | `/api/data/namespaces/&#123;namespace&#125;/audit_logs/scroll`                                                              | Audit Log Scroll Query.                         |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/audit_logs/scroll`                                                              | Audit Log Scroll Query.                         |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/firewall_logs`                                                                  | Firewall Logs Query.                            |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/firewall_logs/aggregation`                                                      | Firewall Logs Aggregation Query.                |
+| GET    | `/api/data/namespaces/&#123;namespace&#125;/firewall_logs/scroll`                                                           | Firewall Logs Scroll Query.                     |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/firewall_logs/scroll`                                                           | Firewall Logs Scroll Query.                     |
+| GET    | `/api/data/namespaces/&#123;namespace&#125;/k8s_audit_logs/scroll`                                                          | K8s Audit Log Scroll Query.                     |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/k8s_audit_logs/scroll`                                                          | K8s Audit Log Scroll Query.                     |
+| GET    | `/api/data/namespaces/&#123;namespace&#125;/k8s_events/scroll`                                                              | K8s Events Scroll Query.                        |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/k8s_events/scroll`                                                              | K8s Events Scroll Query.                        |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/platform_events`                                                                | Platform event Query.                           |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/platform_events/aggregation`                                                    | Platform event Aggregation Query.               |
+| GET    | `/api/data/namespaces/&#123;namespace&#125;/platform_events/scroll`                                                         | Platform event Scroll Query.                    |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/platform_events/scroll`                                                         | Platform event Scroll Query.                    |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/vk8s_audit_logs`                                                                | VK8s Audit Log Query.                           |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/vk8s_audit_logs/aggregation`                                                    | VK8s Audit Log Aggregation Query.               |
+| GET    | `/api/data/namespaces/&#123;namespace&#125;/vk8s_audit_logs/scroll`                                                         | VK8s Audit Log Scroll Query.                    |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/vk8s_audit_logs/scroll`                                                         | VK8s Audit Log Scroll Query.                    |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/vk8s_events`                                                                    | VK8s Events Query.                              |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/vk8s_events/aggregation`                                                        | VK8s Events Aggregation Query.                  |
+| GET    | `/api/data/namespaces/&#123;namespace&#125;/vk8s_events/scroll`                                                             | VK8s Events Scroll Query.                       |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/vk8s_events/scroll`                                                             | VK8s Events Scroll Query.                       |
+| POST   | `/api/observability/connector/namespaces/system/observability/subscribe`                                                    | Subscribe to Observability service.             |
+| POST   | `/api/observability/connector/namespaces/system/observability/unsubscribe`                                                  | Unsubscribe to Observability Synthetic Monitor. |
+| GET    | `/api/observability/synthetic_monitor/namespaces/&#123;namespace&#125;/certificate-report-detail`                           | GET Certificate Report Detail.                  |
+| GET    | `/api/observability/synthetic_monitor/namespaces/&#123;namespace&#125;/certificate-summary`                                 | GET Certificate Summary.                        |
+| GET    | `/api/observability/synthetic_monitor/namespaces/&#123;namespace&#125;/dns-monitor-summary`                                 | GET DNS Monitor Summary.                        |
+| POST   | `/api/observability/synthetic_monitor/namespaces/&#123;namespace&#125;/dns-monitors-health`                                 | GET DNS Monitor Health.                         |
+| GET    | `/api/observability/synthetic_monitor/namespaces/&#123;namespace&#125;/global-history`                                      | GET Global History.                             |
+| GET    | `/api/observability/synthetic_monitor/namespaces/&#123;namespace&#125;/global-summary`                                      | GET Global Summary.                             |
+| GET    | `/api/observability/synthetic_monitor/namespaces/&#123;namespace&#125;/health`                                              | GET Synthetic Monitoring Health Check.          |
+| GET    | `/api/observability/synthetic_monitor/namespaces/&#123;namespace&#125;/http-monitor-detail`                                 | GET HTTP Monitor Detail.                        |
+| GET    | `/api/observability/synthetic_monitor/namespaces/&#123;namespace&#125;/http-monitor-summary`                                | GET HTTP Monitor Summary.                       |
+| POST   | `/api/observability/synthetic_monitor/namespaces/&#123;namespace&#125;/http-monitors-health`                                | GET HTTP Monitor Health.                        |
+| POST   | `/api/observability/synthetic_monitor/namespaces/&#123;namespace&#125;/metric-query`                                        | GET Metric Query Data.                          |
+| GET    | `/api/observability/synthetic_monitor/namespaces/&#123;namespace&#125;/monitor-events`                                      | GET Monitor Events.                             |
+| GET    | `/api/observability/synthetic_monitor/namespaces/&#123;namespace&#125;/monitor-history`                                     | GET Monitor History.                            |
+| GET    | `/api/observability/synthetic_monitor/namespaces/&#123;namespace&#125;/record-type-summary`                                 | GET Record Type Summary.                        |
+| GET    | `/api/observability/synthetic_monitor/namespaces/&#123;namespace&#125;/source-summary`                                      | GET Source Summary.                             |
+| POST   | `/api/observability/synthetic_monitor/namespaces/&#123;namespace&#125;/suggest-values`                                      | Suggest Values.                                 |
+| GET    | `/api/observability/synthetic_monitor/namespaces/&#123;namespace&#125;/tls-report-detail`                                   | GET TLS Report Detail.                          |
+| GET    | `/api/observability/synthetic_monitor/namespaces/&#123;namespace&#125;/tls-report-summary`                                  | GET TLS Report Summary.                         |
+| GET    | `/api/observability/synthetic_monitor/namespaces/&#123;namespace&#125;/tls-summary`                                         | GET TLS Summary.                                |
 
 ## Links
 

--- a/docs/en/api-reference/rate_limiting-api.mdx
+++ b/docs/en/api-reference/rate_limiting-api.mdx
@@ -2,7 +2,7 @@
 title: "⏱️ Rate Limiting API"
 description: "Request throttling, quotas, and policer rules."
 sidebar:
-    hidden: true
+  hidden: true
 ---
 
 Time-based quota enforcement with configurable windows in hours, minutes, or seconds. Protocol-specific controls for traffic shaping.
@@ -27,23 +27,23 @@ Time-based quota enforcement with configurable windows in hours, minutes, or sec
 
 ## Endpoints
 
-| Method | Path | Description |
-|--------|------|-------------|
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/policers` | Create Policer. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/policers/&#123;metadata.name&#125;` | Replace Policer. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/policers` | List Policer. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/policers/&#123;name&#125;` | GET Policer. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/policers/&#123;name&#125;` | DELETE Policer. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/protocol_policers` | Create Protocol Policer. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/protocol_policers/&#123;metadata.name&#125;` | Replace Protocol Policer. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/protocol_policers` | List Protocol Policer. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/protocol_policers/&#123;name&#125;` | GET Protocol Policer. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/protocol_policers/&#123;name&#125;` | DELETE Protocol Policer. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/rate_limiters` | Create Rate Limiter. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/rate_limiters/&#123;metadata.name&#125;` | Replace Rate Limiter. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/rate_limiters` | List Rate Limiter. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/rate_limiters/&#123;name&#125;` | GET Rate Limiter. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/rate_limiters/&#123;name&#125;` | DELETE Rate Limiter. |
+| Method | Path                                                                                                | Description               |
+| ------ | --------------------------------------------------------------------------------------------------- | ------------------------- |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/policers`                                    | Create Policer.           |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/policers/&#123;metadata.name&#125;`          | Replace Policer.          |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/policers`                                             | List Policer.             |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/policers/&#123;name&#125;`                            | GET Policer.              |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/policers/&#123;name&#125;`                            | DELETE Policer.           |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/protocol_policers`                           | Create Protocol Policer.  |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/protocol_policers/&#123;metadata.name&#125;` | Replace Protocol Policer. |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/protocol_policers`                                    | List Protocol Policer.    |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/protocol_policers/&#123;name&#125;`                   | GET Protocol Policer.     |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/protocol_policers/&#123;name&#125;`                   | DELETE Protocol Policer.  |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/rate_limiters`                               | Create Rate Limiter.      |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/rate_limiters/&#123;metadata.name&#125;`     | Replace Rate Limiter.     |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/rate_limiters`                                        | List Rate Limiter.        |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/rate_limiters/&#123;name&#125;`                       | GET Rate Limiter.         |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/rate_limiters/&#123;name&#125;`                       | DELETE Rate Limiter.      |
 
 ## Links
 

--- a/docs/en/api-reference/secops_and_incident_response-api.mdx
+++ b/docs/en/api-reference/secops_and_incident_response-api.mdx
@@ -2,7 +2,7 @@
 title: "🚨 Secops And Incident Response API"
 description: "Threat detection, user risk scoring, and automated blocking."
 sidebar:
-    hidden: true
+  hidden: true
 ---
 
 Malicious user mitigation with threat level classification. Automated response actions for suspicious behavior patterns.
@@ -27,13 +27,13 @@ Malicious user mitigation with threat level classification. Automated response a
 
 ## Endpoints
 
-| Method | Path | Description |
-|--------|------|-------------|
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/malicious_user_mitigations` | Create Malicious User Mitigation. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/malicious_user_mitigations/&#123;metadata.name&#125;` | Replace Malicious User Mitigation. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/malicious_user_mitigations` | List Malicious User Mitigation. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/malicious_user_mitigations/&#123;name&#125;` | GET Malicious User Mitigation. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/malicious_user_mitigations/&#123;name&#125;` | DELETE Malicious User Mitigation. |
+| Method | Path                                                                                                         | Description                        |
+| ------ | ------------------------------------------------------------------------------------------------------------ | ---------------------------------- |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/malicious_user_mitigations`                           | Create Malicious User Mitigation.  |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/malicious_user_mitigations/&#123;metadata.name&#125;` | Replace Malicious User Mitigation. |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/malicious_user_mitigations`                                    | List Malicious User Mitigation.    |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/malicious_user_mitigations/&#123;name&#125;`                   | GET Malicious User Mitigation.     |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/malicious_user_mitigations/&#123;name&#125;`                   | DELETE Malicious User Mitigation.  |
 
 ## Links
 

--- a/docs/en/api-reference/service_mesh-api.mdx
+++ b/docs/en/api-reference/service_mesh-api.mdx
@@ -2,7 +2,7 @@
 title: "🕸️ Service Mesh API"
 description: "Microservice routing and sidecar configuration."
 sidebar:
-    hidden: true
+  hidden: true
 ---
 
 Application type definitions with discovery and learned schema analysis. Traffic pattern inference for intelligent request handling.
@@ -28,52 +28,52 @@ Application type definitions with discovery and learned schema analysis. Traffic
 
 ## Endpoints
 
-| Method | Path | Description |
-|--------|------|-------------|
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/app_settings` | Create App Setting. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/app_settings/&#123;metadata.name&#125;` | Replace App Setting. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/app_settings` | List App Setting. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/app_settings/&#123;name&#125;` | GET App Setting. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/app_settings/&#123;name&#125;` | DELETE App Setting. |
-| GET | `/api/ml/data/namespaces/&#123;namespace&#125;/app_settings/&#123;name&#125;/suspicious_users` | GET Status of Suspicious users. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/app_types` | Create App Type. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/app_types/&#123;metadata.name&#125;` | Replace App Type. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/app_types` | List App Type. |
-| POST | `/api/ml/data/namespaces/&#123;namespace&#125;/app_types/&#123;app_type_name&#125;/api_endpoint/learnt_schema` | GET Learnt Schema per API endpoint. |
-| GET | `/api/ml/data/namespaces/&#123;namespace&#125;/app_types/&#123;app_type_name&#125;/api_endpoint/pdf` | GET PDF |
-| GET | `/api/ml/data/namespaces/&#123;namespace&#125;/app_types/&#123;app_type_name&#125;/api_endpoints` | GET API endpoints. |
-| GET | `/api/ml/data/namespaces/&#123;namespace&#125;/app_types/&#123;app_type_name&#125;/api_endpoints/swagger_spec` | GET Swagger Spec for App Type. |
-| POST | `/api/ml/data/namespaces/&#123;namespace&#125;/app_types/&#123;app_type_name&#125;/override/pop` | Remove Override. |
-| POST | `/api/ml/data/namespaces/&#123;namespace&#125;/app_types/&#123;app_type_name&#125;/override/push` | Add Override. |
-| GET | `/api/ml/data/namespaces/&#123;namespace&#125;/app_types/&#123;app_type_name&#125;/overrides` | GET Override. |
-| POST | `/api/ml/data/namespaces/&#123;namespace&#125;/app_types/&#123;app_type_name&#125;/services/&#123;service_name&#125;/api_endpoint/pdf` | GET Service API Endpoint PDF. |
-| POST | `/api/ml/data/namespaces/&#123;namespace&#125;/app_types/&#123;app_type_name&#125;/services/&#123;service_name&#125;/api_endpoints` | GET Service API Endpoints. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/app_types/&#123;name&#125;` | GET App Type. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/app_types/&#123;name&#125;` | DELETE App Type. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/endpoints` | Create Endpoint. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/endpoints/&#123;metadata.name&#125;` | Replace Endpoint. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/endpoints` | List Endpoint. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/endpoints/&#123;name&#125;` | GET Endpoint. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/endpoints/&#123;name&#125;` | DELETE Endpoint. |
-| POST | `/api/config/namespaces/system/nfv_service/&#123;name&#125;/force-delete` | Force DELETE NFV Service. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/nfv_services` | Create NFV Service. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/nfv_services/&#123;metadata.name&#125;` | Replace NFV Service. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/nfv_services` | List NFV Service. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/nfv_services/metrics` | Metrics |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/nfv_services/&#123;name&#125;` | GET NFV Service. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/nfv_services/&#123;name&#125;` | DELETE NFV Service. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/site_mesh_groups` | Create Site Mesh Group. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/site_mesh_groups/&#123;metadata.name&#125;` | Replace Site Mesh Group. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/site_mesh_groups` | List Site Mesh Group. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/site_mesh_groups/&#123;name&#125;` | GET Site Mesh Group. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/site_mesh_groups/&#123;name&#125;` | DELETE Site Mesh Group. |
-| POST | `/api/maurice/software_os_version` | GET OS based on SW_VERSION. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/virtual_networks` | Create Virtual Network. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/virtual_networks/&#123;metadata.name&#125;` | Replace Virtual Network. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/virtual_network/sid_counters` | SID Counters. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/virtual_networks` | List Virtual Network. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/virtual_networks/&#123;name&#125;` | GET Virtual Network. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/virtual_networks/&#123;name&#125;` | DELETE Virtual Network. |
+| Method | Path                                                                                                                                   | Description                         |
+| ------ | -------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/app_settings`                                                                   | Create App Setting.                 |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/app_settings/&#123;metadata.name&#125;`                                         | Replace App Setting.                |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/app_settings`                                                                            | List App Setting.                   |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/app_settings/&#123;name&#125;`                                                           | GET App Setting.                    |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/app_settings/&#123;name&#125;`                                                           | DELETE App Setting.                 |
+| GET    | `/api/ml/data/namespaces/&#123;namespace&#125;/app_settings/&#123;name&#125;/suspicious_users`                                         | GET Status of Suspicious users.     |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/app_types`                                                                      | Create App Type.                    |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/app_types/&#123;metadata.name&#125;`                                            | Replace App Type.                   |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/app_types`                                                                               | List App Type.                      |
+| POST   | `/api/ml/data/namespaces/&#123;namespace&#125;/app_types/&#123;app_type_name&#125;/api_endpoint/learnt_schema`                         | GET Learnt Schema per API endpoint. |
+| GET    | `/api/ml/data/namespaces/&#123;namespace&#125;/app_types/&#123;app_type_name&#125;/api_endpoint/pdf`                                   | GET PDF                             |
+| GET    | `/api/ml/data/namespaces/&#123;namespace&#125;/app_types/&#123;app_type_name&#125;/api_endpoints`                                      | GET API endpoints.                  |
+| GET    | `/api/ml/data/namespaces/&#123;namespace&#125;/app_types/&#123;app_type_name&#125;/api_endpoints/swagger_spec`                         | GET Swagger Spec for App Type.      |
+| POST   | `/api/ml/data/namespaces/&#123;namespace&#125;/app_types/&#123;app_type_name&#125;/override/pop`                                       | Remove Override.                    |
+| POST   | `/api/ml/data/namespaces/&#123;namespace&#125;/app_types/&#123;app_type_name&#125;/override/push`                                      | Add Override.                       |
+| GET    | `/api/ml/data/namespaces/&#123;namespace&#125;/app_types/&#123;app_type_name&#125;/overrides`                                          | GET Override.                       |
+| POST   | `/api/ml/data/namespaces/&#123;namespace&#125;/app_types/&#123;app_type_name&#125;/services/&#123;service_name&#125;/api_endpoint/pdf` | GET Service API Endpoint PDF.       |
+| POST   | `/api/ml/data/namespaces/&#123;namespace&#125;/app_types/&#123;app_type_name&#125;/services/&#123;service_name&#125;/api_endpoints`    | GET Service API Endpoints.          |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/app_types/&#123;name&#125;`                                                              | GET App Type.                       |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/app_types/&#123;name&#125;`                                                              | DELETE App Type.                    |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/endpoints`                                                                      | Create Endpoint.                    |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/endpoints/&#123;metadata.name&#125;`                                            | Replace Endpoint.                   |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/endpoints`                                                                               | List Endpoint.                      |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/endpoints/&#123;name&#125;`                                                              | GET Endpoint.                       |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/endpoints/&#123;name&#125;`                                                              | DELETE Endpoint.                    |
+| POST   | `/api/config/namespaces/system/nfv_service/&#123;name&#125;/force-delete`                                                              | Force DELETE NFV Service.           |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/nfv_services`                                                                   | Create NFV Service.                 |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/nfv_services/&#123;metadata.name&#125;`                                         | Replace NFV Service.                |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/nfv_services`                                                                            | List NFV Service.                   |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/nfv_services/metrics`                                                                      | Metrics                             |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/nfv_services/&#123;name&#125;`                                                           | GET NFV Service.                    |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/nfv_services/&#123;name&#125;`                                                           | DELETE NFV Service.                 |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/site_mesh_groups`                                                               | Create Site Mesh Group.             |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/site_mesh_groups/&#123;metadata.name&#125;`                                     | Replace Site Mesh Group.            |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/site_mesh_groups`                                                                        | List Site Mesh Group.               |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/site_mesh_groups/&#123;name&#125;`                                                       | GET Site Mesh Group.                |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/site_mesh_groups/&#123;name&#125;`                                                       | DELETE Site Mesh Group.             |
+| POST   | `/api/maurice/software_os_version`                                                                                                     | GET OS based on SW_VERSION.         |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/virtual_networks`                                                               | Create Virtual Network.             |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/virtual_networks/&#123;metadata.name&#125;`                                     | Replace Virtual Network.            |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/virtual_network/sid_counters`                                                              | SID Counters.                       |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/virtual_networks`                                                                        | List Virtual Network.               |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/virtual_networks/&#123;name&#125;`                                                       | GET Virtual Network.                |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/virtual_networks/&#123;name&#125;`                                                       | DELETE Virtual Network.             |
 
 ## Links
 

--- a/docs/en/api-reference/shape-api.mdx
+++ b/docs/en/api-reference/shape-api.mdx
@@ -2,7 +2,7 @@
 title: "🎭 Shape API"
 description: "Bot defense, fraud prevention, and client integrity."
 sidebar:
-    hidden: true
+  hidden: true
 ---
 
 Threat recognition with behavioral analysis and device fingerprinting. Mobile SDK integration for application shielding.
@@ -27,296 +27,296 @@ Threat recognition with behavioral analysis and device fingerprinting. Mobile SD
 
 ## Endpoints
 
-| Method | Path | Description |
-|--------|------|-------------|
-| POST | `/api/shape/dip/namespaces/system/app_provision` | Application Provision. |
-| DELETE | `/api/shape/dip/namespaces/system/application` | DELETE Application. |
-| POST | `/api/shape/dip/namespaces/system/application` | Update Application. |
-| GET | `/api/shape/dip/namespaces/system/applications` | GetApplications. |
-| POST | `/api/shape/dip/namespaces/system/bot/asn` | GET Bot Assessment by Top ASN. |
-| POST | `/api/shape/dip/namespaces/system/bot/transactions` | GET Bot Assessment for Transactions. |
-| POST | `/api/shape/dip/namespaces/system/bot/urls` | GET Bot Assessment by Top URLs. |
-| POST | `/api/shape/dip/namespaces/system/dashboard/age` | GET Devices By Age. |
-| POST | `/api/shape/dip/namespaces/system/dashboard/applications` | GET Information By Applications. |
-| POST | `/api/shape/dip/namespaces/system/dashboard/asn` | GET Devices By ASN. |
-| POST | `/api/shape/dip/namespaces/system/dashboard/country` | GET Devices By Country. |
-| POST | `/api/shape/dip/namespaces/system/dashboard/session` | GET Devices By Session. |
-| POST | `/api/shape/dip/namespaces/system/dashboard/ua` | GET Devices By User-Agent. |
-| POST | `/api/shape/dip/namespaces/system/dashboard/unique` | GET Devices by Unique Access. |
-| POST | `/api/shape/dip/namespaces/system/enable` | Enable Application Traffic Insights. |
-| GET | `/api/shape/dip/namespaces/system/provision/regions` | GET available Regions for Application Traffic Insights. |
-| GET | `/api/shape/dip/namespaces/system/status` | GET Application Traffic Insights Status. |
-| POST | `/api/shape/dip/namespaces/system/validate/src_tag_injection` | Validate JS Injection. |
-| POST | `/api/shape/alerts/namespaces/&#123;metadata.namespace&#125;/alert_gen_policys` | Create Alert Generation Policy. |
-| PUT | `/api/shape/alerts/namespaces/&#123;metadata.namespace&#125;/alert_gen_policys/&#123;metadata.name&#125;` | Replace Alert Generation Policy. |
-| POST | `/api/shape/alerts/namespaces/&#123;namespace&#125;/alert_gen_policy/&#123;name&#125;/status` | Clone Alert Template. |
-| GET | `/api/shape/alerts/namespaces/&#123;namespace&#125;/alert_gen_policys` | List BRM Alert Generation Policy. |
-| GET | `/api/shape/alerts/namespaces/&#123;namespace&#125;/alert_gen_policys/&#123;name&#125;` | GET Alert Generation Policy. |
-| DELETE | `/api/shape/alerts/namespaces/&#123;namespace&#125;/alert_gen_policys/&#123;name&#125;` | DELETE BRM Alert Generation Policy. |
-| POST | `/api/shape/alerts/namespaces/&#123;metadata.namespace&#125;/alert_templates` | Create Domain to protect. |
-| GET | `/api/shape/alerts/namespaces/&#123;namespace&#125;/alert_templates` | List BRM Alerts Alert Template. |
-| GET | `/api/shape/alerts/namespaces/&#123;namespace&#125;/alert_templates/&#123;name&#125;` | GET Protected Domain. |
-| DELETE | `/api/shape/alerts/namespaces/&#123;namespace&#125;/alert_templates/&#123;name&#125;` | DELETE BRM Alerts Alert Template. |
-| POST | `/api/shape/alerts/namespaces/&#123;namespace&#125;/alert_templates/&#123;name&#125;/clone` | Clone Alert Template. |
-| POST | `/api/shape/bot/custom/namespaces/&#123;namespace&#125;/bot_detection_rules` | Deploy Bot Detection Rules. |
-| GET | `/api/shape/bot/custom/namespaces/&#123;namespace&#125;/bot_detection_rules/deployments` | GET list of bot detection rule deployments. |
-| GET | `/api/shape/bot/custom/namespaces/&#123;namespace&#125;/bot_detection_rules/deployments/&#123;deployment_id&#125;` | GET details of a bot detection rule deployment. |
-| GET | `/api/shape/bot/custom/namespaces/&#123;namespace&#125;/bot_detection_rules/draft` | GET bot detection rules which are in draft state. |
-| DELETE | `/api/shape/bot/custom/namespaces/&#123;namespace&#125;/bot_detection_rules/draft` | Discard draft. |
-| POST | `/api/shape/bot/custom/namespaces/&#123;namespace&#125;/bot_detection_rules/draft` | Save draft. |
-| GET | `/api/shape/bot/custom/namespaces/&#123;namespace&#125;/bot_detection_rules/summary` | GET summary of bot detection rules. |
-| GET | `/api/shape/bot/namespaces/&#123;namespace&#125;/bot_detection_rules` | List Bot Detection Rule. |
-| GET | `/api/shape/bot/namespaces/&#123;namespace&#125;/bot_detection_rules/&#123;id&#125;/history` | GET the change history for a bot detection rule. |
-| GET | `/api/shape/bot/namespaces/&#123;namespace&#125;/bot_detection_rules/&#123;name&#125;` | GET Bot Detection Rule. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/suggest-values` | Suggest Values. |
-| GET | `/api/shape/bot/namespaces/&#123;namespace&#125;/bot_detection_updates` | GET bot detection updates. |
-| GET | `/api/shape/bot/namespaces/&#123;namespace&#125;/bot_detection_updates/download_release_notes` | Download BotDetection Updates Release Notes. |
-| GET | `/api/shape/bot/custom/namespaces/&#123;namespace&#125;/bot_endpoint_policies` | List All Bot Endpoint Policies And Versions. |
-| PUT | `/api/shape/bot/custom/namespaces/&#123;namespace&#125;/bot_endpoint_policys/&#123;name&#125;` | Custom Replace Bot Endpoint Policy. |
-| PUT | `/api/shape/bot/namespaces/&#123;metadata.namespace&#125;/bot_endpoint_policys/&#123;metadata.name&#125;` | Replace Bot Endpoint Policy. |
-| GET | `/api/shape/bot/namespaces/&#123;namespace&#125;/bot_endpoint_policy/&#123;name&#125;/versions` | Bot Endpoint Policy Versions. |
-| GET | `/api/shape/bot/namespaces/&#123;namespace&#125;/bot_endpoint_policys` | List Bot Endpoint Policy. |
-| GET | `/api/shape/bot/namespaces/&#123;namespace&#125;/bot_endpoint_policys/&#123;name&#125;` | GET Bot Endpoint Policy. |
-| GET | `/api/shape/bot/namespaces/&#123;namespace&#125;/bot_endpoint_policys/&#123;name&#125;/versions/&#123;number&#125;` | GET Content. |
-| POST | `/api/shape/bot/namespaces/&#123;metadata.namespace&#125;/bot_infrastructures` | Create Bot Infrastructure. |
-| PUT | `/api/shape/bot/namespaces/&#123;metadata.namespace&#125;/bot_infrastructures/&#123;metadata.name&#125;` | Replace Bot Infrastructure. |
-| GET | `/api/shape/bot/namespaces/&#123;namespace&#125;/bot_infrastructures` | List Bot Infrastructure. |
-| GET | `/api/shape/bot/namespaces/&#123;namespace&#125;/bot_infrastructures/&#123;name&#125;` | GET Bot Infrastructure. |
-| GET | `/api/shape/bot/namespaces/&#123;namespace&#125;/bot_infrastructures/&#123;name&#125;/deployment_history` | Deployment History. |
-| GET | `/api/shape/bot/namespaces/&#123;namespace&#125;/bot_infrastructures/&#123;name&#125;/deployment_status` | Deployment Status. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/bot_infrastructures/&#123;name&#125;/policies` | Deploy Policies to Bot Infra. |
-| GET | `/api/shape/bot/custom/namespaces/&#123;namespace&#125;/bot_allowlist_policies` | List All Bot Allowlist Policies And Versions. |
-| PUT | `/api/shape/bot/custom/namespaces/&#123;namespace&#125;/bot_allowlist_policys/&#123;name&#125;` | Custom Replace Bot allowlist Policy. |
-| PUT | `/api/shape/bot/namespaces/&#123;metadata.namespace&#125;/bot_allowlist_policys/&#123;metadata.name&#125;` | Replace Bot allowlist Policy. |
-| GET | `/api/shape/bot/namespaces/&#123;namespace&#125;/bot_allowlist_policy/&#123;name&#125;/versions` | Bot Allowlist Policy Versions. |
-| GET | `/api/shape/bot/namespaces/&#123;namespace&#125;/bot_allowlist_policys` | List Bot allowlist Policy. |
-| GET | `/api/shape/bot/namespaces/&#123;namespace&#125;/bot_allowlist_policys/&#123;name&#125;` | GET Bot allowlist Policy. |
-| GET | `/api/shape/bot/namespaces/&#123;namespace&#125;/bot_allowlist_policys/&#123;name&#125;/versions/&#123;number&#125;` | GET Content. |
-| GET | `/api/shape/bot/namespaces/&#123;namespace&#125;/bot_endpoint_policy/&#123;name&#125;/versions/&#123;number&#125;/mobile_base_config/&#123;os&#125;` | GET Mobile Base Configuration File. |
-| GET | `/api/shape/bot/custom/namespaces/&#123;namespace&#125;/bot_network_policies` | List All Bot Network Policies And Versions. |
-| PUT | `/api/shape/bot/custom/namespaces/&#123;namespace&#125;/bot_network_policys/&#123;name&#125;` | Custom Replace Bot network Policy. |
-| PUT | `/api/shape/bot/namespaces/&#123;metadata.namespace&#125;/bot_network_policys/&#123;metadata.name&#125;` | Replace Bot network Policy. |
-| GET | `/api/shape/bot/namespaces/&#123;namespace&#125;/bot_network_policy/&#123;name&#125;/versions` | Bot Network Policy Versions. |
-| GET | `/api/shape/bot/namespaces/&#123;namespace&#125;/bot_network_policys` | List Bot network Policy. |
-| GET | `/api/shape/bot/namespaces/&#123;namespace&#125;/bot_network_policys/&#123;name&#125;` | GET Bot network Policy. |
-| GET | `/api/shape/bot/namespaces/&#123;namespace&#125;/bot_network_policys/&#123;name&#125;/versions/&#123;number&#125;` | GET Content. |
-| POST | `/api/shape/csd/namespaces/system/init` | Enable Client-Side Defense. |
-| GET | `/api/shape/csd/namespaces/&#123;namespace&#125;/detected_domains` | GET Detected Domains. |
-| GET | `/api/shape/csd/namespaces/&#123;namespace&#125;/domain_details` | GET Domain Details. |
-| GET | `/api/shape/csd/namespaces/&#123;namespace&#125;/formFields` | List All Form Fields with GET method. |
-| POST | `/api/shape/csd/namespaces/&#123;namespace&#125;/formFields` | List All Form Fields. |
-| POST | `/api/shape/csd/namespaces/&#123;namespace&#125;/formFields/analysis` | Update FormField Analysis. |
-| GET | `/api/shape/csd/namespaces/&#123;namespace&#125;/formFields/&#123;id&#125;` | GET Form Field. |
-| GET | `/api/shape/csd/namespaces/&#123;namespace&#125;/js_configuration` | GET JS Injection Configuration. |
-| DELETE | `/api/shape/csd/namespaces/&#123;namespace&#125;/script/justification/&#123;justification_id&#125;` | DELETE Script Justification. |
-| GET | `/api/shape/csd/namespaces/&#123;namespace&#125;/scripts` | List Scripts. |
-| POST | `/api/shape/csd/namespaces/&#123;namespace&#125;/scripts` | List Scripts. |
-| GET | `/api/shape/csd/namespaces/&#123;namespace&#125;/scripts/&#123;id&#125;/behaviors` | List Behaviors By Script. |
-| GET | `/api/shape/csd/namespaces/&#123;namespace&#125;/scripts/&#123;id&#125;/dashboard` | GET Script Overview. |
-| GET | `/api/shape/csd/namespaces/&#123;namespace&#125;/scripts/&#123;id&#125;/formFields` | List Form Fields By Script. |
-| GET | `/api/shape/csd/namespaces/&#123;namespace&#125;/scripts/&#123;id&#125;/networkInteractions` | List Network Interactions By Script. |
-| POST | `/api/shape/csd/namespaces/&#123;namespace&#125;/scripts/&#123;id&#125;/readStatus` | Update Script FormFields ReadStatus. |
-| POST | `/api/shape/csd/namespaces/&#123;namespace&#125;/scripts/&#123;script_id&#125;/affectedUsers` | List Affected Users. |
-| POST | `/api/shape/csd/namespaces/&#123;namespace&#125;/scripts/&#123;script_id&#125;/justification` | Update Script Justification. |
-| GET | `/api/shape/csd/namespaces/&#123;namespace&#125;/status` | GET Status. |
-| GET | `/api/shape/csd/namespaces/&#123;namespace&#125;/summary` | GET Summary. |
-| POST | `/api/shape/csd/namespaces/&#123;namespace&#125;/testjs` | Test JS |
-| POST | `/api/shape/csd/namespaces/&#123;namespace&#125;/update_domains` | Update Domains. |
-| POST | `/api/shape/csd/namespaces/&#123;metadata.namespace&#125;/allowed_domains` | Create Allowed Domain. |
-| GET | `/api/shape/csd/namespaces/&#123;namespace&#125;/allowed_domains` | List Client-Side Defense Allowed Domain. |
-| GET | `/api/shape/csd/namespaces/&#123;namespace&#125;/allowed_domains/&#123;name&#125;` | GET Allowed Domain. |
-| DELETE | `/api/shape/csd/namespaces/&#123;namespace&#125;/allowed_domains/&#123;name&#125;` | DELETE Client-Side Defense Allowed Domain. |
-| POST | `/api/shape/csd/namespaces/&#123;metadata.namespace&#125;/protected_domains` | Create Domain to protect. |
-| GET | `/api/shape/csd/namespaces/&#123;namespace&#125;/protected_domains` | List Client-Side Defense Domain to Protect. |
-| GET | `/api/shape/csd/namespaces/&#123;namespace&#125;/protected_domains/&#123;name&#125;` | GET Protected Domain. |
-| DELETE | `/api/shape/csd/namespaces/&#123;namespace&#125;/protected_domains/&#123;name&#125;` | DELETE Client-Side Defense Domain to Protect. |
-| POST | `/api/shape/csd/namespaces/&#123;metadata.namespace&#125;/mitigated_domains` | Create Mitigated Domain. |
-| GET | `/api/shape/csd/namespaces/&#123;namespace&#125;/mitigated_domains` | List Client-Side Defense Mitigated Domain. |
-| GET | `/api/shape/csd/namespaces/&#123;namespace&#125;/mitigated_domains/&#123;name&#125;` | GET Mitigated Domain. |
-| DELETE | `/api/shape/csd/namespaces/&#123;namespace&#125;/mitigated_domains/&#123;name&#125;` | DELETE Client-Side Defense Mitigated Domain. |
-| POST | `/api/shape/csd/namespaces/&#123;namespace&#125;/detectedDomains` | List All Detected Domains. |
-| POST | `/api/shape/csd/namespaces/system/subscribe` | Subscribe to Client-Side Defense. |
-| POST | `/api/shape/csd/namespaces/system/unsubscribe` | Unsubscribe to Client-Side Defense. |
-| POST | `/api/mobile/app-shield/namespaces/system/mobile-app-shield/addon/subscribe` | Subscribe to Mobile App Shield. |
-| POST | `/api/mobile/app-shield/namespaces/system/mobile-app-shield/addon/unsubscribe` | Unsubscribe to Mobile App Shield. |
-| POST | `/api/mobile/integrator/namespaces/system/mobile-integrator/addon/subscribe` | Subscribe to Mobile Integrator. |
-| POST | `/api/mobile/integrator/namespaces/system/mobile-integrator/addon/unsubscribe` | Unsubscribe to Mobile Integrator. |
-| GET | `/api/object_store/namespaces/&#123;namespace&#125;/stored_objects/mobile-sdk` | GET List Of Mobile SDKs. |
-| GET | `/api/object_store/namespaces/&#123;namespace&#125;/stored_objects/mobile-sdk/&#123;name&#125;/&#123;version&#125;` | GET Mobile SDK. |
-| POST | `/api/mobile/security/namespaces/&#123;metadata.namespace&#125;/mobile_base_configs` | Create Mobile SDK Base Configuration. |
-| PUT | `/api/mobile/security/namespaces/&#123;metadata.namespace&#125;/mobile_base_configs/&#123;metadata.name&#125;` | Replace Mobile SDK Base Configuration. |
-| GET | `/api/mobile/security/namespaces/&#123;namespace&#125;/mobile_base_config_file/&#123;name&#125;` | GET Mobile Base Configuration File. |
-| GET | `/api/mobile/security/namespaces/&#123;namespace&#125;/mobile_base_configs` | List Mobile SDK Base Configuration. |
-| GET | `/api/mobile/security/namespaces/&#123;namespace&#125;/mobile_base_configs/&#123;name&#125;` | GET Mobile SDK Base Configuration. |
-| DELETE | `/api/mobile/security/namespaces/&#123;namespace&#125;/mobile_base_configs/&#123;name&#125;` | DELETE Mobile SDK Base Configuration. |
-| GET | `/api/shape/bot/namespaces/system/apikey` | API Key |
-| GET | `/api/shape/bot/namespaces/system/regions` | Regions |
-| POST | `/api/shape/bot/namespaces/&#123;metadata.namespace&#125;/protected_applications` | Create Protected Application. |
-| PUT | `/api/shape/bot/namespaces/&#123;metadata.namespace&#125;/protected_applications/&#123;metadata.name&#125;` | Replace Protected Application. |
-| GET | `/api/shape/bot/namespaces/&#123;namespace&#125;/protected_applications` | List Protected Application. |
-| GET | `/api/shape/bot/namespaces/&#123;namespace&#125;/protected_applications/&#123;name&#125;` | GET Protected Application. |
-| DELETE | `/api/shape/bot/namespaces/&#123;namespace&#125;/protected_applications/&#123;name&#125;` | DELETE Protected Application. |
-| GET | `/api/shape/bot/namespaces/&#123;namespace&#125;/protected_applications/&#123;name&#125;/config` | Connector Configuration. |
-| GET | `/api/shape/bot/namespaces/&#123;namespace&#125;/protected_applications/&#123;name&#125;/template` | Template Connector. |
-| POST | `/api/shape/bot/namespaces/system/reporting/peers/check` | Check Peer Status. |
-| GET | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/atb` | ATB Status. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/atb` | ATB |
-| GET | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/consumption/summary` | Consumption Summary. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/endpoint/categories` | Endpoint Categories. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/endpoint/categories/&#123;category&#125;` | Endpoint Categories Label. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/endpoint/list` | All Protected Endpoints. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/endpoint/summary` | Endpoint Summary. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/endpoints` | Report Endpoints. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/insight/credential-stuffing-attack` | Insight Event: Credential Stuffing Attack. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/insight/event/bad-bot-reduction` | Insight Bad Bot Reduction. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/insight/event/unaddressed-automations` | Insight Unaddressed Automations. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/insight/personal-stats` | Insight Personal Stats. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/insight/total-automation` | Insight Event: Total Automation. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/malicious/endpoints` | Malicious Report Endpoints. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/malicious/transactions/asn` | Malicious Report Transactions ASN. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/malicious/transactions/browser` | Malicious Report Transactions Browser. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/malicious/transactions/ip` | Malicious Report Transactions IP. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/malicious/transactions/os` | Malicious Report Transactions OS. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/malicious/transactions/ua` | Malicious Report Transactions UA. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/top/endpoints` | Top Attacked Endpoints. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/top/latency/overview` | Top Latency Overview. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/top/latency/overview/apps` | Top Latency Overview Apps. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/top/malicious/asorg` | Top Malicious Bots by ASOrg. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/top/malicious/automation` | Top Malicious Bot Automation Types. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/top/malicious/ip` | Top Malicious Bots by IP address. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/top/malicious/ua` | Top Malicious Bots by User Agent String. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/top/transactions/app` | Top Transactions by Application. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/top/transactions/categories` | Top Categories. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/top/transactions/endpointlabels` | Top Endpoint Labels. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/top/type/good` | Top Good Bots. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/top/type/human/dimension/browser` | Top Human Browser. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/top/type/human/dimension/device` | Top Human Device. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/top/type/human/dimension/geolocation` | Top Human Geolocation. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/top/type/human/dimension/platform` | Top Human Platform. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/top/type/malicious/dimension/app` | Top Malicious Bots by Application. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/top/type/malicious/dimension/apps/timeseries` | Malicious Report APP Time Series. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/top/type/malicious/dimension/asorg` | Top Malicious Bots by ASOrg v2. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/top/type/malicious/dimension/asorg/&#123;attack_type&#125;` | Top ASN of Attack Intent. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/top/type/malicious/dimension/attackintent` | Top Malicious Bots by Attack Intent. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/top/type/malicious/dimension/automation` | Top Malicious Bot Automation Types v2. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/top/type/malicious/dimension/bfp` | Top Attacked BFP. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/top/type/malicious/dimension/endpoints` | Top Attacked Endpoints v2. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/top/type/malicious/dimension/ip` | Top Malicious Bots by IP address v2. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/top/type/malicious/dimension/ip/&#123;attack_type&#125;` | Top Source IP of Attack Intent. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/top/type/malicious/dimension/ua` | Top Malicious Bots by User Agent String v2. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/top/type/malicious/dimension/ua/&#123;attack_type&#125;` | Top User Agent of Attack Intent. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/traffic/dimension/attackintent/timeseries` | Attack Intent Time Series For All Traffic. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/traffic/dimension/categories/timeseries` | Categories Time Series For All Traffic. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/traffic/malicious/dimension/attackintent/timeseries` | Malicious Bot Attack Intent Time Series. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/traffic/malicious/overview/actions` | Malicious Traffic Overview in actions. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/traffic/malicious/overview/metrics` | Malicious Traffic Overview Metrics. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/traffic/malicious/overview/timeseries/actions` | Malicious Traffic Overview Timeseries in Actions. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/traffic/overview` | Traffic Overview. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/traffic/overview/expanded` | Expanded Traffic Overview. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/traffic/overview/timeseries` | Traffic Overview Timeseries. |
-| GET | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/usage/summary` | Usage Summary. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/v1/reporting/forensic/fields` | Forensic Fields. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/v1/reporting/traffic/automated/overview/actions` | Automated Traffic Overview in actions. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/v2/reporting/endpoint/summary` | Endpoint Summary V2. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/v2/reporting/malicious/endpoints` | Malicious Report Endpoints V2. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/v2/reporting/malicious/transactions/asn` | Malicious Report Transactions ASN V2. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/v2/reporting/malicious/transactions/browser` | Malicious Report Transactions Browser V2. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/v2/reporting/malicious/transactions/ip` | Malicious Report Transactions IP V2. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/v2/reporting/malicious/transactions/os` | Malicious Report Transactions OS V2. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/v2/reporting/malicious/transactions/ua` | Malicious Report Transactions UA V2. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/v2/reporting/top/type/good` | Top Good Bots V2. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/v2/reporting/top/type/human/dimension/browser` | Top Human Browser V2. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/v2/reporting/top/type/human/dimension/device` | Top Human Device V2. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/v2/reporting/top/type/human/dimension/geolocation` | Top Human Geolocation V2. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/v2/reporting/top/type/human/dimension/platform` | Top Human Platform V2. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/v2/reporting/top/type/malicious/dimension/apps/timeseries` | Malicious Report APP Time Series V2. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/v2/reporting/top/type/malicious/dimension/asorg/&#123;attack_type&#125;` | Top ASN of Attack Intent V2. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/v2/reporting/top/type/malicious/dimension/attackintent` | Top Malicious Bots by Attack Intent V2. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/v2/reporting/top/type/malicious/dimension/endpoints` | Top Attacked Endpoints v3. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/v2/reporting/top/type/malicious/dimension/ip/&#123;attack_type&#125;` | Top Source IP of Attack Intent V2. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/v2/reporting/top/type/malicious/dimension/ua/&#123;attack_type&#125;` | Top User Agent of Attack Intent V2. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/v2/reporting/traffic/malicious/dimension/attackintent/timeseries` | Malicious Bot Attack Intent Time Series V2. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/v2/reporting/traffic/malicious/overview/actions` | Malicious Traffic Overview in actions V2. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/v2/reporting/traffic/malicious/overview/metrics` | Malicious Traffic Overview Metrics V2. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/v2/reporting/traffic/malicious/overview/timeseries/actions` | Malicious Traffic Overview Timeseries in Actions V2. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/v2/reporting/traffic/overview` | Traffic Overview V2. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/v2/reporting/traffic/overview/expanded` | Expanded Traffic Overview V2. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/v2/reporting/traffic/overview/timeseries` | Traffic Overview Timeseries V2. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/v3/reporting/top/type/good` | Top Good Bots V3. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/v3/reporting/top/type/malicious/dimension/asorg` | Top Malicious Bots by ASOrg v3. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/v3/reporting/top/type/malicious/dimension/automation` | Top Malicious Bot Automation Types v3. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/v3/reporting/top/type/malicious/dimension/ip` | Top Malicious Bots by IP address v3. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/v3/reporting/top/type/malicious/dimension/ua` | Top Malicious Bots by User Agent String v3. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/v3/reporting/traffic/overview` | Traffic Overview V3. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/v3/reporting/traffic/overview/expanded` | Expanded Traffic Overview V3. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/v3/reporting/traffic/overview/timeseries` | Traffic Overview Timeseries V3. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/v4/reporting/top/type/malicious/dimension/endpoints` | Top Attacked Endpoints v4. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/v4/reporting/top/type/malicious/dimension/ua` | Top Malicious Bots by User Agent String v4. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/v4/reporting/traffic/overview/expanded` | Expanded Traffic Overview in Traffic Analyzer. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/v4/reporting/traffic/overview/timeseries` | Traffic Overview Timeseries V4. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/v5/reporting/top/type/malicious/dimension/endpoints` | Top Attacked Endpoints v5. |
-| POST | `/api/shape/bot/namespaces/&#123;namespace&#125;/v5/reporting/traffic/overview/expanded` | Expanded Traffic Overview V5. |
-| POST | `/api/shape/bot/reporting/peers/threat-types` | Peergroup By Threat Types. |
-| POST | `/api/shape/bot/reporting/peers/top-good-bots` | Peer Group Top Good Bots. |
-| POST | `/api/shape/bot/reporting/peers/top-reason-codes` | Peergroup Top Reason Codes. |
-| POST | `/api/shape/bot/reporting/peers/traffic/overview` | Peer Group Traffic Overview. |
-| POST | `/api/shape/bot/namespaces/system/bot-defense/addon/subscribe` | Subscribe to Shape Bot Defense. |
-| POST | `/api/shape/bot/namespaces/system/bot-defense/addon/unsubscribe` | Unsubscribe to Shape Bot Defense. |
-| POST | `/api/shape/bot/subscribe` | Subscribe to Shape Bot Defense. |
-| POST | `/api/shape/bot/unsubscribe` | Unsubscribe to Shape Bot Defense. |
-| POST | `/api/shape/recognize/namespaces/system/recognize/addon/dashboard/channel` | Channel Dashboard. |
-| POST | `/api/shape/recognize/namespaces/system/recognize/addon/dashboard/conversion` | Conversion Dashboard. |
-| POST | `/api/shape/recognize/namespaces/system/recognize/addon/dashboard/enjoy` | Enjoy Dashboard. |
-| POST | `/api/shape/recognize/namespaces/system/recognize/addon/dashboard/friction_aggregation` | Friction Aggregation Dashboard. |
-| POST | `/api/shape/recognize/namespaces/system/recognize/addon/dashboard/friction_histogram` | Friction Histogram Dashboard. |
-| GET | `/api/shape/recognize/namespaces/system/recognize/addon/dashboard/health` | Health Check. |
-| POST | `/api/shape/recognize/namespaces/system/recognize/addon/dashboard/lift` | Lift Dashboard. |
-| POST | `/api/shape/recognize/namespaces/system/recognize/addon/dashboard/rescue` | Rescue Dashboard. |
-| POST | `/api/shape/recognize/namespaces/system/recognize/addon/dashboard/top_reason_code` | Top Reason Codes. |
-| GET | `/api/shape/recognize/namespaces/system/recognize/addon/provision` | GET Recognize Provision Status Addon. |
-| GET | `/api/shape/recognize/namespaces/system/recognize/addon/state` | State |
-| POST | `/api/shape/recognize/namespaces/system/recognize/addon/subscribe` | Subscribe to Shape Recognize. |
-| POST | `/api/shape/recognize/namespaces/system/recognize/addon/unsubscribe` | Unsubscribe to Shape Recognize. |
-| POST | `/api/shape/recognize/namespaces/system/recognize/addon/validate/src_tag_injection` | ValidateSrcTagInjection Addon. |
-| POST | `/api/shape/safeap/namespaces/system/safeap/addon/subscribe` | Subscribe to Safe AP. |
-| POST | `/api/shape/safeap/namespaces/system/safeap/addon/unsubscribe` | Unsubscribe to Safe AP. |
-| POST | `/api/shape/safeap/namespaces/system/safeap/dashboard/getcurrentfrauddata` | GetCurrentFraudData. |
-| POST | `/api/shape/safeap/namespaces/system/safeap/dashboard/gettopriskyaccounts` | GetTopRiskyAccounts. |
-| POST | `/api/shape/safeap/namespaces/system/safeap/dashboard/gettopriskydevices` | GetTopRiskyDevices. |
-| POST | `/api/shape/safeap/namespaces/system/safeap/dashboard/gettopriskyipaddresses` | GetTopRiskyIpAddresses. |
-| POST | `/api/shape/safeap/namespaces/system/safeap/dashboard/gettopriskyreasons` | GetTopRiskyReasons. |
-| POST | `/api/shape/safeap/namespaces/system/safeap/dashboard/gettransactiondata` | GetTransactionData. |
-| GET | `/api/shape/safeap/namespaces/system/safeap/dashboard/health` | Health Check. |
-| POST | `/api/shape/safeap/namespaces/system/safeap/dashboard/safecubejsdata` | GetSafeCubeJSData. |
-| GET | `/api/shape/safe/namespaces/&#123;namespace&#125;/safe/sas/block/audit` | GET SAFE Block table list. |
-| GET | `/api/shape/safe/namespaces/&#123;namespace&#125;/safe/sas/block/csv/audit` | GET SAFE Analyst Block Audit as a CSV file. |
-| GET | `/api/shape/safe/namespaces/&#123;namespace&#125;/safe/sas/block/csv/table` | GET SAFE Analyst Block Table as a CSV file. |
-| GET | `/api/shape/safe/namespaces/&#123;namespace&#125;/safe/sas/block/details` | GET SAFE Block Details. |
-| POST | `/api/shape/safe/namespaces/&#123;namespace&#125;/safe/sas/block/feedback` | PostSafeBlockFeedback. |
-| POST | `/api/shape/safe/namespaces/&#123;namespace&#125;/safe/sas/block/rule` | PostSafeBlockRule. |
-| GET | `/api/shape/safe/namespaces/&#123;namespace&#125;/safe/sas/block/table` | GET SAFE Block table list. |
-| POST | `/api/shape/safe/namespaces/&#123;namespace&#125;/safe/sas/ep` | PostSafeEp. |
-| POST | `/api/shape/safe/namespaces/&#123;namespace&#125;/safe/sas/feedback` | Update Fraud Feedback. |
-| POST | `/api/shape/safe/namespaces/&#123;namespace&#125;/safe/sas/general_feedback` | Update Fraud Feedback. |
-| GET | `/api/shape/safe/namespaces/&#123;namespace&#125;/safe/sas/health` | GetHealthRequest. |
-| POST | `/api/shape/safe/namespaces/&#123;namespace&#125;/safe/sas/provision` | PostSafeProvision. |
-| GET | `/api/shape/safe/namespaces/&#123;namespace&#125;/safe/sas/stats/overview` | GET SAFE Overview. |
-| POST | `/api/shape/safe/namespaces/&#123;namespace&#125;/safe/sas/stats/overview` | PostSafeOverview. |
-| GET | `/api/shape/safe/namespaces/&#123;namespace&#125;/safe/sas/stats/top_locations` | GET SAFE Top Locations. |
-| POST | `/api/shape/safe/namespaces/&#123;namespace&#125;/safe/sas/stats/top_locations` | POST SAFE Top Locations. |
-| GET | `/api/shape/safe/namespaces/&#123;namespace&#125;/safe/sas/stats/top_sources` | GET SAFE Top Sources. |
-| POST | `/api/shape/safe/namespaces/&#123;namespace&#125;/safe/sas/stats/top_sources` | POST SAFE Top Sources. |
-| POST | `/api/shape/safe/namespaces/&#123;namespace&#125;/safe/sas/stats/transactions_over_time` | PostSafeTransactionsOverTime. |
-| GET | `/api/shape/safe/namespaces/&#123;namespace&#125;/safe/sas/summary` | GET SAFE Analyst Summary. |
-| GET | `/api/shape/safe/namespaces/&#123;namespace&#125;/safe/sas/transaction_details` | GET SAFE Anayst Transaction Details. |
-| POST | `/api/shape/safe/namespaces/&#123;namespace&#125;/safe/sas/transaction_details` | PostSafeTransactionDetails. |
-| POST | `/api/shape/safe/namespaces/&#123;namespace&#125;/safe/sas/transaction_device_history` | PostSafeTransactionDeviceHistory. |
-| POST | `/api/shape/safe/namespaces/&#123;namespace&#125;/safe/sas/transaction_locations` | PostSafeTransactionLocations. |
-| POST | `/api/shape/safe/namespaces/&#123;namespace&#125;/safe/sas/transaction_related_sessions` | PostSafeTransactionRelatedSessions. |
-| POST | `/api/shape/safe/namespaces/&#123;namespace&#125;/safe/sas/transaction_timeline` | PostSafeTransactionTimeline. |
-| POST | `/api/shape/safe/namespaces/&#123;namespace&#125;/safe/sas/transactions` | List SAFE Analyst Transactions. |
-| POST | `/api/shape/safe/namespaces/&#123;namespace&#125;/safe/sas/transactions_csv` | GET SAFE Analyst Transactions as a CSV file. |
-| GET | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/config` | Enterprise Config. |
+| Method | Path                                                                                                                                                 | Description                                             |
+| ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
+| POST   | `/api/shape/dip/namespaces/system/app_provision`                                                                                                     | Application Provision.                                  |
+| DELETE | `/api/shape/dip/namespaces/system/application`                                                                                                       | DELETE Application.                                     |
+| POST   | `/api/shape/dip/namespaces/system/application`                                                                                                       | Update Application.                                     |
+| GET    | `/api/shape/dip/namespaces/system/applications`                                                                                                      | GetApplications.                                        |
+| POST   | `/api/shape/dip/namespaces/system/bot/asn`                                                                                                           | GET Bot Assessment by Top ASN.                          |
+| POST   | `/api/shape/dip/namespaces/system/bot/transactions`                                                                                                  | GET Bot Assessment for Transactions.                    |
+| POST   | `/api/shape/dip/namespaces/system/bot/urls`                                                                                                          | GET Bot Assessment by Top URLs.                         |
+| POST   | `/api/shape/dip/namespaces/system/dashboard/age`                                                                                                     | GET Devices By Age.                                     |
+| POST   | `/api/shape/dip/namespaces/system/dashboard/applications`                                                                                            | GET Information By Applications.                        |
+| POST   | `/api/shape/dip/namespaces/system/dashboard/asn`                                                                                                     | GET Devices By ASN.                                     |
+| POST   | `/api/shape/dip/namespaces/system/dashboard/country`                                                                                                 | GET Devices By Country.                                 |
+| POST   | `/api/shape/dip/namespaces/system/dashboard/session`                                                                                                 | GET Devices By Session.                                 |
+| POST   | `/api/shape/dip/namespaces/system/dashboard/ua`                                                                                                      | GET Devices By User-Agent.                              |
+| POST   | `/api/shape/dip/namespaces/system/dashboard/unique`                                                                                                  | GET Devices by Unique Access.                           |
+| POST   | `/api/shape/dip/namespaces/system/enable`                                                                                                            | Enable Application Traffic Insights.                    |
+| GET    | `/api/shape/dip/namespaces/system/provision/regions`                                                                                                 | GET available Regions for Application Traffic Insights. |
+| GET    | `/api/shape/dip/namespaces/system/status`                                                                                                            | GET Application Traffic Insights Status.                |
+| POST   | `/api/shape/dip/namespaces/system/validate/src_tag_injection`                                                                                        | Validate JS Injection.                                  |
+| POST   | `/api/shape/alerts/namespaces/&#123;metadata.namespace&#125;/alert_gen_policys`                                                                      | Create Alert Generation Policy.                         |
+| PUT    | `/api/shape/alerts/namespaces/&#123;metadata.namespace&#125;/alert_gen_policys/&#123;metadata.name&#125;`                                            | Replace Alert Generation Policy.                        |
+| POST   | `/api/shape/alerts/namespaces/&#123;namespace&#125;/alert_gen_policy/&#123;name&#125;/status`                                                        | Clone Alert Template.                                   |
+| GET    | `/api/shape/alerts/namespaces/&#123;namespace&#125;/alert_gen_policys`                                                                               | List BRM Alert Generation Policy.                       |
+| GET    | `/api/shape/alerts/namespaces/&#123;namespace&#125;/alert_gen_policys/&#123;name&#125;`                                                              | GET Alert Generation Policy.                            |
+| DELETE | `/api/shape/alerts/namespaces/&#123;namespace&#125;/alert_gen_policys/&#123;name&#125;`                                                              | DELETE BRM Alert Generation Policy.                     |
+| POST   | `/api/shape/alerts/namespaces/&#123;metadata.namespace&#125;/alert_templates`                                                                        | Create Domain to protect.                               |
+| GET    | `/api/shape/alerts/namespaces/&#123;namespace&#125;/alert_templates`                                                                                 | List BRM Alerts Alert Template.                         |
+| GET    | `/api/shape/alerts/namespaces/&#123;namespace&#125;/alert_templates/&#123;name&#125;`                                                                | GET Protected Domain.                                   |
+| DELETE | `/api/shape/alerts/namespaces/&#123;namespace&#125;/alert_templates/&#123;name&#125;`                                                                | DELETE BRM Alerts Alert Template.                       |
+| POST   | `/api/shape/alerts/namespaces/&#123;namespace&#125;/alert_templates/&#123;name&#125;/clone`                                                          | Clone Alert Template.                                   |
+| POST   | `/api/shape/bot/custom/namespaces/&#123;namespace&#125;/bot_detection_rules`                                                                         | Deploy Bot Detection Rules.                             |
+| GET    | `/api/shape/bot/custom/namespaces/&#123;namespace&#125;/bot_detection_rules/deployments`                                                             | GET list of bot detection rule deployments.             |
+| GET    | `/api/shape/bot/custom/namespaces/&#123;namespace&#125;/bot_detection_rules/deployments/&#123;deployment_id&#125;`                                   | GET details of a bot detection rule deployment.         |
+| GET    | `/api/shape/bot/custom/namespaces/&#123;namespace&#125;/bot_detection_rules/draft`                                                                   | GET bot detection rules which are in draft state.       |
+| DELETE | `/api/shape/bot/custom/namespaces/&#123;namespace&#125;/bot_detection_rules/draft`                                                                   | Discard draft.                                          |
+| POST   | `/api/shape/bot/custom/namespaces/&#123;namespace&#125;/bot_detection_rules/draft`                                                                   | Save draft.                                             |
+| GET    | `/api/shape/bot/custom/namespaces/&#123;namespace&#125;/bot_detection_rules/summary`                                                                 | GET summary of bot detection rules.                     |
+| GET    | `/api/shape/bot/namespaces/&#123;namespace&#125;/bot_detection_rules`                                                                                | List Bot Detection Rule.                                |
+| GET    | `/api/shape/bot/namespaces/&#123;namespace&#125;/bot_detection_rules/&#123;id&#125;/history`                                                         | GET the change history for a bot detection rule.        |
+| GET    | `/api/shape/bot/namespaces/&#123;namespace&#125;/bot_detection_rules/&#123;name&#125;`                                                               | GET Bot Detection Rule.                                 |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/suggest-values`                                                                                     | Suggest Values.                                         |
+| GET    | `/api/shape/bot/namespaces/&#123;namespace&#125;/bot_detection_updates`                                                                              | GET bot detection updates.                              |
+| GET    | `/api/shape/bot/namespaces/&#123;namespace&#125;/bot_detection_updates/download_release_notes`                                                       | Download BotDetection Updates Release Notes.            |
+| GET    | `/api/shape/bot/custom/namespaces/&#123;namespace&#125;/bot_endpoint_policies`                                                                       | List All Bot Endpoint Policies And Versions.            |
+| PUT    | `/api/shape/bot/custom/namespaces/&#123;namespace&#125;/bot_endpoint_policys/&#123;name&#125;`                                                       | Custom Replace Bot Endpoint Policy.                     |
+| PUT    | `/api/shape/bot/namespaces/&#123;metadata.namespace&#125;/bot_endpoint_policys/&#123;metadata.name&#125;`                                            | Replace Bot Endpoint Policy.                            |
+| GET    | `/api/shape/bot/namespaces/&#123;namespace&#125;/bot_endpoint_policy/&#123;name&#125;/versions`                                                      | Bot Endpoint Policy Versions.                           |
+| GET    | `/api/shape/bot/namespaces/&#123;namespace&#125;/bot_endpoint_policys`                                                                               | List Bot Endpoint Policy.                               |
+| GET    | `/api/shape/bot/namespaces/&#123;namespace&#125;/bot_endpoint_policys/&#123;name&#125;`                                                              | GET Bot Endpoint Policy.                                |
+| GET    | `/api/shape/bot/namespaces/&#123;namespace&#125;/bot_endpoint_policys/&#123;name&#125;/versions/&#123;number&#125;`                                  | GET Content.                                            |
+| POST   | `/api/shape/bot/namespaces/&#123;metadata.namespace&#125;/bot_infrastructures`                                                                       | Create Bot Infrastructure.                              |
+| PUT    | `/api/shape/bot/namespaces/&#123;metadata.namespace&#125;/bot_infrastructures/&#123;metadata.name&#125;`                                             | Replace Bot Infrastructure.                             |
+| GET    | `/api/shape/bot/namespaces/&#123;namespace&#125;/bot_infrastructures`                                                                                | List Bot Infrastructure.                                |
+| GET    | `/api/shape/bot/namespaces/&#123;namespace&#125;/bot_infrastructures/&#123;name&#125;`                                                               | GET Bot Infrastructure.                                 |
+| GET    | `/api/shape/bot/namespaces/&#123;namespace&#125;/bot_infrastructures/&#123;name&#125;/deployment_history`                                            | Deployment History.                                     |
+| GET    | `/api/shape/bot/namespaces/&#123;namespace&#125;/bot_infrastructures/&#123;name&#125;/deployment_status`                                             | Deployment Status.                                      |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/bot_infrastructures/&#123;name&#125;/policies`                                                      | Deploy Policies to Bot Infra.                           |
+| GET    | `/api/shape/bot/custom/namespaces/&#123;namespace&#125;/bot_allowlist_policies`                                                                      | List All Bot Allowlist Policies And Versions.           |
+| PUT    | `/api/shape/bot/custom/namespaces/&#123;namespace&#125;/bot_allowlist_policys/&#123;name&#125;`                                                      | Custom Replace Bot allowlist Policy.                    |
+| PUT    | `/api/shape/bot/namespaces/&#123;metadata.namespace&#125;/bot_allowlist_policys/&#123;metadata.name&#125;`                                           | Replace Bot allowlist Policy.                           |
+| GET    | `/api/shape/bot/namespaces/&#123;namespace&#125;/bot_allowlist_policy/&#123;name&#125;/versions`                                                     | Bot Allowlist Policy Versions.                          |
+| GET    | `/api/shape/bot/namespaces/&#123;namespace&#125;/bot_allowlist_policys`                                                                              | List Bot allowlist Policy.                              |
+| GET    | `/api/shape/bot/namespaces/&#123;namespace&#125;/bot_allowlist_policys/&#123;name&#125;`                                                             | GET Bot allowlist Policy.                               |
+| GET    | `/api/shape/bot/namespaces/&#123;namespace&#125;/bot_allowlist_policys/&#123;name&#125;/versions/&#123;number&#125;`                                 | GET Content.                                            |
+| GET    | `/api/shape/bot/namespaces/&#123;namespace&#125;/bot_endpoint_policy/&#123;name&#125;/versions/&#123;number&#125;/mobile_base_config/&#123;os&#125;` | GET Mobile Base Configuration File.                     |
+| GET    | `/api/shape/bot/custom/namespaces/&#123;namespace&#125;/bot_network_policies`                                                                        | List All Bot Network Policies And Versions.             |
+| PUT    | `/api/shape/bot/custom/namespaces/&#123;namespace&#125;/bot_network_policys/&#123;name&#125;`                                                        | Custom Replace Bot network Policy.                      |
+| PUT    | `/api/shape/bot/namespaces/&#123;metadata.namespace&#125;/bot_network_policys/&#123;metadata.name&#125;`                                             | Replace Bot network Policy.                             |
+| GET    | `/api/shape/bot/namespaces/&#123;namespace&#125;/bot_network_policy/&#123;name&#125;/versions`                                                       | Bot Network Policy Versions.                            |
+| GET    | `/api/shape/bot/namespaces/&#123;namespace&#125;/bot_network_policys`                                                                                | List Bot network Policy.                                |
+| GET    | `/api/shape/bot/namespaces/&#123;namespace&#125;/bot_network_policys/&#123;name&#125;`                                                               | GET Bot network Policy.                                 |
+| GET    | `/api/shape/bot/namespaces/&#123;namespace&#125;/bot_network_policys/&#123;name&#125;/versions/&#123;number&#125;`                                   | GET Content.                                            |
+| POST   | `/api/shape/csd/namespaces/system/init`                                                                                                              | Enable Client-Side Defense.                             |
+| GET    | `/api/shape/csd/namespaces/&#123;namespace&#125;/detected_domains`                                                                                   | GET Detected Domains.                                   |
+| GET    | `/api/shape/csd/namespaces/&#123;namespace&#125;/domain_details`                                                                                     | GET Domain Details.                                     |
+| GET    | `/api/shape/csd/namespaces/&#123;namespace&#125;/formFields`                                                                                         | List All Form Fields with GET method.                   |
+| POST   | `/api/shape/csd/namespaces/&#123;namespace&#125;/formFields`                                                                                         | List All Form Fields.                                   |
+| POST   | `/api/shape/csd/namespaces/&#123;namespace&#125;/formFields/analysis`                                                                                | Update FormField Analysis.                              |
+| GET    | `/api/shape/csd/namespaces/&#123;namespace&#125;/formFields/&#123;id&#125;`                                                                          | GET Form Field.                                         |
+| GET    | `/api/shape/csd/namespaces/&#123;namespace&#125;/js_configuration`                                                                                   | GET JS Injection Configuration.                         |
+| DELETE | `/api/shape/csd/namespaces/&#123;namespace&#125;/script/justification/&#123;justification_id&#125;`                                                  | DELETE Script Justification.                            |
+| GET    | `/api/shape/csd/namespaces/&#123;namespace&#125;/scripts`                                                                                            | List Scripts.                                           |
+| POST   | `/api/shape/csd/namespaces/&#123;namespace&#125;/scripts`                                                                                            | List Scripts.                                           |
+| GET    | `/api/shape/csd/namespaces/&#123;namespace&#125;/scripts/&#123;id&#125;/behaviors`                                                                   | List Behaviors By Script.                               |
+| GET    | `/api/shape/csd/namespaces/&#123;namespace&#125;/scripts/&#123;id&#125;/dashboard`                                                                   | GET Script Overview.                                    |
+| GET    | `/api/shape/csd/namespaces/&#123;namespace&#125;/scripts/&#123;id&#125;/formFields`                                                                  | List Form Fields By Script.                             |
+| GET    | `/api/shape/csd/namespaces/&#123;namespace&#125;/scripts/&#123;id&#125;/networkInteractions`                                                         | List Network Interactions By Script.                    |
+| POST   | `/api/shape/csd/namespaces/&#123;namespace&#125;/scripts/&#123;id&#125;/readStatus`                                                                  | Update Script FormFields ReadStatus.                    |
+| POST   | `/api/shape/csd/namespaces/&#123;namespace&#125;/scripts/&#123;script_id&#125;/affectedUsers`                                                        | List Affected Users.                                    |
+| POST   | `/api/shape/csd/namespaces/&#123;namespace&#125;/scripts/&#123;script_id&#125;/justification`                                                        | Update Script Justification.                            |
+| GET    | `/api/shape/csd/namespaces/&#123;namespace&#125;/status`                                                                                             | GET Status.                                             |
+| GET    | `/api/shape/csd/namespaces/&#123;namespace&#125;/summary`                                                                                            | GET Summary.                                            |
+| POST   | `/api/shape/csd/namespaces/&#123;namespace&#125;/testjs`                                                                                             | Test JS                                                 |
+| POST   | `/api/shape/csd/namespaces/&#123;namespace&#125;/update_domains`                                                                                     | Update Domains.                                         |
+| POST   | `/api/shape/csd/namespaces/&#123;metadata.namespace&#125;/allowed_domains`                                                                           | Create Allowed Domain.                                  |
+| GET    | `/api/shape/csd/namespaces/&#123;namespace&#125;/allowed_domains`                                                                                    | List Client-Side Defense Allowed Domain.                |
+| GET    | `/api/shape/csd/namespaces/&#123;namespace&#125;/allowed_domains/&#123;name&#125;`                                                                   | GET Allowed Domain.                                     |
+| DELETE | `/api/shape/csd/namespaces/&#123;namespace&#125;/allowed_domains/&#123;name&#125;`                                                                   | DELETE Client-Side Defense Allowed Domain.              |
+| POST   | `/api/shape/csd/namespaces/&#123;metadata.namespace&#125;/protected_domains`                                                                         | Create Domain to protect.                               |
+| GET    | `/api/shape/csd/namespaces/&#123;namespace&#125;/protected_domains`                                                                                  | List Client-Side Defense Domain to Protect.             |
+| GET    | `/api/shape/csd/namespaces/&#123;namespace&#125;/protected_domains/&#123;name&#125;`                                                                 | GET Protected Domain.                                   |
+| DELETE | `/api/shape/csd/namespaces/&#123;namespace&#125;/protected_domains/&#123;name&#125;`                                                                 | DELETE Client-Side Defense Domain to Protect.           |
+| POST   | `/api/shape/csd/namespaces/&#123;metadata.namespace&#125;/mitigated_domains`                                                                         | Create Mitigated Domain.                                |
+| GET    | `/api/shape/csd/namespaces/&#123;namespace&#125;/mitigated_domains`                                                                                  | List Client-Side Defense Mitigated Domain.              |
+| GET    | `/api/shape/csd/namespaces/&#123;namespace&#125;/mitigated_domains/&#123;name&#125;`                                                                 | GET Mitigated Domain.                                   |
+| DELETE | `/api/shape/csd/namespaces/&#123;namespace&#125;/mitigated_domains/&#123;name&#125;`                                                                 | DELETE Client-Side Defense Mitigated Domain.            |
+| POST   | `/api/shape/csd/namespaces/&#123;namespace&#125;/detectedDomains`                                                                                    | List All Detected Domains.                              |
+| POST   | `/api/shape/csd/namespaces/system/subscribe`                                                                                                         | Subscribe to Client-Side Defense.                       |
+| POST   | `/api/shape/csd/namespaces/system/unsubscribe`                                                                                                       | Unsubscribe to Client-Side Defense.                     |
+| POST   | `/api/mobile/app-shield/namespaces/system/mobile-app-shield/addon/subscribe`                                                                         | Subscribe to Mobile App Shield.                         |
+| POST   | `/api/mobile/app-shield/namespaces/system/mobile-app-shield/addon/unsubscribe`                                                                       | Unsubscribe to Mobile App Shield.                       |
+| POST   | `/api/mobile/integrator/namespaces/system/mobile-integrator/addon/subscribe`                                                                         | Subscribe to Mobile Integrator.                         |
+| POST   | `/api/mobile/integrator/namespaces/system/mobile-integrator/addon/unsubscribe`                                                                       | Unsubscribe to Mobile Integrator.                       |
+| GET    | `/api/object_store/namespaces/&#123;namespace&#125;/stored_objects/mobile-sdk`                                                                       | GET List Of Mobile SDKs.                                |
+| GET    | `/api/object_store/namespaces/&#123;namespace&#125;/stored_objects/mobile-sdk/&#123;name&#125;/&#123;version&#125;`                                  | GET Mobile SDK.                                         |
+| POST   | `/api/mobile/security/namespaces/&#123;metadata.namespace&#125;/mobile_base_configs`                                                                 | Create Mobile SDK Base Configuration.                   |
+| PUT    | `/api/mobile/security/namespaces/&#123;metadata.namespace&#125;/mobile_base_configs/&#123;metadata.name&#125;`                                       | Replace Mobile SDK Base Configuration.                  |
+| GET    | `/api/mobile/security/namespaces/&#123;namespace&#125;/mobile_base_config_file/&#123;name&#125;`                                                     | GET Mobile Base Configuration File.                     |
+| GET    | `/api/mobile/security/namespaces/&#123;namespace&#125;/mobile_base_configs`                                                                          | List Mobile SDK Base Configuration.                     |
+| GET    | `/api/mobile/security/namespaces/&#123;namespace&#125;/mobile_base_configs/&#123;name&#125;`                                                         | GET Mobile SDK Base Configuration.                      |
+| DELETE | `/api/mobile/security/namespaces/&#123;namespace&#125;/mobile_base_configs/&#123;name&#125;`                                                         | DELETE Mobile SDK Base Configuration.                   |
+| GET    | `/api/shape/bot/namespaces/system/apikey`                                                                                                            | API Key                                                 |
+| GET    | `/api/shape/bot/namespaces/system/regions`                                                                                                           | Regions                                                 |
+| POST   | `/api/shape/bot/namespaces/&#123;metadata.namespace&#125;/protected_applications`                                                                    | Create Protected Application.                           |
+| PUT    | `/api/shape/bot/namespaces/&#123;metadata.namespace&#125;/protected_applications/&#123;metadata.name&#125;`                                          | Replace Protected Application.                          |
+| GET    | `/api/shape/bot/namespaces/&#123;namespace&#125;/protected_applications`                                                                             | List Protected Application.                             |
+| GET    | `/api/shape/bot/namespaces/&#123;namespace&#125;/protected_applications/&#123;name&#125;`                                                            | GET Protected Application.                              |
+| DELETE | `/api/shape/bot/namespaces/&#123;namespace&#125;/protected_applications/&#123;name&#125;`                                                            | DELETE Protected Application.                           |
+| GET    | `/api/shape/bot/namespaces/&#123;namespace&#125;/protected_applications/&#123;name&#125;/config`                                                     | Connector Configuration.                                |
+| GET    | `/api/shape/bot/namespaces/&#123;namespace&#125;/protected_applications/&#123;name&#125;/template`                                                   | Template Connector.                                     |
+| POST   | `/api/shape/bot/namespaces/system/reporting/peers/check`                                                                                             | Check Peer Status.                                      |
+| GET    | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/atb`                                                                                      | ATB Status.                                             |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/atb`                                                                                      | ATB                                                     |
+| GET    | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/consumption/summary`                                                                      | Consumption Summary.                                    |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/endpoint/categories`                                                                      | Endpoint Categories.                                    |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/endpoint/categories/&#123;category&#125;`                                                 | Endpoint Categories Label.                              |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/endpoint/list`                                                                            | All Protected Endpoints.                                |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/endpoint/summary`                                                                         | Endpoint Summary.                                       |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/endpoints`                                                                                | Report Endpoints.                                       |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/insight/credential-stuffing-attack`                                                       | Insight Event: Credential Stuffing Attack.              |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/insight/event/bad-bot-reduction`                                                          | Insight Bad Bot Reduction.                              |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/insight/event/unaddressed-automations`                                                    | Insight Unaddressed Automations.                        |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/insight/personal-stats`                                                                   | Insight Personal Stats.                                 |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/insight/total-automation`                                                                 | Insight Event: Total Automation.                        |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/malicious/endpoints`                                                                      | Malicious Report Endpoints.                             |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/malicious/transactions/asn`                                                               | Malicious Report Transactions ASN.                      |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/malicious/transactions/browser`                                                           | Malicious Report Transactions Browser.                  |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/malicious/transactions/ip`                                                                | Malicious Report Transactions IP.                       |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/malicious/transactions/os`                                                                | Malicious Report Transactions OS.                       |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/malicious/transactions/ua`                                                                | Malicious Report Transactions UA.                       |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/top/endpoints`                                                                            | Top Attacked Endpoints.                                 |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/top/latency/overview`                                                                     | Top Latency Overview.                                   |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/top/latency/overview/apps`                                                                | Top Latency Overview Apps.                              |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/top/malicious/asorg`                                                                      | Top Malicious Bots by ASOrg.                            |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/top/malicious/automation`                                                                 | Top Malicious Bot Automation Types.                     |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/top/malicious/ip`                                                                         | Top Malicious Bots by IP address.                       |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/top/malicious/ua`                                                                         | Top Malicious Bots by User Agent String.                |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/top/transactions/app`                                                                     | Top Transactions by Application.                        |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/top/transactions/categories`                                                              | Top Categories.                                         |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/top/transactions/endpointlabels`                                                          | Top Endpoint Labels.                                    |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/top/type/good`                                                                            | Top Good Bots.                                          |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/top/type/human/dimension/browser`                                                         | Top Human Browser.                                      |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/top/type/human/dimension/device`                                                          | Top Human Device.                                       |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/top/type/human/dimension/geolocation`                                                     | Top Human Geolocation.                                  |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/top/type/human/dimension/platform`                                                        | Top Human Platform.                                     |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/top/type/malicious/dimension/app`                                                         | Top Malicious Bots by Application.                      |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/top/type/malicious/dimension/apps/timeseries`                                             | Malicious Report APP Time Series.                       |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/top/type/malicious/dimension/asorg`                                                       | Top Malicious Bots by ASOrg v2.                         |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/top/type/malicious/dimension/asorg/&#123;attack_type&#125;`                               | Top ASN of Attack Intent.                               |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/top/type/malicious/dimension/attackintent`                                                | Top Malicious Bots by Attack Intent.                    |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/top/type/malicious/dimension/automation`                                                  | Top Malicious Bot Automation Types v2.                  |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/top/type/malicious/dimension/bfp`                                                         | Top Attacked BFP.                                       |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/top/type/malicious/dimension/endpoints`                                                   | Top Attacked Endpoints v2.                              |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/top/type/malicious/dimension/ip`                                                          | Top Malicious Bots by IP address v2.                    |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/top/type/malicious/dimension/ip/&#123;attack_type&#125;`                                  | Top Source IP of Attack Intent.                         |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/top/type/malicious/dimension/ua`                                                          | Top Malicious Bots by User Agent String v2.             |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/top/type/malicious/dimension/ua/&#123;attack_type&#125;`                                  | Top User Agent of Attack Intent.                        |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/traffic/dimension/attackintent/timeseries`                                                | Attack Intent Time Series For All Traffic.              |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/traffic/dimension/categories/timeseries`                                                  | Categories Time Series For All Traffic.                 |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/traffic/malicious/dimension/attackintent/timeseries`                                      | Malicious Bot Attack Intent Time Series.                |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/traffic/malicious/overview/actions`                                                       | Malicious Traffic Overview in actions.                  |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/traffic/malicious/overview/metrics`                                                       | Malicious Traffic Overview Metrics.                     |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/traffic/malicious/overview/timeseries/actions`                                            | Malicious Traffic Overview Timeseries in Actions.       |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/traffic/overview`                                                                         | Traffic Overview.                                       |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/traffic/overview/expanded`                                                                | Expanded Traffic Overview.                              |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/traffic/overview/timeseries`                                                              | Traffic Overview Timeseries.                            |
+| GET    | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/usage/summary`                                                                            | Usage Summary.                                          |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/v1/reporting/forensic/fields`                                                                       | Forensic Fields.                                        |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/v1/reporting/traffic/automated/overview/actions`                                                    | Automated Traffic Overview in actions.                  |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/v2/reporting/endpoint/summary`                                                                      | Endpoint Summary V2.                                    |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/v2/reporting/malicious/endpoints`                                                                   | Malicious Report Endpoints V2.                          |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/v2/reporting/malicious/transactions/asn`                                                            | Malicious Report Transactions ASN V2.                   |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/v2/reporting/malicious/transactions/browser`                                                        | Malicious Report Transactions Browser V2.               |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/v2/reporting/malicious/transactions/ip`                                                             | Malicious Report Transactions IP V2.                    |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/v2/reporting/malicious/transactions/os`                                                             | Malicious Report Transactions OS V2.                    |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/v2/reporting/malicious/transactions/ua`                                                             | Malicious Report Transactions UA V2.                    |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/v2/reporting/top/type/good`                                                                         | Top Good Bots V2.                                       |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/v2/reporting/top/type/human/dimension/browser`                                                      | Top Human Browser V2.                                   |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/v2/reporting/top/type/human/dimension/device`                                                       | Top Human Device V2.                                    |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/v2/reporting/top/type/human/dimension/geolocation`                                                  | Top Human Geolocation V2.                               |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/v2/reporting/top/type/human/dimension/platform`                                                     | Top Human Platform V2.                                  |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/v2/reporting/top/type/malicious/dimension/apps/timeseries`                                          | Malicious Report APP Time Series V2.                    |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/v2/reporting/top/type/malicious/dimension/asorg/&#123;attack_type&#125;`                            | Top ASN of Attack Intent V2.                            |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/v2/reporting/top/type/malicious/dimension/attackintent`                                             | Top Malicious Bots by Attack Intent V2.                 |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/v2/reporting/top/type/malicious/dimension/endpoints`                                                | Top Attacked Endpoints v3.                              |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/v2/reporting/top/type/malicious/dimension/ip/&#123;attack_type&#125;`                               | Top Source IP of Attack Intent V2.                      |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/v2/reporting/top/type/malicious/dimension/ua/&#123;attack_type&#125;`                               | Top User Agent of Attack Intent V2.                     |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/v2/reporting/traffic/malicious/dimension/attackintent/timeseries`                                   | Malicious Bot Attack Intent Time Series V2.             |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/v2/reporting/traffic/malicious/overview/actions`                                                    | Malicious Traffic Overview in actions V2.               |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/v2/reporting/traffic/malicious/overview/metrics`                                                    | Malicious Traffic Overview Metrics V2.                  |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/v2/reporting/traffic/malicious/overview/timeseries/actions`                                         | Malicious Traffic Overview Timeseries in Actions V2.    |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/v2/reporting/traffic/overview`                                                                      | Traffic Overview V2.                                    |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/v2/reporting/traffic/overview/expanded`                                                             | Expanded Traffic Overview V2.                           |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/v2/reporting/traffic/overview/timeseries`                                                           | Traffic Overview Timeseries V2.                         |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/v3/reporting/top/type/good`                                                                         | Top Good Bots V3.                                       |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/v3/reporting/top/type/malicious/dimension/asorg`                                                    | Top Malicious Bots by ASOrg v3.                         |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/v3/reporting/top/type/malicious/dimension/automation`                                               | Top Malicious Bot Automation Types v3.                  |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/v3/reporting/top/type/malicious/dimension/ip`                                                       | Top Malicious Bots by IP address v3.                    |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/v3/reporting/top/type/malicious/dimension/ua`                                                       | Top Malicious Bots by User Agent String v3.             |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/v3/reporting/traffic/overview`                                                                      | Traffic Overview V3.                                    |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/v3/reporting/traffic/overview/expanded`                                                             | Expanded Traffic Overview V3.                           |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/v3/reporting/traffic/overview/timeseries`                                                           | Traffic Overview Timeseries V3.                         |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/v4/reporting/top/type/malicious/dimension/endpoints`                                                | Top Attacked Endpoints v4.                              |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/v4/reporting/top/type/malicious/dimension/ua`                                                       | Top Malicious Bots by User Agent String v4.             |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/v4/reporting/traffic/overview/expanded`                                                             | Expanded Traffic Overview in Traffic Analyzer.          |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/v4/reporting/traffic/overview/timeseries`                                                           | Traffic Overview Timeseries V4.                         |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/v5/reporting/top/type/malicious/dimension/endpoints`                                                | Top Attacked Endpoints v5.                              |
+| POST   | `/api/shape/bot/namespaces/&#123;namespace&#125;/v5/reporting/traffic/overview/expanded`                                                             | Expanded Traffic Overview V5.                           |
+| POST   | `/api/shape/bot/reporting/peers/threat-types`                                                                                                        | Peergroup By Threat Types.                              |
+| POST   | `/api/shape/bot/reporting/peers/top-good-bots`                                                                                                       | Peer Group Top Good Bots.                               |
+| POST   | `/api/shape/bot/reporting/peers/top-reason-codes`                                                                                                    | Peergroup Top Reason Codes.                             |
+| POST   | `/api/shape/bot/reporting/peers/traffic/overview`                                                                                                    | Peer Group Traffic Overview.                            |
+| POST   | `/api/shape/bot/namespaces/system/bot-defense/addon/subscribe`                                                                                       | Subscribe to Shape Bot Defense.                         |
+| POST   | `/api/shape/bot/namespaces/system/bot-defense/addon/unsubscribe`                                                                                     | Unsubscribe to Shape Bot Defense.                       |
+| POST   | `/api/shape/bot/subscribe`                                                                                                                           | Subscribe to Shape Bot Defense.                         |
+| POST   | `/api/shape/bot/unsubscribe`                                                                                                                         | Unsubscribe to Shape Bot Defense.                       |
+| POST   | `/api/shape/recognize/namespaces/system/recognize/addon/dashboard/channel`                                                                           | Channel Dashboard.                                      |
+| POST   | `/api/shape/recognize/namespaces/system/recognize/addon/dashboard/conversion`                                                                        | Conversion Dashboard.                                   |
+| POST   | `/api/shape/recognize/namespaces/system/recognize/addon/dashboard/enjoy`                                                                             | Enjoy Dashboard.                                        |
+| POST   | `/api/shape/recognize/namespaces/system/recognize/addon/dashboard/friction_aggregation`                                                              | Friction Aggregation Dashboard.                         |
+| POST   | `/api/shape/recognize/namespaces/system/recognize/addon/dashboard/friction_histogram`                                                                | Friction Histogram Dashboard.                           |
+| GET    | `/api/shape/recognize/namespaces/system/recognize/addon/dashboard/health`                                                                            | Health Check.                                           |
+| POST   | `/api/shape/recognize/namespaces/system/recognize/addon/dashboard/lift`                                                                              | Lift Dashboard.                                         |
+| POST   | `/api/shape/recognize/namespaces/system/recognize/addon/dashboard/rescue`                                                                            | Rescue Dashboard.                                       |
+| POST   | `/api/shape/recognize/namespaces/system/recognize/addon/dashboard/top_reason_code`                                                                   | Top Reason Codes.                                       |
+| GET    | `/api/shape/recognize/namespaces/system/recognize/addon/provision`                                                                                   | GET Recognize Provision Status Addon.                   |
+| GET    | `/api/shape/recognize/namespaces/system/recognize/addon/state`                                                                                       | State                                                   |
+| POST   | `/api/shape/recognize/namespaces/system/recognize/addon/subscribe`                                                                                   | Subscribe to Shape Recognize.                           |
+| POST   | `/api/shape/recognize/namespaces/system/recognize/addon/unsubscribe`                                                                                 | Unsubscribe to Shape Recognize.                         |
+| POST   | `/api/shape/recognize/namespaces/system/recognize/addon/validate/src_tag_injection`                                                                  | ValidateSrcTagInjection Addon.                          |
+| POST   | `/api/shape/safeap/namespaces/system/safeap/addon/subscribe`                                                                                         | Subscribe to Safe AP.                                   |
+| POST   | `/api/shape/safeap/namespaces/system/safeap/addon/unsubscribe`                                                                                       | Unsubscribe to Safe AP.                                 |
+| POST   | `/api/shape/safeap/namespaces/system/safeap/dashboard/getcurrentfrauddata`                                                                           | GetCurrentFraudData.                                    |
+| POST   | `/api/shape/safeap/namespaces/system/safeap/dashboard/gettopriskyaccounts`                                                                           | GetTopRiskyAccounts.                                    |
+| POST   | `/api/shape/safeap/namespaces/system/safeap/dashboard/gettopriskydevices`                                                                            | GetTopRiskyDevices.                                     |
+| POST   | `/api/shape/safeap/namespaces/system/safeap/dashboard/gettopriskyipaddresses`                                                                        | GetTopRiskyIpAddresses.                                 |
+| POST   | `/api/shape/safeap/namespaces/system/safeap/dashboard/gettopriskyreasons`                                                                            | GetTopRiskyReasons.                                     |
+| POST   | `/api/shape/safeap/namespaces/system/safeap/dashboard/gettransactiondata`                                                                            | GetTransactionData.                                     |
+| GET    | `/api/shape/safeap/namespaces/system/safeap/dashboard/health`                                                                                        | Health Check.                                           |
+| POST   | `/api/shape/safeap/namespaces/system/safeap/dashboard/safecubejsdata`                                                                                | GetSafeCubeJSData.                                      |
+| GET    | `/api/shape/safe/namespaces/&#123;namespace&#125;/safe/sas/block/audit`                                                                              | GET SAFE Block table list.                              |
+| GET    | `/api/shape/safe/namespaces/&#123;namespace&#125;/safe/sas/block/csv/audit`                                                                          | GET SAFE Analyst Block Audit as a CSV file.             |
+| GET    | `/api/shape/safe/namespaces/&#123;namespace&#125;/safe/sas/block/csv/table`                                                                          | GET SAFE Analyst Block Table as a CSV file.             |
+| GET    | `/api/shape/safe/namespaces/&#123;namespace&#125;/safe/sas/block/details`                                                                            | GET SAFE Block Details.                                 |
+| POST   | `/api/shape/safe/namespaces/&#123;namespace&#125;/safe/sas/block/feedback`                                                                           | PostSafeBlockFeedback.                                  |
+| POST   | `/api/shape/safe/namespaces/&#123;namespace&#125;/safe/sas/block/rule`                                                                               | PostSafeBlockRule.                                      |
+| GET    | `/api/shape/safe/namespaces/&#123;namespace&#125;/safe/sas/block/table`                                                                              | GET SAFE Block table list.                              |
+| POST   | `/api/shape/safe/namespaces/&#123;namespace&#125;/safe/sas/ep`                                                                                       | PostSafeEp.                                             |
+| POST   | `/api/shape/safe/namespaces/&#123;namespace&#125;/safe/sas/feedback`                                                                                 | Update Fraud Feedback.                                  |
+| POST   | `/api/shape/safe/namespaces/&#123;namespace&#125;/safe/sas/general_feedback`                                                                         | Update Fraud Feedback.                                  |
+| GET    | `/api/shape/safe/namespaces/&#123;namespace&#125;/safe/sas/health`                                                                                   | GetHealthRequest.                                       |
+| POST   | `/api/shape/safe/namespaces/&#123;namespace&#125;/safe/sas/provision`                                                                                | PostSafeProvision.                                      |
+| GET    | `/api/shape/safe/namespaces/&#123;namespace&#125;/safe/sas/stats/overview`                                                                           | GET SAFE Overview.                                      |
+| POST   | `/api/shape/safe/namespaces/&#123;namespace&#125;/safe/sas/stats/overview`                                                                           | PostSafeOverview.                                       |
+| GET    | `/api/shape/safe/namespaces/&#123;namespace&#125;/safe/sas/stats/top_locations`                                                                      | GET SAFE Top Locations.                                 |
+| POST   | `/api/shape/safe/namespaces/&#123;namespace&#125;/safe/sas/stats/top_locations`                                                                      | POST SAFE Top Locations.                                |
+| GET    | `/api/shape/safe/namespaces/&#123;namespace&#125;/safe/sas/stats/top_sources`                                                                        | GET SAFE Top Sources.                                   |
+| POST   | `/api/shape/safe/namespaces/&#123;namespace&#125;/safe/sas/stats/top_sources`                                                                        | POST SAFE Top Sources.                                  |
+| POST   | `/api/shape/safe/namespaces/&#123;namespace&#125;/safe/sas/stats/transactions_over_time`                                                             | PostSafeTransactionsOverTime.                           |
+| GET    | `/api/shape/safe/namespaces/&#123;namespace&#125;/safe/sas/summary`                                                                                  | GET SAFE Analyst Summary.                               |
+| GET    | `/api/shape/safe/namespaces/&#123;namespace&#125;/safe/sas/transaction_details`                                                                      | GET SAFE Anayst Transaction Details.                    |
+| POST   | `/api/shape/safe/namespaces/&#123;namespace&#125;/safe/sas/transaction_details`                                                                      | PostSafeTransactionDetails.                             |
+| POST   | `/api/shape/safe/namespaces/&#123;namespace&#125;/safe/sas/transaction_device_history`                                                               | PostSafeTransactionDeviceHistory.                       |
+| POST   | `/api/shape/safe/namespaces/&#123;namespace&#125;/safe/sas/transaction_locations`                                                                    | PostSafeTransactionLocations.                           |
+| POST   | `/api/shape/safe/namespaces/&#123;namespace&#125;/safe/sas/transaction_related_sessions`                                                             | PostSafeTransactionRelatedSessions.                     |
+| POST   | `/api/shape/safe/namespaces/&#123;namespace&#125;/safe/sas/transaction_timeline`                                                                     | PostSafeTransactionTimeline.                            |
+| POST   | `/api/shape/safe/namespaces/&#123;namespace&#125;/safe/sas/transactions`                                                                             | List SAFE Analyst Transactions.                         |
+| POST   | `/api/shape/safe/namespaces/&#123;namespace&#125;/safe/sas/transactions_csv`                                                                         | GET SAFE Analyst Transactions as a CSV file.            |
+| GET    | `/api/shape/bot/namespaces/&#123;namespace&#125;/reporting/config`                                                                                   | Enterprise Config.                                      |
 
 ## Links
 

--- a/docs/en/api-reference/sites-api.mdx
+++ b/docs/en/api-reference/sites-api.mdx
@@ -2,7 +2,7 @@
 title: "🌍 Sites API"
 description: "Cloud and edge node deployments."
 sidebar:
-    hidden: true
+  hidden: true
 ---
 
 AWS, Azure, GCP VPC integration with transit gateways. Label-based selection for policy application across regions.
@@ -30,158 +30,158 @@ AWS, Azure, GCP VPC integration with transit gateways. Label-based selection for
 
 ## Endpoints
 
-| Method | Path | Description |
-|--------|------|-------------|
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/aws_tgw_sites` | Create AWS TGW site. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/aws_tgw_sites/&#123;metadata.name&#125;` | Replace AWS TGW site. |
-| POST | `/api/config/namespaces/&#123;namespace&#125;/aws_tgw_site/&#123;name&#125;/set_tgw_info` | Configure TGW Information. |
-| POST | `/api/config/namespaces/&#123;namespace&#125;/aws_tgw_site/&#123;name&#125;/set_vip_info` | Configure AWS TGW Site VIP Information. |
-| POST | `/api/config/namespaces/&#123;namespace&#125;/aws_tgw_site/&#123;name&#125;/set_vpc_ip_prefixes` | Configure VPC IP prefixes. |
-| POST | `/api/config/namespaces/&#123;namespace&#125;/aws_tgw_site/&#123;name&#125;/set_vpn_tunnels` | Configure VPN Tunnels. |
-| POST | `/api/config/namespaces/&#123;namespace&#125;/aws_tgw_site/&#123;name&#125;/validate_config` | Validate AWS TGW Config. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/aws_tgw_sites` | List Configure AWS TGW Site. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/aws_tgw_sites/&#123;name&#125;` | GET AWS TGW site. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/aws_tgw_sites/&#123;name&#125;` | DELETE Configure AWS TGW Site. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/aws_vpc_sites` | Create AWS VPC site. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/aws_vpc_sites/&#123;metadata.name&#125;` | Replace AWS VPC site. |
-| POST | `/api/config/namespaces/&#123;namespace&#125;/aws_vpc_site/&#123;name&#125;/set_cloud_site_info` | Configure AWS VPC Site Information. |
-| POST | `/api/config/namespaces/&#123;namespace&#125;/aws_vpc_site/&#123;name&#125;/set_vip_info` | Configure AWS VPC Site VIP Information. |
-| POST | `/api/config/namespaces/&#123;namespace&#125;/aws_vpc_site/&#123;name&#125;/storage/set_vpc_k8s_hostnames` | Configure VPC K8s hostnames. |
-| POST | `/api/config/namespaces/&#123;namespace&#125;/aws_vpc_site/&#123;name&#125;/validate_config` | Validate AWS VPC Site Config. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/aws_vpc_sites` | List Configure AWS VPC Site. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/aws_vpc_sites/&#123;name&#125;` | GET AWS VPC site. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/aws_vpc_sites/&#123;name&#125;` | DELETE Configure AWS VPC Site. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/voltstack_sites` | Create App Stack site. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/voltstack_sites/&#123;metadata.name&#125;` | Replace App Stack site. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/voltstack_sites` | List Configure App Stack Site. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/voltstack_sites/&#123;name&#125;` | GET App Stack site. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/voltstack_sites/&#123;name&#125;` | DELETE Configure App Stack Site. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/azure_vnet_sites` | Create Azure VNet site. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/azure_vnet_sites/&#123;metadata.name&#125;` | Replace Azure VNet site. |
-| POST | `/api/config/namespaces/&#123;namespace&#125;/azure_vnet_site/&#123;name&#125;/set_cloud_site_info` | Configure Azure VNet Site Information. |
-| POST | `/api/config/namespaces/&#123;namespace&#125;/azure_vnet_site/&#123;name&#125;/set_vip_info` | Configure Azure VNet Site VIP Information. |
-| POST | `/api/config/namespaces/&#123;namespace&#125;/azure_vnet_site/&#123;name&#125;/validate_config` | Validate Azure VNet Site Config. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/azure_vnet_sites` | List Configure Azure VNet Site. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/azure_vnet_sites/&#123;name&#125;` | GET Azure VNet site. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/azure_vnet_sites/&#123;name&#125;` | DELETE Configure Azure VNet Site. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/gcp_vpc_sites` | Create GCP VPC site. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/gcp_vpc_sites/&#123;metadata.name&#125;` | Replace GCP VPC site. |
-| POST | `/api/config/namespaces/&#123;namespace&#125;/gcp_vpc_site/&#123;name&#125;/set_cloud_site_info` | Configure GCP VPC Site Information. |
-| POST | `/api/config/namespaces/&#123;namespace&#125;/gcp_vpc_site/&#123;name&#125;/validate_config` | Validate GCP VPC Site Config. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/gcp_vpc_sites` | List Configure GCP VPC Site. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/gcp_vpc_sites/&#123;name&#125;` | GET GCP VPC site. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/gcp_vpc_sites/&#123;name&#125;` | DELETE Configure GCP VPC Site. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/securemesh_sites` | Create Secure Mesh site. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/securemesh_sites/&#123;metadata.name&#125;` | Replace Secure Mesh site. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/securemesh_sites` | List Configure Secure Mesh Site. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/securemesh_sites/&#123;name&#125;` | GET Secure Mesh site. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/securemesh_sites/&#123;name&#125;` | DELETE Configure Secure Mesh Site. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/securemesh_site_v2s` | Create Secure Mesh site. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/securemesh_site_v2s/&#123;metadata.name&#125;` | Replace Secure Mesh site. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/securemesh_site_v2s` | List Configure Secure Mesh Site. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/securemesh_site_v2s/&#123;name&#125;` | GET Secure Mesh site. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/securemesh_site_v2s/&#123;name&#125;` | DELETE Configure Secure Mesh Site. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/k8s_clusters` | Create Configuration Specification. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/k8s_clusters/&#123;metadata.name&#125;` | Replace Configuration Specification. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/k8s_clusters` | List K8s Cluster. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/k8s_clusters/&#123;name&#125;` | GET Configuration Specification. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/k8s_clusters/&#123;name&#125;` | DELETE K8s Cluster. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/firewall_logs` | Firewall Logs Query. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/firewall_logs/aggregation` | Firewall Logs Aggregation Query. |
-| GET | `/api/data/namespaces/&#123;namespace&#125;/firewall_logs/scroll` | Firewall Logs Scroll Query. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/firewall_logs/scroll` | Firewall Logs Scroll Query. |
-| GET | `/api/data/namespaces/&#123;namespace&#125;/k8s_audit_logs/scroll` | K8s Audit Log Scroll Query. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/k8s_audit_logs/scroll` | K8s Audit Log Scroll Query. |
-| GET | `/api/data/namespaces/&#123;namespace&#125;/k8s_events/scroll` | K8s Events Scroll Query. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/k8s_events/scroll` | K8s Events Scroll Query. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/platform_events` | Platform event Query. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/platform_events/aggregation` | Platform event Aggregation Query. |
-| GET | `/api/data/namespaces/&#123;namespace&#125;/platform_events/scroll` | Platform event Scroll Query. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/platform_events/scroll` | Platform event Scroll Query. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/site/&#123;site&#125;/external_connector/&#123;external_connector&#125;/logs` | External connector log query. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/site/&#123;site&#125;/k8s_audit_logs` | K8s Audit Log Query. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/site/&#123;site&#125;/k8s_audit_logs/aggregation` | K8s Audit Log Aggregation Query. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/site/&#123;site&#125;/k8s_events` | K8s Events Query. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/site/&#123;site&#125;/k8s_events/aggregation` | K8s Events Aggregation Query. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/vk8s_audit_logs` | VK8s Audit Log Query. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/vk8s_audit_logs/aggregation` | VK8s Audit Log Aggregation Query. |
-| GET | `/api/data/namespaces/&#123;namespace&#125;/vk8s_audit_logs/scroll` | VK8s Audit Log Scroll Query. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/vk8s_audit_logs/scroll` | VK8s Audit Log Scroll Query. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/vk8s_events` | VK8s Events Query. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/vk8s_events/aggregation` | VK8s Events Aggregation Query. |
-| GET | `/api/data/namespaces/&#123;namespace&#125;/vk8s_events/scroll` | VK8s Events Scroll Query. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/vk8s_events/scroll` | VK8s Events Scroll Query. |
-| POST | `/api/web/namespaces/system/revoke/global-kubeconfigs` | Revoke Global Kubeconfig. |
-| POST | `/api/data/namespaces/system/site/&#123;name&#125;/status` | Check Site Exist. |
-| GET | `/api/data/namespaces/system/site/&#123;site&#125;/api/v1/configmaps` | ConfigMap List. |
-| GET | `/api/data/namespaces/system/site/&#123;site&#125;/api/v1/endpoints` | Endpoints List. |
-| GET | `/api/data/namespaces/system/site/&#123;site&#125;/api/v1/namespaces` | Namespace List. |
-| GET | `/api/data/namespaces/system/site/&#123;site&#125;/api/v1/namespaces/&#123;namespace&#125;/configmaps` | ConfigMap List. |
-| GET | `/api/data/namespaces/system/site/&#123;site&#125;/api/v1/namespaces/&#123;namespace&#125;/endpoints` | Endpoints List. |
-| GET | `/api/data/namespaces/system/site/&#123;site&#125;/api/v1/namespaces/&#123;namespace&#125;/persistentvolumeclaims` | PersistentVolumeClaim List. |
-| GET | `/api/data/namespaces/system/site/&#123;site&#125;/api/v1/namespaces/&#123;namespace&#125;/pods` | Pod List |
-| GET | `/api/data/namespaces/system/site/&#123;site&#125;/api/v1/namespaces/&#123;namespace&#125;/secrets` | Secret List. |
-| GET | `/api/data/namespaces/system/site/&#123;site&#125;/api/v1/namespaces/&#123;namespace&#125;/services` | Service List. |
-| GET | `/api/data/namespaces/system/site/&#123;site&#125;/api/v1/nodes` | Namespace List. |
-| GET | `/api/data/namespaces/system/site/&#123;site&#125;/api/v1/persistentvolumeclaims` | PersistentVolumeClaim List. |
-| GET | `/api/data/namespaces/system/site/&#123;site&#125;/api/v1/persistentvolumes` | PersistentVolume List. |
-| GET | `/api/data/namespaces/system/site/&#123;site&#125;/api/v1/pods` | Pod List |
-| GET | `/api/data/namespaces/system/site/&#123;site&#125;/api/v1/secrets` | Secret List. |
-| GET | `/api/data/namespaces/system/site/&#123;site&#125;/api/v1/services` | Service List. |
-| GET | `/api/data/namespaces/system/site/&#123;site&#125;/apis/apps/v1/daemonsets` | DaemonSet List. |
-| GET | `/api/data/namespaces/system/site/&#123;site&#125;/apis/apps/v1/deployments` | Deployment List. |
-| GET | `/api/data/namespaces/system/site/&#123;site&#125;/apis/apps/v1/namespaces/&#123;namespace&#125;/daemonsets` | DaemonSet List. |
-| GET | `/api/data/namespaces/system/site/&#123;site&#125;/apis/apps/v1/namespaces/&#123;namespace&#125;/deployments` | Deployment List. |
-| GET | `/api/data/namespaces/system/site/&#123;site&#125;/apis/apps/v1/namespaces/&#123;namespace&#125;/replicasets` | ReplicaSet List. |
-| GET | `/api/data/namespaces/system/site/&#123;site&#125;/apis/apps/v1/namespaces/&#123;namespace&#125;/statefulsets` | StatefulSet List. |
-| GET | `/api/data/namespaces/system/site/&#123;site&#125;/apis/apps/v1/replicasets` | ReplicaSet List. |
-| GET | `/api/data/namespaces/system/site/&#123;site&#125;/apis/apps/v1/statefulsets` | StatefulSet List. |
-| GET | `/api/data/namespaces/system/site/&#123;site&#125;/apis/batch/v1/jobs` | Job List |
-| GET | `/api/data/namespaces/system/site/&#123;site&#125;/apis/batch/v1/namespaces/&#123;namespace&#125;/jobs` | Job List |
-| GET | `/api/data/namespaces/system/site/&#123;site&#125;/apis/batch/v1beta1/cronjobs` | CronJob List. |
-| GET | `/api/data/namespaces/system/site/&#123;site&#125;/apis/batch/v1beta1/namespaces/&#123;namespace&#125;/cronjobs` | CronJob List. |
-| POST | `/api/data/namespaces/system/site/&#123;site&#125;/namespaces/&#123;namespace&#125;/pods/metrics` | Pods Metrics. |
-| POST | `/api/data/namespaces/system/site/&#123;site&#125;/namespaces/&#123;namespace&#125;/virtualmachineinstances/metrics` | VirtualMachineInstances Metrics. |
-| POST | `/api/data/namespaces/system/site/&#123;site&#125;/pods/metrics` | Pods Metrics. |
-| POST | `/api/data/namespaces/system/site/&#123;site&#125;/virtualmachineinstances/metrics` | VirtualMachineInstances Metrics. |
-| GET | `/api/web/namespaces/system/sites/&#123;site&#125;/global-kubeconfigs` | List Global Kube Configs. |
-| POST | `/api/web/namespaces/system/sites/&#123;site&#125;/global-kubeconfigs` | Create Global Kube Config. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/sites/&#123;metadata.name&#125;` | Replace Site. |
-| POST | `/api/register/namespaces/&#123;namespace&#125;/site/&#123;name&#125;/state` | Set site state. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/site/&#123;site&#125;/status/metrics` | Site Status Metrics. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/sites` | List Site |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/sites/&#123;name&#125;` | GET Site |
-| POST | `/api/config/namespaces/&#123;namespace&#125;/sites/&#123;name&#125;/local-kubeconfig` | Create K8s Cluster Local Kube Config. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/sites/&#123;name&#125;/local-kubeconfigs` | List Local Kube Configs. |
-| POST | `/api/config/namespaces/&#123;namespace&#125;/sites/&#123;name&#125;/upgrade_os` | Upgrade OS. |
-| POST | `/api/config/namespaces/&#123;namespace&#125;/sites/&#123;name&#125;/upgrade_sw` | Upgrade SW. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/global_networks` | Global Network List. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/segments` | Segment List. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/graph/site` | Site Graph Query. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/graph/site/edge` | Site Edge Query. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/graph/site/node` | Site Node Query. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/interface` | Interface List. |
-| POST | `/api/data/namespaces/system/topology/dc_cluster_group/&#123;dc_cluster_group&#125;` | DC Cluster Topology. |
-| GET | `/api/data/namespaces/system/topology/dc_cluster_groups` | DC Cluster Groups Summary. |
-| GET | `/api/data/namespaces/system/topology/network/&#123;id&#125;/route_tables` | GET Network Route Tables. |
-| GET | `/api/data/namespaces/system/topology/route_table/&#123;name&#125;` | GET Route Table. |
-| GET | `/api/data/namespaces/system/topology/site/&#123;name&#125;/networks` | GET Site Networks. |
-| POST | `/api/data/namespaces/system/topology/site/&#123;site&#125;` | Site Topology. |
-| POST | `/api/data/namespaces/system/topology/site_mesh_group/&#123;site_mesh_group&#125;` | Site Mesh Topology. |
-| GET | `/api/data/namespaces/system/topology/site_mesh_groups` | Site Mesh Groups Summary. |
-| GET | `/api/data/namespaces/system/topology/tgw/&#123;id&#125;/route_tables` | GET TGW Route Tables. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/virtual_k8ss` | Create Virtual Kubernetes. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/virtual_k8ss/&#123;metadata.name&#125;` | Replace Virtual Kubernetes. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/virtual_k8s/pvc/metrics` | PVC Metrics. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/virtual_k8ss` | List Virtual Kubernetes. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/virtual_k8ss/&#123;name&#125;` | GET Virtual Kubernetes. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/virtual_k8ss/&#123;name&#125;` | DELETE Virtual Kubernetes. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/virtual_sites` | Create Virtual Site. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/virtual_sites/&#123;metadata.name&#125;` | Replace Virtual Site. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/virtual_sites` | List Virtual Site. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/virtual_sites/&#123;name&#125;` | GET Virtual Site. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/virtual_sites/&#123;name&#125;` | DELETE Virtual Site. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/virtual_sites/&#123;name&#125;/selectees` | GET Selectees. |
+| Method | Path                                                                                                                      | Description                                |
+| ------ | ------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/aws_tgw_sites`                                                     | Create AWS TGW site.                       |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/aws_tgw_sites/&#123;metadata.name&#125;`                           | Replace AWS TGW site.                      |
+| POST   | `/api/config/namespaces/&#123;namespace&#125;/aws_tgw_site/&#123;name&#125;/set_tgw_info`                                 | Configure TGW Information.                 |
+| POST   | `/api/config/namespaces/&#123;namespace&#125;/aws_tgw_site/&#123;name&#125;/set_vip_info`                                 | Configure AWS TGW Site VIP Information.    |
+| POST   | `/api/config/namespaces/&#123;namespace&#125;/aws_tgw_site/&#123;name&#125;/set_vpc_ip_prefixes`                          | Configure VPC IP prefixes.                 |
+| POST   | `/api/config/namespaces/&#123;namespace&#125;/aws_tgw_site/&#123;name&#125;/set_vpn_tunnels`                              | Configure VPN Tunnels.                     |
+| POST   | `/api/config/namespaces/&#123;namespace&#125;/aws_tgw_site/&#123;name&#125;/validate_config`                              | Validate AWS TGW Config.                   |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/aws_tgw_sites`                                                              | List Configure AWS TGW Site.               |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/aws_tgw_sites/&#123;name&#125;`                                             | GET AWS TGW site.                          |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/aws_tgw_sites/&#123;name&#125;`                                             | DELETE Configure AWS TGW Site.             |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/aws_vpc_sites`                                                     | Create AWS VPC site.                       |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/aws_vpc_sites/&#123;metadata.name&#125;`                           | Replace AWS VPC site.                      |
+| POST   | `/api/config/namespaces/&#123;namespace&#125;/aws_vpc_site/&#123;name&#125;/set_cloud_site_info`                          | Configure AWS VPC Site Information.        |
+| POST   | `/api/config/namespaces/&#123;namespace&#125;/aws_vpc_site/&#123;name&#125;/set_vip_info`                                 | Configure AWS VPC Site VIP Information.    |
+| POST   | `/api/config/namespaces/&#123;namespace&#125;/aws_vpc_site/&#123;name&#125;/storage/set_vpc_k8s_hostnames`                | Configure VPC K8s hostnames.               |
+| POST   | `/api/config/namespaces/&#123;namespace&#125;/aws_vpc_site/&#123;name&#125;/validate_config`                              | Validate AWS VPC Site Config.              |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/aws_vpc_sites`                                                              | List Configure AWS VPC Site.               |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/aws_vpc_sites/&#123;name&#125;`                                             | GET AWS VPC site.                          |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/aws_vpc_sites/&#123;name&#125;`                                             | DELETE Configure AWS VPC Site.             |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/voltstack_sites`                                                   | Create App Stack site.                     |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/voltstack_sites/&#123;metadata.name&#125;`                         | Replace App Stack site.                    |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/voltstack_sites`                                                            | List Configure App Stack Site.             |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/voltstack_sites/&#123;name&#125;`                                           | GET App Stack site.                        |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/voltstack_sites/&#123;name&#125;`                                           | DELETE Configure App Stack Site.           |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/azure_vnet_sites`                                                  | Create Azure VNet site.                    |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/azure_vnet_sites/&#123;metadata.name&#125;`                        | Replace Azure VNet site.                   |
+| POST   | `/api/config/namespaces/&#123;namespace&#125;/azure_vnet_site/&#123;name&#125;/set_cloud_site_info`                       | Configure Azure VNet Site Information.     |
+| POST   | `/api/config/namespaces/&#123;namespace&#125;/azure_vnet_site/&#123;name&#125;/set_vip_info`                              | Configure Azure VNet Site VIP Information. |
+| POST   | `/api/config/namespaces/&#123;namespace&#125;/azure_vnet_site/&#123;name&#125;/validate_config`                           | Validate Azure VNet Site Config.           |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/azure_vnet_sites`                                                           | List Configure Azure VNet Site.            |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/azure_vnet_sites/&#123;name&#125;`                                          | GET Azure VNet site.                       |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/azure_vnet_sites/&#123;name&#125;`                                          | DELETE Configure Azure VNet Site.          |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/gcp_vpc_sites`                                                     | Create GCP VPC site.                       |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/gcp_vpc_sites/&#123;metadata.name&#125;`                           | Replace GCP VPC site.                      |
+| POST   | `/api/config/namespaces/&#123;namespace&#125;/gcp_vpc_site/&#123;name&#125;/set_cloud_site_info`                          | Configure GCP VPC Site Information.        |
+| POST   | `/api/config/namespaces/&#123;namespace&#125;/gcp_vpc_site/&#123;name&#125;/validate_config`                              | Validate GCP VPC Site Config.              |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/gcp_vpc_sites`                                                              | List Configure GCP VPC Site.               |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/gcp_vpc_sites/&#123;name&#125;`                                             | GET GCP VPC site.                          |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/gcp_vpc_sites/&#123;name&#125;`                                             | DELETE Configure GCP VPC Site.             |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/securemesh_sites`                                                  | Create Secure Mesh site.                   |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/securemesh_sites/&#123;metadata.name&#125;`                        | Replace Secure Mesh site.                  |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/securemesh_sites`                                                           | List Configure Secure Mesh Site.           |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/securemesh_sites/&#123;name&#125;`                                          | GET Secure Mesh site.                      |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/securemesh_sites/&#123;name&#125;`                                          | DELETE Configure Secure Mesh Site.         |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/securemesh_site_v2s`                                               | Create Secure Mesh site.                   |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/securemesh_site_v2s/&#123;metadata.name&#125;`                     | Replace Secure Mesh site.                  |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/securemesh_site_v2s`                                                        | List Configure Secure Mesh Site.           |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/securemesh_site_v2s/&#123;name&#125;`                                       | GET Secure Mesh site.                      |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/securemesh_site_v2s/&#123;name&#125;`                                       | DELETE Configure Secure Mesh Site.         |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/k8s_clusters`                                                      | Create Configuration Specification.        |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/k8s_clusters/&#123;metadata.name&#125;`                            | Replace Configuration Specification.       |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/k8s_clusters`                                                               | List K8s Cluster.                          |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/k8s_clusters/&#123;name&#125;`                                              | GET Configuration Specification.           |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/k8s_clusters/&#123;name&#125;`                                              | DELETE K8s Cluster.                        |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/firewall_logs`                                                                | Firewall Logs Query.                       |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/firewall_logs/aggregation`                                                    | Firewall Logs Aggregation Query.           |
+| GET    | `/api/data/namespaces/&#123;namespace&#125;/firewall_logs/scroll`                                                         | Firewall Logs Scroll Query.                |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/firewall_logs/scroll`                                                         | Firewall Logs Scroll Query.                |
+| GET    | `/api/data/namespaces/&#123;namespace&#125;/k8s_audit_logs/scroll`                                                        | K8s Audit Log Scroll Query.                |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/k8s_audit_logs/scroll`                                                        | K8s Audit Log Scroll Query.                |
+| GET    | `/api/data/namespaces/&#123;namespace&#125;/k8s_events/scroll`                                                            | K8s Events Scroll Query.                   |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/k8s_events/scroll`                                                            | K8s Events Scroll Query.                   |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/platform_events`                                                              | Platform event Query.                      |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/platform_events/aggregation`                                                  | Platform event Aggregation Query.          |
+| GET    | `/api/data/namespaces/&#123;namespace&#125;/platform_events/scroll`                                                       | Platform event Scroll Query.               |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/platform_events/scroll`                                                       | Platform event Scroll Query.               |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/site/&#123;site&#125;/external_connector/&#123;external_connector&#125;/logs` | External connector log query.              |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/site/&#123;site&#125;/k8s_audit_logs`                                         | K8s Audit Log Query.                       |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/site/&#123;site&#125;/k8s_audit_logs/aggregation`                             | K8s Audit Log Aggregation Query.           |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/site/&#123;site&#125;/k8s_events`                                             | K8s Events Query.                          |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/site/&#123;site&#125;/k8s_events/aggregation`                                 | K8s Events Aggregation Query.              |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/vk8s_audit_logs`                                                              | VK8s Audit Log Query.                      |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/vk8s_audit_logs/aggregation`                                                  | VK8s Audit Log Aggregation Query.          |
+| GET    | `/api/data/namespaces/&#123;namespace&#125;/vk8s_audit_logs/scroll`                                                       | VK8s Audit Log Scroll Query.               |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/vk8s_audit_logs/scroll`                                                       | VK8s Audit Log Scroll Query.               |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/vk8s_events`                                                                  | VK8s Events Query.                         |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/vk8s_events/aggregation`                                                      | VK8s Events Aggregation Query.             |
+| GET    | `/api/data/namespaces/&#123;namespace&#125;/vk8s_events/scroll`                                                           | VK8s Events Scroll Query.                  |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/vk8s_events/scroll`                                                           | VK8s Events Scroll Query.                  |
+| POST   | `/api/web/namespaces/system/revoke/global-kubeconfigs`                                                                    | Revoke Global Kubeconfig.                  |
+| POST   | `/api/data/namespaces/system/site/&#123;name&#125;/status`                                                                | Check Site Exist.                          |
+| GET    | `/api/data/namespaces/system/site/&#123;site&#125;/api/v1/configmaps`                                                     | ConfigMap List.                            |
+| GET    | `/api/data/namespaces/system/site/&#123;site&#125;/api/v1/endpoints`                                                      | Endpoints List.                            |
+| GET    | `/api/data/namespaces/system/site/&#123;site&#125;/api/v1/namespaces`                                                     | Namespace List.                            |
+| GET    | `/api/data/namespaces/system/site/&#123;site&#125;/api/v1/namespaces/&#123;namespace&#125;/configmaps`                    | ConfigMap List.                            |
+| GET    | `/api/data/namespaces/system/site/&#123;site&#125;/api/v1/namespaces/&#123;namespace&#125;/endpoints`                     | Endpoints List.                            |
+| GET    | `/api/data/namespaces/system/site/&#123;site&#125;/api/v1/namespaces/&#123;namespace&#125;/persistentvolumeclaims`        | PersistentVolumeClaim List.                |
+| GET    | `/api/data/namespaces/system/site/&#123;site&#125;/api/v1/namespaces/&#123;namespace&#125;/pods`                          | Pod List                                   |
+| GET    | `/api/data/namespaces/system/site/&#123;site&#125;/api/v1/namespaces/&#123;namespace&#125;/secrets`                       | Secret List.                               |
+| GET    | `/api/data/namespaces/system/site/&#123;site&#125;/api/v1/namespaces/&#123;namespace&#125;/services`                      | Service List.                              |
+| GET    | `/api/data/namespaces/system/site/&#123;site&#125;/api/v1/nodes`                                                          | Namespace List.                            |
+| GET    | `/api/data/namespaces/system/site/&#123;site&#125;/api/v1/persistentvolumeclaims`                                         | PersistentVolumeClaim List.                |
+| GET    | `/api/data/namespaces/system/site/&#123;site&#125;/api/v1/persistentvolumes`                                              | PersistentVolume List.                     |
+| GET    | `/api/data/namespaces/system/site/&#123;site&#125;/api/v1/pods`                                                           | Pod List                                   |
+| GET    | `/api/data/namespaces/system/site/&#123;site&#125;/api/v1/secrets`                                                        | Secret List.                               |
+| GET    | `/api/data/namespaces/system/site/&#123;site&#125;/api/v1/services`                                                       | Service List.                              |
+| GET    | `/api/data/namespaces/system/site/&#123;site&#125;/apis/apps/v1/daemonsets`                                               | DaemonSet List.                            |
+| GET    | `/api/data/namespaces/system/site/&#123;site&#125;/apis/apps/v1/deployments`                                              | Deployment List.                           |
+| GET    | `/api/data/namespaces/system/site/&#123;site&#125;/apis/apps/v1/namespaces/&#123;namespace&#125;/daemonsets`              | DaemonSet List.                            |
+| GET    | `/api/data/namespaces/system/site/&#123;site&#125;/apis/apps/v1/namespaces/&#123;namespace&#125;/deployments`             | Deployment List.                           |
+| GET    | `/api/data/namespaces/system/site/&#123;site&#125;/apis/apps/v1/namespaces/&#123;namespace&#125;/replicasets`             | ReplicaSet List.                           |
+| GET    | `/api/data/namespaces/system/site/&#123;site&#125;/apis/apps/v1/namespaces/&#123;namespace&#125;/statefulsets`            | StatefulSet List.                          |
+| GET    | `/api/data/namespaces/system/site/&#123;site&#125;/apis/apps/v1/replicasets`                                              | ReplicaSet List.                           |
+| GET    | `/api/data/namespaces/system/site/&#123;site&#125;/apis/apps/v1/statefulsets`                                             | StatefulSet List.                          |
+| GET    | `/api/data/namespaces/system/site/&#123;site&#125;/apis/batch/v1/jobs`                                                    | Job List                                   |
+| GET    | `/api/data/namespaces/system/site/&#123;site&#125;/apis/batch/v1/namespaces/&#123;namespace&#125;/jobs`                   | Job List                                   |
+| GET    | `/api/data/namespaces/system/site/&#123;site&#125;/apis/batch/v1beta1/cronjobs`                                           | CronJob List.                              |
+| GET    | `/api/data/namespaces/system/site/&#123;site&#125;/apis/batch/v1beta1/namespaces/&#123;namespace&#125;/cronjobs`          | CronJob List.                              |
+| POST   | `/api/data/namespaces/system/site/&#123;site&#125;/namespaces/&#123;namespace&#125;/pods/metrics`                         | Pods Metrics.                              |
+| POST   | `/api/data/namespaces/system/site/&#123;site&#125;/namespaces/&#123;namespace&#125;/virtualmachineinstances/metrics`      | VirtualMachineInstances Metrics.           |
+| POST   | `/api/data/namespaces/system/site/&#123;site&#125;/pods/metrics`                                                          | Pods Metrics.                              |
+| POST   | `/api/data/namespaces/system/site/&#123;site&#125;/virtualmachineinstances/metrics`                                       | VirtualMachineInstances Metrics.           |
+| GET    | `/api/web/namespaces/system/sites/&#123;site&#125;/global-kubeconfigs`                                                    | List Global Kube Configs.                  |
+| POST   | `/api/web/namespaces/system/sites/&#123;site&#125;/global-kubeconfigs`                                                    | Create Global Kube Config.                 |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/sites/&#123;metadata.name&#125;`                                   | Replace Site.                              |
+| POST   | `/api/register/namespaces/&#123;namespace&#125;/site/&#123;name&#125;/state`                                              | Set site state.                            |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/site/&#123;site&#125;/status/metrics`                                         | Site Status Metrics.                       |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/sites`                                                                      | List Site                                  |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/sites/&#123;name&#125;`                                                     | GET Site                                   |
+| POST   | `/api/config/namespaces/&#123;namespace&#125;/sites/&#123;name&#125;/local-kubeconfig`                                    | Create K8s Cluster Local Kube Config.      |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/sites/&#123;name&#125;/local-kubeconfigs`                                   | List Local Kube Configs.                   |
+| POST   | `/api/config/namespaces/&#123;namespace&#125;/sites/&#123;name&#125;/upgrade_os`                                          | Upgrade OS.                                |
+| POST   | `/api/config/namespaces/&#123;namespace&#125;/sites/&#123;name&#125;/upgrade_sw`                                          | Upgrade SW.                                |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/global_networks`                                     | Global Network List.                       |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/segments`                                            | Segment List.                              |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/graph/site`                                                                   | Site Graph Query.                          |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/graph/site/edge`                                                              | Site Edge Query.                           |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/graph/site/node`                                                              | Site Node Query.                           |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/interface`                                           | Interface List.                            |
+| POST   | `/api/data/namespaces/system/topology/dc_cluster_group/&#123;dc_cluster_group&#125;`                                      | DC Cluster Topology.                       |
+| GET    | `/api/data/namespaces/system/topology/dc_cluster_groups`                                                                  | DC Cluster Groups Summary.                 |
+| GET    | `/api/data/namespaces/system/topology/network/&#123;id&#125;/route_tables`                                                | GET Network Route Tables.                  |
+| GET    | `/api/data/namespaces/system/topology/route_table/&#123;name&#125;`                                                       | GET Route Table.                           |
+| GET    | `/api/data/namespaces/system/topology/site/&#123;name&#125;/networks`                                                     | GET Site Networks.                         |
+| POST   | `/api/data/namespaces/system/topology/site/&#123;site&#125;`                                                              | Site Topology.                             |
+| POST   | `/api/data/namespaces/system/topology/site_mesh_group/&#123;site_mesh_group&#125;`                                        | Site Mesh Topology.                        |
+| GET    | `/api/data/namespaces/system/topology/site_mesh_groups`                                                                   | Site Mesh Groups Summary.                  |
+| GET    | `/api/data/namespaces/system/topology/tgw/&#123;id&#125;/route_tables`                                                    | GET TGW Route Tables.                      |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/virtual_k8ss`                                                      | Create Virtual Kubernetes.                 |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/virtual_k8ss/&#123;metadata.name&#125;`                            | Replace Virtual Kubernetes.                |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/virtual_k8s/pvc/metrics`                                                      | PVC Metrics.                               |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/virtual_k8ss`                                                               | List Virtual Kubernetes.                   |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/virtual_k8ss/&#123;name&#125;`                                              | GET Virtual Kubernetes.                    |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/virtual_k8ss/&#123;name&#125;`                                              | DELETE Virtual Kubernetes.                 |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/virtual_sites`                                                     | Create Virtual Site.                       |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/virtual_sites/&#123;metadata.name&#125;`                           | Replace Virtual Site.                      |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/virtual_sites`                                                              | List Virtual Site.                         |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/virtual_sites/&#123;name&#125;`                                             | GET Virtual Site.                          |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/virtual_sites/&#123;name&#125;`                                             | DELETE Virtual Site.                       |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/virtual_sites/&#123;name&#125;/selectees`                                   | GET Selectees.                             |
 
 ## Links
 

--- a/docs/en/api-reference/statistics-api.mdx
+++ b/docs/en/api-reference/statistics-api.mdx
@@ -2,7 +2,7 @@
 title: "📈 Statistics API"
 description: "Alerts, logs, flow analytics, and reporting."
 sidebar:
-    hidden: true
+  hidden: true
 ---
 
 Alerting policies with receiver integrations. Log aggregation, topology views, and site health tracking.
@@ -29,96 +29,96 @@ Alerting policies with receiver integrations. Log aggregation, topology views, a
 
 ## Endpoints
 
-| Method | Path | Description |
-|--------|------|-------------|
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/alert_policys` | Create Alert Policy. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/alert_policys/&#123;metadata.name&#125;` | Replace Alert Policy. |
-| POST | `/api/alert/namespaces/&#123;namespace&#125;/alert_policy/match` | GET Alert Policy Match. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/alert_policys` | List Alert Policy. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/alert_policys/&#123;name&#125;` | GET Alert Policy. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/alert_policys/&#123;name&#125;` | DELETE Alert Policy. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/alert_receivers` | Create Alert Receiver. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/alert_receivers/&#123;metadata.name&#125;` | Replace Alert Receiver. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/alert_receivers` | List Alert Receiver. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/alert_receivers/&#123;name&#125;` | GET Alert Receiver. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/alert_receivers/&#123;name&#125;` | DELETE Alert Receiver. |
-| POST | `/api/alert/namespaces/&#123;namespace&#125;/alert_receivers/&#123;name&#125;/confirm` | Confirm Alert Receiver. |
-| POST | `/api/alert/namespaces/&#123;namespace&#125;/alert_receivers/&#123;name&#125;/test` | Test Alert Receiver. |
-| POST | `/api/alert/namespaces/&#123;namespace&#125;/alert_receivers/&#123;name&#125;/verify` | Verify Alert Receiver. |
-| GET | `/api/data/namespaces/system/all_ns_alerts` | GET Alerts. |
-| PUT | `/api/web/namespaces/system/catalogs` | List |
-| GET | `/api/discovery/custom/namespaces/&#123;namespace&#125;/discovered_services` | List discovered services of specific type. |
-| GET | `/api/discovery/namespaces/&#123;namespace&#125;/discovered_services` | List Discovered Services. |
-| GET | `/api/discovery/namespaces/&#123;namespace&#125;/discovered_services/&#123;name&#125;` | GET Discovered Service Object. |
-| POST | `/api/discovery/namespaces/&#123;namespace&#125;/discovered_services/&#123;name&#125;/create_http_load_balancer` | Create HTTP/HTTPS load balancer. |
-| POST | `/api/discovery/namespaces/&#123;namespace&#125;/discovered_services/&#123;name&#125;/create_tcp_load_balancer` | Create TCP load balancer. |
-| POST | `/api/discovery/namespaces/&#123;namespace&#125;/discovered_services/&#123;name&#125;/disable_visibility` | Disable visibility in all workspaces. |
-| POST | `/api/discovery/namespaces/&#123;namespace&#125;/discovered_services/&#123;name&#125;/enable_visibility` | Enable visibility in all workspaces. |
-| POST | `/api/discovery/namespaces/&#123;namespace&#125;/suggest-values` | Suggest Values. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/flow_anomalys` | List Flow Anomaly. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/flow_anomalys/&#123;name&#125;` | GET Flow Anomaly. |
-| POST | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/ver/matching_flows` | Show Matching Flows. |
-| POST | `/api/config/namespaces/system/flow-collection/addon/subscribe` | Subscribe to Flow Collection. |
-| GET | `/api/config/namespaces/system/flow-collection/addon/subscription-status` | Check subscription status for Flow Collection. |
-| POST | `/api/config/namespaces/system/flow-collection/addon/unsubscribe` | Unsubscribe to Flow Collection. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/global_log_receivers` | Create Global Log Receiver. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/global_log_receivers/&#123;metadata.name&#125;` | Replace Global Log Receiver. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/global_log_receiver/status` | Global Log Receiver Status. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/global_log_receivers` | List Global Log Receiver. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/global_log_receivers/&#123;name&#125;` | GET Global Log Receiver. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/global_log_receivers/&#123;name&#125;` | DELETE Global Log Receiver. |
-| POST | `/api/log_receiver/namespaces/&#123;namespace&#125;/global_log_receivers/&#123;name&#125;/test` | Test Global Log Receiver. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/log_receivers` | Create Log Receiver. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/log_receivers/&#123;metadata.name&#125;` | Replace Log Receiver. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/log_receivers` | List Log Receiver. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/log_receivers/&#123;name&#125;` | GET Log Receiver. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/log_receivers/&#123;name&#125;` | DELETE Log Receiver. |
-| POST | `/api/config/namespaces/&#123;namespace&#125;/log_receivers/&#123;name&#125;/test` | Test Log Receiver. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/firewall_logs` | Firewall Logs Query. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/firewall_logs/aggregation` | Firewall Logs Aggregation Query. |
-| GET | `/api/data/namespaces/&#123;namespace&#125;/firewall_logs/scroll` | Firewall Logs Scroll Query. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/firewall_logs/scroll` | Firewall Logs Scroll Query. |
-| GET | `/api/data/namespaces/&#123;namespace&#125;/k8s_audit_logs/scroll` | K8s Audit Log Scroll Query. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/k8s_audit_logs/scroll` | K8s Audit Log Scroll Query. |
-| GET | `/api/data/namespaces/&#123;namespace&#125;/k8s_events/scroll` | K8s Events Scroll Query. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/k8s_events/scroll` | K8s Events Scroll Query. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/platform_events` | Platform event Query. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/platform_events/aggregation` | Platform event Aggregation Query. |
-| GET | `/api/data/namespaces/&#123;namespace&#125;/platform_events/scroll` | Platform event Scroll Query. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/platform_events/scroll` | Platform event Scroll Query. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/vk8s_audit_logs` | VK8s Audit Log Query. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/vk8s_audit_logs/aggregation` | VK8s Audit Log Aggregation Query. |
-| GET | `/api/data/namespaces/&#123;namespace&#125;/vk8s_audit_logs/scroll` | VK8s Audit Log Scroll Query. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/vk8s_audit_logs/scroll` | VK8s Audit Log Scroll Query. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/vk8s_events` | VK8s Events Query. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/vk8s_events/aggregation` | VK8s Events Aggregation Query. |
-| GET | `/api/data/namespaces/&#123;namespace&#125;/vk8s_events/scroll` | VK8s Events Scroll Query. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/vk8s_events/scroll` | VK8s Events Scroll Query. |
-| GET | `/api/report/namespaces/&#123;namespace&#125;/reports/&#123;name&#125;` | GET Report. |
-| GET | `/api/report/namespaces/&#123;namespace&#125;/reports/&#123;name&#125;/download` | Download Report. |
-| POST | `/api/report/namespaces/&#123;metadata.namespace&#125;/report_configs` | Create Report Configuration. |
-| PUT | `/api/report/namespaces/&#123;metadata.namespace&#125;/report_configs/&#123;metadata.name&#125;` | Replace Report Configuration. |
-| GET | `/api/report/namespaces/&#123;namespace&#125;/report_configs` | List Report Configuration. |
-| POST | `/api/report/namespaces/&#123;namespace&#125;/report_configs/list-reports-history` | List Reports History. |
-| POST | `/api/report/namespaces/&#123;namespace&#125;/report_configs/list-reports-history-bot-defence` | List Reports History Bot Defence. |
-| POST | `/api/report/namespaces/&#123;namespace&#125;/report_configs/list-reports-history-waap` | List Reports History Waap. |
-| GET | `/api/report/namespaces/&#123;namespace&#125;/report_configs/&#123;name&#125;` | GET Report Configuration. |
-| DELETE | `/api/report/namespaces/&#123;namespace&#125;/report_configs/&#123;name&#125;` | DELETE Report Configuration. |
-| POST | `/api/report/namespaces/&#123;namespace&#125;/report_configs/&#123;name&#125;/generate` | Generate Report Now. |
-| POST | `/api/data/namespaces/system/graph/all_ns_service` | Service Graph Query All Namespaces. |
-| POST | `/api/data/namespaces/system/topology/dc_cluster_group/&#123;dc_cluster_group&#125;` | DC Cluster Topology. |
-| GET | `/api/data/namespaces/system/topology/dc_cluster_groups` | DC Cluster Groups Summary. |
-| GET | `/api/data/namespaces/system/topology/network/&#123;id&#125;/route_tables` | GET Network Route Tables. |
-| GET | `/api/data/namespaces/system/topology/route_table/&#123;name&#125;` | GET Route Table. |
-| POST | `/api/data/namespaces/system/topology/site_mesh_group/&#123;site_mesh_group&#125;` | Site Mesh Topology. |
-| GET | `/api/data/namespaces/system/topology/site_mesh_groups` | Site Mesh Groups Summary. |
-| GET | `/api/data/namespaces/system/topology/tgw/&#123;id&#125;/route_tables` | GET TGW Route Tables. |
-| POST | `/api/infraprotect/namespaces/&#123;namespace&#125;/graph/l3l4/by_application/&#123;network_id&#125;` | L3l4 Application traffic Query. |
-| POST | `/api/infraprotect/namespaces/&#123;namespace&#125;/graph/l3l4/by_mitigation/&#123;mitigation_id&#125;` | L3l4 Mitigation Traffic Query. |
-| POST | `/api/infraprotect/namespaces/&#123;namespace&#125;/graph/l3l4/by_network/&#123;network_id&#125;` | L3l4 Network Traffic Query. |
-| POST | `/api/infraprotect/namespaces/&#123;namespace&#125;/graph/l3l4/by_zone/&#123;network_id&#125;` | L3l4 Zone Traffic Query. |
-| POST | `/api/infraprotect/namespaces/&#123;namespace&#125;/graph/l3l4/event_count/&#123;network_id&#125;` | L3l4 Event count. |
-| POST | `/api/infraprotect/namespaces/&#123;namespace&#125;/graph/l3l4/top_talkers/&#123;network_id&#125;` | L3l4 Top talkers Query. |
+| Method | Path                                                                                                             | Description                                    |
+| ------ | ---------------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/alert_policys`                                            | Create Alert Policy.                           |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/alert_policys/&#123;metadata.name&#125;`                  | Replace Alert Policy.                          |
+| POST   | `/api/alert/namespaces/&#123;namespace&#125;/alert_policy/match`                                                 | GET Alert Policy Match.                        |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/alert_policys`                                                     | List Alert Policy.                             |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/alert_policys/&#123;name&#125;`                                    | GET Alert Policy.                              |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/alert_policys/&#123;name&#125;`                                    | DELETE Alert Policy.                           |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/alert_receivers`                                          | Create Alert Receiver.                         |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/alert_receivers/&#123;metadata.name&#125;`                | Replace Alert Receiver.                        |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/alert_receivers`                                                   | List Alert Receiver.                           |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/alert_receivers/&#123;name&#125;`                                  | GET Alert Receiver.                            |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/alert_receivers/&#123;name&#125;`                                  | DELETE Alert Receiver.                         |
+| POST   | `/api/alert/namespaces/&#123;namespace&#125;/alert_receivers/&#123;name&#125;/confirm`                           | Confirm Alert Receiver.                        |
+| POST   | `/api/alert/namespaces/&#123;namespace&#125;/alert_receivers/&#123;name&#125;/test`                              | Test Alert Receiver.                           |
+| POST   | `/api/alert/namespaces/&#123;namespace&#125;/alert_receivers/&#123;name&#125;/verify`                            | Verify Alert Receiver.                         |
+| GET    | `/api/data/namespaces/system/all_ns_alerts`                                                                      | GET Alerts.                                    |
+| PUT    | `/api/web/namespaces/system/catalogs`                                                                            | List                                           |
+| GET    | `/api/discovery/custom/namespaces/&#123;namespace&#125;/discovered_services`                                     | List discovered services of specific type.     |
+| GET    | `/api/discovery/namespaces/&#123;namespace&#125;/discovered_services`                                            | List Discovered Services.                      |
+| GET    | `/api/discovery/namespaces/&#123;namespace&#125;/discovered_services/&#123;name&#125;`                           | GET Discovered Service Object.                 |
+| POST   | `/api/discovery/namespaces/&#123;namespace&#125;/discovered_services/&#123;name&#125;/create_http_load_balancer` | Create HTTP/HTTPS load balancer.               |
+| POST   | `/api/discovery/namespaces/&#123;namespace&#125;/discovered_services/&#123;name&#125;/create_tcp_load_balancer`  | Create TCP load balancer.                      |
+| POST   | `/api/discovery/namespaces/&#123;namespace&#125;/discovered_services/&#123;name&#125;/disable_visibility`        | Disable visibility in all workspaces.          |
+| POST   | `/api/discovery/namespaces/&#123;namespace&#125;/discovered_services/&#123;name&#125;/enable_visibility`         | Enable visibility in all workspaces.           |
+| POST   | `/api/discovery/namespaces/&#123;namespace&#125;/suggest-values`                                                 | Suggest Values.                                |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/flow_anomalys`                                                     | List Flow Anomaly.                             |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/flow_anomalys/&#123;name&#125;`                                    | GET Flow Anomaly.                              |
+| POST   | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/ver/matching_flows`                        | Show Matching Flows.                           |
+| POST   | `/api/config/namespaces/system/flow-collection/addon/subscribe`                                                  | Subscribe to Flow Collection.                  |
+| GET    | `/api/config/namespaces/system/flow-collection/addon/subscription-status`                                        | Check subscription status for Flow Collection. |
+| POST   | `/api/config/namespaces/system/flow-collection/addon/unsubscribe`                                                | Unsubscribe to Flow Collection.                |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/global_log_receivers`                                     | Create Global Log Receiver.                    |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/global_log_receivers/&#123;metadata.name&#125;`           | Replace Global Log Receiver.                   |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/global_log_receiver/status`                                          | Global Log Receiver Status.                    |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/global_log_receivers`                                              | List Global Log Receiver.                      |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/global_log_receivers/&#123;name&#125;`                             | GET Global Log Receiver.                       |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/global_log_receivers/&#123;name&#125;`                             | DELETE Global Log Receiver.                    |
+| POST   | `/api/log_receiver/namespaces/&#123;namespace&#125;/global_log_receivers/&#123;name&#125;/test`                  | Test Global Log Receiver.                      |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/log_receivers`                                            | Create Log Receiver.                           |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/log_receivers/&#123;metadata.name&#125;`                  | Replace Log Receiver.                          |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/log_receivers`                                                     | List Log Receiver.                             |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/log_receivers/&#123;name&#125;`                                    | GET Log Receiver.                              |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/log_receivers/&#123;name&#125;`                                    | DELETE Log Receiver.                           |
+| POST   | `/api/config/namespaces/&#123;namespace&#125;/log_receivers/&#123;name&#125;/test`                               | Test Log Receiver.                             |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/firewall_logs`                                                       | Firewall Logs Query.                           |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/firewall_logs/aggregation`                                           | Firewall Logs Aggregation Query.               |
+| GET    | `/api/data/namespaces/&#123;namespace&#125;/firewall_logs/scroll`                                                | Firewall Logs Scroll Query.                    |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/firewall_logs/scroll`                                                | Firewall Logs Scroll Query.                    |
+| GET    | `/api/data/namespaces/&#123;namespace&#125;/k8s_audit_logs/scroll`                                               | K8s Audit Log Scroll Query.                    |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/k8s_audit_logs/scroll`                                               | K8s Audit Log Scroll Query.                    |
+| GET    | `/api/data/namespaces/&#123;namespace&#125;/k8s_events/scroll`                                                   | K8s Events Scroll Query.                       |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/k8s_events/scroll`                                                   | K8s Events Scroll Query.                       |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/platform_events`                                                     | Platform event Query.                          |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/platform_events/aggregation`                                         | Platform event Aggregation Query.              |
+| GET    | `/api/data/namespaces/&#123;namespace&#125;/platform_events/scroll`                                              | Platform event Scroll Query.                   |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/platform_events/scroll`                                              | Platform event Scroll Query.                   |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/vk8s_audit_logs`                                                     | VK8s Audit Log Query.                          |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/vk8s_audit_logs/aggregation`                                         | VK8s Audit Log Aggregation Query.              |
+| GET    | `/api/data/namespaces/&#123;namespace&#125;/vk8s_audit_logs/scroll`                                              | VK8s Audit Log Scroll Query.                   |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/vk8s_audit_logs/scroll`                                              | VK8s Audit Log Scroll Query.                   |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/vk8s_events`                                                         | VK8s Events Query.                             |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/vk8s_events/aggregation`                                             | VK8s Events Aggregation Query.                 |
+| GET    | `/api/data/namespaces/&#123;namespace&#125;/vk8s_events/scroll`                                                  | VK8s Events Scroll Query.                      |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/vk8s_events/scroll`                                                  | VK8s Events Scroll Query.                      |
+| GET    | `/api/report/namespaces/&#123;namespace&#125;/reports/&#123;name&#125;`                                          | GET Report.                                    |
+| GET    | `/api/report/namespaces/&#123;namespace&#125;/reports/&#123;name&#125;/download`                                 | Download Report.                               |
+| POST   | `/api/report/namespaces/&#123;metadata.namespace&#125;/report_configs`                                           | Create Report Configuration.                   |
+| PUT    | `/api/report/namespaces/&#123;metadata.namespace&#125;/report_configs/&#123;metadata.name&#125;`                 | Replace Report Configuration.                  |
+| GET    | `/api/report/namespaces/&#123;namespace&#125;/report_configs`                                                    | List Report Configuration.                     |
+| POST   | `/api/report/namespaces/&#123;namespace&#125;/report_configs/list-reports-history`                               | List Reports History.                          |
+| POST   | `/api/report/namespaces/&#123;namespace&#125;/report_configs/list-reports-history-bot-defence`                   | List Reports History Bot Defence.              |
+| POST   | `/api/report/namespaces/&#123;namespace&#125;/report_configs/list-reports-history-waap`                          | List Reports History Waap.                     |
+| GET    | `/api/report/namespaces/&#123;namespace&#125;/report_configs/&#123;name&#125;`                                   | GET Report Configuration.                      |
+| DELETE | `/api/report/namespaces/&#123;namespace&#125;/report_configs/&#123;name&#125;`                                   | DELETE Report Configuration.                   |
+| POST   | `/api/report/namespaces/&#123;namespace&#125;/report_configs/&#123;name&#125;/generate`                          | Generate Report Now.                           |
+| POST   | `/api/data/namespaces/system/graph/all_ns_service`                                                               | Service Graph Query All Namespaces.            |
+| POST   | `/api/data/namespaces/system/topology/dc_cluster_group/&#123;dc_cluster_group&#125;`                             | DC Cluster Topology.                           |
+| GET    | `/api/data/namespaces/system/topology/dc_cluster_groups`                                                         | DC Cluster Groups Summary.                     |
+| GET    | `/api/data/namespaces/system/topology/network/&#123;id&#125;/route_tables`                                       | GET Network Route Tables.                      |
+| GET    | `/api/data/namespaces/system/topology/route_table/&#123;name&#125;`                                              | GET Route Table.                               |
+| POST   | `/api/data/namespaces/system/topology/site_mesh_group/&#123;site_mesh_group&#125;`                               | Site Mesh Topology.                            |
+| GET    | `/api/data/namespaces/system/topology/site_mesh_groups`                                                          | Site Mesh Groups Summary.                      |
+| GET    | `/api/data/namespaces/system/topology/tgw/&#123;id&#125;/route_tables`                                           | GET TGW Route Tables.                          |
+| POST   | `/api/infraprotect/namespaces/&#123;namespace&#125;/graph/l3l4/by_application/&#123;network_id&#125;`            | L3l4 Application traffic Query.                |
+| POST   | `/api/infraprotect/namespaces/&#123;namespace&#125;/graph/l3l4/by_mitigation/&#123;mitigation_id&#125;`          | L3l4 Mitigation Traffic Query.                 |
+| POST   | `/api/infraprotect/namespaces/&#123;namespace&#125;/graph/l3l4/by_network/&#123;network_id&#125;`                | L3l4 Network Traffic Query.                    |
+| POST   | `/api/infraprotect/namespaces/&#123;namespace&#125;/graph/l3l4/by_zone/&#123;network_id&#125;`                   | L3l4 Zone Traffic Query.                       |
+| POST   | `/api/infraprotect/namespaces/&#123;namespace&#125;/graph/l3l4/event_count/&#123;network_id&#125;`               | L3l4 Event count.                              |
+| POST   | `/api/infraprotect/namespaces/&#123;namespace&#125;/graph/l3l4/top_talkers/&#123;network_id&#125;`               | L3l4 Top talkers Query.                        |
 
 ## Links
 

--- a/docs/en/api-reference/support-api.mdx
+++ b/docs/en/api-reference/support-api.mdx
@@ -2,7 +2,7 @@
 title: "🎫 Support API"
 description: "Tickets, escalations, and network diagnostics."
 sidebar:
-    hidden: true
+  hidden: true
 ---
 
 Issue lifecycle with comments, severity changes, and resolution tracking. Packet capture for connection analysis.
@@ -27,65 +27,65 @@ Issue lifecycle with comments, severity changes, and resolution tracking. Packet
 
 ## Endpoints
 
-| Method | Path | Description |
-|--------|------|-------------|
-| POST | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/ver/resync_crl` | Resync CRL. |
-| POST | `/api/web/namespaces/system/child_tenant/support_tickets` | List of support tickets created for a child tenant. |
-| POST | `/api/web/namespaces/system/customer_support/tax_exempt_request` | Tax exemption verification request. |
-| POST | `/api/web/namespaces/&#123;metadata.namespace&#125;/customer_supports` | Create Customer Support. |
-| GET | `/api/web/namespaces/&#123;namespace&#125;/admin/customer_supports` | List all tenant tickets. |
-| POST | `/api/web/namespaces/&#123;namespace&#125;/customer_support/&#123;name&#125;/close` | Close a customer support ticket. |
-| POST | `/api/web/namespaces/&#123;namespace&#125;/customer_support/&#123;name&#125;/comment` | Add comment to a customer support ticket. |
-| POST | `/api/web/namespaces/&#123;namespace&#125;/customer_support/&#123;name&#125;/escalate` | Escalate a ticket. |
-| POST | `/api/web/namespaces/&#123;namespace&#125;/customer_support/&#123;name&#125;/priority` | Change priority of a ticket. |
-| POST | `/api/web/namespaces/&#123;namespace&#125;/customer_support/&#123;name&#125;/reopen` | Reopen a closed customer support ticket. |
-| GET | `/api/web/namespaces/&#123;namespace&#125;/customer_supports` | List Customer Support. |
-| GET | `/api/web/namespaces/&#123;namespace&#125;/customer_supports/&#123;name&#125;` | GET Customer Support. |
-| GET | `/api/web/namespaces/system/customer_support/&#123;name&#125;/comment/&#123;comment_id&#125;/attachment/&#123;attachment_id&#125;` | GET attachment. |
-| GET | `/api/operate/namespaces/system/sites/&#123;site&#125;/vpm/debug/global/check-debug-info-collection` | Check Debug Info Collection. |
-| GET | `/api/operate/namespaces/system/sites/&#123;site&#125;/vpm/debug/global/diagnosis` | Diagnosis |
-| GET | `/api/operate/namespaces/system/sites/&#123;site&#125;/vpm/debug/global/download-debug-info-collection` | Download Debug Info Collection. |
-| GET | `/api/operate/namespaces/system/sites/&#123;site&#125;/vpm/debug/global/health` | Health |
-| POST | `/api/operate/namespaces/system/sites/&#123;site&#125;/vpm/debug/&#123;node&#125;/change-password` | ChangePassword. |
-| GET | `/api/operate/namespaces/system/sites/&#123;site&#125;/vpm/debug/&#123;node&#125;/start-debug-info-collection` | Start Debug Info Collection. |
-| GET | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/vpm/debug/global/list-service` | List F5XC services. |
-| GET | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/vpm/debug/global/&#123;vesnamespace&#125;/status` | Status |
-| POST | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/vpm/debug/&#123;node&#125;/exec` | Exec |
-| GET | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/vpm/debug/&#123;node&#125;/exec-log` | Exec Log |
-| POST | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/vpm/debug/&#123;node&#125;/exec-user` | ExecUser |
-| POST | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/vpm/debug/&#123;node&#125;/host-ping` | Host Ping |
-| POST | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/vpm/debug/&#123;node&#125;/reboot` | Reboot node. |
-| GET | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/vpm/debug/&#123;node&#125;/&#123;service&#125;/log` | Log |
-| POST | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/vpm/debug/&#123;node&#125;/&#123;service&#125;/soft-restart` | Soft restart. |
-| GET | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/ver/dhcp_leases` | Show DHCP Leases. |
-| POST | `/api/operate/namespaces/system/sites/&#123;site&#125;/vpm/debug/global/allow-f5-ssh` | Allow F5 SSH. |
-| GET | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/vpm/lte/&#123;node&#125;/config` | GET LTE configuration. |
-| POST | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/vpm/lte/&#123;node&#125;/config` | Update LTE configuration. |
-| POST | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/vpm/lte/&#123;node&#125;/disconnect` | Disconnect. |
-| GET | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/vpm/lte/&#123;node&#125;/info` | Show LTE info. |
-| POST | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/ver/ping` | Ping |
-| POST | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/ver/fetchdump` | FetchDump |
-| POST | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/ver/list_tcpdump` | List Tcpdump. |
-| POST | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/ver/stop_tcpdump` | Stop Tcpdump. |
-| POST | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/ver/tcpdump` | Tcpdump |
-| POST | `/api/web/namespaces/shared/ticket_tracking_systems/jira_projects_issue_types` | JIRA Projects & Issue Types. |
-| POST | `/api/web/namespaces/shared/ticket_tracking_systems/validate_ticket_tracking_system` | Validate Ticket Tracking System. |
-| POST | `/api/web/namespaces/&#123;metadata.namespace&#125;/ticket_tracking_systems` | Create Ticket Tracking System. |
-| PUT | `/api/web/namespaces/&#123;metadata.namespace&#125;/ticket_tracking_systems/&#123;metadata.name&#125;` | Replace Ticket Tracking System. |
-| GET | `/api/web/namespaces/&#123;namespace&#125;/ticket_tracking_systems` | List Ticket Tracking System. |
-| GET | `/api/web/namespaces/&#123;namespace&#125;/ticket_tracking_systems/&#123;name&#125;` | GET Ticket Tracking System. |
-| DELETE | `/api/web/namespaces/&#123;namespace&#125;/ticket_tracking_systems/&#123;name&#125;` | DELETE Ticket Tracking System. |
-| GET | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/vpm/usb/&#123;node&#125;/config` | GET USB configuration. |
-| POST | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/vpm/usb/&#123;node&#125;/config` | Update USB configuration. |
-| GET | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/vpm/usb/&#123;node&#125;/list` | List USB devices. |
-| GET | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/vpm/usb/&#123;node&#125;/rules` | List USB Enablement Rules. |
-| POST | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/vpm/usb/&#123;node&#125;/rules/add` | Add USB Enablement Rules. |
-| POST | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/vpm/usb/&#123;node&#125;/rules/delete` | DELETE USB Enablement Rules. |
-| GET | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/vpm/wifi/&#123;node&#125;/config` | GET WIFI configuration. |
-| POST | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/vpm/wifi/&#123;node&#125;/config` | Update WIFI configuration. |
-| POST | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/vpm/wifi/&#123;node&#125;/disconnect` | Disconnect. |
-| GET | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/vpm/wifi/&#123;node&#125;/info` | Show WIFI info. |
-| GET | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/vpm/wifi/&#123;node&#125;/list` | List WIFI networks. |
+| Method | Path                                                                                                                               | Description                                         |
+| ------ | ---------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
+| POST   | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/ver/resync_crl`                                              | Resync CRL.                                         |
+| POST   | `/api/web/namespaces/system/child_tenant/support_tickets`                                                                          | List of support tickets created for a child tenant. |
+| POST   | `/api/web/namespaces/system/customer_support/tax_exempt_request`                                                                   | Tax exemption verification request.                 |
+| POST   | `/api/web/namespaces/&#123;metadata.namespace&#125;/customer_supports`                                                             | Create Customer Support.                            |
+| GET    | `/api/web/namespaces/&#123;namespace&#125;/admin/customer_supports`                                                                | List all tenant tickets.                            |
+| POST   | `/api/web/namespaces/&#123;namespace&#125;/customer_support/&#123;name&#125;/close`                                                | Close a customer support ticket.                    |
+| POST   | `/api/web/namespaces/&#123;namespace&#125;/customer_support/&#123;name&#125;/comment`                                              | Add comment to a customer support ticket.           |
+| POST   | `/api/web/namespaces/&#123;namespace&#125;/customer_support/&#123;name&#125;/escalate`                                             | Escalate a ticket.                                  |
+| POST   | `/api/web/namespaces/&#123;namespace&#125;/customer_support/&#123;name&#125;/priority`                                             | Change priority of a ticket.                        |
+| POST   | `/api/web/namespaces/&#123;namespace&#125;/customer_support/&#123;name&#125;/reopen`                                               | Reopen a closed customer support ticket.            |
+| GET    | `/api/web/namespaces/&#123;namespace&#125;/customer_supports`                                                                      | List Customer Support.                              |
+| GET    | `/api/web/namespaces/&#123;namespace&#125;/customer_supports/&#123;name&#125;`                                                     | GET Customer Support.                               |
+| GET    | `/api/web/namespaces/system/customer_support/&#123;name&#125;/comment/&#123;comment_id&#125;/attachment/&#123;attachment_id&#125;` | GET attachment.                                     |
+| GET    | `/api/operate/namespaces/system/sites/&#123;site&#125;/vpm/debug/global/check-debug-info-collection`                               | Check Debug Info Collection.                        |
+| GET    | `/api/operate/namespaces/system/sites/&#123;site&#125;/vpm/debug/global/diagnosis`                                                 | Diagnosis                                           |
+| GET    | `/api/operate/namespaces/system/sites/&#123;site&#125;/vpm/debug/global/download-debug-info-collection`                            | Download Debug Info Collection.                     |
+| GET    | `/api/operate/namespaces/system/sites/&#123;site&#125;/vpm/debug/global/health`                                                    | Health                                              |
+| POST   | `/api/operate/namespaces/system/sites/&#123;site&#125;/vpm/debug/&#123;node&#125;/change-password`                                 | ChangePassword.                                     |
+| GET    | `/api/operate/namespaces/system/sites/&#123;site&#125;/vpm/debug/&#123;node&#125;/start-debug-info-collection`                     | Start Debug Info Collection.                        |
+| GET    | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/vpm/debug/global/list-service`                               | List F5XC services.                                 |
+| GET    | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/vpm/debug/global/&#123;vesnamespace&#125;/status`            | Status                                              |
+| POST   | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/vpm/debug/&#123;node&#125;/exec`                             | Exec                                                |
+| GET    | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/vpm/debug/&#123;node&#125;/exec-log`                         | Exec Log                                            |
+| POST   | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/vpm/debug/&#123;node&#125;/exec-user`                        | ExecUser                                            |
+| POST   | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/vpm/debug/&#123;node&#125;/host-ping`                        | Host Ping                                           |
+| POST   | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/vpm/debug/&#123;node&#125;/reboot`                           | Reboot node.                                        |
+| GET    | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/vpm/debug/&#123;node&#125;/&#123;service&#125;/log`          | Log                                                 |
+| POST   | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/vpm/debug/&#123;node&#125;/&#123;service&#125;/soft-restart` | Soft restart.                                       |
+| GET    | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/ver/dhcp_leases`                                             | Show DHCP Leases.                                   |
+| POST   | `/api/operate/namespaces/system/sites/&#123;site&#125;/vpm/debug/global/allow-f5-ssh`                                              | Allow F5 SSH.                                       |
+| GET    | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/vpm/lte/&#123;node&#125;/config`                             | GET LTE configuration.                              |
+| POST   | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/vpm/lte/&#123;node&#125;/config`                             | Update LTE configuration.                           |
+| POST   | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/vpm/lte/&#123;node&#125;/disconnect`                         | Disconnect.                                         |
+| GET    | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/vpm/lte/&#123;node&#125;/info`                               | Show LTE info.                                      |
+| POST   | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/ver/ping`                                                    | Ping                                                |
+| POST   | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/ver/fetchdump`                                               | FetchDump                                           |
+| POST   | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/ver/list_tcpdump`                                            | List Tcpdump.                                       |
+| POST   | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/ver/stop_tcpdump`                                            | Stop Tcpdump.                                       |
+| POST   | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/ver/tcpdump`                                                 | Tcpdump                                             |
+| POST   | `/api/web/namespaces/shared/ticket_tracking_systems/jira_projects_issue_types`                                                     | Jira Projects & Issue Types.                        |
+| POST   | `/api/web/namespaces/shared/ticket_tracking_systems/validate_ticket_tracking_system`                                               | Validate Ticket Tracking System.                    |
+| POST   | `/api/web/namespaces/&#123;metadata.namespace&#125;/ticket_tracking_systems`                                                       | Create Ticket Tracking System.                      |
+| PUT    | `/api/web/namespaces/&#123;metadata.namespace&#125;/ticket_tracking_systems/&#123;metadata.name&#125;`                             | Replace Ticket Tracking System.                     |
+| GET    | `/api/web/namespaces/&#123;namespace&#125;/ticket_tracking_systems`                                                                | List Ticket Tracking System.                        |
+| GET    | `/api/web/namespaces/&#123;namespace&#125;/ticket_tracking_systems/&#123;name&#125;`                                               | GET Ticket Tracking System.                         |
+| DELETE | `/api/web/namespaces/&#123;namespace&#125;/ticket_tracking_systems/&#123;name&#125;`                                               | DELETE Ticket Tracking System.                      |
+| GET    | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/vpm/usb/&#123;node&#125;/config`                             | GET USB configuration.                              |
+| POST   | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/vpm/usb/&#123;node&#125;/config`                             | Update USB configuration.                           |
+| GET    | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/vpm/usb/&#123;node&#125;/list`                               | List USB devices.                                   |
+| GET    | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/vpm/usb/&#123;node&#125;/rules`                              | List USB Enablement Rules.                          |
+| POST   | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/vpm/usb/&#123;node&#125;/rules/add`                          | Add USB Enablement Rules.                           |
+| POST   | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/vpm/usb/&#123;node&#125;/rules/delete`                       | DELETE USB Enablement Rules.                        |
+| GET    | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/vpm/wifi/&#123;node&#125;/config`                            | GET Wi-Fi configuration.                            |
+| POST   | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/vpm/wifi/&#123;node&#125;/config`                            | Update Wi-Fi configuration.                         |
+| POST   | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/vpm/wifi/&#123;node&#125;/disconnect`                        | Disconnect.                                         |
+| GET    | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/vpm/wifi/&#123;node&#125;/info`                              | Show Wi-Fi info.                                    |
+| GET    | `/api/operate/namespaces/&#123;namespace&#125;/sites/&#123;site&#125;/vpm/wifi/&#123;node&#125;/list`                              | List Wi-Fi networks.                                |
 
 ## Links
 

--- a/docs/en/api-reference/telemetry_and_insights-api.mdx
+++ b/docs/en/api-reference/telemetry_and_insights-api.mdx
@@ -2,7 +2,7 @@
 title: "📉 Telemetry And Insights API"
 description: "Metrics collection, analysis, and visualization."
 sidebar:
-    hidden: true
+  hidden: true
 ---
 
 Collection endpoints, metrics storage, and insight generation for observability workflows.
@@ -26,35 +26,35 @@ Collection endpoints, metrics storage, and insight generation for observability 
 
 ## Endpoints
 
-| Method | Path | Description |
-|--------|------|-------------|
-| POST | `/api/data/namespaces/&#123;namespace&#125;/graph/connectivity` | Connectivity Graph Query. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/graph/connectivity/edge` | Connectivity Edge Query. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/graph/connectivity/node` | Connectivity Node Query. |
-| GET | `/api/discovery/custom/namespaces/&#123;namespace&#125;/discovered_services` | List discovered services of specific type. |
-| GET | `/api/discovery/namespaces/&#123;namespace&#125;/discovered_services` | List Discovered Services. |
-| GET | `/api/discovery/namespaces/&#123;namespace&#125;/discovered_services/&#123;name&#125;` | GET Discovered Service Object. |
-| POST | `/api/discovery/namespaces/&#123;namespace&#125;/discovered_services/&#123;name&#125;/create_http_load_balancer` | Create HTTP/HTTPS load balancer. |
-| POST | `/api/discovery/namespaces/&#123;namespace&#125;/discovered_services/&#123;name&#125;/create_tcp_load_balancer` | Create TCP load balancer. |
-| POST | `/api/discovery/namespaces/&#123;namespace&#125;/discovered_services/&#123;name&#125;/disable_visibility` | Disable visibility in all workspaces. |
-| POST | `/api/discovery/namespaces/&#123;namespace&#125;/discovered_services/&#123;name&#125;/enable_visibility` | Enable visibility in all workspaces. |
-| GET | `/api/data/namespaces/&#123;namespace&#125;/discovered_services/&#123;name&#125;/health_status` | Discovered Service Health Status. |
-| POST | `/api/discovery/namespaces/&#123;namespace&#125;/suggest-values` | Suggest Values. |
-| POST | `/api/config/namespaces/system/flow-collection/addon/subscribe` | Subscribe to Flow Collection. |
-| GET | `/api/config/namespaces/system/flow-collection/addon/subscription-status` | Check subscription status for Flow Collection. |
-| POST | `/api/config/namespaces/system/flow-collection/addon/unsubscribe` | Unsubscribe to Flow Collection. |
-| POST | `/api/data/namespaces/system/flows/flow_collection` | Flow Collection. |
-| POST | `/api/data/namespaces/system/flows/top_flow_anomalies` | Flow Anomaly detection. |
-| POST | `/api/data/namespaces/system/flows/top_talkers` | Top Talkers. |
-| POST | `/api/data/namespaces/system/graph/all_ns_service` | Service Graph Query All Namespaces. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/graph/lb_cache_content` | Cacheability query Query. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/graph/service` | Service Graph Query. |
-| GET | `/api/data/namespaces/&#123;namespace&#125;/graph/service/app_types` | Application Types. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/graph/service/edge` | Service Edge Query. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/graph/service/node` | Service Node Query. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/graph/service/node/instance` | Service Instance Query. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/graph/service/node/instances` | Service Instances Query. |
-| GET | `/api/data/namespaces/&#123;namespace&#125;/&#123;kind&#125;/&#123;name&#125;/status_at_site` | GET Status. |
+| Method | Path                                                                                                             | Description                                    |
+| ------ | ---------------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/graph/connectivity`                                                  | Connectivity Graph Query.                      |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/graph/connectivity/edge`                                             | Connectivity Edge Query.                       |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/graph/connectivity/node`                                             | Connectivity Node Query.                       |
+| GET    | `/api/discovery/custom/namespaces/&#123;namespace&#125;/discovered_services`                                     | List discovered services of specific type.     |
+| GET    | `/api/discovery/namespaces/&#123;namespace&#125;/discovered_services`                                            | List Discovered Services.                      |
+| GET    | `/api/discovery/namespaces/&#123;namespace&#125;/discovered_services/&#123;name&#125;`                           | GET Discovered Service Object.                 |
+| POST   | `/api/discovery/namespaces/&#123;namespace&#125;/discovered_services/&#123;name&#125;/create_http_load_balancer` | Create HTTP/HTTPS load balancer.               |
+| POST   | `/api/discovery/namespaces/&#123;namespace&#125;/discovered_services/&#123;name&#125;/create_tcp_load_balancer`  | Create TCP load balancer.                      |
+| POST   | `/api/discovery/namespaces/&#123;namespace&#125;/discovered_services/&#123;name&#125;/disable_visibility`        | Disable visibility in all workspaces.          |
+| POST   | `/api/discovery/namespaces/&#123;namespace&#125;/discovered_services/&#123;name&#125;/enable_visibility`         | Enable visibility in all workspaces.           |
+| GET    | `/api/data/namespaces/&#123;namespace&#125;/discovered_services/&#123;name&#125;/health_status`                  | Discovered Service Health Status.              |
+| POST   | `/api/discovery/namespaces/&#123;namespace&#125;/suggest-values`                                                 | Suggest Values.                                |
+| POST   | `/api/config/namespaces/system/flow-collection/addon/subscribe`                                                  | Subscribe to Flow Collection.                  |
+| GET    | `/api/config/namespaces/system/flow-collection/addon/subscription-status`                                        | Check subscription status for Flow Collection. |
+| POST   | `/api/config/namespaces/system/flow-collection/addon/unsubscribe`                                                | Unsubscribe to Flow Collection.                |
+| POST   | `/api/data/namespaces/system/flows/flow_collection`                                                              | Flow Collection.                               |
+| POST   | `/api/data/namespaces/system/flows/top_flow_anomalies`                                                           | Flow Anomaly detection.                        |
+| POST   | `/api/data/namespaces/system/flows/top_talkers`                                                                  | Top Talkers.                                   |
+| POST   | `/api/data/namespaces/system/graph/all_ns_service`                                                               | Service Graph Query All Namespaces.            |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/graph/lb_cache_content`                                              | Cacheability query Query.                      |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/graph/service`                                                       | Service Graph Query.                           |
+| GET    | `/api/data/namespaces/&#123;namespace&#125;/graph/service/app_types`                                             | Application Types.                             |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/graph/service/edge`                                                  | Service Edge Query.                            |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/graph/service/node`                                                  | Service Node Query.                            |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/graph/service/node/instance`                                         | Service Instance Query.                        |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/graph/service/node/instances`                                        | Service Instances Query.                       |
+| GET    | `/api/data/namespaces/&#123;namespace&#125;/&#123;kind&#125;/&#123;name&#125;/status_at_site`                    | GET Status.                                    |
 
 ## Links
 

--- a/docs/en/api-reference/tenant_and_identity-api.mdx
+++ b/docs/en/api-reference/tenant_and_identity-api.mdx
@@ -2,7 +2,7 @@
 title: "🪪 Tenant And Identity API"
 description: "User profiles, sessions, and OTP settings."
 sidebar:
-    hidden: true
+  hidden: true
 ---
 
 Account view configurations and admin alert channels. One-time password resets, provisioning flows, and active connection monitoring.
@@ -28,240 +28,240 @@ Account view configurations and admin alert channels. One-time password resets, 
 
 ## Endpoints
 
-| Method | Path | Description |
-|--------|------|-------------|
-| GET | `/api/web/namespaces/system/allowed_tenants/support-tenant/access` | GET Support Tenant Access. |
-| POST | `/api/web/namespaces/system/allowed_tenants/support-tenant/access` | Update Support Tenant Access. |
-| POST | `/api/web/namespaces/&#123;metadata.namespace&#125;/allowed_tenants` | Create Allowed Tenant. |
-| PUT | `/api/web/namespaces/&#123;metadata.namespace&#125;/allowed_tenants/&#123;metadata.name&#125;` | Replace Allowed Tenant. |
-| GET | `/api/web/namespaces/&#123;namespace&#125;/allowed_tenants` | List Allowed Tenant. |
-| GET | `/api/web/namespaces/&#123;namespace&#125;/allowed_tenants/&#123;name&#125;` | GET Allowed Tenant. |
-| DELETE | `/api/web/namespaces/&#123;namespace&#125;/allowed_tenants/&#123;name&#125;` | DELETE Allowed Tenant. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/authentications` | Create Authentication. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/authentications/&#123;metadata.name&#125;` | Replace Authentication. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/authentications` | List Authentication. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/authentications/&#123;name&#125;` | GET Authentication. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/authentications/&#123;name&#125;` | DELETE Authentication. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/authorization_servers` | Create Authorization Server. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/authorization_servers/&#123;metadata.name&#125;` | Replace Authorization Server. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/authorization_servers` | List Authorization Server. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/authorization_servers/&#123;name&#125;` | GET Authorization Server. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/authorization_servers/&#123;name&#125;` | DELETE Authorization Server. |
-| POST | `/api/waf/namespaces/&#123;namespace&#125;/authorization_servers/&#123;name&#125;/update` | Update Authorization Server. |
-| GET | `/api/web/namespaces/system/partner-management/child_tenants` | List of Child Tenants. |
-| POST | `/api/web/namespaces/system/partner-management/child_tenants/migrate` | Migrate Child Tenants. |
-| GET | `/api/web/namespaces/system/partner-management/customer_supports` | List all support tickets created in child tenant. |
-| POST | `/api/web/namespaces/system/partner-management/customer_supports` | Create customer support ticket in child tenant. |
-| GET | `/api/web/namespaces/system/partner-management/customer_supports/&#123;tp_id&#125;` | GET customer support ticket in child tenant. |
-| POST | `/api/web/namespaces/system/partner-management/customer_supports/&#123;tp_id&#125;/close` | Close a customer support ticket in child tenant. |
-| POST | `/api/web/namespaces/system/partner-management/customer_supports/&#123;tp_id&#125;/comment` | Add comment to a customer support ticket in child tenant. |
-| POST | `/api/web/namespaces/system/partner-management/customer_supports/&#123;tp_id&#125;/escalate` | Escalate a ticket in child tenant. |
-| POST | `/api/web/namespaces/system/partner-management/customer_supports/&#123;tp_id&#125;/priority` | Change priority of a ticket in child tenant. |
-| POST | `/api/web/namespaces/system/partner-management/customer_supports/&#123;tp_id&#125;/reopen` | Reopen a closed customer support ticket in child tenant. |
-| POST | `/api/web/namespaces/&#123;metadata.namespace&#125;/child_tenants` | Child Tenant. |
-| PUT | `/api/web/namespaces/&#123;metadata.namespace&#125;/child_tenants/&#123;metadata.name&#125;` | Replace Child Tenant. |
-| GET | `/api/web/namespaces/&#123;namespace&#125;/child_tenants` | List Child Tenant. |
-| GET | `/api/web/namespaces/&#123;namespace&#125;/child_tenants/&#123;name&#125;` | GET Child Tenant. |
-| DELETE | `/api/web/namespaces/&#123;namespace&#125;/child_tenants/&#123;name&#125;` | DELETE Child Tenant. |
-| GET | `/api/web/namespaces/system/partner-management/child_tenant_managers/&#123;name&#125;/child_tenants` | List child tenants for a given child tenant manager. |
-| POST | `/api/web/namespaces/system/partner-management/child_tenant_managers/&#123;name&#125;/child_tenants/migrate` | Migrate CTM child tenants. |
-| POST | `/api/web/namespaces/&#123;metadata.namespace&#125;/child_tenant_managers` | Child Tenant Manager. |
-| PUT | `/api/web/namespaces/&#123;metadata.namespace&#125;/child_tenant_managers/&#123;metadata.name&#125;` | Replace Child Tenant Manager. |
-| GET | `/api/web/namespaces/&#123;namespace&#125;/child_tenant_managers` | List Child Tenant Manager. |
-| GET | `/api/web/namespaces/&#123;namespace&#125;/child_tenant_managers/&#123;name&#125;` | GET Child Tenant Manager. |
-| DELETE | `/api/web/namespaces/&#123;namespace&#125;/child_tenant_managers/&#123;name&#125;` | DELETE Child Tenant Manager. |
-| GET | `/api/web/namespaces/system/partner-management/customer_supports/&#123;tp_id&#125;/comment/&#123;comment_id&#125;/attachment/&#123;attachment_id&#125;` | GET attachment. |
-| POST | `/api/cloud-data/namespaces/system/cloud_user_accounts/discover_networks` | Discover Cloud Networks. |
-| POST | `/api/web/namespaces/&#123;metadata.namespace&#125;/contacts` | Create Contact. |
-| PUT | `/api/web/namespaces/&#123;metadata.namespace&#125;/contacts/&#123;metadata.name&#125;` | Replace Contact. |
-| GET | `/api/web/namespaces/&#123;namespace&#125;/contacts` | List Contact. |
-| GET | `/api/web/namespaces/&#123;namespace&#125;/contacts/&#123;name&#125;` | GET Contact. |
-| DELETE | `/api/web/namespaces/&#123;namespace&#125;/contacts/&#123;name&#125;` | DELETE Contact. |
-| GET | `/api/web/namespaces/system/managed_client/customer_supports` | List tickets of managed tenant. |
-| POST | `/api/web/namespaces/system/managed_client/customer_supports` | Create customer support ticket in managed tenant. |
-| GET | `/api/web/namespaces/system/managed_client/customer_supports/&#123;tp_id&#125;` | GET customer support ticket in managed tenant. |
-| POST | `/api/web/namespaces/system/managed_client/customer_supports/&#123;tp_id&#125;/close` | Close a customer support ticket in managed tenant. |
-| POST | `/api/web/namespaces/system/managed_client/customer_supports/&#123;tp_id&#125;/comment` | Add comment to a customer support ticket in managed tenant. |
-| POST | `/api/web/namespaces/system/managed_client/customer_supports/&#123;tp_id&#125;/escalate` | Escalate a ticket in managed tenant. |
-| POST | `/api/web/namespaces/system/managed_client/customer_supports/&#123;tp_id&#125;/priority` | Priority of a ticket in managed tenant. |
-| POST | `/api/web/namespaces/system/managed_client/customer_supports/&#123;tp_id&#125;/reopen` | Reopen a closed customer support ticket in managed tenant. |
-| GET | `/api/web/namespaces/system/managed_tenants_by_user` | GET List of Managed Tenant By User. |
-| GET | `/api/web/namespaces/system/managed_tenants_list` | GET List of Managed Tenant. |
-| GET | `/api/web/namespaces/system/support-tenant/managed_tenants` | List of Managed Tenant By User For Support Operations. |
-| POST | `/api/web/namespaces/&#123;metadata.namespace&#125;/managed_tenants` | Create Managed Tenant. |
-| PUT | `/api/web/namespaces/&#123;metadata.namespace&#125;/managed_tenants/&#123;metadata.name&#125;` | Replace Managed Tenant. |
-| GET | `/api/web/namespaces/&#123;namespace&#125;/managed_tenants` | List Managed Tenant. |
-| GET | `/api/web/namespaces/&#123;namespace&#125;/managed_tenants/&#123;name&#125;` | GET Managed Tenant. |
-| DELETE | `/api/web/namespaces/&#123;namespace&#125;/managed_tenants/&#123;name&#125;` | DELETE Managed Tenant. |
-| GET | `/api/web/namespaces/system/managed_client/customer_supports/&#123;tp_id&#125;/comment/&#123;comment_id&#125;/attachment/&#123;attachment_id&#125;` | GET attachment. |
-| GET | `/api/web/namespaces` | List Namespace. |
-| POST | `/api/web/namespaces` | Create Namespace. |
-| POST | `/api/config/namespaces/system/all_application_inventory` | All Application Objects Inventory. |
-| POST | `/api/config/namespaces/system/all_application_inventory_waf_filters` | All Application Objects Inventory with WAF Filters. |
-| POST | `/api/ml/data/namespaces/system/api_endpoints/all_ns_stats` | GET API Endpoints Stats for All Namespaces. |
-| POST | `/api/web/namespaces/system/evaluate-api-access` | Evaluate API Access. |
-| POST | `/api/web/namespaces/system/evaluate-batch-api-access` | Evaluate Batch API Access. |
-| POST | `/api/web/namespaces/system/lookup-user-roles` | Lookup User Roles. |
-| POST | `/api/config/namespaces/system/networking_inventory` | Networking Objects Inventory. |
-| POST | `/api/cloud-data/namespaces/system/suggest-values` | Suggest Values. |
-| POST | `/api/config/namespaces/system/update_allow_advertise_on_public` | Update allow advertise on public. |
-| POST | `/api/config/namespaces/system/validate_rules` | Validate Rules. |
-| PUT | `/api/web/namespaces/&#123;metadata.name&#125;` | Replace Namespace. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/active_alert_policies` | GET Active Alert Policies. |
-| POST | `/api/config/namespaces/&#123;namespace&#125;/active_alert_policies` | Set Active Alert Policies. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/active_network_policies` | GET Active Network Policies. |
-| POST | `/api/config/namespaces/&#123;namespace&#125;/active_network_policies` | Set Active Network Policies. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/active_service_policies` | GET Active Service Policies. |
-| POST | `/api/config/namespaces/&#123;namespace&#125;/active_service_policies` | Set Active Service Policies. |
-| POST | `/api/ml/data/namespaces/&#123;namespace&#125;/api_endpoints/stats` | GET API Endpoints Stats for Namespace. |
-| POST | `/api/config/namespaces/&#123;namespace&#125;/application_inventory` | Application Objects Inventory. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/fast_acls_for_internet_vips` | GET FastACLs For Internet VIPs. |
-| POST | `/api/config/namespaces/&#123;namespace&#125;/fast_acls_for_internet_vips` | Set FastACLs For Internet VIPs. |
-| POST | `/api/web/namespaces/&#123;namespace&#125;/suggest-values` | Suggest Values. |
-| GET | `/api/web/namespaces/&#123;name&#125;` | GET Namespace. |
-| POST | `/api/web/namespaces/&#123;name&#125;/cascade_delete` | Cascade DELETE. |
-| GET | `/api/web/namespaces/&#123;namespace&#125;/namespace_roles` | List Namespace Role. |
-| GET | `/api/web/namespaces/&#123;namespace&#125;/namespace_roles/&#123;name&#125;` | GET Namespace Role. |
-| POST | `/api/config/namespaces/&#123;namespace&#125;/dynamic-data` | Dynamic Data. |
-| GET | `/api/web/namespaces/&#123;namespace&#125;/rbac_policys` | List RBAC Policy. |
-| GET | `/api/web/namespaces/&#123;namespace&#125;/rbac_policys/&#123;name&#125;` | GET RBAC Policy. |
-| GET | `/api/web/custom/namespaces/&#123;namespace&#125;/roles` | Custom List Roles. |
-| POST | `/api/web/custom/namespaces/&#123;namespace&#125;/roles` | Custom Create Role. |
-| GET | `/api/web/custom/namespaces/&#123;namespace&#125;/roles/&#123;name&#125;` | Custom GET Role. |
-| PUT | `/api/web/custom/namespaces/&#123;namespace&#125;/roles/&#123;name&#125;` | Custom Replace Role. |
-| POST | `/api/web/namespaces/&#123;metadata.namespace&#125;/roles` | Create Role. |
-| PUT | `/api/web/namespaces/&#123;metadata.namespace&#125;/roles/&#123;metadata.name&#125;` | Replace Role. |
-| GET | `/api/web/namespaces/&#123;namespace&#125;/roles` | List Role |
-| GET | `/api/web/namespaces/&#123;namespace&#125;/roles/&#123;name&#125;` | GET Role |
-| DELETE | `/api/web/namespaces/&#123;namespace&#125;/roles/&#123;name&#125;` | DELETE Role. |
-| GET | `/api/web/custom/namespaces/&#123;namespace&#125;/oidc_provider/&#123;name&#125;` | GET |
-| POST | `/api/web/custom/namespaces/&#123;namespace&#125;/oidc_provider/&#123;name&#125;/delete` | DELETE |
-| GET | `/api/web/custom/namespaces/&#123;namespace&#125;/oidc_providers` | List |
-| POST | `/api/web/custom/namespaces/&#123;namespace&#125;/oidc_providers` | Create |
-| GET | `/api/web/custom/namespaces/&#123;namespace&#125;/oidc_providers/&#123;name&#125;` | GET |
-| POST | `/api/web/custom/namespaces/&#123;namespace&#125;/oidc_providers/&#123;name&#125;` | Replace |
-| PUT | `/api/web/custom/namespaces/&#123;namespace&#125;/oidc_providers/&#123;name&#125;` | Replace |
-| POST | `/api/web/custom/namespaces/&#123;namespace&#125;/oidc_providers/&#123;name&#125;/delete` | DELETE |
-| GET | `/api/web/custom/namespaces/&#123;namespace&#125;/oidc_providers/&#123;name&#125;/mappers` | GET OIDC mappers. |
-| POST | `/api/web/custom/namespaces/&#123;namespace&#125;/oidc_providers/&#123;name&#125;/mappers` | Update OIDC mappers. |
-| PUT | `/api/web/custom/namespaces/&#123;namespace&#125;/oidc_providers/&#123;name&#125;/scim` | Update OIDC provider SCIM Integration. |
-| GET | `/no_auth/countries/&#123;country_code&#125;/states/&#123;prefix&#125;` | List states. |
-| GET | `/no_auth/countries/&#123;country_code&#125;/states/&#123;state_code&#125;/cities/&#123;prefix&#125;` | List cities. |
-| GET | `/no_auth/countries/&#123;prefix&#125;` | List countries. |
-| POST | `/no_auth/login/validate_registration` | Validate Registration. |
-| POST | `/no_auth/send_password_email` | Send Password Email. |
-| GET | `/no_auth/signup/&#123;name&#125;` | Read Signup. |
-| POST | `/no_auth/validate_contact` | Validate contact. |
-| GET | `/api/web/custom/countries/&#123;country_code&#125;/states/&#123;prefix&#125;` | List states. |
-| GET | `/api/web/custom/countries/&#123;country_code&#125;/states/&#123;state_code&#125;/cities/&#123;prefix&#125;` | List cities. |
-| GET | `/api/web/custom/countries/&#123;prefix&#125;` | List countries. |
-| GET | `/api/scim/namespaces/system/v2/Groups` | List group based on filters. |
-| POST | `/api/scim/namespaces/system/v2/Groups` | Create group with users. |
-| GET | `/api/scim/namespaces/system/v2/Groups/&#123;id&#125;` | List group based on ID. |
-| DELETE | `/api/scim/namespaces/system/v2/Groups/&#123;id&#125;` | DELETE group based on ID. |
-| PUT | `/api/scim/namespaces/system/v2/Groups/&#123;id&#125;` | Replace group based on ID. |
-| PATCH | `/api/scim/namespaces/system/v2/Groups/&#123;id&#125;` | PATCH group based on ID. |
-| GET | `/api/scim/namespaces/system/v2/ResourceTypes` | GET supported resources type. |
-| GET | `/api/scim/namespaces/system/v2/ResourceTypes/&#123;id&#125;` | GET supported resources type. |
-| GET | `/api/scim/namespaces/system/v2/Schemas` | Schemas |
-| GET | `/api/scim/namespaces/system/v2/Schemas/&#123;id&#125;` | Schemas By ID. |
-| GET | `/api/scim/namespaces/system/v2/ServiceProviderConfig` | List service provider configs. |
-| GET | `/api/scim/namespaces/system/v2/Users` | GET all users. |
-| POST | `/api/scim/namespaces/system/v2/Users` | Create User with Role Assignment. |
-| GET | `/api/scim/namespaces/system/v2/Users/&#123;id&#125;` | GET User with ID. |
-| DELETE | `/api/scim/namespaces/system/v2/Users/&#123;id&#125;` | DELETE user by ID. |
-| PUT | `/api/scim/namespaces/system/v2/Users/&#123;id&#125;` | Update User and Role Assignments. |
-| PATCH | `/api/scim/namespaces/system/v2/Users/&#123;id&#125;` | PATCH User. |
-| GET | `/no_auth/cname/lookup` | Lookup cname. |
-| GET | `/no_auth/tenant/idm/settings/password_policy` | GetPasswordPolicy. |
-| POST | `/api/web/namespaces/system/tenant/domain_owner/assign` | Assign domain owner. |
-| POST | `/api/web/namespaces/system/tenant/domain_owner/unassign` | Unassign domain owner. |
-| GET | `/api/web/namespaces/system/tenant/idm/events/last_login` | GetLastLoginMap. |
-| GET | `/api/web/namespaces/system/tenant/idm/events/login` | GetLoginEvents. |
-| POST | `/api/web/namespaces/system/tenant/idm/events/login_in_time` | GetLoginEventsInTimeFrame. |
-| GET | `/api/web/namespaces/system/tenant/idm/settings` | GetIDMSettings. |
-| PUT | `/api/web/namespaces/system/tenant/idm/settings` | UpdateIDMSettings. |
-| GET | `/api/web/namespaces/system/tenant/idm/users/inactive` | ListInactiveUsers. |
-| GET | `/api/web/namespaces/system/tenant/lookup` | Lookup cname. |
-| POST | `/api/web/namespaces/system/tenant/request-delete` | DELETE Tenant. |
-| GET | `/api/web/namespaces/system/tenant/settings` | Tenant Settings. |
-| PUT | `/api/web/namespaces/system/tenant/settings` | Tenant Settings. |
-| PUT | `/api/web/namespaces/system/tenant/settings/otp/disable` | Disable tenant level OTP. |
-| PUT | `/api/web/namespaces/system/tenant/settings/otp/enable` | Enable tenant level OTP. |
-| GET | `/api/web/namespaces/system/tenant/settings/tenant/favicon` | Tenant favicon. |
-| GET | `/api/web/namespaces/system/tenant/settings/tenant/image` | Tenant profile image. |
-| DELETE | `/api/web/namespaces/system/tenant/settings/tenant/image` | DELETE tenant profile image. |
-| PUT | `/api/web/namespaces/system/tenant/settings/tenant/image` | Update tenant profile image. |
-| GET | `/api/web/namespaces/system/tenant/settings/tenant/logo` | Tenant logo. |
-| GET | `/api/web/namespaces/system/tenant/support-info` | Support Info. |
-| GET | `/api/web/namespaces/system/tenant/tenant-escalation-doc` | Tenant escalation document. |
-| PUT | `/api/saas/namespaces/system/v2/tenant/deactivate` | DeactivateTenant. |
-| GET | `/api/web/static/namespaces/system/tenant/settings/tenant/favicon` | Tenant favicon. |
-| GET | `/api/web/static/namespaces/system/tenant/settings/tenant/image` | Tenant profile image. |
-| GET | `/api/config/tenants/&#123;tenant&#125;/summary` | Summary |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/tenant_configurations` | Create tenant configuration. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/tenant_configurations/&#123;metadata.name&#125;` | Replace tenant configuration. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/tenant_configurations` | List Tenant Configuration. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/tenant_configurations/&#123;name&#125;` | GET tenant configuration. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/tenant_configurations/&#123;name&#125;` | DELETE Tenant Configuration. |
-| POST | `/api/web/namespaces/system/tenant_management/delegated_access/subscribe` | Subscribe Delegated Access Addon Service. |
-| POST | `/api/web/namespaces/system/tenant_management/delegated_access/unsubscribe` | Unsubscribe Delegated Access Addon Service. |
-| POST | `/api/web/namespaces/&#123;metadata.namespace&#125;/tenant_profiles` | Create Tenant Profile. |
-| PUT | `/api/web/namespaces/&#123;metadata.namespace&#125;/tenant_profiles/&#123;metadata.name&#125;` | Replace Tenant Profile. |
-| GET | `/api/web/namespaces/&#123;namespace&#125;/tenant_profiles` | List Tenant Profile. |
-| GET | `/api/web/namespaces/&#123;namespace&#125;/tenant_profiles/&#123;name&#125;` | GET Tenant Profile. |
-| DELETE | `/api/web/namespaces/&#123;namespace&#125;/tenant_profiles/&#123;name&#125;` | DELETE Tenant Profile. |
-| POST | `/api/web/custom/idm/user/sync` | Sync user |
-| PUT | `/api/web/custom/namespaces/system/users/group_add` | Add user to groups. |
-| PUT | `/api/web/custom/namespaces/system/users/group_remove` | Remove user from groups. |
-| POST | `/api/web/custom/namespaces/&#123;namespace&#125;/accept_tos` | Accept TOS. |
-| POST | `/api/web/custom/namespaces/&#123;namespace&#125;/role_users` | Assign role to User. |
-| POST | `/api/web/custom/namespaces/&#123;namespace&#125;/send_password_email` | Send Password Email. |
-| GET | `/api/web/custom/namespaces/&#123;namespace&#125;/tos` | GET TOS |
-| GET | `/api/web/custom/namespaces/&#123;namespace&#125;/user_roles` | GET User and Role Assignments. |
-| POST | `/api/web/custom/namespaces/&#123;namespace&#125;/user_roles` | Create User with Role Assignment. |
-| PUT | `/api/web/custom/namespaces/&#123;namespace&#125;/user_roles` | Update User and Role Assignments. |
-| POST | `/api/web/custom/namespaces/&#123;namespace&#125;/user_roles/&#123;name&#125;` | Update User and Role Assignments. |
-| POST | `/api/web/custom/namespaces/&#123;namespace&#125;/users/cascade_delete` | DELETE User and Related Objects. |
-| GET | `/api/web/custom/namespaces/&#123;namespace&#125;/whoami` | GET User Details. |
-| POST | `/api/web/custom/password/admin_reset` | Reset password by admin. |
-| POST | `/api/web/custom/password/reset` | Reset password. |
-| GET | `/api/web/custom/namespaces/system/user_groups` | GET all User Groups for the tenant. |
-| POST | `/api/web/custom/namespaces/system/user_groups` | Create User Group. |
-| POST | `/api/web/custom/namespaces/system/user_groups/analyze_for_deletion` | Analyze For Deletion. |
-| GET | `/api/web/custom/namespaces/system/user_groups/&#123;name&#125;` | Fetch all the details for a group provided the group ID. |
-| DELETE | `/api/web/custom/namespaces/system/user_groups/&#123;name&#125;` | DELETE a group provided the group ID. |
-| PUT | `/api/web/custom/namespaces/system/user_groups/&#123;name&#125;` | Replace the User Group fields / accesses / associations. |
-| PUT | `/api/web/custom/namespaces/system/user_groups/&#123;name&#125;/assign_namespace_roles` | Assign role to User Group. |
-| PUT | `/api/web/custom/namespaces/system/user_groups/&#123;name&#125;/remove_namespace_roles` | Remove role from User Group. |
-| GET | `/api/web/namespaces/&#123;namespace&#125;/user_groups` | List User Group. |
-| GET | `/api/web/namespaces/&#123;namespace&#125;/user_groups/&#123;name&#125;` | GET User Group. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/user_identifications` | Create User Identification. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/user_identifications/&#123;metadata.name&#125;` | Replace User Identification. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/user_identifications` | List User Identification. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/user_identifications/&#123;name&#125;` | GET User Identification. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/user_identifications/&#123;name&#125;` | DELETE User Identification. |
-| GET | `/api/web/namespaces/system/user/admin_notifications` | GET admin ntfn preferences. |
-| PUT | `/api/web/namespaces/system/user/admin_notifications` | Update admin ntfn preferences. |
-| PUT | `/api/web/namespaces/system/user/admin_notifications/unset` | Unset admin ntfn preference. |
-| GET | `/api/web/namespaces/system/user/combined_notifications` | GET combined ntfn preferences. |
-| PUT | `/api/web/namespaces/system/user/combined_notifications` | Update combined ntfn preferences. |
-| GET | `/api/web/namespaces/system/user/notifications` | GET ntfn preferences. |
-| PUT | `/api/web/namespaces/system/user/notifications` | Update ntfn preferences. |
-| PUT | `/api/web/namespaces/system/user/notifications/unset` | Unset ntfn preference. |
-| PUT | `/api/web/namespaces/system/user/otp/admin_reset` | ResetOtpDeviceByAdmin. |
-| GET | `/api/web/namespaces/system/user/sessions` | GetUserSessions. |
-| GET | `/api/web/namespaces/system/user/settings` | GET |
-| PUT | `/api/web/namespaces/system/user/settings` | Update |
-| PUT | `/api/web/namespaces/system/user/settings/idm/disable` | DisableUserInIDM. |
-| PUT | `/api/web/namespaces/system/user/settings/idm/enable` | EnableUserInIDM. |
-| GET | `/api/web/namespaces/system/user/settings/image` | GetUserProfileImage. |
-| DELETE | `/api/web/namespaces/system/user/settings/image` | DeleteUserImage. |
-| PUT | `/api/web/namespaces/system/user/settings/image` | UpdateUserImage. |
-| PUT | `/api/web/namespaces/system/user/settings/request_initial_access` | Request Initial Access. |
-| GET | `/api/web/namespaces/system/user/settings/view_preference` | GET view preference. |
-| PUT | `/api/web/namespaces/system/user/settings/view_preference` | Set view preference. |
-| GET | `/api/config/namespaces/system/was/user_token` | GET Web App Scanning Service User Token. |
+| Method | Path                                                                                                                                                    | Description                                                 |
+| ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
+| GET    | `/api/web/namespaces/system/allowed_tenants/support-tenant/access`                                                                                      | GET Support Tenant Access.                                  |
+| POST   | `/api/web/namespaces/system/allowed_tenants/support-tenant/access`                                                                                      | Update Support Tenant Access.                               |
+| POST   | `/api/web/namespaces/&#123;metadata.namespace&#125;/allowed_tenants`                                                                                    | Create Allowed Tenant.                                      |
+| PUT    | `/api/web/namespaces/&#123;metadata.namespace&#125;/allowed_tenants/&#123;metadata.name&#125;`                                                          | Replace Allowed Tenant.                                     |
+| GET    | `/api/web/namespaces/&#123;namespace&#125;/allowed_tenants`                                                                                             | List Allowed Tenant.                                        |
+| GET    | `/api/web/namespaces/&#123;namespace&#125;/allowed_tenants/&#123;name&#125;`                                                                            | GET Allowed Tenant.                                         |
+| DELETE | `/api/web/namespaces/&#123;namespace&#125;/allowed_tenants/&#123;name&#125;`                                                                            | DELETE Allowed Tenant.                                      |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/authentications`                                                                                 | Create Authentication.                                      |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/authentications/&#123;metadata.name&#125;`                                                       | Replace Authentication.                                     |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/authentications`                                                                                          | List Authentication.                                        |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/authentications/&#123;name&#125;`                                                                         | GET Authentication.                                         |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/authentications/&#123;name&#125;`                                                                         | DELETE Authentication.                                      |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/authorization_servers`                                                                           | Create Authorization Server.                                |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/authorization_servers/&#123;metadata.name&#125;`                                                 | Replace Authorization Server.                               |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/authorization_servers`                                                                                    | List Authorization Server.                                  |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/authorization_servers/&#123;name&#125;`                                                                   | GET Authorization Server.                                   |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/authorization_servers/&#123;name&#125;`                                                                   | DELETE Authorization Server.                                |
+| POST   | `/api/waf/namespaces/&#123;namespace&#125;/authorization_servers/&#123;name&#125;/update`                                                               | Update Authorization Server.                                |
+| GET    | `/api/web/namespaces/system/partner-management/child_tenants`                                                                                           | List of Child Tenants.                                      |
+| POST   | `/api/web/namespaces/system/partner-management/child_tenants/migrate`                                                                                   | Migrate Child Tenants.                                      |
+| GET    | `/api/web/namespaces/system/partner-management/customer_supports`                                                                                       | List all support tickets created in child tenant.           |
+| POST   | `/api/web/namespaces/system/partner-management/customer_supports`                                                                                       | Create customer support ticket in child tenant.             |
+| GET    | `/api/web/namespaces/system/partner-management/customer_supports/&#123;tp_id&#125;`                                                                     | GET customer support ticket in child tenant.                |
+| POST   | `/api/web/namespaces/system/partner-management/customer_supports/&#123;tp_id&#125;/close`                                                               | Close a customer support ticket in child tenant.            |
+| POST   | `/api/web/namespaces/system/partner-management/customer_supports/&#123;tp_id&#125;/comment`                                                             | Add comment to a customer support ticket in child tenant.   |
+| POST   | `/api/web/namespaces/system/partner-management/customer_supports/&#123;tp_id&#125;/escalate`                                                            | Escalate a ticket in child tenant.                          |
+| POST   | `/api/web/namespaces/system/partner-management/customer_supports/&#123;tp_id&#125;/priority`                                                            | Change priority of a ticket in child tenant.                |
+| POST   | `/api/web/namespaces/system/partner-management/customer_supports/&#123;tp_id&#125;/reopen`                                                              | Reopen a closed customer support ticket in child tenant.    |
+| POST   | `/api/web/namespaces/&#123;metadata.namespace&#125;/child_tenants`                                                                                      | Child Tenant.                                               |
+| PUT    | `/api/web/namespaces/&#123;metadata.namespace&#125;/child_tenants/&#123;metadata.name&#125;`                                                            | Replace Child Tenant.                                       |
+| GET    | `/api/web/namespaces/&#123;namespace&#125;/child_tenants`                                                                                               | List Child Tenant.                                          |
+| GET    | `/api/web/namespaces/&#123;namespace&#125;/child_tenants/&#123;name&#125;`                                                                              | GET Child Tenant.                                           |
+| DELETE | `/api/web/namespaces/&#123;namespace&#125;/child_tenants/&#123;name&#125;`                                                                              | DELETE Child Tenant.                                        |
+| GET    | `/api/web/namespaces/system/partner-management/child_tenant_managers/&#123;name&#125;/child_tenants`                                                    | List child tenants for a given child tenant manager.        |
+| POST   | `/api/web/namespaces/system/partner-management/child_tenant_managers/&#123;name&#125;/child_tenants/migrate`                                            | Migrate CTM child tenants.                                  |
+| POST   | `/api/web/namespaces/&#123;metadata.namespace&#125;/child_tenant_managers`                                                                              | Child Tenant Manager.                                       |
+| PUT    | `/api/web/namespaces/&#123;metadata.namespace&#125;/child_tenant_managers/&#123;metadata.name&#125;`                                                    | Replace Child Tenant Manager.                               |
+| GET    | `/api/web/namespaces/&#123;namespace&#125;/child_tenant_managers`                                                                                       | List Child Tenant Manager.                                  |
+| GET    | `/api/web/namespaces/&#123;namespace&#125;/child_tenant_managers/&#123;name&#125;`                                                                      | GET Child Tenant Manager.                                   |
+| DELETE | `/api/web/namespaces/&#123;namespace&#125;/child_tenant_managers/&#123;name&#125;`                                                                      | DELETE Child Tenant Manager.                                |
+| GET    | `/api/web/namespaces/system/partner-management/customer_supports/&#123;tp_id&#125;/comment/&#123;comment_id&#125;/attachment/&#123;attachment_id&#125;` | GET attachment.                                             |
+| POST   | `/api/cloud-data/namespaces/system/cloud_user_accounts/discover_networks`                                                                               | Discover Cloud Networks.                                    |
+| POST   | `/api/web/namespaces/&#123;metadata.namespace&#125;/contacts`                                                                                           | Create Contact.                                             |
+| PUT    | `/api/web/namespaces/&#123;metadata.namespace&#125;/contacts/&#123;metadata.name&#125;`                                                                 | Replace Contact.                                            |
+| GET    | `/api/web/namespaces/&#123;namespace&#125;/contacts`                                                                                                    | List Contact.                                               |
+| GET    | `/api/web/namespaces/&#123;namespace&#125;/contacts/&#123;name&#125;`                                                                                   | GET Contact.                                                |
+| DELETE | `/api/web/namespaces/&#123;namespace&#125;/contacts/&#123;name&#125;`                                                                                   | DELETE Contact.                                             |
+| GET    | `/api/web/namespaces/system/managed_client/customer_supports`                                                                                           | List tickets of managed tenant.                             |
+| POST   | `/api/web/namespaces/system/managed_client/customer_supports`                                                                                           | Create customer support ticket in managed tenant.           |
+| GET    | `/api/web/namespaces/system/managed_client/customer_supports/&#123;tp_id&#125;`                                                                         | GET customer support ticket in managed tenant.              |
+| POST   | `/api/web/namespaces/system/managed_client/customer_supports/&#123;tp_id&#125;/close`                                                                   | Close a customer support ticket in managed tenant.          |
+| POST   | `/api/web/namespaces/system/managed_client/customer_supports/&#123;tp_id&#125;/comment`                                                                 | Add comment to a customer support ticket in managed tenant. |
+| POST   | `/api/web/namespaces/system/managed_client/customer_supports/&#123;tp_id&#125;/escalate`                                                                | Escalate a ticket in managed tenant.                        |
+| POST   | `/api/web/namespaces/system/managed_client/customer_supports/&#123;tp_id&#125;/priority`                                                                | Priority of a ticket in managed tenant.                     |
+| POST   | `/api/web/namespaces/system/managed_client/customer_supports/&#123;tp_id&#125;/reopen`                                                                  | Reopen a closed customer support ticket in managed tenant.  |
+| GET    | `/api/web/namespaces/system/managed_tenants_by_user`                                                                                                    | GET List of Managed Tenant By User.                         |
+| GET    | `/api/web/namespaces/system/managed_tenants_list`                                                                                                       | GET List of Managed Tenant.                                 |
+| GET    | `/api/web/namespaces/system/support-tenant/managed_tenants`                                                                                             | List of Managed Tenant By User For Support Operations.      |
+| POST   | `/api/web/namespaces/&#123;metadata.namespace&#125;/managed_tenants`                                                                                    | Create Managed Tenant.                                      |
+| PUT    | `/api/web/namespaces/&#123;metadata.namespace&#125;/managed_tenants/&#123;metadata.name&#125;`                                                          | Replace Managed Tenant.                                     |
+| GET    | `/api/web/namespaces/&#123;namespace&#125;/managed_tenants`                                                                                             | List Managed Tenant.                                        |
+| GET    | `/api/web/namespaces/&#123;namespace&#125;/managed_tenants/&#123;name&#125;`                                                                            | GET Managed Tenant.                                         |
+| DELETE | `/api/web/namespaces/&#123;namespace&#125;/managed_tenants/&#123;name&#125;`                                                                            | DELETE Managed Tenant.                                      |
+| GET    | `/api/web/namespaces/system/managed_client/customer_supports/&#123;tp_id&#125;/comment/&#123;comment_id&#125;/attachment/&#123;attachment_id&#125;`     | GET attachment.                                             |
+| GET    | `/api/web/namespaces`                                                                                                                                   | List Namespace.                                             |
+| POST   | `/api/web/namespaces`                                                                                                                                   | Create Namespace.                                           |
+| POST   | `/api/config/namespaces/system/all_application_inventory`                                                                                               | All Application Objects Inventory.                          |
+| POST   | `/api/config/namespaces/system/all_application_inventory_waf_filters`                                                                                   | All Application Objects Inventory with WAF Filters.         |
+| POST   | `/api/ml/data/namespaces/system/api_endpoints/all_ns_stats`                                                                                             | GET API Endpoints Stats for All Namespaces.                 |
+| POST   | `/api/web/namespaces/system/evaluate-api-access`                                                                                                        | Evaluate API Access.                                        |
+| POST   | `/api/web/namespaces/system/evaluate-batch-api-access`                                                                                                  | Evaluate Batch API Access.                                  |
+| POST   | `/api/web/namespaces/system/lookup-user-roles`                                                                                                          | Lookup User Roles.                                          |
+| POST   | `/api/config/namespaces/system/networking_inventory`                                                                                                    | Networking Objects Inventory.                               |
+| POST   | `/api/cloud-data/namespaces/system/suggest-values`                                                                                                      | Suggest Values.                                             |
+| POST   | `/api/config/namespaces/system/update_allow_advertise_on_public`                                                                                        | Update allow advertise on public.                           |
+| POST   | `/api/config/namespaces/system/validate_rules`                                                                                                          | Validate Rules.                                             |
+| PUT    | `/api/web/namespaces/&#123;metadata.name&#125;`                                                                                                         | Replace Namespace.                                          |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/active_alert_policies`                                                                                    | GET Active Alert Policies.                                  |
+| POST   | `/api/config/namespaces/&#123;namespace&#125;/active_alert_policies`                                                                                    | Set Active Alert Policies.                                  |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/active_network_policies`                                                                                  | GET Active Network Policies.                                |
+| POST   | `/api/config/namespaces/&#123;namespace&#125;/active_network_policies`                                                                                  | Set Active Network Policies.                                |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/active_service_policies`                                                                                  | GET Active Service Policies.                                |
+| POST   | `/api/config/namespaces/&#123;namespace&#125;/active_service_policies`                                                                                  | Set Active Service Policies.                                |
+| POST   | `/api/ml/data/namespaces/&#123;namespace&#125;/api_endpoints/stats`                                                                                     | GET API Endpoints Stats for Namespace.                      |
+| POST   | `/api/config/namespaces/&#123;namespace&#125;/application_inventory`                                                                                    | Application Objects Inventory.                              |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/fast_acls_for_internet_vips`                                                                              | GET FastACLs For Internet VIPs.                             |
+| POST   | `/api/config/namespaces/&#123;namespace&#125;/fast_acls_for_internet_vips`                                                                              | Set FastACLs For Internet VIPs.                             |
+| POST   | `/api/web/namespaces/&#123;namespace&#125;/suggest-values`                                                                                              | Suggest Values.                                             |
+| GET    | `/api/web/namespaces/&#123;name&#125;`                                                                                                                  | GET Namespace.                                              |
+| POST   | `/api/web/namespaces/&#123;name&#125;/cascade_delete`                                                                                                   | Cascade DELETE.                                             |
+| GET    | `/api/web/namespaces/&#123;namespace&#125;/namespace_roles`                                                                                             | List Namespace Role.                                        |
+| GET    | `/api/web/namespaces/&#123;namespace&#125;/namespace_roles/&#123;name&#125;`                                                                            | GET Namespace Role.                                         |
+| POST   | `/api/config/namespaces/&#123;namespace&#125;/dynamic-data`                                                                                             | Dynamic Data.                                               |
+| GET    | `/api/web/namespaces/&#123;namespace&#125;/rbac_policys`                                                                                                | List RBAC Policy.                                           |
+| GET    | `/api/web/namespaces/&#123;namespace&#125;/rbac_policys/&#123;name&#125;`                                                                               | GET RBAC Policy.                                            |
+| GET    | `/api/web/custom/namespaces/&#123;namespace&#125;/roles`                                                                                                | Custom List Roles.                                          |
+| POST   | `/api/web/custom/namespaces/&#123;namespace&#125;/roles`                                                                                                | Custom Create Role.                                         |
+| GET    | `/api/web/custom/namespaces/&#123;namespace&#125;/roles/&#123;name&#125;`                                                                               | Custom GET Role.                                            |
+| PUT    | `/api/web/custom/namespaces/&#123;namespace&#125;/roles/&#123;name&#125;`                                                                               | Custom Replace Role.                                        |
+| POST   | `/api/web/namespaces/&#123;metadata.namespace&#125;/roles`                                                                                              | Create Role.                                                |
+| PUT    | `/api/web/namespaces/&#123;metadata.namespace&#125;/roles/&#123;metadata.name&#125;`                                                                    | Replace Role.                                               |
+| GET    | `/api/web/namespaces/&#123;namespace&#125;/roles`                                                                                                       | List Role                                                   |
+| GET    | `/api/web/namespaces/&#123;namespace&#125;/roles/&#123;name&#125;`                                                                                      | GET Role                                                    |
+| DELETE | `/api/web/namespaces/&#123;namespace&#125;/roles/&#123;name&#125;`                                                                                      | DELETE Role.                                                |
+| GET    | `/api/web/custom/namespaces/&#123;namespace&#125;/oidc_provider/&#123;name&#125;`                                                                       | GET                                                         |
+| POST   | `/api/web/custom/namespaces/&#123;namespace&#125;/oidc_provider/&#123;name&#125;/delete`                                                                | DELETE                                                      |
+| GET    | `/api/web/custom/namespaces/&#123;namespace&#125;/oidc_providers`                                                                                       | List                                                        |
+| POST   | `/api/web/custom/namespaces/&#123;namespace&#125;/oidc_providers`                                                                                       | Create                                                      |
+| GET    | `/api/web/custom/namespaces/&#123;namespace&#125;/oidc_providers/&#123;name&#125;`                                                                      | GET                                                         |
+| POST   | `/api/web/custom/namespaces/&#123;namespace&#125;/oidc_providers/&#123;name&#125;`                                                                      | Replace                                                     |
+| PUT    | `/api/web/custom/namespaces/&#123;namespace&#125;/oidc_providers/&#123;name&#125;`                                                                      | Replace                                                     |
+| POST   | `/api/web/custom/namespaces/&#123;namespace&#125;/oidc_providers/&#123;name&#125;/delete`                                                               | DELETE                                                      |
+| GET    | `/api/web/custom/namespaces/&#123;namespace&#125;/oidc_providers/&#123;name&#125;/mappers`                                                              | GET OIDC mappers.                                           |
+| POST   | `/api/web/custom/namespaces/&#123;namespace&#125;/oidc_providers/&#123;name&#125;/mappers`                                                              | Update OIDC mappers.                                        |
+| PUT    | `/api/web/custom/namespaces/&#123;namespace&#125;/oidc_providers/&#123;name&#125;/scim`                                                                 | Update OIDC provider SCIM Integration.                      |
+| GET    | `/no_auth/countries/&#123;country_code&#125;/states/&#123;prefix&#125;`                                                                                 | List states.                                                |
+| GET    | `/no_auth/countries/&#123;country_code&#125;/states/&#123;state_code&#125;/cities/&#123;prefix&#125;`                                                   | List cities.                                                |
+| GET    | `/no_auth/countries/&#123;prefix&#125;`                                                                                                                 | List countries.                                             |
+| POST   | `/no_auth/login/validate_registration`                                                                                                                  | Validate Registration.                                      |
+| POST   | `/no_auth/send_password_email`                                                                                                                          | Send Password Email.                                        |
+| GET    | `/no_auth/signup/&#123;name&#125;`                                                                                                                      | Read Signup.                                                |
+| POST   | `/no_auth/validate_contact`                                                                                                                             | Validate contact.                                           |
+| GET    | `/api/web/custom/countries/&#123;country_code&#125;/states/&#123;prefix&#125;`                                                                          | List states.                                                |
+| GET    | `/api/web/custom/countries/&#123;country_code&#125;/states/&#123;state_code&#125;/cities/&#123;prefix&#125;`                                            | List cities.                                                |
+| GET    | `/api/web/custom/countries/&#123;prefix&#125;`                                                                                                          | List countries.                                             |
+| GET    | `/api/scim/namespaces/system/v2/Groups`                                                                                                                 | List group based on filters.                                |
+| POST   | `/api/scim/namespaces/system/v2/Groups`                                                                                                                 | Create group with users.                                    |
+| GET    | `/api/scim/namespaces/system/v2/Groups/&#123;id&#125;`                                                                                                  | List group based on ID.                                     |
+| DELETE | `/api/scim/namespaces/system/v2/Groups/&#123;id&#125;`                                                                                                  | DELETE group based on ID.                                   |
+| PUT    | `/api/scim/namespaces/system/v2/Groups/&#123;id&#125;`                                                                                                  | Replace group based on ID.                                  |
+| PATCH  | `/api/scim/namespaces/system/v2/Groups/&#123;id&#125;`                                                                                                  | PATCH group based on ID.                                    |
+| GET    | `/api/scim/namespaces/system/v2/ResourceTypes`                                                                                                          | GET supported resources type.                               |
+| GET    | `/api/scim/namespaces/system/v2/ResourceTypes/&#123;id&#125;`                                                                                           | GET supported resources type.                               |
+| GET    | `/api/scim/namespaces/system/v2/Schemas`                                                                                                                | Schemas                                                     |
+| GET    | `/api/scim/namespaces/system/v2/Schemas/&#123;id&#125;`                                                                                                 | Schemas By ID.                                              |
+| GET    | `/api/scim/namespaces/system/v2/ServiceProviderConfig`                                                                                                  | List service provider configs.                              |
+| GET    | `/api/scim/namespaces/system/v2/Users`                                                                                                                  | GET all users.                                              |
+| POST   | `/api/scim/namespaces/system/v2/Users`                                                                                                                  | Create User with Role Assignment.                           |
+| GET    | `/api/scim/namespaces/system/v2/Users/&#123;id&#125;`                                                                                                   | GET User with ID.                                           |
+| DELETE | `/api/scim/namespaces/system/v2/Users/&#123;id&#125;`                                                                                                   | DELETE user by ID.                                          |
+| PUT    | `/api/scim/namespaces/system/v2/Users/&#123;id&#125;`                                                                                                   | Update User and Role Assignments.                           |
+| PATCH  | `/api/scim/namespaces/system/v2/Users/&#123;id&#125;`                                                                                                   | PATCH User.                                                 |
+| GET    | `/no_auth/cname/lookup`                                                                                                                                 | Lookup cname.                                               |
+| GET    | `/no_auth/tenant/idm/settings/password_policy`                                                                                                          | GetPasswordPolicy.                                          |
+| POST   | `/api/web/namespaces/system/tenant/domain_owner/assign`                                                                                                 | Assign domain owner.                                        |
+| POST   | `/api/web/namespaces/system/tenant/domain_owner/unassign`                                                                                               | Unassign domain owner.                                      |
+| GET    | `/api/web/namespaces/system/tenant/idm/events/last_login`                                                                                               | GetLastLoginMap.                                            |
+| GET    | `/api/web/namespaces/system/tenant/idm/events/login`                                                                                                    | GetLoginEvents.                                             |
+| POST   | `/api/web/namespaces/system/tenant/idm/events/login_in_time`                                                                                            | GetLoginEventsInTimeFrame.                                  |
+| GET    | `/api/web/namespaces/system/tenant/idm/settings`                                                                                                        | GetIDMSettings.                                             |
+| PUT    | `/api/web/namespaces/system/tenant/idm/settings`                                                                                                        | UpdateIDMSettings.                                          |
+| GET    | `/api/web/namespaces/system/tenant/idm/users/inactive`                                                                                                  | ListInactiveUsers.                                          |
+| GET    | `/api/web/namespaces/system/tenant/lookup`                                                                                                              | Lookup cname.                                               |
+| POST   | `/api/web/namespaces/system/tenant/request-delete`                                                                                                      | DELETE Tenant.                                              |
+| GET    | `/api/web/namespaces/system/tenant/settings`                                                                                                            | Tenant Settings.                                            |
+| PUT    | `/api/web/namespaces/system/tenant/settings`                                                                                                            | Tenant Settings.                                            |
+| PUT    | `/api/web/namespaces/system/tenant/settings/otp/disable`                                                                                                | Disable tenant level OTP.                                   |
+| PUT    | `/api/web/namespaces/system/tenant/settings/otp/enable`                                                                                                 | Enable tenant level OTP.                                    |
+| GET    | `/api/web/namespaces/system/tenant/settings/tenant/favicon`                                                                                             | Tenant favicon.                                             |
+| GET    | `/api/web/namespaces/system/tenant/settings/tenant/image`                                                                                               | Tenant profile image.                                       |
+| DELETE | `/api/web/namespaces/system/tenant/settings/tenant/image`                                                                                               | DELETE tenant profile image.                                |
+| PUT    | `/api/web/namespaces/system/tenant/settings/tenant/image`                                                                                               | Update tenant profile image.                                |
+| GET    | `/api/web/namespaces/system/tenant/settings/tenant/logo`                                                                                                | Tenant logo.                                                |
+| GET    | `/api/web/namespaces/system/tenant/support-info`                                                                                                        | Support Info.                                               |
+| GET    | `/api/web/namespaces/system/tenant/tenant-escalation-doc`                                                                                               | Tenant escalation document.                                 |
+| PUT    | `/api/saas/namespaces/system/v2/tenant/deactivate`                                                                                                      | DeactivateTenant.                                           |
+| GET    | `/api/web/static/namespaces/system/tenant/settings/tenant/favicon`                                                                                      | Tenant favicon.                                             |
+| GET    | `/api/web/static/namespaces/system/tenant/settings/tenant/image`                                                                                        | Tenant profile image.                                       |
+| GET    | `/api/config/tenants/&#123;tenant&#125;/summary`                                                                                                        | Summary                                                     |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/tenant_configurations`                                                                           | Create tenant configuration.                                |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/tenant_configurations/&#123;metadata.name&#125;`                                                 | Replace tenant configuration.                               |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/tenant_configurations`                                                                                    | List Tenant Configuration.                                  |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/tenant_configurations/&#123;name&#125;`                                                                   | GET tenant configuration.                                   |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/tenant_configurations/&#123;name&#125;`                                                                   | DELETE Tenant Configuration.                                |
+| POST   | `/api/web/namespaces/system/tenant_management/delegated_access/subscribe`                                                                               | Subscribe Delegated Access Addon Service.                   |
+| POST   | `/api/web/namespaces/system/tenant_management/delegated_access/unsubscribe`                                                                             | Unsubscribe Delegated Access Addon Service.                 |
+| POST   | `/api/web/namespaces/&#123;metadata.namespace&#125;/tenant_profiles`                                                                                    | Create Tenant Profile.                                      |
+| PUT    | `/api/web/namespaces/&#123;metadata.namespace&#125;/tenant_profiles/&#123;metadata.name&#125;`                                                          | Replace Tenant Profile.                                     |
+| GET    | `/api/web/namespaces/&#123;namespace&#125;/tenant_profiles`                                                                                             | List Tenant Profile.                                        |
+| GET    | `/api/web/namespaces/&#123;namespace&#125;/tenant_profiles/&#123;name&#125;`                                                                            | GET Tenant Profile.                                         |
+| DELETE | `/api/web/namespaces/&#123;namespace&#125;/tenant_profiles/&#123;name&#125;`                                                                            | DELETE Tenant Profile.                                      |
+| POST   | `/api/web/custom/idm/user/sync`                                                                                                                         | Sync user                                                   |
+| PUT    | `/api/web/custom/namespaces/system/users/group_add`                                                                                                     | Add user to groups.                                         |
+| PUT    | `/api/web/custom/namespaces/system/users/group_remove`                                                                                                  | Remove user from groups.                                    |
+| POST   | `/api/web/custom/namespaces/&#123;namespace&#125;/accept_tos`                                                                                           | Accept TOS.                                                 |
+| POST   | `/api/web/custom/namespaces/&#123;namespace&#125;/role_users`                                                                                           | Assign role to User.                                        |
+| POST   | `/api/web/custom/namespaces/&#123;namespace&#125;/send_password_email`                                                                                  | Send Password Email.                                        |
+| GET    | `/api/web/custom/namespaces/&#123;namespace&#125;/tos`                                                                                                  | GET TOS                                                     |
+| GET    | `/api/web/custom/namespaces/&#123;namespace&#125;/user_roles`                                                                                           | GET User and Role Assignments.                              |
+| POST   | `/api/web/custom/namespaces/&#123;namespace&#125;/user_roles`                                                                                           | Create User with Role Assignment.                           |
+| PUT    | `/api/web/custom/namespaces/&#123;namespace&#125;/user_roles`                                                                                           | Update User and Role Assignments.                           |
+| POST   | `/api/web/custom/namespaces/&#123;namespace&#125;/user_roles/&#123;name&#125;`                                                                          | Update User and Role Assignments.                           |
+| POST   | `/api/web/custom/namespaces/&#123;namespace&#125;/users/cascade_delete`                                                                                 | DELETE User and Related Objects.                            |
+| GET    | `/api/web/custom/namespaces/&#123;namespace&#125;/whoami`                                                                                               | GET User Details.                                           |
+| POST   | `/api/web/custom/password/admin_reset`                                                                                                                  | Reset password by admin.                                    |
+| POST   | `/api/web/custom/password/reset`                                                                                                                        | Reset password.                                             |
+| GET    | `/api/web/custom/namespaces/system/user_groups`                                                                                                         | GET all User Groups for the tenant.                         |
+| POST   | `/api/web/custom/namespaces/system/user_groups`                                                                                                         | Create User Group.                                          |
+| POST   | `/api/web/custom/namespaces/system/user_groups/analyze_for_deletion`                                                                                    | Analyze For Deletion.                                       |
+| GET    | `/api/web/custom/namespaces/system/user_groups/&#123;name&#125;`                                                                                        | Fetch all the details for a group provided the group ID.    |
+| DELETE | `/api/web/custom/namespaces/system/user_groups/&#123;name&#125;`                                                                                        | DELETE a group provided the group ID.                       |
+| PUT    | `/api/web/custom/namespaces/system/user_groups/&#123;name&#125;`                                                                                        | Replace the User Group fields / accesses / associations.    |
+| PUT    | `/api/web/custom/namespaces/system/user_groups/&#123;name&#125;/assign_namespace_roles`                                                                 | Assign role to User Group.                                  |
+| PUT    | `/api/web/custom/namespaces/system/user_groups/&#123;name&#125;/remove_namespace_roles`                                                                 | Remove role from User Group.                                |
+| GET    | `/api/web/namespaces/&#123;namespace&#125;/user_groups`                                                                                                 | List User Group.                                            |
+| GET    | `/api/web/namespaces/&#123;namespace&#125;/user_groups/&#123;name&#125;`                                                                                | GET User Group.                                             |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/user_identifications`                                                                            | Create User Identification.                                 |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/user_identifications/&#123;metadata.name&#125;`                                                  | Replace User Identification.                                |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/user_identifications`                                                                                     | List User Identification.                                   |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/user_identifications/&#123;name&#125;`                                                                    | GET User Identification.                                    |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/user_identifications/&#123;name&#125;`                                                                    | DELETE User Identification.                                 |
+| GET    | `/api/web/namespaces/system/user/admin_notifications`                                                                                                   | GET admin ntfn preferences.                                 |
+| PUT    | `/api/web/namespaces/system/user/admin_notifications`                                                                                                   | Update admin ntfn preferences.                              |
+| PUT    | `/api/web/namespaces/system/user/admin_notifications/unset`                                                                                             | Unset admin ntfn preference.                                |
+| GET    | `/api/web/namespaces/system/user/combined_notifications`                                                                                                | GET combined ntfn preferences.                              |
+| PUT    | `/api/web/namespaces/system/user/combined_notifications`                                                                                                | Update combined ntfn preferences.                           |
+| GET    | `/api/web/namespaces/system/user/notifications`                                                                                                         | GET ntfn preferences.                                       |
+| PUT    | `/api/web/namespaces/system/user/notifications`                                                                                                         | Update ntfn preferences.                                    |
+| PUT    | `/api/web/namespaces/system/user/notifications/unset`                                                                                                   | Unset ntfn preference.                                      |
+| PUT    | `/api/web/namespaces/system/user/otp/admin_reset`                                                                                                       | ResetOtpDeviceByAdmin.                                      |
+| GET    | `/api/web/namespaces/system/user/sessions`                                                                                                              | GetUserSessions.                                            |
+| GET    | `/api/web/namespaces/system/user/settings`                                                                                                              | GET                                                         |
+| PUT    | `/api/web/namespaces/system/user/settings`                                                                                                              | Update                                                      |
+| PUT    | `/api/web/namespaces/system/user/settings/idm/disable`                                                                                                  | DisableUserInIDM.                                           |
+| PUT    | `/api/web/namespaces/system/user/settings/idm/enable`                                                                                                   | EnableUserInIDM.                                            |
+| GET    | `/api/web/namespaces/system/user/settings/image`                                                                                                        | GetUserProfileImage.                                        |
+| DELETE | `/api/web/namespaces/system/user/settings/image`                                                                                                        | DeleteUserImage.                                            |
+| PUT    | `/api/web/namespaces/system/user/settings/image`                                                                                                        | UpdateUserImage.                                            |
+| PUT    | `/api/web/namespaces/system/user/settings/request_initial_access`                                                                                       | Request Initial Access.                                     |
+| GET    | `/api/web/namespaces/system/user/settings/view_preference`                                                                                              | GET view preference.                                        |
+| PUT    | `/api/web/namespaces/system/user/settings/view_preference`                                                                                              | Set view preference.                                        |
+| GET    | `/api/config/namespaces/system/was/user_token`                                                                                                          | GET Web App Scanning Service User Token.                    |
 
 ## Links
 

--- a/docs/en/api-reference/threat_campaign-api.mdx
+++ b/docs/en/api-reference/threat_campaign-api.mdx
@@ -2,7 +2,7 @@
 title: "⚠️ Threat Campaign API"
 description: "Attack detection, tracking, and mitigation rules."
 sidebar:
-    hidden: true
+  hidden: true
 ---
 
 Detection policies, attack tracking, and automated mitigation rule generation for security operations.
@@ -25,9 +25,9 @@ Detection policies, attack tracking, and automated mitigation rule generation fo
 
 ## Endpoints
 
-| Method | Path | Description |
-|--------|------|-------------|
-| GET | `/api/waf/threat_campaign/&#123;id&#125;` | GET Threat Campaign by ID. |
+| Method | Path                                      | Description                |
+| ------ | ----------------------------------------- | -------------------------- |
+| GET    | `/api/waf/threat_campaign/&#123;id&#125;` | GET Threat Campaign by ID. |
 
 ## Links
 

--- a/docs/en/api-reference/users-api.mdx
+++ b/docs/en/api-reference/users-api.mdx
@@ -2,7 +2,7 @@
 title: "👥 Users API"
 description: "Account tokens, labels, and cloud-init config."
 sidebar:
-    hidden: true
+  hidden: true
 ---
 
 Site enrollment credentials with automatic expiration. Taxonomy keys define allowed categorization while auto-derived tags apply dynamically.
@@ -28,22 +28,22 @@ Site enrollment credentials with automatic expiration. Taxonomy keys define allo
 
 ## Endpoints
 
-| Method | Path | Description |
-|--------|------|-------------|
-| GET | `/api/config/namespaces/system/implicit_labels` | GET Implicit Labels. |
-| POST | `/api/config/namespaces/&#123;namespace&#125;/known_label/create` | Create |
-| POST | `/api/config/namespaces/&#123;namespace&#125;/known_label/delete` | DELETE |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/known_labels` | GET |
-| POST | `/api/config/namespaces/&#123;namespace&#125;/known_label_key/create` | Create |
-| POST | `/api/config/namespaces/&#123;namespace&#125;/known_label_key/delete` | DELETE |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/known_label_keys` | GET |
-| GET | `/api/register/namespaces/system/get-cloud-init-config` | GET Cloud Init Config. |
-| POST | `/api/register/namespaces/&#123;metadata.namespace&#125;/tokens` | Create Token. |
-| PUT | `/api/register/namespaces/&#123;metadata.namespace&#125;/tokens/&#123;metadata.name&#125;` | Replace Token. |
-| GET | `/api/register/namespaces/&#123;namespace&#125;/tokens` | List Token. |
-| GET | `/api/register/namespaces/&#123;namespace&#125;/tokens/&#123;name&#125;` | GET Token |
-| DELETE | `/api/register/namespaces/&#123;namespace&#125;/tokens/&#123;name&#125;` | DELETE Token. |
-| POST | `/api/register/namespaces/&#123;namespace&#125;/tokens/&#123;name&#125;/state` | Set Token State. |
+| Method | Path                                                                                       | Description            |
+| ------ | ------------------------------------------------------------------------------------------ | ---------------------- |
+| GET    | `/api/config/namespaces/system/implicit_labels`                                            | GET Implicit Labels.   |
+| POST   | `/api/config/namespaces/&#123;namespace&#125;/known_label/create`                          | Create                 |
+| POST   | `/api/config/namespaces/&#123;namespace&#125;/known_label/delete`                          | DELETE                 |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/known_labels`                                | GET                    |
+| POST   | `/api/config/namespaces/&#123;namespace&#125;/known_label_key/create`                      | Create                 |
+| POST   | `/api/config/namespaces/&#123;namespace&#125;/known_label_key/delete`                      | DELETE                 |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/known_label_keys`                            | GET                    |
+| GET    | `/api/register/namespaces/system/get-cloud-init-config`                                    | GET Cloud Init Config. |
+| POST   | `/api/register/namespaces/&#123;metadata.namespace&#125;/tokens`                           | Create Token.          |
+| PUT    | `/api/register/namespaces/&#123;metadata.namespace&#125;/tokens/&#123;metadata.name&#125;` | Replace Token.         |
+| GET    | `/api/register/namespaces/&#123;namespace&#125;/tokens`                                    | List Token.            |
+| GET    | `/api/register/namespaces/&#123;namespace&#125;/tokens/&#123;name&#125;`                   | GET Token              |
+| DELETE | `/api/register/namespaces/&#123;namespace&#125;/tokens/&#123;name&#125;`                   | DELETE Token.          |
+| POST   | `/api/register/namespaces/&#123;namespace&#125;/tokens/&#123;name&#125;/state`             | Set Token State.       |
 
 ## Links
 

--- a/docs/en/api-reference/virtual-api.mdx
+++ b/docs/en/api-reference/virtual-api.mdx
@@ -2,7 +2,7 @@
 title: "⚖️ Virtual API"
 description: "HTTP, TCP, UDP load balancing with origin pools."
 sidebar:
-    hidden: true
+  hidden: true
 ---
 
 Traffic distribution across regions with routing rules. Health checks and failover policies.
@@ -36,160 +36,160 @@ Traffic distribution across regions with routing rules. Health checks and failov
 
 ## Endpoints
 
-| Method | Path | Description |
-|--------|------|-------------|
-| POST | `/api/data/namespaces/system/app_firewall/all_ns_metrics` | MetricsAllNamespaces. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/app_firewalls` | Create Application Firewall. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/app_firewalls/&#123;metadata.name&#125;` | Replace Application Firewall. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/app_firewall/metrics` | Metrics |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/app_firewalls` | List Application Firewall. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/app_firewalls/&#123;name&#125;` | GET Application Firewall. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/app_firewalls/&#123;name&#125;` | DELETE Application Firewall. |
-| POST | `/api/data/namespaces/system/app_security/all_ns_events` | Security Events Query All Namespaces. |
-| POST | `/api/data/namespaces/system/app_security/all_ns_events/aggregation` | Security Events Aggregation Query All Namespaces. |
-| POST | `/api/data/namespaces/system/app_security/all_ns_search/loadbalancers` | Search load balancers All Namespaces. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/app_security/events` | Security Events Query. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/app_security/events/aggregation` | Security Events Aggregation Query. |
-| GET | `/api/data/namespaces/&#123;namespace&#125;/app_security/events/scroll` | Security Event Scroll Query. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/app_security/events/scroll` | Security Event Scroll Query. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/app_security/incidents` | Security Incidents Query. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/app_security/incidents/aggregation` | Security Incidents Aggregation Query. |
-| GET | `/api/data/namespaces/&#123;namespace&#125;/app_security/incidents/scroll` | Security Incidents Scroll Query. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/app_security/incidents/scroll` | Security Incidents Scroll Query. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/app_security/metrics` | Security Events Metrics. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/app_security/search/loadbalancers` | Search load balancers. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/app_security/suspicious_user_logs` | Suspicious User Logs Query. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/app_security/suspicious_user_logs/aggregation` | Suspicious User Logs Aggregation Query. |
-| GET | `/api/data/namespaces/&#123;namespace&#125;/app_security/suspicious_user_logs/scroll` | Suspicious User Logs Scroll Query. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/app_security/suspicious_user_logs/scroll` | Suspicious User Logs Scroll Query. |
-| POST | `/api/config/namespaces/&#123;namespace&#125;/http_loadbalancers/&#123;name&#125;/api_endpoint_protection/suggestion` | Suggest API endpoint protection rule. |
-| POST | `/api/config/namespaces/&#123;namespace&#125;/http_loadbalancers/&#123;name&#125;/block_client/suggestion` | Suggest block client rule. |
-| POST | `/api/config/namespaces/&#123;namespace&#125;/http_loadbalancers/&#123;name&#125;/data_exposure/suggestion` | Suggest sensitive data rule. |
-| POST | `/api/config/namespaces/&#123;namespace&#125;/http_loadbalancers/&#123;name&#125;/ddos_mitigation/suggestion` | Suggest DDoS Mitigation rule. |
-| POST | `/api/config/namespaces/&#123;namespace&#125;/http_loadbalancers/&#123;name&#125;/oas_validation/suggestion` | Suggest Open API specification validation rule. |
-| POST | `/api/config/namespaces/&#123;namespace&#125;/http_loadbalancers/&#123;name&#125;/rate_limit/suggestion` | Suggest rate limit rule. |
-| POST | `/api/config/namespaces/&#123;namespace&#125;/http_loadbalancers/&#123;name&#125;/trust_client/suggestion` | Suggest trust client rule. |
-| POST | `/api/config/namespaces/&#123;namespace&#125;/http_loadbalancers/&#123;name&#125;/waf_exclusion/suggestion` | Suggest WAF Exclusion Rule. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/clusters` | Create Cluster. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/clusters/&#123;metadata.name&#125;` | Replace Cluster. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/clusters` | List Cluster. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/clusters/&#123;name&#125;` | GET Cluster. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/clusters/&#123;name&#125;` | DELETE Cluster. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/http_loadbalancers` | Create HTTP Load Balancer. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/http_loadbalancers/&#123;metadata.name&#125;` | Replace HTTP Load Balancer. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/http_loadbalancers` | List Configure HTTP Load Balancer. |
-| POST | `/api/config/namespaces/&#123;namespace&#125;/http_loadbalancers/get_security_config` | GET Security Config for HTTP Load Balancer. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/http_loadbalancers/&#123;name&#125;` | GET HTTP Load Balancer. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/http_loadbalancers/&#123;name&#125;` | DELETE Configure HTTP Load Balancer. |
-| POST | `/api/config/namespaces/&#123;namespace&#125;/http_loadbalancers/&#123;name&#125;/api_definitions/assign` | Assign API Definition. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/http_loadbalancers/&#123;name&#125;/api_definitions/available` | List Available API Definitions. |
-| POST | `/api/ml/data/namespaces/&#123;namespace&#125;/http_loadbalancers/&#123;name&#125;/api_endpoints` | GET API Endpoints. |
-| GET | `/api/ml/data/namespaces/&#123;namespace&#125;/http_loadbalancers/&#123;name&#125;/api_endpoints/swagger_spec` | GET Swagger Spec for HTTP Load Balancer. |
-| POST | `/api/ml/data/namespaces/&#123;namespace&#125;/http_loadbalancers/&#123;name&#125;/api_inventory/api_endpoints/get_schema_updates` | GET API Endpoints Schema Updates. |
-| POST | `/api/ml/data/namespaces/&#123;namespace&#125;/http_loadbalancers/&#123;name&#125;/api_inventory/api_endpoints/update_schemas` | Update API Endpoints Schemas. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/http_loadbalancers/&#123;name&#125;/dos_automitigation_rules` | GET DoS Auto-Mitigation Rules for HTTP Load Balancer. |
+| Method | Path                                                                                                                                                 | Description                                             |
+| ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
+| POST   | `/api/data/namespaces/system/app_firewall/all_ns_metrics`                                                                                            | MetricsAllNamespaces.                                   |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/app_firewalls`                                                                                | Create Application Firewall.                            |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/app_firewalls/&#123;metadata.name&#125;`                                                      | Replace Application Firewall.                           |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/app_firewall/metrics`                                                                                    | Metrics                                                 |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/app_firewalls`                                                                                         | List Application Firewall.                              |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/app_firewalls/&#123;name&#125;`                                                                        | GET Application Firewall.                               |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/app_firewalls/&#123;name&#125;`                                                                        | DELETE Application Firewall.                            |
+| POST   | `/api/data/namespaces/system/app_security/all_ns_events`                                                                                             | Security Events Query All Namespaces.                   |
+| POST   | `/api/data/namespaces/system/app_security/all_ns_events/aggregation`                                                                                 | Security Events Aggregation Query All Namespaces.       |
+| POST   | `/api/data/namespaces/system/app_security/all_ns_search/loadbalancers`                                                                               | Search load balancers All Namespaces.                   |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/app_security/events`                                                                                     | Security Events Query.                                  |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/app_security/events/aggregation`                                                                         | Security Events Aggregation Query.                      |
+| GET    | `/api/data/namespaces/&#123;namespace&#125;/app_security/events/scroll`                                                                              | Security Event Scroll Query.                            |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/app_security/events/scroll`                                                                              | Security Event Scroll Query.                            |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/app_security/incidents`                                                                                  | Security Incidents Query.                               |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/app_security/incidents/aggregation`                                                                      | Security Incidents Aggregation Query.                   |
+| GET    | `/api/data/namespaces/&#123;namespace&#125;/app_security/incidents/scroll`                                                                           | Security Incidents Scroll Query.                        |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/app_security/incidents/scroll`                                                                           | Security Incidents Scroll Query.                        |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/app_security/metrics`                                                                                    | Security Events Metrics.                                |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/app_security/search/loadbalancers`                                                                       | Search load balancers.                                  |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/app_security/suspicious_user_logs`                                                                       | Suspicious User Logs Query.                             |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/app_security/suspicious_user_logs/aggregation`                                                           | Suspicious User Logs Aggregation Query.                 |
+| GET    | `/api/data/namespaces/&#123;namespace&#125;/app_security/suspicious_user_logs/scroll`                                                                | Suspicious User Logs Scroll Query.                      |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/app_security/suspicious_user_logs/scroll`                                                                | Suspicious User Logs Scroll Query.                      |
+| POST   | `/api/config/namespaces/&#123;namespace&#125;/http_loadbalancers/&#123;name&#125;/api_endpoint_protection/suggestion`                                | Suggest API endpoint protection rule.                   |
+| POST   | `/api/config/namespaces/&#123;namespace&#125;/http_loadbalancers/&#123;name&#125;/block_client/suggestion`                                           | Suggest block client rule.                              |
+| POST   | `/api/config/namespaces/&#123;namespace&#125;/http_loadbalancers/&#123;name&#125;/data_exposure/suggestion`                                          | Suggest sensitive data rule.                            |
+| POST   | `/api/config/namespaces/&#123;namespace&#125;/http_loadbalancers/&#123;name&#125;/ddos_mitigation/suggestion`                                        | Suggest DDoS Mitigation rule.                           |
+| POST   | `/api/config/namespaces/&#123;namespace&#125;/http_loadbalancers/&#123;name&#125;/oas_validation/suggestion`                                         | Suggest Open API specification validation rule.         |
+| POST   | `/api/config/namespaces/&#123;namespace&#125;/http_loadbalancers/&#123;name&#125;/rate_limit/suggestion`                                             | Suggest rate limit rule.                                |
+| POST   | `/api/config/namespaces/&#123;namespace&#125;/http_loadbalancers/&#123;name&#125;/trust_client/suggestion`                                           | Suggest trust client rule.                              |
+| POST   | `/api/config/namespaces/&#123;namespace&#125;/http_loadbalancers/&#123;name&#125;/waf_exclusion/suggestion`                                          | Suggest WAF Exclusion Rule.                             |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/clusters`                                                                                     | Create Cluster.                                         |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/clusters/&#123;metadata.name&#125;`                                                           | Replace Cluster.                                        |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/clusters`                                                                                              | List Cluster.                                           |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/clusters/&#123;name&#125;`                                                                             | GET Cluster.                                            |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/clusters/&#123;name&#125;`                                                                             | DELETE Cluster.                                         |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/http_loadbalancers`                                                                           | Create HTTP Load Balancer.                              |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/http_loadbalancers/&#123;metadata.name&#125;`                                                 | Replace HTTP Load Balancer.                             |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/http_loadbalancers`                                                                                    | List Configure HTTP Load Balancer.                      |
+| POST   | `/api/config/namespaces/&#123;namespace&#125;/http_loadbalancers/get_security_config`                                                                | GET Security Config for HTTP Load Balancer.             |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/http_loadbalancers/&#123;name&#125;`                                                                   | GET HTTP Load Balancer.                                 |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/http_loadbalancers/&#123;name&#125;`                                                                   | DELETE Configure HTTP Load Balancer.                    |
+| POST   | `/api/config/namespaces/&#123;namespace&#125;/http_loadbalancers/&#123;name&#125;/api_definitions/assign`                                            | Assign API Definition.                                  |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/http_loadbalancers/&#123;name&#125;/api_definitions/available`                                         | List Available API Definitions.                         |
+| POST   | `/api/ml/data/namespaces/&#123;namespace&#125;/http_loadbalancers/&#123;name&#125;/api_endpoints`                                                    | GET API Endpoints.                                      |
+| GET    | `/api/ml/data/namespaces/&#123;namespace&#125;/http_loadbalancers/&#123;name&#125;/api_endpoints/swagger_spec`                                       | GET Swagger Spec for HTTP Load Balancer.                |
+| POST   | `/api/ml/data/namespaces/&#123;namespace&#125;/http_loadbalancers/&#123;name&#125;/api_inventory/api_endpoints/get_schema_updates`                   | GET API Endpoints Schema Updates.                       |
+| POST   | `/api/ml/data/namespaces/&#123;namespace&#125;/http_loadbalancers/&#123;name&#125;/api_inventory/api_endpoints/update_schemas`                       | Update API Endpoints Schemas.                           |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/http_loadbalancers/&#123;name&#125;/dos_automitigation_rules`                                          | GET DoS Auto-Mitigation Rules for HTTP Load Balancer.   |
 | DELETE | `/api/config/namespaces/&#123;namespace&#125;/http_loadbalancers/&#123;name&#125;/dos_automitigation_rules/&#123;dos_automitigation_rule_name&#125;` | DELETE DoS Auto-Mitigation Rule for HTTP Load Balancer. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/http_loadbalancers/&#123;name&#125;/get-dns-info` | GET DNS Info. |
-| POST | `/api/config/namespaces/&#123;namespace&#125;/http_loadbalancers/&#123;name&#125;/l7ddos_rps_threshold` | Set L7 DDoS RPS Threshold. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/protocol_inspections` | Create Protocol Inspection. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/protocol_inspections/&#123;metadata.name&#125;` | Replace Protocol Inspection. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/protocol_inspections` | List Configure Protocol Inspection. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/protocol_inspections/&#123;name&#125;` | GET Protocol Inspection. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/protocol_inspections/&#123;name&#125;` | DELETE Configure Protocol Inspection. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/tcp_loadbalancers` | Create TCP Load Balancer. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/tcp_loadbalancers/&#123;metadata.name&#125;` | Replace TCP Load Balancer. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/tcp_loadbalancers` | List Configure TCP Load Balancer. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/tcp_loadbalancers/&#123;name&#125;` | GET TCP Load Balancer. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/tcp_loadbalancers/&#123;name&#125;` | DELETE Configure TCP Load Balancer. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/tcp_loadbalancers/&#123;name&#125;/get-dns-info` | GET DNS Info. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/udp_loadbalancers` | Create UDP Load Balancer. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/udp_loadbalancers/&#123;metadata.name&#125;` | Replace UDP Load Balancer. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/udp_loadbalancers` | List Configure UDP Load Balancer. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/udp_loadbalancers/&#123;name&#125;` | GET UDP Load Balancer. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/udp_loadbalancers/&#123;name&#125;` | DELETE Configure UDP Load Balancer. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/udp_loadbalancers/&#123;name&#125;/get-dns-info` | GET DNS Info. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/enhanced_firewall_policys` | Create Enhanced Firewall Policy. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/enhanced_firewall_policys/&#123;metadata.name&#125;` | Replace Enhanced Firewall Policy. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/enhanced_firewall_policy/hits` | Enhanced Firewall Policy Hits. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/enhanced_firewall_policys` | List Enhanced Firewall Policy. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/enhanced_firewall_policys/&#123;name&#125;` | GET Enhanced Firewall Policy. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/enhanced_firewall_policys/&#123;name&#125;` | DELETE Enhanced Firewall Policy. |
-| POST | `/api/config/namespaces/system/malware_protection/addon/subscribe` | Subscribe to Malware Protection. |
-| POST | `/api/config/namespaces/system/malware_protection/addon/unsubscribe` | Unsubscribe to Malware Protection. |
-| POST | `/api/config/dns/namespaces/&#123;metadata.namespace&#125;/geo_location_sets` | Create Geolocation. |
-| PUT | `/api/config/dns/namespaces/&#123;metadata.namespace&#125;/geo_location_sets/&#123;metadata.name&#125;` | Replace Geolocation Set. |
-| GET | `/api/config/dns/namespaces/&#123;namespace&#125;/geo_location_sets` | List Geolocation Set. |
-| GET | `/api/config/dns/namespaces/&#123;namespace&#125;/geo_location_sets/&#123;name&#125;` | GET Geolocation Set. |
-| DELETE | `/api/config/dns/namespaces/&#123;namespace&#125;/geo_location_sets/&#123;name&#125;` | DELETE Geolocation Set. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/healthchecks` | Create Health Check. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/healthchecks/&#123;metadata.name&#125;` | Replace Health Check. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/healthchecks` | List Health Check. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/healthchecks/&#123;name&#125;` | GET Health Check. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/healthchecks/&#123;name&#125;` | DELETE Health Check. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/origin_pools` | Create Origin Pool. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/origin_pools/&#123;metadata.name&#125;` | Replace Origin Pool. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/origin_pools` | List Origin Pool. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/origin_pools/&#123;name&#125;` | GET Origin Pool. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/origin_pools/&#123;name&#125;` | DELETE Origin Pool. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/proxies` | Create Proxy. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/proxies/&#123;metadata.name&#125;` | Replace Proxy. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/proxies` | List Proxy. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/proxies/&#123;name&#125;` | GET Proxy |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/proxies/&#123;name&#125;` | DELETE Proxy. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/proxies/&#123;name&#125;/ca_certificate` | GET proxy Server CA Certificate. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/rate_limiter_policys` | Create Specification. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/rate_limiter_policys/&#123;metadata.name&#125;` | Replace Specification. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/rate_limiter_policys` | List Rate Limiter Policy. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/rate_limiter_policys/&#123;name&#125;` | GET Specification. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/rate_limiter_policys/&#123;name&#125;` | DELETE Rate Limiter Policy. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/service_policys` | Create Service Policy. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/service_policys/&#123;metadata.name&#125;` | Replace Service Policy. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/service_policys` | List Service Policy. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/service_policys/&#123;name&#125;` | GET Service Policy. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/service_policys/&#123;name&#125;` | DELETE Service Policy. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/service_policy_rules` | Create Service Policy Rule. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/service_policy_rules/&#123;metadata.name&#125;` | Replace Service Policy Rule. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/service_policy_rules` | List Service Policy Rule. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/service_policy_rules/&#123;name&#125;` | GET Service Policy Rule. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/service_policy_rules/&#123;name&#125;` | DELETE Service Policy Rule. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/service_policy_sets` | List Service Policy Set. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/service_policy_sets/&#123;name&#125;` | GET Service Policy Set. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/virtual_hosts` | Create Virtual Host. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/virtual_hosts/&#123;metadata.name&#125;` | Replace Virtual Host. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/virtual_hosts` | List Virtual Host. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/virtual_hosts/&#123;name&#125;` | GET Virtual Host. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/virtual_hosts/&#123;name&#125;` | DELETE Virtual Host. |
-| POST | `/api/config/namespaces/&#123;namespace&#125;/virtual_hosts/&#123;name&#125;/api_definitions/assign` | Assign API Definition. |
-| POST | `/api/ml/data/namespaces/&#123;namespace&#125;/virtual_hosts/&#123;name&#125;/api_endpoint` | GET API Endpoint. |
-| GET | `/api/ml/data/namespaces/&#123;namespace&#125;/virtual_hosts/&#123;name&#125;/api_endpoint/learnt_schema` | GET GET Learnt Schema per API endpoint. |
-| GET | `/api/ml/data/namespaces/&#123;namespace&#125;/virtual_hosts/&#123;name&#125;/api_endpoint/pdf` | GET API Endpoint PDF. |
-| GET | `/api/ml/data/namespaces/&#123;namespace&#125;/virtual_hosts/&#123;name&#125;/api_endpoint/sources_openapi_schema` | GET relevant source OpenApi schema per API endpoint. |
-| POST | `/api/ml/data/namespaces/&#123;namespace&#125;/virtual_hosts/&#123;name&#125;/api_endpoint/unmerge_sources_openapi_schema` | Unmerge Source from API Endpoint. |
-| GET | `/api/ml/data/namespaces/&#123;namespace&#125;/virtual_hosts/&#123;name&#125;/api_endpoints` | GET API Endpoints. |
-| GET | `/api/ml/data/namespaces/&#123;namespace&#125;/virtual_hosts/&#123;name&#125;/api_endpoints/stats` | GET API Endpoints Stats for Virtual Host. |
-| POST | `/api/ml/data/namespaces/&#123;namespace&#125;/virtual_hosts/&#123;name&#125;/api_endpoints/summary/calls_by_response_code` | GET Total API Calls for Virtual Host. |
-| POST | `/api/ml/data/namespaces/&#123;namespace&#125;/virtual_hosts/&#123;name&#125;/api_endpoints/summary/top_active` | GET Top APIs Endpoints for Virtual Host. |
-| POST | `/api/ml/data/namespaces/&#123;namespace&#125;/virtual_hosts/&#123;name&#125;/api_endpoints/summary/top_sensitive_data` | GET Sensitive Data Summary for Virtual Host. |
-| GET | `/api/ml/data/namespaces/&#123;namespace&#125;/virtual_hosts/&#123;name&#125;/api_endpoints/swagger_spec` | GET Swagger Spec for App Type. |
-| POST | `/api/ml/data/namespaces/&#123;namespace&#125;/virtual_hosts/&#123;name&#125;/api_inventory/api_endpoints/get_schema_updates` | GET API Endpoints Schema Updates. |
-| POST | `/api/ml/data/namespaces/&#123;namespace&#125;/virtual_hosts/&#123;name&#125;/api_inventory/api_endpoints/update_schemas` | Update API Endpoints Schemas. |
-| POST | `/api/ml/data/namespaces/&#123;namespace&#125;/virtual_hosts/&#123;name&#125;/create_ticket` | Create a ticket for a vulnerability. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/virtual_hosts/&#123;name&#125;/get-dns-info` | GET DNS Info. |
-| POST | `/api/ml/data/namespaces/&#123;namespace&#125;/virtual_hosts/&#123;name&#125;/unlink_tickets` | Unlink Tickets. |
-| POST | `/api/ml/data/namespaces/&#123;namespace&#125;/virtual_hosts/&#123;name&#125;/vulnerabilities` | GET Vulnerabilities for Virtual Host. |
-| POST | `/api/ml/data/namespaces/&#123;namespace&#125;/virtual_hosts/&#123;name&#125;/vulnerability/update_state` | Update Vulnerabilities for Virtual Host. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/wafs/metrics/client/rule_hits` | Client Rule Hits Metrics. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/wafs/metrics/client/security_events` | Client Security Events Metrics. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/wafs/metrics/server/rule_hits` | Server Rule Hits Metrics. |
-| POST | `/api/data/namespaces/&#123;namespace&#125;/wafs/metrics/server/security_events` | Server Security Events Metrics. |
-| POST | `/api/config/namespaces/&#123;metadata.namespace&#125;/waf_exclusion_policys` | Create WAF Exclusion Policy. |
-| PUT | `/api/config/namespaces/&#123;metadata.namespace&#125;/waf_exclusion_policys/&#123;metadata.name&#125;` | Replace WAF Exclusion Policy. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/waf_exclusion_policys` | List WAF Exclusion Policy. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/waf_exclusion_policys/&#123;name&#125;` | GET WAF Exclusion Policy. |
-| DELETE | `/api/config/namespaces/&#123;namespace&#125;/waf_exclusion_policys/&#123;name&#125;` | DELETE WAF Exclusion Policy. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/virtual_hosts/&#123;vh_name&#125;/active_staged_signatures` | Active Staged Signatures. |
-| GET | `/api/config/namespaces/&#123;namespace&#125;/virtual_hosts/&#123;vh_name&#125;/released_signatures` | Released Signatures. |
-| POST | `/api/ml/data/namespaces/&#123;namespace&#125;/virtual_hosts/&#123;vh_name&#125;/staged_signatures` | Staged Signatures. |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/http_loadbalancers/&#123;name&#125;/get-dns-info`                                                      | GET DNS Info.                                           |
+| POST   | `/api/config/namespaces/&#123;namespace&#125;/http_loadbalancers/&#123;name&#125;/l7ddos_rps_threshold`                                              | Set L7 DDoS RPS Threshold.                              |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/protocol_inspections`                                                                         | Create Protocol Inspection.                             |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/protocol_inspections/&#123;metadata.name&#125;`                                               | Replace Protocol Inspection.                            |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/protocol_inspections`                                                                                  | List Configure Protocol Inspection.                     |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/protocol_inspections/&#123;name&#125;`                                                                 | GET Protocol Inspection.                                |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/protocol_inspections/&#123;name&#125;`                                                                 | DELETE Configure Protocol Inspection.                   |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/tcp_loadbalancers`                                                                            | Create TCP Load Balancer.                               |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/tcp_loadbalancers/&#123;metadata.name&#125;`                                                  | Replace TCP Load Balancer.                              |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/tcp_loadbalancers`                                                                                     | List Configure TCP Load Balancer.                       |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/tcp_loadbalancers/&#123;name&#125;`                                                                    | GET TCP Load Balancer.                                  |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/tcp_loadbalancers/&#123;name&#125;`                                                                    | DELETE Configure TCP Load Balancer.                     |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/tcp_loadbalancers/&#123;name&#125;/get-dns-info`                                                       | GET DNS Info.                                           |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/udp_loadbalancers`                                                                            | Create UDP Load Balancer.                               |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/udp_loadbalancers/&#123;metadata.name&#125;`                                                  | Replace UDP Load Balancer.                              |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/udp_loadbalancers`                                                                                     | List Configure UDP Load Balancer.                       |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/udp_loadbalancers/&#123;name&#125;`                                                                    | GET UDP Load Balancer.                                  |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/udp_loadbalancers/&#123;name&#125;`                                                                    | DELETE Configure UDP Load Balancer.                     |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/udp_loadbalancers/&#123;name&#125;/get-dns-info`                                                       | GET DNS Info.                                           |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/enhanced_firewall_policys`                                                                    | Create Enhanced Firewall Policy.                        |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/enhanced_firewall_policys/&#123;metadata.name&#125;`                                          | Replace Enhanced Firewall Policy.                       |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/enhanced_firewall_policy/hits`                                                                           | Enhanced Firewall Policy Hits.                          |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/enhanced_firewall_policys`                                                                             | List Enhanced Firewall Policy.                          |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/enhanced_firewall_policys/&#123;name&#125;`                                                            | GET Enhanced Firewall Policy.                           |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/enhanced_firewall_policys/&#123;name&#125;`                                                            | DELETE Enhanced Firewall Policy.                        |
+| POST   | `/api/config/namespaces/system/malware_protection/addon/subscribe`                                                                                   | Subscribe to Malware Protection.                        |
+| POST   | `/api/config/namespaces/system/malware_protection/addon/unsubscribe`                                                                                 | Unsubscribe to Malware Protection.                      |
+| POST   | `/api/config/dns/namespaces/&#123;metadata.namespace&#125;/geo_location_sets`                                                                        | Create Geolocation.                                     |
+| PUT    | `/api/config/dns/namespaces/&#123;metadata.namespace&#125;/geo_location_sets/&#123;metadata.name&#125;`                                              | Replace Geolocation Set.                                |
+| GET    | `/api/config/dns/namespaces/&#123;namespace&#125;/geo_location_sets`                                                                                 | List Geolocation Set.                                   |
+| GET    | `/api/config/dns/namespaces/&#123;namespace&#125;/geo_location_sets/&#123;name&#125;`                                                                | GET Geolocation Set.                                    |
+| DELETE | `/api/config/dns/namespaces/&#123;namespace&#125;/geo_location_sets/&#123;name&#125;`                                                                | DELETE Geolocation Set.                                 |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/healthchecks`                                                                                 | Create Health Check.                                    |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/healthchecks/&#123;metadata.name&#125;`                                                       | Replace Health Check.                                   |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/healthchecks`                                                                                          | List Health Check.                                      |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/healthchecks/&#123;name&#125;`                                                                         | GET Health Check.                                       |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/healthchecks/&#123;name&#125;`                                                                         | DELETE Health Check.                                    |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/origin_pools`                                                                                 | Create Origin Pool.                                     |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/origin_pools/&#123;metadata.name&#125;`                                                       | Replace Origin Pool.                                    |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/origin_pools`                                                                                          | List Origin Pool.                                       |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/origin_pools/&#123;name&#125;`                                                                         | GET Origin Pool.                                        |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/origin_pools/&#123;name&#125;`                                                                         | DELETE Origin Pool.                                     |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/proxies`                                                                                      | Create Proxy.                                           |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/proxies/&#123;metadata.name&#125;`                                                            | Replace Proxy.                                          |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/proxies`                                                                                               | List Proxy.                                             |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/proxies/&#123;name&#125;`                                                                              | GET Proxy                                               |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/proxies/&#123;name&#125;`                                                                              | DELETE Proxy.                                           |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/proxies/&#123;name&#125;/ca_certificate`                                                               | GET proxy Server CA Certificate.                        |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/rate_limiter_policys`                                                                         | Create Specification.                                   |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/rate_limiter_policys/&#123;metadata.name&#125;`                                               | Replace Specification.                                  |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/rate_limiter_policys`                                                                                  | List Rate Limiter Policy.                               |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/rate_limiter_policys/&#123;name&#125;`                                                                 | GET Specification.                                      |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/rate_limiter_policys/&#123;name&#125;`                                                                 | DELETE Rate Limiter Policy.                             |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/service_policys`                                                                              | Create Service Policy.                                  |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/service_policys/&#123;metadata.name&#125;`                                                    | Replace Service Policy.                                 |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/service_policys`                                                                                       | List Service Policy.                                    |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/service_policys/&#123;name&#125;`                                                                      | GET Service Policy.                                     |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/service_policys/&#123;name&#125;`                                                                      | DELETE Service Policy.                                  |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/service_policy_rules`                                                                         | Create Service Policy Rule.                             |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/service_policy_rules/&#123;metadata.name&#125;`                                               | Replace Service Policy Rule.                            |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/service_policy_rules`                                                                                  | List Service Policy Rule.                               |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/service_policy_rules/&#123;name&#125;`                                                                 | GET Service Policy Rule.                                |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/service_policy_rules/&#123;name&#125;`                                                                 | DELETE Service Policy Rule.                             |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/service_policy_sets`                                                                                   | List Service Policy Set.                                |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/service_policy_sets/&#123;name&#125;`                                                                  | GET Service Policy Set.                                 |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/virtual_hosts`                                                                                | Create Virtual Host.                                    |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/virtual_hosts/&#123;metadata.name&#125;`                                                      | Replace Virtual Host.                                   |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/virtual_hosts`                                                                                         | List Virtual Host.                                      |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/virtual_hosts/&#123;name&#125;`                                                                        | GET Virtual Host.                                       |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/virtual_hosts/&#123;name&#125;`                                                                        | DELETE Virtual Host.                                    |
+| POST   | `/api/config/namespaces/&#123;namespace&#125;/virtual_hosts/&#123;name&#125;/api_definitions/assign`                                                 | Assign API Definition.                                  |
+| POST   | `/api/ml/data/namespaces/&#123;namespace&#125;/virtual_hosts/&#123;name&#125;/api_endpoint`                                                          | GET API Endpoint.                                       |
+| GET    | `/api/ml/data/namespaces/&#123;namespace&#125;/virtual_hosts/&#123;name&#125;/api_endpoint/learnt_schema`                                            | GET GET Learnt Schema per API endpoint.                 |
+| GET    | `/api/ml/data/namespaces/&#123;namespace&#125;/virtual_hosts/&#123;name&#125;/api_endpoint/pdf`                                                      | GET API Endpoint PDF.                                   |
+| GET    | `/api/ml/data/namespaces/&#123;namespace&#125;/virtual_hosts/&#123;name&#125;/api_endpoint/sources_openapi_schema`                                   | GET relevant source OpenAPI schema per API endpoint.    |
+| POST   | `/api/ml/data/namespaces/&#123;namespace&#125;/virtual_hosts/&#123;name&#125;/api_endpoint/unmerge_sources_openapi_schema`                           | Unmerge Source from API Endpoint.                       |
+| GET    | `/api/ml/data/namespaces/&#123;namespace&#125;/virtual_hosts/&#123;name&#125;/api_endpoints`                                                         | GET API Endpoints.                                      |
+| GET    | `/api/ml/data/namespaces/&#123;namespace&#125;/virtual_hosts/&#123;name&#125;/api_endpoints/stats`                                                   | GET API Endpoints Stats for Virtual Host.               |
+| POST   | `/api/ml/data/namespaces/&#123;namespace&#125;/virtual_hosts/&#123;name&#125;/api_endpoints/summary/calls_by_response_code`                          | GET Total API Calls for Virtual Host.                   |
+| POST   | `/api/ml/data/namespaces/&#123;namespace&#125;/virtual_hosts/&#123;name&#125;/api_endpoints/summary/top_active`                                      | GET Top APIs Endpoints for Virtual Host.                |
+| POST   | `/api/ml/data/namespaces/&#123;namespace&#125;/virtual_hosts/&#123;name&#125;/api_endpoints/summary/top_sensitive_data`                              | GET Sensitive Data Summary for Virtual Host.            |
+| GET    | `/api/ml/data/namespaces/&#123;namespace&#125;/virtual_hosts/&#123;name&#125;/api_endpoints/swagger_spec`                                            | GET Swagger Spec for App Type.                          |
+| POST   | `/api/ml/data/namespaces/&#123;namespace&#125;/virtual_hosts/&#123;name&#125;/api_inventory/api_endpoints/get_schema_updates`                        | GET API Endpoints Schema Updates.                       |
+| POST   | `/api/ml/data/namespaces/&#123;namespace&#125;/virtual_hosts/&#123;name&#125;/api_inventory/api_endpoints/update_schemas`                            | Update API Endpoints Schemas.                           |
+| POST   | `/api/ml/data/namespaces/&#123;namespace&#125;/virtual_hosts/&#123;name&#125;/create_ticket`                                                         | Create a ticket for a vulnerability.                    |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/virtual_hosts/&#123;name&#125;/get-dns-info`                                                           | GET DNS Info.                                           |
+| POST   | `/api/ml/data/namespaces/&#123;namespace&#125;/virtual_hosts/&#123;name&#125;/unlink_tickets`                                                        | Unlink Tickets.                                         |
+| POST   | `/api/ml/data/namespaces/&#123;namespace&#125;/virtual_hosts/&#123;name&#125;/vulnerabilities`                                                       | GET Vulnerabilities for Virtual Host.                   |
+| POST   | `/api/ml/data/namespaces/&#123;namespace&#125;/virtual_hosts/&#123;name&#125;/vulnerability/update_state`                                            | Update Vulnerabilities for Virtual Host.                |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/wafs/metrics/client/rule_hits`                                                                           | Client Rule Hits Metrics.                               |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/wafs/metrics/client/security_events`                                                                     | Client Security Events Metrics.                         |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/wafs/metrics/server/rule_hits`                                                                           | Server Rule Hits Metrics.                               |
+| POST   | `/api/data/namespaces/&#123;namespace&#125;/wafs/metrics/server/security_events`                                                                     | Server Security Events Metrics.                         |
+| POST   | `/api/config/namespaces/&#123;metadata.namespace&#125;/waf_exclusion_policys`                                                                        | Create WAF Exclusion Policy.                            |
+| PUT    | `/api/config/namespaces/&#123;metadata.namespace&#125;/waf_exclusion_policys/&#123;metadata.name&#125;`                                              | Replace WAF Exclusion Policy.                           |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/waf_exclusion_policys`                                                                                 | List WAF Exclusion Policy.                              |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/waf_exclusion_policys/&#123;name&#125;`                                                                | GET WAF Exclusion Policy.                               |
+| DELETE | `/api/config/namespaces/&#123;namespace&#125;/waf_exclusion_policys/&#123;name&#125;`                                                                | DELETE WAF Exclusion Policy.                            |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/virtual_hosts/&#123;vh_name&#125;/active_staged_signatures`                                            | Active Staged Signatures.                               |
+| GET    | `/api/config/namespaces/&#123;namespace&#125;/virtual_hosts/&#123;vh_name&#125;/released_signatures`                                                 | Released Signatures.                                    |
+| POST   | `/api/ml/data/namespaces/&#123;namespace&#125;/virtual_hosts/&#123;vh_name&#125;/staged_signatures`                                                  | Staged Signatures.                                      |
 
 ## Links
 

--- a/docs/en/api-reference/vpm_and_node_management-api.mdx
+++ b/docs/en/api-reference/vpm_and_node_management-api.mdx
@@ -2,7 +2,7 @@
 title: "🖥️ Vpm And Node Management API"
 description: "Node lifecycle, fleet grouping, and orchestration."
 sidebar:
-    hidden: true
+  hidden: true
 ---
 
 Lifecycle control, fleet configuration, and deployment policies for distributed node management.
@@ -26,9 +26,9 @@ Lifecycle control, fleet configuration, and deployment policies for distributed 
 
 ## Endpoints
 
-| Method | Path | Description |
-|--------|------|-------------|
-| GET | `/api/data/namespaces/system/upgrade_status` | Upgrade Status. |
+| Method | Path                                         | Description     |
+| ------ | -------------------------------------------- | --------------- |
+| GET    | `/api/data/namespaces/system/upgrade_status` | Upgrade Status. |
 
 ## Links
 

--- a/docs/en/constraint-metadata.mdx
+++ b/docs/en/constraint-metadata.mdx
@@ -42,7 +42,7 @@ The `x-f5xc-constraints` extension provides deterministic knowledge about field 
 - **9,851 constraints** across all F5 XC API specs
 - **50+ pattern types** (string, array, numeric)
 - **95% confidence** on high-priority fields (names, ports, identifiers)
-- **3-tier reconciliation**: EXISTING > DISCOVERY > INFERRED
+- **3-tier reconciliation**: `EXISTING > DISCOVERY > INFERRED`
 
 ---
 
@@ -73,13 +73,13 @@ The `x-f5xc-constraints` extension provides deterministic knowledge about field 
 
 ### Field Descriptions
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `constraintType` | string | Data type (string, array, number, object) |
-| `deterministic` | boolean | High-confidence flag (confidence >= 0.9) for AI generation |
-| `category` | string | Constraint category for grouping and reporting |
-| *(constraint keys)* | various | Type-specific constraint keys flattened at top level (e.g., `minLength`, `maxItems`, `minimum`) |
-| `metadata` | object | Source tracking, confidence, validation timestamp |
+| Field               | Type    | Description                                                                                     |
+| ------------------- | ------- | ----------------------------------------------------------------------------------------------- |
+| `constraintType`    | string  | Data type (string, array, number, object)                                                       |
+| `deterministic`     | boolean | High-confidence flag (confidence >= 0.9) for AI generation                                      |
+| `category`          | string  | Constraint category for grouping and reporting                                                  |
+| _(constraint keys)_ | various | Type-specific constraint keys flattened at top level (e.g., `minLength`, `maxItems`, `minimum`) |
+| `metadata`          | object  | Source tracking, confidence, validation timestamp                                               |
 
 ---
 
@@ -120,26 +120,26 @@ The `x-f5xc-constraints` extension provides deterministic knowledge about field 
 
 #### Supported Formats
 
-| Format | Description | Example |
-|--------|-------------|---------|
-| `dns-label` | RFC 1123 DNS label (1-63 chars) | `my-service` |
-| `fqdn` | Fully qualified domain name | `api.example.com` |
-| `email` | RFC 5322 email address | `user@example.com` |
-| `url` | RFC 3986 URI/URL | `https://example.com/api` |
-| `ipv4` | IPv4 address | `192.168.1.1` |
-| `ipv6` | IPv6 address | `2001:db8::1` |
-| `uuid` | RFC 4122 UUID | `550e8400-e29b-41d4-a716-446655440000` |
-| `date-time` | ISO 8601 timestamp | `2026-01-19T12:00:00Z` |
-| `date` | ISO 8601 date | `2026-01-19` |
-| `time` | ISO 8601 time | `12:00:00` |
-| `json` | JSON string (parseable) | `{"key": "value"}` |
-| `yaml` | YAML string (parseable) | `key: value` |
-| `base64` | Base64-encoded string | `SGVsbG8gV29ybGQ=` |
-| `hex` | Hexadecimal string | `48656c6c6f` |
-| `mac-address` | MAC address | `00:1A:2B:3C:4D:5E` |
-| `phone` | E.164 phone number | `+1-555-123-4567` |
+| Format        | Description                     | Example                                |
+| ------------- | ------------------------------- | -------------------------------------- |
+| `dns-label`   | RFC 1123 DNS label (1-63 chars) | `my-service`                           |
+| `fqdn`        | Fully qualified domain name     | `api.example.com`                      |
+| `email`       | RFC 5322 email address          | `user@example.com`                     |
+| `url`         | RFC 3986 URI/URL                | `https://example.com/api`              |
+| `ipv4`        | IPv4 address                    | `192.168.1.1`                          |
+| `ipv6`        | IPv6 address                    | `2001:db8::1`                          |
+| `uuid`        | RFC 4122 UUID                   | `550e8400-e29b-41d4-a716-446655440000` |
+| `date-time`   | ISO 8601 timestamp              | `2026-01-19T12:00:00Z`                 |
+| `date`        | ISO 8601 date                   | `2026-01-19`                           |
+| `time`        | ISO 8601 time                   | `12:00:00`                             |
+| `json`        | JSON string (parseable)         | `{"key": "value"}`                     |
+| `yaml`        | YAML string (parseable)         | `key: value`                           |
+| `base64`      | Base64-encoded string           | `SGVsbG8gV29ybGQ=`                     |
+| `hex`         | Hexadecimal string              | `48656c6c6f`                           |
+| `mac-address` | MAC address                     | `00:1A:2B:3C:4D:5E`                    |
+| `phone`       | E.164 phone number              | `+1-555-123-4567`                      |
 
-### Array Constraints
+### Array constraint structure
 
 ```json
 {
@@ -150,13 +150,13 @@ The `x-f5xc-constraints` extension provides deterministic knowledge about field 
   "uniqueItems": true,
   "metadata": {
     "source": "inferred",
-    "confidence": 0.90
+    "confidence": 0.9
   },
   "deterministic": true
 }
 ```
 
-### Numeric Constraints
+### Numeric constraint structure
 
 ```json
 {
@@ -182,56 +182,68 @@ The `x-f5xc-constraints` extension provides deterministic knowledge about field 
 ### String Format Constraints
 
 **DNS Labels** (`format: "dns-label"`):
+
 - DNS label names must be 1-63 lowercase alphanumeric characters
 - Hyphens allowed but not at start/end (RFC 1123)
 - Example: `my-service`, `api-gateway`, `lb-prod-01`
 
 **Email Addresses** (`format: "email"`):
+
 - Email addresses must be valid per RFC 5322
 - Maximum 254 characters
 - Example: `admin@example.com`, `api+webhook@service.io`
 
 **FQDNs** (`format: "fqdn"`):
+
 - Fully Qualified Domain Names must be 1-253 characters
 - Dot-separated DNS labels
 - Example: `api.example.com`, `service.production.internal`
 
 **URLs** (`format: "url"`):
+
 - URLs must be valid URIs per RFC 3986
 - Must include scheme (http/https)
 - Example: `https://api.example.com/v1`, `http://localhost:8080`
 
 **IPv4 Addresses** (`format: "ipv4"`):
+
 - IPv4 addresses must be in dotted-decimal notation
 - Example: `192.168.1.1`, `10.0.0.1`
 
 **UUIDs** (`format: "uuid"`):
+
 - UUIDs must follow RFC 4122 format
 - Example: `550e8400-e29b-41d4-a716-446655440000`
 
 **Timestamps** (`format: "date-time"`):
+
 - Timestamps must be ISO 8601 format
 - Example: `2026-01-19T12:00:00Z`, `2026-01-19T12:00:00+00:00`
 
-### Numeric Constraints
+### Numeric constraint guidance
 
 **Port Numbers**:
+
 - Port numbers must be integers between 1 and 65535
 - Standard ports: 80 (HTTP), 443 (HTTPS), 22 (SSH)
 
 **VLAN IDs**:
+
 - VLAN IDs must be integers between 1 and 4094 (802.1Q standard)
 
 **Timeouts**:
+
 - Timeouts must be 1-3600 seconds (1 hour maximum)
 
-### Array Constraints
+### Array constraint guidance
 
 **Origin Pools**:
+
 - Array of origin pools requires at least 1 item, maximum 50 items
 - Each item must be unique
 
 **Tags**:
+
 - Tags array allows 0-100 items
 - Items need not be unique
 
@@ -242,6 +254,7 @@ The `x-f5xc-constraints` extension provides deterministic knowledge about field 
 ### Example 1: DNS Label Name Validation
 
 **Constraint**:
+
 ```json
 {
   "constraintType": "string",
@@ -254,12 +267,14 @@ The `x-f5xc-constraints` extension provides deterministic knowledge about field 
 ```
 
 **Valid Values**:
+
 - ✅ `my-service`
 - ✅ `api-gateway`
 - ✅ `lb-prod-01`
 - ✅ `web`
 
 **Invalid Values**:
+
 - ❌ `My-Service` (uppercase not allowed)
 - ❌ `-my-service` (hyphen at start)
 - ❌ `my-service-` (hyphen at end)
@@ -269,6 +284,7 @@ The `x-f5xc-constraints` extension provides deterministic knowledge about field 
 ### Example 2: Port Number Validation
 
 **Constraint**:
+
 ```json
 {
   "constraintType": "number",
@@ -279,12 +295,14 @@ The `x-f5xc-constraints` extension provides deterministic knowledge about field 
 ```
 
 **Valid Values**:
+
 - ✅ `80` (HTTP)
 - ✅ `443` (HTTPS)
 - ✅ `8080` (common alternative HTTP)
 - ✅ `65535` (maximum port)
 
 **Invalid Values**:
+
 - ❌ `0` (below minimum)
 - ❌ `65536` (above maximum)
 - ❌ `-1` (negative)
@@ -293,6 +311,7 @@ The `x-f5xc-constraints` extension provides deterministic knowledge about field 
 ### Example 3: Array Size Validation
 
 **Constraint**:
+
 ```json
 {
   "constraintType": "array",
@@ -304,10 +323,12 @@ The `x-f5xc-constraints` extension provides deterministic knowledge about field 
 ```
 
 **Valid Values**:
+
 - ✅ `["origin-1"]` (1 item)
 - ✅ `["origin-1", "origin-2", "origin-3"]` (3 items, all unique)
 
 **Invalid Values**:
+
 - ❌ `[]` (below minimum)
 - ❌ `["origin-1", "origin-1"]` (duplicate items)
 - ❌ `[array with 51 items]` (above maximum)
@@ -318,21 +339,23 @@ The `x-f5xc-constraints` extension provides deterministic knowledge about field 
 
 ### Score Interpretation
 
-| Range | Interpretation | Usage |
-|-------|----------------|-------|
-| 0.90-1.00 | **High confidence** | Deterministic flag enabled, use for AI generation |
-| 0.70-0.89 | **Medium confidence** | Advisory, recommend user confirmation |
-| 0.50-0.69 | **Low confidence** | Informational only, require user validation |
-| < 0.50 | **Very low** | Not included in constraints |
+| Range          | Interpretation        | Usage                                             |
+| -------------- | --------------------- | ------------------------------------------------- |
+| 0.90-1.00      | **High confidence**   | Deterministic flag enabled, use for AI generation |
+| 0.70-0.89      | **Medium confidence** | Advisory, recommend user confirmation             |
+| 0.50-0.69      | **Low confidence**    | Informational only, require user validation       |
+| Less than 0.50 | **Very low**          | Not included in constraints                       |
 
 ### Deterministic Flag
 
 The `deterministic` boolean flag is set when:
-- Confidence score >= 0.9
+
+- Confidence score is at least 0.9
 - Pattern has been validated against discovery data OR
 - Pattern matches well-established standards (RFC, ISO, etc.)
 
 **Usage in AI generation**:
+
 ```python
 if constraint.get("deterministic"):
     # Generate value automatically without asking user
@@ -387,6 +410,7 @@ Discovery constraints are extracted from:
 ### AI Assistant Integration
 
 **Generate valid resource names**:
+
 ```python
 def generate_resource_name(schema_property):
     constraints = schema_property.get("x-f5xc-constraints", {})
@@ -406,6 +430,7 @@ def generate_resource_name(schema_property):
 ### CLI Tool Integration
 
 **Provide input validation**:
+
 ```python
 def validate_cli_input(field_name, user_value, constraints):
     if not constraints:
@@ -432,6 +457,7 @@ def validate_cli_input(field_name, user_value, constraints):
 ### Terraform Provider Integration
 
 **Schema generation**:
+
 ```go
 func generateTerraformSchema(property map[string]interface{}) *schema.Schema {
     constraints := property["x-f5xc-constraints"].(map[string]interface{})
@@ -458,33 +484,34 @@ func generateTerraformSchema(property map[string]interface{}) *schema.Schema {
 ### IDE Extension Integration
 
 **Autocomplete and validation**:
+
 ```typescript
 function provideCompletions(field: FieldInfo): CompletionItem[] {
-    const constraints = field.schema['x-f5xc-constraints'];
-    if (!constraints) return [];
+  const constraints = field.schema["x-f5xc-constraints"];
+  if (!constraints) return [];
 
-    const items: CompletionItem[] = [];
+  const items: CompletionItem[] = [];
 
-    // Add format-specific completions
-    if (constraints.format === 'dns-label') {
-        items.push({
-            label: 'my-service',
-            detail: 'Example DNS label',
-            kind: CompletionItemKind.Value
-        });
-    }
+  // Add format-specific completions
+  if (constraints.format === "dns-label") {
+    items.push({
+      label: "my-service",
+      detail: "Example DNS label",
+      kind: CompletionItemKind.Value,
+    });
+  }
 
-    // Add validation hint
-    if (constraints.deterministic) {
-        items.push({
-            label: '✨ Auto-generate',
-            detail: 'Generate valid value automatically',
-            kind: CompletionItemKind.Function,
-            command: { command: 'f5xc.generateValue', arguments: [field] }
-        });
-    }
+  // Add validation hint
+  if (constraints.deterministic) {
+    items.push({
+      label: "✨ Auto-generate",
+      detail: "Generate valid value automatically",
+      kind: CompletionItemKind.Function,
+      command: { command: "f5xc.generateValue", arguments: [field] },
+    });
+  }
 
-    return items;
+  return items;
 }
 ```
 
@@ -494,31 +521,31 @@ function provideCompletions(field: FieldInfo): CompletionItem[] {
 
 ### High-Confidence Patterns (0.95-0.99)
 
-| Pattern | Field Name Regex | Constraint Type | Example |
-|---------|------------------|-----------------|---------|
-| DNS Label | `\bname$` | String (1-63 chars, dns-label) | `my-service` |
-| Namespace | `\bnamespace$` | String (1-63 chars, dns-label) | `production` |
-| Port | `\bport$` | Number (1-65535) | `443` |
-| VLAN ID | `\b(vlan)?_?id$` | Number (1-4094) | `100` |
-| UUID | `\buuid$` | String (36 chars, uuid format) | `550e8400-...` |
-| Email | `\bemail$` | String (max 254 chars, email) | `user@example.com` |
-| Timestamp | `\b(timestamp\|created_at\|updated_at)$` | String (ISO 8601) | `2026-01-19T12:00:00Z` |
+| Pattern   | Field Name Regex                         | Constraint Type                | Example                |
+| --------- | ---------------------------------------- | ------------------------------ | ---------------------- |
+| DNS Label | `\bname$`                                | String (1-63 chars, dns-label) | `my-service`           |
+| Namespace | `\bnamespace$`                           | String (1-63 chars, dns-label) | `production`           |
+| Port      | `\bport$`                                | Number (1-65535)               | `443`                  |
+| VLAN ID   | `\b(vlan)?_?id$`                         | Number (1-4094)                | `100`                  |
+| UUID      | `\buuid$`                                | String (36 chars, uuid format) | `550e8400-...`         |
+| Email     | `\bemail$`                               | String (max 254 chars, email)  | `user@example.com`     |
+| Timestamp | `\b(timestamp\|created_at\|updated_at)$` | String (ISO 8601)              | `2026-01-19T12:00:00Z` |
 
 ### Medium-Confidence Patterns (0.80-0.94)
 
-| Pattern | Field Name Regex | Constraint Type | Example |
-|---------|------------------|-----------------|---------|
-| Username | `\b(user\|username)$` | String (1-64 chars, alphanumeric) | `admin` |
-| Display Name | `\b(display_?)?name$` | String (1-256 chars, free text) | `My Service` |
-| Description | `\b(comment\|description\|note)$` | String (max 4096 chars) | `Service description` |
-| Path | `\bpath$` | String (max 2048 chars) | `/api/v1/resources` |
+| Pattern      | Field Name Regex                  | Constraint Type                   | Example               |
+| ------------ | --------------------------------- | --------------------------------- | --------------------- |
+| Username     | `\b(user\|username)$`             | String (1-64 chars, alphanumeric) | `admin`               |
+| Display Name | `\b(display_?)?name$`             | String (1-256 chars, free text)   | `My Service`          |
+| Description  | `\b(comment\|description\|note)$` | String (max 4096 chars)           | `Service description` |
+| Path         | `\bpath$`                         | String (max 2048 chars)           | `/api/v1/resources`   |
 
 ---
 
 ## Support and Feedback
 
-- **Issues**: Report constraint accuracy issues at https://github.com/f5-sales-demo/api-specs-enriched/issues
-- **Documentation**: Full API documentation at https://f5-sales-demo.github.io/api-specs-enriched/
+- **Issues**: Report constraint accuracy issues in [GitHub issues](https://github.com/f5-sales-demo/api-specs-enriched/issues)
+- **Documentation**: See the [full API documentation](https://f5-sales-demo.github.io/api-specs-enriched/)
 - **MCP Integration**: See `f5xc-api-mcp` repository for MCP server integration examples
 
 ---
@@ -527,4 +554,3 @@ function provideCompletions(field: FieldInfo): CompletionItem[] {
 **Last Updated**: 2026-01-19
 **Constraints Reconciled**: 9,851
 **Pattern Coverage**: 50+ types
-

--- a/docs/en/development.mdx
+++ b/docs/en/development.mdx
@@ -68,20 +68,21 @@ Download (ETag) → Enrich → Normalize → Merge → Lint → Serve
 
 ### Directory Structure
 
-| Directory | Purpose | Git Status |
-|-----------|---------|------------|
-| `specs/original/` | F5 source specs | Gitignored |
-| `specs/discovered/` | API discovery output | Tracked (openapi.json, session.json) |
-| `docs/specifications/api/` | Generated domain specs | Gitignored |
-| `scripts/` | Python pipeline scripts | Tracked |
-| `config/` | Pipeline configuration | Tracked |
-| `reports/` | Generated reports | Gitignored |
+| Directory                  | Purpose                 | Git Status                           |
+| -------------------------- | ----------------------- | ------------------------------------ |
+| `specs/original/`          | F5 source specs         | Gitignored                           |
+| `specs/discovered/`        | API discovery output    | Tracked (openapi.json, session.json) |
+| `docs/specifications/api/` | Generated domain specs  | Gitignored                           |
+| `scripts/`                 | Python pipeline scripts | Tracked                              |
+| `config/`                  | Pipeline configuration  | Tracked                              |
+| `reports/`                 | Generated reports       | Gitignored                           |
 
 ## Workflow Patterns
 
 ### 1. Discovery Workflow
 
 **Prerequisites**:
+
 - VPN connection to F5 XC environment
 - Valid API credentials
 
@@ -101,6 +102,7 @@ make push-discovery
 ```
 
 **Discovery captures**:
+
 - Actual required/optional fields
 - Enum values from live responses
 - Default values
@@ -121,12 +123,12 @@ Releases are automated:
 
 **Version Bump Rules**:
 
-| Condition | Bump Type | Example |
-|-----------|-----------|---------|
-| `[major]` in commit | Major | 1.0.0 → 2.0.0 |
-| `BREAKING CHANGE` in commit | Major | 1.0.0 → 2.0.0 |
-| New domain spec added | Minor | 1.0.0 → 1.1.0 |
-| Any other change | Patch | 1.0.0 → 1.0.1 |
+| Condition                   | Bump Type | Example       |
+| --------------------------- | --------- | ------------- |
+| `[major]` in commit         | Major     | 1.0.0 → 2.0.0 |
+| `BREAKING CHANGE` in commit | Major     | 1.0.0 → 2.0.0 |
+| New domain spec added       | Minor     | 1.0.0 → 1.1.0 |
+| Any other change            | Patch     | 1.0.0 → 1.0.1 |
 
 ### 3. Development Workflow
 
@@ -265,7 +267,7 @@ normalization:
     enabled: true
 ```
 
-### Spectral Linting Rules
+### Spectral linter rules
 
 ```yaml
 # config/spectral.yaml
@@ -283,33 +285,34 @@ The enrichment pipeline uses vendor extensions to embed validation and default v
 
 ### Extension Categories
 
-| Extension | Meaning | Implication |
-|-----------|---------|-------------|
-| `x-f5xc-server-default` | The F5 XC API server applies this value when the field is omitted | Field is optional; omitting it produces the documented default behavior |
-| `x-f5xc-recommended-value` | The F5 XC web console pre-populates this value for new resources | Field has no server default but this value represents typical configuration |
-| `x-f5xc-recommended-oneof-variant` | The F5 XC console preselects this OneOf variant | Identifies the typical choice when multiple mutually exclusive options exist |
-| `x-f5xc-conflicts-with` | Lists other properties that cannot be used together with this field | Property is part of a OneOf group; only one of the conflicting properties can be specified |
+| Extension                          | Meaning                                                             | Implication                                                                                |
+| ---------------------------------- | ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| `x-f5xc-server-default`            | The F5 XC API server applies this value when the field is omitted   | Field is optional; omitting it produces the documented default behavior                    |
+| `x-f5xc-recommended-value`         | The F5 XC web console pre-populates this value for new resources    | Field has no server default but this value represents typical configuration                |
+| `x-f5xc-recommended-oneof-variant` | The F5 XC console preselects this OneOf variant                     | Identifies the typical choice when multiple mutually exclusive options exist               |
+| `x-f5xc-conflicts-with`            | Lists other properties that cannot be used together with this field | Property is part of a OneOf group; only one of the conflicting properties can be specified |
 
 ### Required Field Extensions
 
-| Extension | Source | Purpose |
-|-----------|--------|---------|
+| Extension                | Source              | Purpose                                 |
+| ------------------------ | ------------------- | --------------------------------------- |
 | `x-ves-required: "true"` | F5 XC original spec | Field requires non-zero/non-empty value |
-| `x-f5xc-required-for` | Enrichment pipeline | Context-specific required status |
+| `x-f5xc-required-for`    | Enrichment pipeline | Context-specific required status        |
 
 **x-f5xc-required-for contexts**:
+
 - `create`: Required when creating the resource
 - `update`: Required when updating the resource
 - `minimum_config`: Required for minimum viable configuration
 
 ### Default Value and OneOf Extensions
 
-| Extension | Purpose |
-|-----------|---------|
-| `x-f5xc-server-default: true` | Marks server-applied defaults |
-| `x-f5xc-recommended-value` | F5 XC console pre-populated value |
-| `x-f5xc-recommended-oneof-variant` | Recommended OneOf variant |
-| `x-f5xc-conflicts-with` | Mutual exclusivity with other OneOf properties |
+| Extension                          | Purpose                                        |
+| ---------------------------------- | ---------------------------------------------- |
+| `x-f5xc-server-default: true`      | Marks server-applied defaults                  |
+| `x-f5xc-recommended-value`         | F5 XC console pre-populated value              |
+| `x-f5xc-recommended-oneof-variant` | Recommended OneOf variant                      |
+| `x-f5xc-conflicts-with`            | Mutual exclusivity with other OneOf properties |
 
 #### x-f5xc-server-default
 
@@ -368,6 +371,7 @@ use_origin_server_name:
 ```
 
 **Use cases**:
+
 - Terraform providers can generate validation rules
 - CLI tools can warn about conflicting field combinations
 - AI assistants can generate correct OneOf configurations
@@ -379,35 +383,35 @@ use_origin_server_name:
 
 The enricher inspects `x-ves-validation-rules` to infer required status:
 
-| Rule | Implication |
-|------|-------------|
-| `ves.io.schema.rules.message.required: "true"` | Field is required |
-| `ves.io.schema.rules.uint32.gte: N` | If N >= 1 and no server default, field is required |
-| `ves.io.schema.rules.repeated.min_items: N` | If N >= 1, array requires at least N items |
-| `ves.io.schema.rules.string.min_bytes: N` | If N >= 1, string requires at least N bytes |
+| Rule                                           | Implication                                        |
+| ---------------------------------------------- | -------------------------------------------------- |
+| `ves.io.schema.rules.message.required: "true"` | Field is required                                  |
+| `ves.io.schema.rules.uint32.gte: N`            | If N >= 1 and no server default, field is required |
+| `ves.io.schema.rules.repeated.min_items: N`    | If N >= 1, array requires at least N items         |
+| `ves.io.schema.rules.string.min_bytes: N`      | If N >= 1, string requires at least N bytes        |
 
 ### Resources with Server-Applied Defaults
 
 Some resources accept empty specs because the server applies defaults:
 
-| Resource | Server-Applied Defaults |
-|----------|------------------------|
-| `app_firewall` | `monitoring: \{\}`, `default_detection_settings: \{\}` |
-| `rate_limiter` | `limits: []`, `user_identification: []` |
-| `api_definition` | `swagger_specs: []`, default `api_groups` |
-| `healthcheck` | `jitter: 0`, `jitter_percent: 0`, nested http_health_check defaults |
+| Resource         | Server-Applied Defaults                                             |
+| ---------------- | ------------------------------------------------------------------- |
+| `app_firewall`   | `monitoring: \{\}`, `default_detection_settings: \{\}`              |
+| `rate_limiter`   | `limits: []`, `user_identification: []`                             |
+| `api_definition` | `swagger_specs: []`, default `api_groups`                           |
+| `healthcheck`    | `jitter: 0`, `jitter_percent: 0`, nested http_health_check defaults |
 
 For these resources, `x-f5xc-required-for.create` may be `false` even when `x-ves-required` is `true`.
 
 ### Default Value Patterns
 
-| Pattern | Type | Example |
-|---------|------|---------|
-| `\{\}` | Empty object (choice selection) | `monitoring: \{\}` |
-| `[]` | Empty array | `expected_status_codes: []` |
-| `0` | Numeric | `jitter: 0` |
-| `""` | String | `expected_response: ""` |
-| `false` | Boolean | `use_http2: false` |
+| Pattern | Type                            | Example                     |
+| ------- | ------------------------------- | --------------------------- |
+| `\{\}`  | Empty object (choice selection) | `monitoring: \{\}`          |
+| `[]`    | Empty array                     | `expected_status_codes: []` |
+| `0`     | Numeric                         | `jitter: 0`                 |
+| `""`    | String                          | `expected_response: ""`     |
+| `false` | Boolean                         | `use_http2: false`          |
 
 ### Adding Discovered Defaults
 
@@ -442,7 +446,7 @@ echo $F5XC_API_URL
 # Format: https://tenant.console.ves.volterra.io/api
 ```
 
-### Lint Errors on Generated Specs
+### Linting errors on generated specs
 
 ```bash
 # Check lint report
@@ -482,38 +486,37 @@ Add exclusion to `.pre-commit-config.yaml`:
 
 ### Make Targets
 
-| Target | Description |
-|--------|-------------|
-| `make build` | Full build (download + pipeline) |
-| `make rebuild` | Quick rebuild (skip download) |
-| `make download` | Download specs (ETag cached) |
-| `make download-force` | Force download |
-| `make pipeline` | Run enrichment pipeline |
-| `make lint` | Spectral linting |
-| `make serve` | Local documentation server |
-| `make discover` | API discovery (VPN required) |
-| `make push-discovery` | Commit discovery data |
-| `make clean` | Remove generated files |
-| `make pre-commit-run` | Run all quality checks |
+| Target                | Description                      |
+| --------------------- | -------------------------------- |
+| `make build`          | Full build (download + pipeline) |
+| `make rebuild`        | Quick rebuild (skip download)    |
+| `make download`       | Download specs (ETag cached)     |
+| `make download-force` | Force download                   |
+| `make pipeline`       | Run enrichment pipeline          |
+| `make lint`           | Spectral linting                 |
+| `make serve`          | Local documentation server       |
+| `make discover`       | API discovery (VPN required)     |
+| `make push-discovery` | Commit discovery data            |
+| `make clean`          | Remove generated files           |
+| `make pre-commit-run` | Run all quality checks           |
 
 ### Environment Variables
 
-| Variable | Purpose |
-|----------|---------|
-| `F5XC_API_URL` | F5 XC tenant API URL |
+| Variable         | Purpose                  |
+| ---------------- | ------------------------ |
+| `F5XC_API_URL`   | F5 XC tenant API URL     |
 | `F5XC_API_TOKEN` | API authentication token |
 
 ### Key Files
 
-| File | Purpose |
-|------|---------|
-| `.etag` | Last downloaded ETag |
-| `CHANGELOG.md` | Auto-generated changelog |
-| `config/enrichment.yaml` | Enrichment rules |
-| `config/normalization.yaml` | Normalization rules |
-| `config/discovery.yaml` | Discovery settings |
-| `config/spectral.yaml` | Linting rules |
+| File                                  | Purpose                       |
+| ------------------------------------- | ----------------------------- |
+| `.etag`                               | Last downloaded ETag          |
+| `CHANGELOG.md`                        | Auto-generated changelog      |
+| `config/enrichment.yaml`              | Enrichment rules              |
+| `config/normalization.yaml`           | Normalization rules           |
+| `config/discovery.yaml`               | Discovery settings            |
+| `config/spectral.yaml`                | Linter rules                  |
 | `scripts/utils/version_calculator.py` | Tag-based version calculation |
 
 **Note**: Version is derived from git tags (e.g., `v2.0.38`), not from a `.version` file.
-

--- a/docs/en/extensions/catalog.md
+++ b/docs/en/extensions/catalog.md
@@ -3,8 +3,6 @@ title: "Enrichment Extension Catalog"
 description: "Source of truth for every x-* extension in the enriched OpenAPI specifications"
 ---
 
-# Enrichment Extension Catalog
-
 Source of truth for every `x-*` extension that appears in
 `docs/specifications/api/*.json`. Parity with
 `scripts/utils/extension_constants.py` is enforced by

--- a/docs/en/validation-spec.mdx
+++ b/docs/en/validation-spec.mdx
@@ -47,9 +47,19 @@ Specifies fields required for each operation type per resource.
     },
     "resources": {
       "origin_pool": {
-        "create": ["metadata.name", "metadata.namespace", "spec.origin_servers", "spec.port"],
+        "create": [
+          "metadata.name",
+          "metadata.namespace",
+          "spec.origin_servers",
+          "spec.port"
+        ],
         "update": ["metadata.name", "metadata.namespace"],
-        "minimum_config": ["metadata.name", "metadata.namespace", "spec.origin_servers", "spec.port"]
+        "minimum_config": [
+          "metadata.name",
+          "metadata.namespace",
+          "spec.origin_servers",
+          "spec.port"
+        ]
       }
     }
   }
@@ -66,11 +76,26 @@ Defines allowed values for constrained fields.
     "loadbalancer_algorithm": {
       "description": "Load balancing algorithm for distributing traffic across origin servers",
       "values": [
-        {"value": "ROUND_ROBIN", "description": "Each healthy endpoint selected in round robin order"},
-        {"value": "LEAST_REQUEST", "description": "Endpoint with fewest active requests selected"},
-        {"value": "RING_HASH", "description": "Consistent hashing using ring hash of endpoint names"},
-        {"value": "RANDOM", "description": "Random healthy endpoint selection"},
-        {"value": "LB_OVERRIDE", "description": "Hash policy inherited from parent load balancer"}
+        {
+          "value": "ROUND_ROBIN",
+          "description": "Each healthy endpoint selected in round robin order"
+        },
+        {
+          "value": "LEAST_REQUEST",
+          "description": "Endpoint with fewest active requests selected"
+        },
+        {
+          "value": "RING_HASH",
+          "description": "Consistent hashing using ring hash of endpoint names"
+        },
+        {
+          "value": "RANDOM",
+          "description": "Random healthy endpoint selection"
+        },
+        {
+          "value": "LB_OVERRIDE",
+          "description": "Hash policy inherited from parent load balancer"
+        }
       ],
       "default": "ROUND_ROBIN"
     }
@@ -86,8 +111,8 @@ Type-level validation defaults and pattern-based rules.
 {
   "constraints": {
     "type_defaults": {
-      "string": {"minLength": 0, "maxLength": 1024},
-      "integer": {"minimum": 0, "maximum": 2147483647}
+      "string": { "minLength": 0, "maxLength": 1024 },
+      "integer": { "minimum": 0, "maximum": 2147483647 }
     }
   }
 }
@@ -102,7 +127,7 @@ Field name pattern-based validation rules with confidence scores.
   "patterns": [
     {
       "pattern": "\\bport$",
-      "constraints": {"minimum": 1, "maximum": 65535},
+      "constraints": { "minimum": 1, "maximum": 65535 },
       "confidence": 0.99,
       "description": "Valid TCP/UDP port range"
     },
@@ -113,7 +138,7 @@ Field name pattern-based validation rules with confidence scores.
         "maxLength": 63,
         "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
       },
-      "confidence": 0.90,
+      "confidence": 0.9,
       "description": "Kubernetes-style naming convention"
     }
   ]
@@ -199,15 +224,15 @@ All default values organized by resource type in a unified structure.
 
 #### Default Categories
 
-| Category | Description | Source |
-|----------|-------------|--------|
-| `server_applied` | Values the API applies when fields are omitted | Live API testing |
-| `recommended` | F5 XC web console pre-populated values | UI analysis |
-| `advanced_options` | Nested defaults within advanced_options objects | API discovery |
-| `oneof_choices` | Default OneOf variant selections | API behavior |
-| `oneof_recommended` | Recommended OneOf variants | Console defaults |
-| `nested_recommended` | Recommended values for nested schemas | UI analysis |
-| `ui_vs_server` | Cases where UI defaults differ from API defaults | Comparative analysis |
+| Category             | Description                                      | Source               |
+| -------------------- | ------------------------------------------------ | -------------------- |
+| `server_applied`     | Values the API applies when fields are omitted   | Live API testing     |
+| `recommended`        | F5 XC web console pre-populated values           | UI analysis          |
+| `advanced_options`   | Nested defaults within advanced_options objects  | API discovery        |
+| `oneof_choices`      | Default OneOf variant selections                 | API behavior         |
+| `oneof_recommended`  | Recommended OneOf variants                       | Console defaults     |
+| `nested_recommended` | Recommended values for nested schemas            | UI analysis          |
+| `ui_vs_server`       | Cases where UI defaults differ from API defaults | Comparative analysis |
 
 ### conditional_requirements
 
@@ -220,7 +245,11 @@ Mutually exclusive fields and conditional dependencies.
       "healthcheck": {
         "mutually_exclusive": [
           {
-            "fields": ["spec.http_health_check", "spec.tcp_health_check", "spec.udp_icmp_health_check"],
+            "fields": [
+              "spec.http_health_check",
+              "spec.tcp_health_check",
+              "spec.udp_icmp_health_check"
+            ],
             "reason": "Choose exactly one health check type"
           }
         ],
@@ -242,9 +271,11 @@ Minimum viable configurations with working examples.
       "origin_pool": {
         "description": "Backend origin servers for load balancing",
         "example": {
-          "metadata": {"name": "backend-pool", "namespace": "default"},
+          "metadata": { "name": "backend-pool", "namespace": "default" },
           "spec": {
-            "origin_servers": [{"public_name": {"dns_name": "backend1.example.com"}}],
+            "origin_servers": [
+              { "public_name": { "dns_name": "backend1.example.com" } }
+            ],
             "port": 8080
           }
         }
@@ -258,24 +289,24 @@ Minimum viable configurations with working examples.
 
 The enriched OpenAPI specs embed validation metadata using these extensions:
 
-| Extension | Purpose | Location |
-|-----------|---------|----------|
-| `x-f5xc-required-for` | Context-specific required fields | Schema properties |
-| `x-f5xc-server-default` | Marks server-applied defaults | Schema properties |
-| `x-f5xc-recommended-value` | Recommended default value | Schema properties |
-| `x-f5xc-recommended-oneof-variant` | Recommended OneOf variant | Schema definitions |
-| `x-f5xc-conditions` | Conditional requirements | Schema properties |
-| `x-f5xc-minimum-configuration` | Minimum config examples | Schema definitions |
-| `x-f5xc-validation` | Discovery-derived constraints | Schema properties |
+| Extension                          | Purpose                          | Location           |
+| ---------------------------------- | -------------------------------- | ------------------ |
+| `x-f5xc-required-for`              | Context-specific required fields | Schema properties  |
+| `x-f5xc-server-default`            | Marks server-applied defaults    | Schema properties  |
+| `x-f5xc-recommended-value`         | Recommended default value        | Schema properties  |
+| `x-f5xc-recommended-oneof-variant` | Recommended OneOf variant        | Schema definitions |
+| `x-f5xc-conditions`                | Conditional requirements         | Schema properties  |
+| `x-f5xc-minimum-configuration`     | Minimum config examples          | Schema definitions |
+| `x-f5xc-validation`                | Discovery-derived constraints    | Schema properties  |
 
 ## Data Access
 
 ### Publication URLs
 
-| Source | URL |
-|--------|-----|
-| GitHub Pages | `https://f5-sales-demo.github.io/api-specs-enriched/specifications/api/validation.json` |
-| Raw GitHub | `https://raw.githubusercontent.com/f5-sales-demo/api-specs-enriched/main/docs/specifications/api/validation.json` |
+| Source       | URL                                                                                                               |
+| ------------ | ----------------------------------------------------------------------------------------------------------------- |
+| GitHub Pages | `https://f5-sales-demo.github.io/api-specs-enriched/specifications/api/validation.json`                           |
+| Raw GitHub   | `https://raw.githubusercontent.com/f5-sales-demo/api-specs-enriched/main/docs/specifications/api/validation.json` |
 
 ### Local Path
 
@@ -285,11 +316,11 @@ After running the pipeline: `docs/specifications/api/validation.json`
 
 The validation spec follows semantic versioning in the `version` field:
 
-| Change Type | Version Bump | Example |
-|-------------|--------------|---------|
-| Breaking structure changes | Major | Field renames, removed sections |
-| New validation rules or resources | Minor | New resource defaults |
-| Bug fixes or description updates | Patch | Typo corrections |
+| Change Type                       | Version Bump | Example                         |
+| --------------------------------- | ------------ | ------------------------------- |
+| Breaking structure changes        | Major        | Field renames, removed sections |
+| New validation rules or resources | Minor        | New resource defaults           |
+| Bug fixes or description updates  | Patch        | Typo corrections                |
 
 ## Reconciliation Priority
 
@@ -308,9 +339,8 @@ When multiple sources provide constraints, the reconciliation priority is:
 
 ## Changelog
 
-| Version | Date | Changes |
-|---------|------|---------|
-| 2.1.2 | 2026-01-18 | Rewritten as pure API reference; added oneof_recommended and nested_recommended categories |
-| 2.1.0 | 2026-01-18 | Unified defaults structure replacing fragmented sections |
-| 2.0.0 | 2026-01-15 | Initial validation specification |
-
+| Version | Date       | Changes                                                                                    |
+| ------- | ---------- | ------------------------------------------------------------------------------------------ |
+| 2.1.2   | 2026-01-18 | Rewritten as pure API reference; added oneof_recommended and nested_recommended categories |
+| 2.1.0   | 2026-01-18 | Unified defaults structure replacing fragmented sections                                   |
+| 2.0.0   | 2026-01-15 | Initial validation specification                                                           |

--- a/docs/superpowers/specs/2026-05-27-native-api-docs-design.md
+++ b/docs/superpowers/specs/2026-05-27-native-api-docs-design.md
@@ -19,13 +19,13 @@ Replace iframe+Scalar rendering with the `starlight-openapi` Starlight plugin, w
 
 ### Current flow
 
-```
+```text
 Python pipeline → enriched JSON → Scalar HTML viewer → iframe in MDX → Starlight page
 ```
 
 ### Target flow
 
-```
+```text
 Python pipeline → enriched JSON → starlight-openapi → native .astro pages
 ```
 
@@ -93,7 +93,7 @@ The existing `docs/api-reference/index.mdx` card catalog page stays. Cards link 
 ## Changes to generate_api_viewer.py
 
 | Function | Action |
-|----------|--------|
+| ---------- | -------- |
 | `generate_viewer_html()` | Remove |
 | `generate_domain_mdx()` | Remove |
 | `generate_catalog_mdx()` | Keep — update `href` to match plugin routes |

--- a/scripts/generate_api_viewer.py
+++ b/scripts/generate_api_viewer.py
@@ -98,7 +98,7 @@ def generate_catalog_mdx(
             )
 
         cards_block = "\n".join(cards)
-        cards_sections.append(f"### {cat}\n\n<CardGrid>\n{cards_block}\n</CardGrid>")
+        cards_sections.append(f"## {cat}\n\n<CardGrid>\n{cards_block}\n</CardGrid>")
 
     all_sections = "\n\n".join(cards_sections)
 
@@ -121,8 +121,11 @@ endpoint details, request and response schemas, and code examples.
 
 UPSTREAM_TYPOS = {
     "Con" + "nnect": "Connect",
+    "JI" + "RA": "Jira",
+    "Open" + "Api": "OpenAPI",
     "Subsci" + "ption": "Subscription",
     "Insatn" + "ce": "Instance",
+    "WI" + "FI": "Wi-Fi",
     "avaialab" + "le": "available",
     "Sou" + "ce": "Source",
     "pro" + "xys": "proxies",
@@ -182,7 +185,7 @@ def generate_domain_summary(spec: dict) -> str:
 
     endpoints_table = ""
     if rows:
-        header = "| Method | Path | Description |\n|--------|------|-------------|"
+        header = "| Method | Path | Description |\n| --- | --- | --- |"
         endpoints_table = f"## Endpoints\n\n{header}\n" + "\n".join(rows)
 
     use_cases_block = ""
@@ -205,32 +208,36 @@ def generate_domain_summary(spec: dict) -> str:
 
     description_line = medium_desc or short_desc or title
 
-    return f"""---
+    frontmatter = f"""---
 title: "{icon} {title} API"
 description: "{_escape_mdx(short_desc or title)}"
 sidebar:
     hidden: true
----
-
-{_escape_mdx(description_line)}
-
-- **Category**: {category}
-- **Complexity**: {complexity}
-- **Paths**: {path_count} | **Schemas**: {schema_count}
-- **Tier**: {tier}
-{f"- {related_block}" if related_block else ""}
-
-{use_cases_block}
-
-{resources_block}
-
-{endpoints_table}
-
-## Links
+---"""
+    overview_lines = [
+        _escape_mdx(description_line),
+        "",
+        f"- **Category**: {category}",
+        f"- **Complexity**: {complexity}",
+        f"- **Paths**: {path_count} | **Schemas**: {schema_count}",
+        f"- **Tier**: {tier}",
+    ]
+    if related_block:
+        overview_lines.append(f"- {related_block}")
+    overview = "\n".join(overview_lines)
+    links_block = f"""## Links
 
 - [Interactive API Reference](../../../api-reference/{domain}/)
-- [OpenAPI Specification JSON](../../../specifications/api/{domain}.json)
-"""
+- [OpenAPI Specification JSON](../../../specifications/api/{domain}.json)"""
+    sections = [
+        frontmatter,
+        overview,
+        use_cases_block,
+        resources_block,
+        endpoints_table,
+        links_block,
+    ]
+    return "\n\n".join(section for section in sections if section) + "\n"
 
 
 def main() -> int:
@@ -267,7 +274,6 @@ def main() -> int:
         summary_path = MDX_DIR / f"{spec['domain']}-api.mdx"
         summary_path.write_text(generate_domain_summary(spec))
         summary_count += 1
-
     # Generate starlight-openapi plugin configuration
     config_content = generate_openapi_specs_config(specs)
     OPENAPI_CONFIG_PATH.write_text(config_content)

--- a/tests/test_generate_api_viewer.py
+++ b/tests/test_generate_api_viewer.py
@@ -1,0 +1,68 @@
+"""Regression tests for generated API-reference Markdown."""
+
+from __future__ import annotations
+
+import json
+
+from scripts import generate_api_viewer
+
+
+def test_catalog_uses_h2_category_sections() -> None:
+    """Catalog category headings follow the document hierarchy."""
+    rendered = generate_api_viewer.generate_catalog_mdx(
+        [
+            {
+                "domain": "example",
+                "title": "Example",
+                "x-f5xc-category": "Security",
+            },
+        ],
+    )
+
+    assert "\n## Security\n" in rendered
+    assert "\n### Security\n" not in rendered
+
+
+def test_domain_summary_emits_consistent_table_spacing(tmp_path, monkeypatch) -> None:
+    """Generated endpoint tables satisfy markdownlint's compact table style."""
+    monkeypatch.setattr(generate_api_viewer, "SPEC_DIR", tmp_path)
+    (tmp_path / "example.json").write_text(
+        json.dumps(
+            {
+                "paths": {
+                    "/v1/widgets": {
+                        "get": {"summary": "List widgets."},
+                    },
+                },
+            },
+        ),
+    )
+
+    rendered = generate_api_viewer.generate_domain_summary(
+        {
+            "domain": "example",
+            "title": "Example",
+            "path_count": 1,
+            "schema_count": 0,
+        },
+    )
+
+    assert "| Method | Path | Description |\n| --- | --- | --- |" in rendered
+
+
+def test_domain_summary_omits_blank_generated_sections(tmp_path, monkeypatch) -> None:
+    """Empty optional sections do not emit consecutive blank lines."""
+    monkeypatch.setattr(generate_api_viewer, "SPEC_DIR", tmp_path)
+
+    rendered = generate_api_viewer.generate_domain_summary(
+        {
+            "domain": "example",
+            "title": "Example",
+            "path_count": 0,
+            "schema_count": 0,
+        },
+    )
+
+    assert "\n\n\n" not in rendered
+    assert "## Use Cases" not in rendered
+    assert "## Primary Resources" not in rendered


### PR DESCRIPTION
Closes #1262

## Summary

- fix API reference Markdown in the generator and regenerate its outputs
- make generated endpoint tables and section hierarchy conform to the fleet rules
- clean authored English Markdown and MDX without changing locale trees
- add generator regression tests for headings, tables, and optional-section spacing

## Verification

- uv run pytest: 2,292 passed, 6 skipped, 1 expected failure
- full enrichment pre-commit pipeline: passed
- generator run twice: identical SHA-1 31d8933b0f38d839482e318c6533255303b981f8
- changed-file markdownlint: passed
- changed-file MDX and Markdown prose lint: passed
- focused generator tests after rebase: 3 passed

## Tooling follow-up

The managed pre-commit prose hooks lose executable mode downstream; docs-control#1044 and docs-control#1045 fix the invocation centrally. CI already invokes the same script through bash.