### PR TITLE
fix: pin workflow actions and secure dispatch

### DIFF
--- a/.github/workflows/sync-and-enrich.yml
+++ b/.github/workflows/sync-and-enrich.yml
@@ -1,3 +1,4 @@
+---
 name: Sync and Enrich API Specs
 
 on:
@@ -55,10 +56,10 @@ jobs:
       etag: ${{ steps.check.outputs.etag }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Setup Python
-        uses: actions/setup-python@v6.2.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: 'pip'
@@ -133,14 +134,14 @@ jobs:
       has_changes: ${{ steps.detect.outputs.has_changes }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 0  # Full history needed for git describe --tags
           fetch-tags: true  # Explicitly fetch tags for version calculation
           token: ${{ secrets.VERSION_BUMP_PAT }}  # Use admin PAT for bypass permissions
 
       - name: Setup Python
-        uses: actions/setup-python@v6.2.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: 'pip'
@@ -161,7 +162,7 @@ jobs:
       - name: Restore specs cache
         if: github.event_name == 'push'
         id: specs-cache
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: specs/original
           key: specs-original-${{ steps.release-info.outputs.release_tag }}
@@ -174,7 +175,7 @@ jobs:
 
       - name: Save specs cache
         if: steps.specs-cache.outputs.cache-hit != 'true' && github.event_name == 'push'
-        uses: actions/cache/save@v5
+        uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: specs/original
           key: specs-original-${{ steps.release-info.outputs.release_tag }}
@@ -215,7 +216,7 @@ jobs:
       - name: Restore enriched output cache
         if: github.event_name != 'workflow_dispatch'
         id: enriched-cache
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: docs/specifications/api
           key: enriched-${{ steps.specs-fingerprint.outputs.hash }}-${{ steps.pipeline-fingerprint.outputs.hash }}-biome-${{ steps.biome.outputs.version }}
@@ -227,7 +228,7 @@ jobs:
           sudo apt-get install -y default-jre
 
       - name: Setup Node.js for Spectral
-        uses: actions/setup-node@v6.3.0
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: '22'
 
@@ -274,7 +275,7 @@ jobs:
 
       - name: Save enriched output cache
         if: steps.enriched-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v5
+        uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: docs/specifications/api
           key: enriched-${{ steps.specs-fingerprint.outputs.hash }}-${{ steps.pipeline-fingerprint.outputs.hash }}-biome-${{ steps.biome.outputs.version }}
@@ -523,7 +524,7 @@ jobs:
 
       - name: Upload docs artifact for deployment
         if: steps.detect.outputs.has_changes == 'true'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: docs-site
           path: docs
@@ -739,22 +740,22 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Download docs artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: docs-site
           path: docs
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
         with:
           path: docs
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
 
   # ==========================================================================
   # NOTIFY DOWNSTREAM REPOSITORIES
@@ -770,7 +771,7 @@ jobs:
       has_targets: ${{ steps.matrix.outputs.has_targets }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Install PyYAML
         run: pip install pyyaml
@@ -810,17 +811,20 @@ jobs:
       matrix: ${{ fromJSON(needs.build-downstream-matrix.outputs.matrix) }}
       fail-fast: false
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+
       - name: Dispatch to ${{ matrix.downstream.repo }}
         env:
+          GH_TOKEN: ${{ secrets.DOWNSTREAM_DISPATCH_TOKEN }}
+          TARGET_OWNER: ${{ matrix.downstream.owner }}
+          TARGET_REPO: ${{ matrix.downstream.repo }}
+          EVENT_TYPE: ${{ matrix.downstream.event_type }}
           VERSION: ${{ needs.sync-and-enrich.outputs.version }}
-          REPO: ${{ github.repository }}
-        uses: peter-evans/repository-dispatch@v3
-        with:
-          token: ${{ secrets.DOWNSTREAM_DISPATCH_TOKEN }}
-          repository: ${{ matrix.downstream.owner }}/${{ matrix.downstream.repo }}
-          event-type: ${{ matrix.downstream.event_type }}
-          # yamllint disable-line rule:line-length
-          client-payload: '{"version":"${{ needs.sync-and-enrich.outputs.version }}","release_tag":"v${{ needs.sync-and-enrich.outputs.version }}","release_url":"https://github.com/${{ github.repository }}/releases/tag/v${{ needs.sync-and-enrich.outputs.version }}","timestamp":"${{ github.event.repository.updated_at }}","trigger_source":"${{ github.repository }}","run_id":"${{ github.run_id }}"}'
+          SOURCE_REPOSITORY: ${{ github.repository }}
+          SOURCE_UPDATED_AT: ${{ github.event.repository.updated_at }}
+          SOURCE_RUN_ID: ${{ github.run_id }}
+        run: bash scripts/release/dispatch-downstream.sh
 
       - name: Log dispatch result
         env:
@@ -869,11 +873,11 @@ jobs:
 
       - name: Checkout repository
         if: steps.check_failure.outputs.has_failure == 'true'
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Setup Python
         if: steps.check_failure.outputs.has_failure == 'true'
-        uses: actions/setup-python@v6.2.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: 'pip'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,12 +25,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 0  # verify_governance needs base..head diff
 
       - name: Setup Python
-        uses: actions/setup-python@v6.2.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: 'pip'
@@ -72,10 +72,10 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Setup Python
-        uses: actions/setup-python@v6.2.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: 'pip'
@@ -217,7 +217,7 @@ jobs:
 
       - name: Upload contract-diff artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: contract-diff
           path: reports/contract_diff.*
@@ -226,7 +226,7 @@ jobs:
       - name: Post violations to PR
         if: failure() && github.event_name == 'pull_request'
         continue-on-error: true  # 64KB body cap is still possible
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const fs = require('fs');

--- a/scripts/release/dispatch-downstream.sh
+++ b/scripts/release/dispatch-downstream.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+set -euo pipefail
+
+required=(
+  GH_TOKEN
+  TARGET_OWNER
+  TARGET_REPO
+  EVENT_TYPE
+  VERSION
+  SOURCE_REPOSITORY
+  SOURCE_UPDATED_AT
+  SOURCE_RUN_ID
+)
+
+for name in "${required[@]}"; do
+  if [ -z "${!name:-}" ]; then
+    echo "[ERROR] ${name} is required" >&2
+    exit 2
+  fi
+done
+
+if [[ ! "$TARGET_OWNER" =~ ^[A-Za-z0-9]([A-Za-z0-9-]{0,37}[A-Za-z0-9])?$ ]]; then
+  echo "[ERROR] TARGET_OWNER is malformed" >&2
+  exit 2
+fi
+if [[ ! "$TARGET_REPO" =~ ^[A-Za-z0-9._-]{1,100}$ ]]; then
+  echo "[ERROR] TARGET_REPO is malformed" >&2
+  exit 2
+fi
+if [[ ! "$EVENT_TYPE" =~ ^[A-Za-z0-9_.-]{1,100}$ ]]; then
+  echo "[ERROR] EVENT_TYPE is malformed" >&2
+  exit 2
+fi
+if [[ ! "$VERSION" =~ ^[0-9]+(\.[0-9]+){2}([-+.][0-9A-Za-z.-]+)?$ ]]; then
+  echo "[ERROR] VERSION is malformed" >&2
+  exit 2
+fi
+if [[ ! "$SOURCE_REPOSITORY" =~ ^[A-Za-z0-9-]+/[A-Za-z0-9._-]+$ ]]; then
+  echo "[ERROR] SOURCE_REPOSITORY is malformed" >&2
+  exit 2
+fi
+if [[ ! "$SOURCE_UPDATED_AT" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]]; then
+  echo "[ERROR] SOURCE_UPDATED_AT is malformed" >&2
+  exit 2
+fi
+if [[ ! "$SOURCE_RUN_ID" =~ ^[1-9][0-9]*$ ]]; then
+  echo "[ERROR] SOURCE_RUN_ID is malformed" >&2
+  exit 2
+fi
+
+dispatch_gh=${DISPATCH_GH:-gh}
+if ! command -v "$dispatch_gh" >/dev/null 2>&1; then
+  echo "[ERROR] DISPATCH_GH is not executable" >&2
+  exit 2
+fi
+
+jq -cn \
+  --arg event_type "$EVENT_TYPE" \
+  --arg version "$VERSION" \
+  --arg source_repository "$SOURCE_REPOSITORY" \
+  --arg timestamp "$SOURCE_UPDATED_AT" \
+  --arg run_id "$SOURCE_RUN_ID" \
+  '{
+    event_type: $event_type,
+    client_payload: {
+      version: $version,
+      release_tag: ("v" + $version),
+      release_url: (
+        "https://github.com/" + $source_repository + "/releases/tag/v" + $version
+      ),
+      timestamp: $timestamp,
+      trigger_source: $source_repository,
+      run_id: $run_id
+    }
+  }' |
+  "$dispatch_gh" api --method POST \
+    "repos/${TARGET_OWNER}/${TARGET_REPO}/dispatches" \
+    --input -

--- a/tests/shell/test_dispatch_downstream.py
+++ b/tests/shell/test_dispatch_downstream.py
@@ -1,0 +1,147 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+"""Tests for the dependency-free downstream repository dispatch helper."""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT = _ROOT / "scripts" / "release" / "dispatch-downstream.sh"
+_WORKFLOW = _ROOT / ".github" / "workflows" / "sync-and-enrich.yml"
+_REQUIRED_ENV = {
+    "GH_TOKEN": "test-token",
+    "TARGET_OWNER": "f5-sales-demo",
+    "TARGET_REPO": "terraform-provider-xcsh",
+    "EVENT_TYPE": "enriched-specs-updated",
+    "VERSION": "2.1.211",
+    "SOURCE_REPOSITORY": "f5-sales-demo/api-specs-enriched",
+    "SOURCE_UPDATED_AT": "2026-08-03T03:10:54Z",
+    "SOURCE_RUN_ID": "30781155338",
+}
+
+
+def _fake_gh(tmp_path: Path) -> tuple[Path, Path, Path]:
+    args_path = tmp_path / "args"
+    input_path = tmp_path / "input.json"
+    fake = tmp_path / "gh"
+    fake.write_text(
+        """#!/usr/bin/env bash
+set -eu
+printf '%s\n' "$@" > "$FAKE_GH_ARGS"
+cat > "$FAKE_GH_INPUT"
+"""
+    )
+    fake.chmod(fake.stat().st_mode | stat.S_IEXEC)
+    return fake, args_path, input_path
+
+
+def _run(
+    tmp_path: Path,
+    *,
+    overrides: dict[str, str] | None = None,
+    remove: str | None = None,
+) -> tuple[subprocess.CompletedProcess[str], Path, Path]:
+    fake, args_path, input_path = _fake_gh(tmp_path)
+    env = {
+        **os.environ,
+        **_REQUIRED_ENV,
+        "DISPATCH_GH": str(fake),
+        "FAKE_GH_ARGS": str(args_path),
+        "FAKE_GH_INPUT": str(input_path),
+    }
+    if overrides is not None:
+        env.update(overrides)
+    if remove is not None:
+        env.pop(remove)
+
+    result = subprocess.run(
+        ["bash", str(_SCRIPT)],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+        timeout=10,
+    )
+    return result, args_path, input_path
+
+
+def test_dispatch_uses_exact_endpoint_and_payload(tmp_path: Path) -> None:
+    result, args_path, input_path = _run(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    assert args_path.read_text().splitlines() == [
+        "api",
+        "--method",
+        "POST",
+        "repos/f5-sales-demo/terraform-provider-xcsh/dispatches",
+        "--input",
+        "-",
+    ]
+    assert json.loads(input_path.read_text()) == {
+        "event_type": "enriched-specs-updated",
+        "client_payload": {
+            "version": "2.1.211",
+            "release_tag": "v2.1.211",
+            "release_url": (
+                "https://github.com/f5-sales-demo/api-specs-enriched/releases/tag/v2.1.211"
+            ),
+            "timestamp": "2026-08-03T03:10:54Z",
+            "trigger_source": "f5-sales-demo/api-specs-enriched",
+            "run_id": "30781155338",
+        },
+    }
+
+
+@pytest.mark.parametrize("name", sorted(_REQUIRED_ENV))
+def test_dispatch_fails_closed_when_input_is_missing(tmp_path: Path, name: str) -> None:
+    result, args_path, _ = _run(tmp_path, remove=name)
+
+    assert result.returncode != 0
+    assert name in result.stderr
+    assert not args_path.exists()
+
+
+@pytest.mark.parametrize(
+    ("name", "value"),
+    [
+        ("TARGET_OWNER", "f5-sales-demo/escape"),
+        ("TARGET_REPO", "../escape"),
+        ("EVENT_TYPE", "invalid event"),
+        ("VERSION", "2.1.211/escape"),
+        ("SOURCE_REPOSITORY", "missing-slash"),
+        ("SOURCE_UPDATED_AT", "not-a-timestamp"),
+        ("SOURCE_RUN_ID", "not-a-run-id"),
+    ],
+)
+def test_dispatch_rejects_malformed_input(tmp_path: Path, name: str, value: str) -> None:
+    result, args_path, _ = _run(tmp_path, overrides={name: value})
+
+    assert result.returncode != 0
+    assert name in result.stderr
+    assert not args_path.exists()
+
+
+def test_workflow_delegates_dispatch_without_a_third_party_action() -> None:
+    workflow = _WORKFLOW.read_text()
+
+    assert "run: bash scripts/release/dispatch-downstream.sh" in workflow
+    assert "peter-evans/repository-dispatch@" not in workflow
+
+
+def test_notify_job_checks_out_the_dispatch_helper_before_running_it() -> None:
+    workflow = _WORKFLOW.read_text()
+    notify_job = workflow.split("\n  notify-downstream:\n", maxsplit=1)[1].split(
+        "\n  # ==========================================================================",
+        maxsplit=1,
+    )[0]
+
+    checkout = "uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803"
+    dispatch = "run: bash scripts/release/dispatch-downstream.sh"
+    assert notify_job.index(checkout) < notify_job.index(dispatch)

--- a/tests/test_workflow_action_pins.py
+++ b/tests/test_workflow_action_pins.py
@@ -1,0 +1,40 @@
+import re
+from pathlib import Path
+
+WORKFLOWS = Path(__file__).parents[1] / ".github" / "workflows"
+USES_LINE = re.compile(r"^\s*(?:-\s*)?uses:\s*(\S+)")
+IMMUTABLE_REMOTE_USE = re.compile(r"^[^@\s]+@[0-9a-f]{40}$")
+
+
+def test_uses_parser_accepts_job_and_inline_step_syntax() -> None:
+    reference = "actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803"
+
+    for line in (f"    uses: {reference}", f"    - uses: {reference}"):
+        match = USES_LINE.match(line)
+        assert match is not None
+        assert match.group(1) == reference
+
+
+def test_every_remote_action_reference_is_immutable() -> None:
+    mutable: list[str] = []
+
+    for workflow in sorted(WORKFLOWS.glob("*.y*ml")):
+        for line_number, line in enumerate(workflow.read_text().splitlines(), start=1):
+            match = USES_LINE.match(line)
+            if match is None:
+                continue
+            reference = match.group(1)
+            if reference.startswith("./"):
+                continue
+            if IMMUTABLE_REMOTE_USE.fullmatch(reference) is None:
+                mutable.append(
+                    f"{workflow.relative_to(WORKFLOWS.parent.parent)}:{line_number}: {reference}"
+                )
+
+    assert not mutable, "Mutable remote action references:\n" + "\n".join(mutable)
+
+
+def test_privileged_dispatch_has_no_third_party_action_dependency() -> None:
+    workflow = (WORKFLOWS / "sync-and-enrich.yml").read_text()
+
+    assert "peter-evans/repository-dispatch@" not in workflow


### PR DESCRIPTION
## Summary

- replace all mutable remote action references in the release and test workflows with immutable 40-character commit SHAs
- remove the privileged third-party repository-dispatch action and send the same validated payload through `gh api`
- fail closed on missing or malformed dispatch inputs before invoking the API
- add repository-wide workflow action-pin enforcement, including both `uses:` and inline `- uses:` syntax
- prove checkout ordering, exact endpoint/payload behavior, failure propagation, and third-party dispatch removal

No documentation or translation files are changed.

## Verification

- focused security/dispatch tests: 21 passed
- complete pytest suite: 2313 passed, 6 skipped, 1 xfailed
- complete commit hooks: passed, including enrichment, Spectral, Ruff, ShellCheck, shfmt, Actionlint, workflow security, infrastructure security, secret detection, and YAML lint
- staged PII enforce scan: clean
- staged PII audit scan: clean
- independent adversarial review: clean
- post-hook path check: exactly five intended paths, zero unstaged or generated changes

Closes #1258
Closes #1091
