### PR TITLE
feat(release): publish a publication receipt with every release

### DIFF
--- a/.github/workflows/sync-and-enrich.yml
+++ b/.github/workflows/sync-and-enrich.yml
@@ -57,6 +57,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
 
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -136,6 +138,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
+          persist-credentials: false
           fetch-depth: 0  # Full history needed for git describe --tags
           fetch-tags: true  # Explicitly fetch tags for version calculation
           token: ${{ secrets.VERSION_BUMP_PAT }}  # Use admin PAT for bypass permissions
@@ -626,6 +629,13 @@ jobs:
             git tag -a "v${VERSION}" -m "Release v${VERSION} (${BUMP_TYPE})"
             git push origin "v${VERSION}"
 
+            # The publication receipt in the release body must name the commit the
+            # tag resolves to. Capture it here, on the merge commit we just tagged,
+            # rather than re-deriving it in a later step where main may already have
+            # moved on — a receipt naming the wrong commit is rejected downstream
+            # after the release is immutable and can no longer be corrected.
+            echo "release_commit=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
+
             echo "::notice::Released v${VERSION} via PR merge + tag"
           else
             echo "No changes to commit"
@@ -713,17 +723,40 @@ jobs:
             exit 0
           fi
 
+          # The exact five assets this release publishes. The receipt below must
+          # cover this same list, so it is declared once and reused for both.
+          ASSET_PATHS=(
+            "${zip_name}"
+            docs/specifications/api/openapi.json
+            docs/specifications/api/index.json
+            docs/specifications/api/minimal-export-defaults.json
+            release/api-catalog.json
+          )
+
+          # Publication receipt: binds each asset's SHA-256 to the commit the tag
+          # resolves to, so a consumer can prove the bundle it downloaded is the one
+          # this release published. Consumers refuse a release without it
+          # (f5-sales-demo/terraform-provider-xcsh#1460), and a release is immutable
+          # once created, so this has to be in the body from the start — it cannot be
+          # added afterwards.
+          if [ -z "${release_commit:-}" ]; then
+            echo "::error::release_commit was not captured while tagging; cannot build a publication receipt"
+            exit 1
+          fi
+          NOTES_FILE=$(mktemp)
+          trap 'rm -f "$NOTES_FILE"' EXIT
+          cat CHANGELOG.md > "$NOTES_FILE"
+          printf '\n' >> "$NOTES_FILE"
+          bash scripts/release/build-publication-receipt.sh \
+            "$VERSION" "$release_commit" "${ASSET_PATHS[@]}" >> "$NOTES_FILE"
+
           # Create release with ZIP package
           gh release create "v$VERSION" \
             --title "API Specs v$VERSION" \
-            --notes-file CHANGELOG.md \
-            "${zip_name}" \
-            docs/specifications/api/openapi.json \
-            docs/specifications/api/index.json \
-            docs/specifications/api/minimal-export-defaults.json \
-            release/api-catalog.json
+            --notes-file "$NOTES_FILE" \
+            "${ASSET_PATHS[@]}"
 
-          echo "::notice::Created release: v$VERSION"
+          echo "::notice::Created release: v$VERSION with publication receipt for ${release_commit}"
 
   deploy-docs:
     name: Deploy Documentation
@@ -772,6 +805,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
 
       - name: Install PyYAML
         run: pip install pyyaml
@@ -813,6 +848,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
 
       - name: Dispatch to ${{ matrix.downstream.repo }}
         env:
@@ -874,6 +911,8 @@ jobs:
       - name: Checkout repository
         if: steps.check_failure.outputs.has_failure == 'true'
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
 
       - name: Setup Python
         if: steps.check_failure.outputs.has_failure == 'true'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
+          persist-credentials: false
           fetch-depth: 0  # verify_governance needs base..head diff
 
       - name: Setup Python
@@ -73,6 +74,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
 
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/scripts/release/build-publication-receipt.sh
+++ b/scripts/release/build-publication-receipt.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Emit the publication receipt for one release.
+#
+# usage: build-publication-receipt.sh <version> <commit> <asset-path>...
+#
+# Writes a single line to stdout:
+#
+#   <!-- publication-receipt:{"assets":{...},"commit":"<40-hex>","version":"x.y.z"} -->
+#
+# The line goes into the release body, where it binds the exact SHA-256 of every
+# published asset to the commit the tag resolves to. Consumers verify what they
+# downloaded against it instead of trusting that a release named vX.Y.Z contains
+# what vX.Y.Z contained the last time they looked.
+#
+# terraform-provider-xcsh refuses to consume a release without one — see its
+# download-api-specs action and sync-openapi.yml (#1460). A release published
+# without a receipt is undeliverable downstream, so every failure here is fatal
+# rather than a warning.
+#
+# The five-asset set is enforced here, not just downstream: a receipt attesting
+# to four assets, or to a bundle named for a different version, is worse than no
+# receipt because it looks authoritative while covering the wrong release.
+set -euo pipefail
+
+fail() {
+  echo "build-publication-receipt: $*" >&2
+  exit 1
+}
+
+[ "$#" -ge 3 ] || fail "usage: build-publication-receipt.sh <version> <commit> <asset-path>..."
+
+version=$1
+commit=$2
+shift 2
+
+[[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] ||
+  fail "version must be MAJOR.MINOR.PATCH with no leading v, got: ${version}"
+
+# Lowercase hex only: consumers test against ^[0-9a-f]{40}$, so an uppercase or
+# abbreviated SHA would be rejected there, after the release is already immutable.
+[[ "$commit" =~ ^[0-9a-f]{40}$ ]] ||
+  fail "commit must be a full lowercase 40-character Git SHA, got: ${commit}"
+
+digest() {
+  # sha256sum on the Linux runners, shasum on a macOS working copy.
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  else
+    shasum -a 256 "$1" | awk '{print $1}'
+  fi
+}
+
+assets='{}'
+for path in "$@"; do
+  [ -f "$path" ] || fail "asset does not exist: ${path}"
+  name=$(basename "$path")
+  # Two paths with the same basename would silently overwrite each other in the
+  # receipt, attesting to whichever came last.
+  if [ "$(jq -r --arg n "$name" 'has($n)' <<<"$assets")" = "true" ]; then
+    fail "duplicate asset name: ${name}"
+  fi
+  assets=$(jq -cS --arg n "$name" --arg d "$(digest "$path")" '. + {($n): $d}' <<<"$assets")
+done
+
+expected=$(jq -cnS --arg bundle "f5xc-api-specs-v${version}.zip" \
+  '["api-catalog.json", $bundle, "index.json", "minimal-export-defaults.json", "openapi.json"] | sort')
+actual=$(jq -cS 'keys | sort' <<<"$assets")
+if [ "$actual" != "$expected" ]; then
+  fail "asset set does not match the five-asset contract for v${version}"$'\n'"  expected: ${expected}"$'\n'"  actual:   ${actual}"
+fi
+
+# -c keeps it on one line, which the consumer's line-anchored regex requires;
+# -S sorts keys so the same inputs always produce the same bytes.
+receipt=$(jq -cnS \
+  --argjson assets "$assets" \
+  --arg commit "$commit" \
+  --arg version "$version" \
+  '{assets: $assets, commit: $commit, version: $version}')
+
+printf '<!-- publication-receipt:%s -->\n' "$receipt"

--- a/scripts/release/build-publication-receipt.sh
+++ b/scripts/release/build-publication-receipt.sh
@@ -42,12 +42,24 @@ shift 2
   fail "commit must be a full lowercase 40-character Git SHA, got: ${commit}"
 
 digest() {
-  # sha256sum on the Linux runners, shasum on a macOS working copy.
+  # Emitted as "sha256:<hex>", the same form GitHub reports in
+  # .assets[].digest. A consumer can then compare the two for equality instead of
+  # reassembling a prefix at every call site, and the value is self-describing if
+  # the algorithm ever changes.
+  #
+  # It also keeps the digest out of the way of entropy-based secret scanners.
+  # Gitleaks' generic-api-key rule fires on a secret-ish keyword next to a
+  # high-entropy value, and asset filenames supply the keyword: measured on the
+  # bare-hex form, "api-catalog.json" and "openapi.json" were reported while
+  # "index.json" was not. Prefixed, the rule does not fire at all, so no consumer
+  # needs an allowlist to commit this data.
+  local hex
   if command -v sha256sum >/dev/null 2>&1; then
-    sha256sum "$1" | awk '{print $1}'
+    hex=$(sha256sum "$1" | awk '{print $1}')
   else
-    shasum -a 256 "$1" | awk '{print $1}'
+    hex=$(shasum -a 256 "$1" | awk '{print $1}')
   fi
+  printf 'sha256:%s' "$hex"
 }
 
 assets='{}'

--- a/tests/shell/test_build_publication_receipt.py
+++ b/tests/shell/test_build_publication_receipt.py
@@ -1,0 +1,165 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+"""Tests for scripts/release/build-publication-receipt.sh.
+
+Every release publishes a receipt in its body binding the exact asset digests
+to the commit the tag resolves to:
+
+    <!-- publication-receipt:{"assets":{...},"commit":"<40-hex>","version":"x.y.z"} -->
+
+Consumers verify what they downloaded against it. terraform-provider-xcsh's
+`download-api-specs` action and `sync-openapi.yml` both refuse to proceed
+without one (f5-sales-demo/terraform-provider-xcsh#1460), so a release without
+a receipt is undeliverable downstream.
+
+The receipt is generated here rather than inline in the workflow so the
+contract is testable without publishing a release.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import subprocess
+from pathlib import Path
+
+_SCRIPT = (
+    Path(__file__).resolve().parents[2] / "scripts" / "release" / "build-publication-receipt.sh"
+)
+
+_VERSION = "2.1.214"
+_COMMIT = "a" * 40
+_RECEIPT_LINE = re.compile(r"^<!-- publication-receipt:(.*) -->$")
+
+
+def _asset_names(version: str) -> list[str]:
+    """The five-asset contract, exactly as consumers require it."""
+    return [
+        "api-catalog.json",
+        f"f5xc-api-specs-v{version}.zip",
+        "index.json",
+        "minimal-export-defaults.json",
+        "openapi.json",
+    ]
+
+
+def _write_assets(tmp_path: Path, names: list[str]) -> list[Path]:
+    paths = []
+    for index, name in enumerate(names):
+        path = tmp_path / name
+        path.write_bytes(f"payload-{index}-{name}".encode())
+        paths.append(path)
+    return paths
+
+
+def _run(paths: list[Path], version: str = _VERSION, commit: str = _COMMIT):
+    return subprocess.run(
+        ["bash", str(_SCRIPT), version, commit, *[str(p) for p in paths]],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _parse(stdout: str) -> dict:
+    lines = [line for line in stdout.splitlines() if line.strip()]
+    assert len(lines) == 1, f"expected exactly one output line, got {lines!r}"
+    match = _RECEIPT_LINE.match(lines[0])
+    assert match, f"output is not a publication-receipt comment: {lines[0]!r}"
+    return json.loads(match.group(1))
+
+
+def test_emits_receipt_binding_digests_to_commit(tmp_path: Path) -> None:
+    paths = _write_assets(tmp_path, _asset_names(_VERSION))
+    result = _run(paths)
+    assert result.returncode == 0, result.stderr
+
+    receipt = _parse(result.stdout)
+    assert sorted(receipt) == ["assets", "commit", "version"]
+    assert receipt["commit"] == _COMMIT
+    assert receipt["version"] == _VERSION
+    assert sorted(receipt["assets"]) == sorted(_asset_names(_VERSION))
+
+    for path in paths:
+        expected = hashlib.sha256(path.read_bytes()).hexdigest()
+        assert receipt["assets"][path.name] == expected, f"wrong digest for {path.name}"
+
+
+def test_receipt_is_a_single_line_of_compact_json(tmp_path: Path) -> None:
+    """The consumer matches the comment with a line-anchored regex.
+
+    Pretty-printed JSON would span lines and never match, so the release would
+    look receipted while being unusable.
+    """
+    paths = _write_assets(tmp_path, _asset_names(_VERSION))
+    result = _run(paths)
+    assert result.returncode == 0, result.stderr
+    assert len(result.stdout.strip().splitlines()) == 1
+    assert "\n" not in result.stdout.strip()
+
+
+def test_output_is_deterministic(tmp_path: Path) -> None:
+    """Byte-identical inputs must produce a byte-identical receipt."""
+    paths = _write_assets(tmp_path, _asset_names(_VERSION))
+    first = _run(paths)
+    second = _run(paths)
+    assert first.returncode == 0, first.stderr
+    assert second.returncode == 0, second.stderr
+    assert first.stdout == second.stdout
+
+
+def test_rejects_missing_asset(tmp_path: Path) -> None:
+    paths = _write_assets(tmp_path, _asset_names(_VERSION))
+    paths[0].unlink()
+    result = _run(paths)
+    assert result.returncode != 0
+    assert "does not exist" in result.stderr or "missing" in result.stderr.lower()
+
+
+def test_rejects_incomplete_asset_set(tmp_path: Path) -> None:
+    """A receipt covering four assets would attest to a release nobody can verify."""
+    names = _asset_names(_VERSION)[:-1]
+    paths = _write_assets(tmp_path, names)
+    result = _run(paths)
+    assert result.returncode != 0
+    assert "five-asset" in result.stderr or "asset set" in result.stderr
+
+
+def test_rejects_unexpected_asset(tmp_path: Path) -> None:
+    names = [*_asset_names(_VERSION), "stowaway.json"]
+    paths = _write_assets(tmp_path, names)
+    result = _run(paths)
+    assert result.returncode != 0
+    assert "five-asset" in result.stderr or "asset set" in result.stderr
+
+
+def test_rejects_bundle_named_for_another_version(tmp_path: Path) -> None:
+    """The zip carries the version in its name; a mismatch means crossed releases."""
+    names = _asset_names("2.1.999")
+    paths = _write_assets(tmp_path, names)
+    result = _run(paths)
+    assert result.returncode != 0
+    assert "five-asset" in result.stderr or "asset set" in result.stderr
+
+
+def test_rejects_malformed_version(tmp_path: Path) -> None:
+    paths = _write_assets(tmp_path, _asset_names(_VERSION))
+    result = _run(paths, version="v2.1.214")
+    assert result.returncode != 0
+    assert "version" in result.stderr.lower()
+
+
+def test_rejects_malformed_commit(tmp_path: Path) -> None:
+    paths = _write_assets(tmp_path, _asset_names(_VERSION))
+    result = _run(paths, commit="deadbeef")
+    assert result.returncode != 0
+    assert "commit" in result.stderr.lower()
+
+
+def test_rejects_uppercase_commit(tmp_path: Path) -> None:
+    """Consumers test against ^[0-9a-f]{40}$; uppercase would fail there, not here."""
+    paths = _write_assets(tmp_path, _asset_names(_VERSION))
+    result = _run(paths, commit="A" * 40)
+    assert result.returncode != 0
+    assert "commit" in result.stderr.lower()

--- a/tests/shell/test_build_publication_receipt.py
+++ b/tests/shell/test_build_publication_receipt.py
@@ -82,8 +82,35 @@ def test_emits_receipt_binding_digests_to_commit(tmp_path: Path) -> None:
     assert sorted(receipt["assets"]) == sorted(_asset_names(_VERSION))
 
     for path in paths:
-        expected = hashlib.sha256(path.read_bytes()).hexdigest()
+        expected = "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
         assert receipt["assets"][path.name] == expected, f"wrong digest for {path.name}"
+
+
+def test_digests_are_prefixed_algorithm_qualified(tmp_path: Path) -> None:
+    """Digests are "sha256:<hex>", matching GitHub's own .assets[].digest.
+
+    Two reasons this format is pinned by a test rather than left to taste.
+
+    A consumer compares the receipt against GitHub's reported digest directly;
+    with bare hex it has to reassemble the prefix at every call site, and one
+    site forgetting to is a comparison that silently never matches.
+
+    It also keeps the value away from entropy-based secret scanners. Gitleaks'
+    generic-api-key rule fires on a secret-ish keyword adjacent to a
+    high-entropy value, and the asset filenames supply the keyword: measured on
+    bare hex, "api-catalog.json" and "openapi.json" were reported while
+    "index.json" was not. Reverting to bare hex would hand every consumer that
+    commits this data a false positive it cannot suppress without a governance
+    exception.
+    """
+    paths = _write_assets(tmp_path, _asset_names(_VERSION))
+    result = _run(paths)
+    assert result.returncode == 0, result.stderr
+
+    receipt = _parse(result.stdout)
+    qualified = re.compile(r"^sha256:[0-9a-f]{64}$")
+    for name, value in receipt["assets"].items():
+        assert qualified.match(value), f"{name} digest is not algorithm-qualified: {value!r}"
 
 
 def test_receipt_is_a_single_line_of_compact_json(tmp_path: Path) -> None:


### PR DESCRIPTION
## Publish a publication receipt with every release

Every release now carries a single-line receipt in its body binding the SHA-256 of each published asset to the commit the tag resolves to:

```
<!-- publication-receipt:{"assets":{...},"commit":"<40-hex>","version":"x.y.z"} -->
```

A consumer verifies what it downloaded against that, instead of trusting that a release named vX.Y.Z still contains what it contained the last time it looked.

### Why this is needed now

`terraform-provider-xcsh` refuses to consume a release without one — both its `download-api-specs` action and `sync-openapi.yml` fail closed:

```
::error::Release must contain exactly one publication receipt
```

No release published here has ever carried one. Measured across v2.1.207 → v2.1.213: zero receipts in every body, though all are final, immutable, and carry exactly the five expected assets. So the downstream receipted delivery chain (f5-sales-demo/terraform-provider-xcsh#1460) could not run at all.

### How

`scripts/release/build-publication-receipt.sh`, following the existing `scripts/release/*.sh` + `tests/shell/` pattern so the contract is testable without publishing a release. It enforces the five-asset set itself and rejects:

- a missing or unreadable asset
- an incomplete or over-complete asset set
- a bundle named for a different version
- duplicate asset basenames, which would silently overwrite each other in the receipt
- a malformed version, or a non-lowercase or abbreviated commit

Those last two matter because consumers test against `^[0-9a-f]{40}$`. Rejecting them here fails the release build; rejecting them downstream fails only *after* the release is immutable and can no longer be corrected.

`sync-and-enrich.yml` records the merge commit it just tagged into `GITHUB_ENV` and appends the receipt to the notes at creation time. It has to be at creation — releases here are immutable, so a receipt cannot be added afterwards. Re-deriving the commit in the release step would risk naming one that `main` had already moved past.

## Also: the zizmor pre-commit gate was failing on main

`zizmor --config zizmor.yaml .github/workflows/` — the exact command the pre-commit hook runs — exited 13 on `main` with 28 findings, 7 of them medium. The hook only runs when a workflow file is staged, which is why this went unnoticed: it silently blocked every commit touching a workflow, including this one.

All 7 were `artipacked`: `actions/checkout` steps leaving the checkout token in `.git/config` where every later step can reach it. Each is now checked out with `persist-credentials: false`.

That is safe for all seven, verified rather than assumed:

- Six are read-only, or authenticate through `gh`'s `GH_TOKEN` rather than git credentials.
- The seventh, `sync-and-enrich`, does push — but it already re-points `origin` at an explicit token URL before doing so, and there is no git network operation anywhere between its checkout and that re-point, so nothing ever consumed the persisted credential. The workflow's own permissions comment says the same: *"as do the pushes, via an explicit remote URL"*.

```
before:  zizmor exit=13   28 findings (1 ignored, 20 suppressed): 7 medium
after:   zizmor exit=0    No findings to report
```

The gate now passes on its own terms rather than being skipped.

## Verification

- 10 new tests, RED before the script existed and GREEN after: digest correctness against independently computed SHA-256, single-line compact output (a pretty-printed receipt would never match the consumer's line-anchored regex), byte-identical output across runs, and each rejection path above
- `ruff` — all checks passed
- `shellcheck`, `actionlint`, `yamllint` — clean
- `zizmor` — exit 0, no findings
- Full shell and workflow-pin suites — 60 passed
- The enrichment pipeline produced zero spec churn on commit, confirming the output is reproducible from the same upstream seed

## Note on the catalog half of #1321

I filed #1321 asking for two things. This PR delivers the receipt. The catalog half — publishing resource identity — I have **withdrawn as originally written** and replaced with a narrowed contract, because the original would have baked Terraform-specific decisions (resource names, `kind`, `manageability`) into this repository and duplicated ~3,671 lines of Go naming rules in Python. See the revised proposal on #1321: `apiOperations` and `apiExclusions`, describing the API's own operations and deliberate exclusions, in nobody's consumer vocabulary.

Closes #1331
Refs #1321
Refs f5-sales-demo/terraform-provider-xcsh#1460
