### PR TITLE
feat(catalog): publish apiOperations and apiExclusions

### DIFF
--- a/scripts/compile_catalog.py
+++ b/scripts/compile_catalog.py
@@ -39,6 +39,7 @@ def merge_spec_files(dir_path: Path) -> dict[str, Any]:
     """Read all OpenAPI JSON files in a directory and merge their paths and components."""
     merged_paths: dict[str, Any] = {}
     merged_schemas: dict[str, Any] = {}
+    collisions: list[dict[str, Any]] = []
 
     for spec_file in sorted(dir_path.glob("*.json")):
         try:
@@ -56,6 +57,34 @@ def merge_spec_files(dir_path: Path) -> dict[str, Any]:
                 continue
             if path not in merged_paths:
                 merged_paths[path] = {}
+            # Two specifications can claim the same path and method with different
+            # operationIds. update() is last-writer-wins, and files are read in
+            # filename order, so the loser used to vanish on alphabetical accident:
+            # ves.io.schema.discovery_cloud lost
+            # /api/discovery/namespaces/{namespace}/suggest-values to
+            # ves.io.schema.discovered_service, leaving 282 of 283 identities in the
+            # catalog with nothing recording the 283rd.
+            #
+            # The merge still resolves the same way — an OpenAPI document cannot hold
+            # two operations on one path and method — but the displacement is now
+            # recorded so it can be published rather than lost.
+            for method, incoming in path_item.items():
+                if method in _NON_OPERATION_KEYS or not isinstance(incoming, dict):
+                    continue
+                existing = merged_paths[path].get(method)
+                if not isinstance(existing, dict):
+                    continue
+                previous_id = existing.get("operationId") or ""
+                incoming_id = incoming.get("operationId") or ""
+                if previous_id and incoming_id and previous_id != incoming_id:
+                    collisions.append(
+                        {
+                            "path": path,
+                            "method": method.upper(),
+                            "winningOperationId": incoming_id,
+                            "losingOperationId": previous_id,
+                        },
+                    )
             merged_paths[path].update(path_item)
 
         # Merge components.schemas
@@ -66,6 +95,10 @@ def merge_spec_files(dir_path: Path) -> dict[str, Any]:
         "openapi": "3.0.3",
         "paths": merged_paths,
         "components": {"schemas": merged_schemas},
+        "x-f5xc-path-collisions": sorted(
+            collisions,
+            key=lambda c: (c["path"], c["method"], c["losingOperationId"]),
+        ),
     }
 
 
@@ -631,6 +664,218 @@ def _deduplicate_global_op_names(categories: list[dict[str, Any]]) -> None:
                 global_seen[op["name"]] = cat["name"]
 
 
+DEFAULT_EXCLUSIONS_CONFIG = Path("config/api_exclusions.yaml")
+
+# An operationId is "<identity>.<RpcContainer>.<Method>", where the identity is a
+# lowercase dotted run under ves.io.schema and the container is the first
+# CamelCase segment.
+#
+# The container is matched structurally, NOT by looking for "API". The published
+# specifications use 58 distinct container names, and four of them spell it "Api"
+# (UpgradeStatusCustomApi, SoftwareVersionOsImageCustomApi,
+# WafSignatureChangelogCustomApi, SignatureCustomApi). Splitting on a literal
+# ".API." silently loses seven operations across three identities; handling only
+# API/CustomAPI loses far more. Publishing the identity so no consumer has to
+# repeat this parse is the reason these sections exist.
+_API_OPERATION_ID = re.compile(
+    r"^(?P<identity>ves\.io\.schema(?:\.[a-z0-9_]+)*)"
+    r"\.(?P<container>[A-Z][A-Za-z0-9_]*)"
+    r"\.(?P<rpc>[A-Za-z0-9_]+)$",
+)
+
+# Path items hold these beside their operations; they are not operations.
+_NON_OPERATION_KEYS = frozenset(
+    {"parameters", "$ref", "summary", "description", "servers"},
+)
+
+
+def extract_api_identity(operation_id: str) -> tuple[str, str, str] | None:
+    """Split an operationId into (apiIdentity, rpcContainer, rpcMethod).
+
+    Returns None when the value is not a schema-qualified operationId.
+    """
+    match = _API_OPERATION_ID.match(operation_id or "")
+    if match is None:
+        return None
+    return match["identity"], match["container"], match["rpc"]
+
+
+def surface_from_path(path: str) -> str:
+    """Return the API surface a path is published on, e.g. "config" or "web".
+
+    The surface is the segment after /api/, read from the path rather than from
+    `tags` because the path is what a caller actually requests.
+
+    Not every published path sits under /api/ — `/no_auth/namespaces/...` is one
+    real example — so a path whose first segment is not "api" reports that first
+    segment as its surface.
+    """
+    segments = [segment for segment in (path or "").split("/") if segment]
+    if not segments:
+        raise ValueError(f"path does not carry an API surface: {path!r}")
+    if segments[0] != "api":
+        return segments[0]
+    if len(segments) < 2:
+        raise ValueError(f"path does not carry an API surface: {path!r}")
+    return segments[1]
+
+
+def _request_schema_key(operation: dict[str, Any]) -> str | None:
+    """Return the request body's schema key, or None when it takes no body."""
+    schema = (
+        (operation.get("requestBody") or {})
+        .get("content", {})
+        .get("application/json", {})
+        .get("schema", {})
+    )
+    ref = schema.get("$ref")
+    if not isinstance(ref, str) or not ref:
+        return None
+    return ref.rsplit("/", 1)[-1]
+
+
+def build_api_operations(paths: dict[str, Any]) -> list[dict[str, Any]]:
+    """Group every published operation under its ves.io.schema identity.
+
+    Ordering is total and independent of traversal order: identities sorted, then
+    operations by (method, path). An unparseable operationId or a duplicate one is
+    an error rather than a skip — silently dropping either is how a consumer ends
+    up with a contract that looks complete and is not.
+    """
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    seen_operation_ids: dict[str, str] = {}
+
+    for path, path_item in (paths or {}).items():
+        if not isinstance(path_item, dict):
+            continue
+        for method, operation in path_item.items():
+            if method in _NON_OPERATION_KEYS or not isinstance(operation, dict):
+                continue
+            operation_id = operation.get("operationId") or ""
+            parsed = extract_api_identity(operation_id)
+            if parsed is None:
+                # An operationId that claims to be schema-qualified but does not
+                # parse is a hard error: that is the casing-and-format bug class
+                # this inventory exists to eliminate, and skipping it is exactly
+                # how a consumer ends up with a contract that looks complete.
+                #
+                # An operationId that makes no such claim is simply not an F5
+                # schema API — a hand-written endpoint, a fixture — and has no
+                # identity to publish, so it is not part of this section.
+                if operation_id.startswith("ves.io.schema"):
+                    raise ValueError(
+                        f"{method.upper()} {path} has a schema-qualified operationId "
+                        f"that does not parse: {operation_id!r}",
+                    )
+                continue
+            identity = parsed[0]
+            if operation_id in seen_operation_ids:
+                raise ValueError(
+                    f"duplicate operationId {operation_id!r}: "
+                    f"{seen_operation_ids[operation_id]} and {method.upper()} {path}",
+                )
+            seen_operation_ids[operation_id] = f"{method.upper()} {path}"
+
+            entry: dict[str, Any] = {
+                "method": method.upper(),
+                "path": path,
+                "operationId": operation_id,
+                "surface": surface_from_path(path),
+            }
+            request_schema = _request_schema_key(operation)
+            if request_schema is not None:
+                entry["requestSchema"] = request_schema
+            grouped.setdefault(identity, []).append(entry)
+
+    return [
+        {
+            "apiIdentity": identity,
+            "operations": sorted(operations, key=lambda o: (o["method"], o["path"])),
+        }
+        for identity, operations in sorted(grouped.items())
+    ]
+
+
+def collision_exclusions(
+    collisions: list[dict[str, Any]],
+    published_identities: set[str],
+) -> list[dict[str, Any]]:
+    """Turn displaced path claims into stated exclusions.
+
+    Only an identity that lost every claim it had is excluded. One that lost a
+    single path but still owns another stays published — excluding it would claim
+    the whole API is unavailable when one operation was displaced.
+    """
+    excluded: dict[str, dict[str, Any]] = {}
+    for collision in collisions or []:
+        parsed = extract_api_identity(collision.get("losingOperationId") or "")
+        if parsed is None:
+            continue
+        identity = parsed[0]
+        if identity in published_identities or identity in excluded:
+            continue
+        winner = extract_api_identity(collision.get("winningOperationId") or "")
+        winner_identity = winner[0] if winner else collision.get("winningOperationId")
+        excluded[identity] = {
+            "apiIdentity": identity,
+            "classification": "path-collision",
+            "reason": (
+                f"{collision['method']} {collision['path']} is claimed by both this API "
+                f"and {winner_identity}, which owns it in the published specification"
+            ),
+        }
+    return list(excluded.values())
+
+
+def build_api_exclusions(
+    config_path: Path,
+    published_identities: set[str],
+) -> list[dict[str, Any]]:
+    """Read the deliberately-withheld identities, if any are declared.
+
+    An absent configuration means nothing is withheld, which is a different
+    statement from "unknown" — that distinction is the reason consumers can tell a
+    deliberate exclusion from a missing API. Every entry must carry a
+    classification and a reason, and an identity cannot be both published and
+    excluded: the two sections partition the identity space or "excluded" means
+    nothing.
+    """
+    if not Path(config_path).exists():
+        return []
+
+    import yaml  # noqa: PLC0415 — optional dependency, only needed when configured
+
+    document = yaml.safe_load(Path(config_path).read_text(encoding="utf-8")) or {}
+    declared = document.get("exclusions") or []
+
+    exclusions: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for item in declared:
+        identity = (item or {}).get("apiIdentity")
+        if not identity:
+            raise ValueError("every exclusion requires an apiIdentity")
+        classification = item.get("classification")
+        reason = item.get("reason")
+        if not classification or not reason:
+            raise ValueError(
+                f"exclusion {identity} requires both a classification and a reason",
+            )
+        if identity in seen:
+            raise ValueError(f"duplicate exclusion for {identity}")
+        if identity in published_identities:
+            raise ValueError(f"{identity} is both published and excluded")
+        seen.add(identity)
+        exclusions.append(
+            {
+                "apiIdentity": identity,
+                "classification": classification,
+                "reason": reason,
+            },
+        )
+
+    return sorted(exclusions, key=lambda entry: (entry["apiIdentity"], entry["classification"]))
+
+
 def compile_catalog(openapi: dict[str, Any]) -> dict[str, Any]:
     """Transform an OpenAPI 3.0 spec dict into xcsh api-catalog.json format."""
     paths = openapi.get("paths", {})
@@ -655,6 +900,20 @@ def compile_catalog(openapi: dict[str, Any]) -> dict[str, Any]:
     tag_version = get_version_from_tags()
     version = env_version or (tag_version if tag_version != "0.0.0" else "1.0.0")
 
+    # The operation inventory, keyed by the API's own ves.io.schema identity.
+    # `categories` groups operations for human browsing; this groups them by the
+    # identity a machine consumer keys on, and states each operation's exact
+    # method, path and surface so nothing has to be inferred from a name.
+    api_operations = build_api_operations(paths)
+    published_identities = {entry["apiIdentity"] for entry in api_operations}
+    api_exclusions = build_api_exclusions(DEFAULT_EXCLUSIONS_CONFIG, published_identities)
+    # Identities displaced by a path collision are stated here rather than lost.
+    api_exclusions = sorted(
+        api_exclusions
+        + collision_exclusions(openapi.get("x-f5xc-path-collisions") or [], published_identities),
+        key=lambda entry: (entry["apiIdentity"], entry["classification"]),
+    )
+
     return {
         "service": "f5xc",
         "displayName": "F5 Distributed Cloud",
@@ -663,6 +922,8 @@ def compile_catalog(openapi: dict[str, Any]) -> dict[str, Any]:
         "auth": F5XC_AUTH,
         "defaults": F5XC_DEFAULTS,
         "categories": categories,
+        "apiOperations": api_operations,
+        "apiExclusions": api_exclusions,
     }
 
 

--- a/tests/test_api_operations.py
+++ b/tests/test_api_operations.py
@@ -1,0 +1,468 @@
+"""Tests for the apiOperations / apiExclusions sections of api-catalog.json.
+
+The catalog publishes, for every ``ves.io.schema.*`` identity, the exact operations
+the API exposes: method, path, operationId and surface. Consumers read those
+verbatim instead of inferring a method and path from an operation name.
+
+Publishing the identity explicitly is the whole point. Deriving it by parsing an
+operationId looks trivial and is not: the specifications use 58 distinct RPC
+container names, and four of them spell it ``Api`` rather than ``API``
+(UpgradeStatusCustomApi, SoftwareVersionOsImageCustomApi,
+WafSignatureChangelogCustomApi, SignatureCustomApi). A consumer that splits on a
+literal ``.API.`` silently loses seven operations across three identities, and a
+consumer that handles only ``API``/``CustomAPI`` loses more. Every case below that
+looks redundant is guarding one of those real spellings.
+
+See f5-sales-demo/api-specs-enriched#1321 and
+f5-sales-demo/terraform-provider-xcsh#1460.
+"""
+
+# pylint: disable=missing-function-docstring
+import json
+
+import pytest
+
+from scripts.compile_catalog import (
+    build_api_exclusions,
+    build_api_operations,
+    compile_catalog,
+    extract_api_identity,
+    surface_from_path,
+)
+
+
+def _operation(operation_id, request_ref=None):
+    operation = {"operationId": operation_id, "responses": {"200": {"description": "ok"}}}
+    if request_ref is not None:
+        operation["requestBody"] = {
+            "content": {"application/json": {"schema": {"$ref": request_ref}}},
+        }
+    return operation
+
+
+# --------------------------------------------------------------------------- #
+# Identity extraction
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    ("operation_id", "identity", "container", "rpc"),
+    [
+        (
+            "ves.io.schema.namespace.API.Create",
+            "ves.io.schema.namespace",
+            "API",
+            "Create",
+        ),
+        (
+            "ves.io.schema.api_sec.api_crawler.API.Create",
+            "ves.io.schema.api_sec.api_crawler",
+            "API",
+            "Create",
+        ),
+        (
+            "ves.io.schema.views.http_loadbalancer.CustomAPI.Delete",
+            "ves.io.schema.views.http_loadbalancer",
+            "CustomAPI",
+            "Delete",
+        ),
+        # Lowercase 'pi'. Four containers in the published specs spell it this way;
+        # a consumer matching a literal "API" token drops them.
+        (
+            "ves.io.schema.upgrade_status.UpgradeStatusCustomApi.PreUpgradeCheck",
+            "ves.io.schema.upgrade_status",
+            "UpgradeStatusCustomApi",
+            "PreUpgradeCheck",
+        ),
+        (
+            "ves.io.schema.virtual_appliance.SoftwareVersionOsImageCustomApi.GetImage",
+            "ves.io.schema.virtual_appliance",
+            "SoftwareVersionOsImageCustomApi",
+            "GetImage",
+        ),
+        # Container names that contain no "API"/"Api" substring at all.
+        (
+            "ves.io.schema.sahaya.SahayaAPI.List",
+            "ves.io.schema.sahaya",
+            "SahayaAPI",
+            "List",
+        ),
+        (
+            "ves.io.schema.uam.UamKubeConfigAPI.Get",
+            "ves.io.schema.uam",
+            "UamKubeConfigAPI",
+            "Get",
+        ),
+    ],
+)
+def test_extract_api_identity_handles_every_container_spelling(
+    operation_id, identity, container, rpc
+):
+    assert extract_api_identity(operation_id) == (identity, container, rpc)
+
+
+@pytest.mark.parametrize(
+    "operation_id",
+    [
+        "",
+        "not.an.identity",
+        "ves.io.schema.namespace",  # no RPC container
+        "ves.io.schema.namespace.API",  # container but no method
+        "ves.io.notschema.thing.API.Create",  # wrong root
+        "ves.io.schema.Namespace.API.Create",  # identity segments are lowercase
+    ],
+)
+def test_extract_api_identity_rejects_malformed_ids(operation_id):
+    assert extract_api_identity(operation_id) is None
+
+
+# --------------------------------------------------------------------------- #
+# Surface
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    ("path", "surface"),
+    [
+        ("/api/config/namespaces/{namespace}/api_crawlers", "config"),
+        ("/api/web/namespaces/{namespace}/api_credentials", "web"),
+        ("/api/maurice/upgradable_sw_versions", "maurice"),
+        ("/api/ml/data/namespaces/{namespace}/staged", "ml"),
+        ("/api/data-intelligence/namespaces/{namespace}/x", "data-intelligence"),
+    ],
+)
+def test_surface_from_path(path, surface):
+    assert surface_from_path(path) == surface
+
+
+def test_surface_from_path_rejects_paths_without_a_surface():
+    for path in ("/", "/api", "/api/"):
+        with pytest.raises(ValueError, match="does not carry an API surface"):
+            surface_from_path(path)
+
+
+def test_surface_from_path_handles_roots_outside_api():
+    """Not every published path sits under /api/ — /no_auth/... is a real one."""
+    assert surface_from_path("/no_auth/namespaces/system/billing/plan_transition") == "no_auth"
+
+
+# --------------------------------------------------------------------------- #
+# apiOperations
+# --------------------------------------------------------------------------- #
+
+
+def _sample_paths():
+    return {
+        "/api/config/namespaces/{namespace}/api_crawlers": {
+            "post": _operation(
+                "ves.io.schema.api_sec.api_crawler.API.Create",
+                "#/components/schemas/api_crawlerCreateRequest",
+            ),
+            "get": _operation("ves.io.schema.api_sec.api_crawler.API.List"),
+        },
+        "/api/web/namespaces/{namespace}/alerts": {
+            "get": _operation("ves.io.schema.alert.API.List"),
+        },
+        "/api/maurice/upgradable_sw_versions": {
+            "get": _operation(
+                "ves.io.schema.upgrade_status.UpgradeStatusCustomApi.GetUpgradableSWVersions"
+            ),
+        },
+    }
+
+
+def test_groups_operations_by_identity_in_sorted_order():
+    grouped = build_api_operations(_sample_paths())
+    identities = [entry["apiIdentity"] for entry in grouped]
+    assert identities == sorted(identities)
+    assert identities == [
+        "ves.io.schema.alert",
+        "ves.io.schema.api_sec.api_crawler",
+        "ves.io.schema.upgrade_status",
+    ]
+    assert len(identities) == len(set(identities)), "an identity appears twice"
+
+
+def test_each_operation_carries_an_explicit_method_path_and_surface():
+    grouped = build_api_operations(_sample_paths())
+    crawler = next(e for e in grouped if e["apiIdentity"] == "ves.io.schema.api_sec.api_crawler")
+    assert [(o["method"], o["path"]) for o in crawler["operations"]] == [
+        ("GET", "/api/config/namespaces/{namespace}/api_crawlers"),
+        ("POST", "/api/config/namespaces/{namespace}/api_crawlers"),
+    ]
+    for operation in crawler["operations"]:
+        assert operation["method"] == operation["method"].upper()
+        assert operation["path"].startswith("/")
+        assert operation["surface"] == "config"
+        assert operation["operationId"]
+
+
+def test_operations_are_sorted_by_method_then_path():
+    paths = {
+        "/api/config/b": {"post": _operation("ves.io.schema.thing.API.CreateSecond")},
+        "/api/config/a": {
+            "post": _operation("ves.io.schema.thing.API.CreateFirst"),
+            "get": _operation("ves.io.schema.thing.API.GetFirst"),
+        },
+    }
+    operations = build_api_operations(paths)[0]["operations"]
+    assert [(o["method"], o["path"]) for o in operations] == [
+        ("GET", "/api/config/a"),
+        ("POST", "/api/config/a"),
+        ("POST", "/api/config/b"),
+    ]
+
+
+def test_request_schema_is_recorded_only_when_the_operation_takes_a_body():
+    grouped = build_api_operations(_sample_paths())
+    crawler = next(e for e in grouped if e["apiIdentity"] == "ves.io.schema.api_sec.api_crawler")
+    post = next(o for o in crawler["operations"] if o["method"] == "POST")
+    get = next(o for o in crawler["operations"] if o["method"] == "GET")
+    assert post["requestSchema"] == "api_crawlerCreateRequest"
+    assert "requestSchema" not in get
+
+
+def test_duplicate_operation_ids_are_rejected():
+    """One operationId must identify one operation, or a consumer cannot key on it."""
+    paths = {
+        "/api/config/a": {"post": _operation("ves.io.schema.thing.API.Create")},
+        "/api/config/b": {"post": _operation("ves.io.schema.thing.API.Create")},
+    }
+    with pytest.raises(ValueError, match="duplicate operationId"):
+        build_api_operations(paths)
+
+
+def test_malformed_schema_qualified_operation_id_is_rejected_rather_than_dropped():
+    """This is the casing-and-format bug class the inventory exists to eliminate.
+
+    An id that claims to be schema-qualified and does not parse must fail loudly:
+    skipping it is how an identity disappears from a contract that still looks
+    complete.
+    """
+    paths = {"/api/config/a": {"post": _operation("ves.io.schema.thing.lowercase.container")}}
+    with pytest.raises(ValueError, match="does not parse"):
+        build_api_operations(paths)
+
+
+def test_operation_ids_that_are_not_f5_schema_apis_are_not_inventoried():
+    """A hand-written or fixture endpoint has no ves.io.schema identity to publish.
+
+    It is omitted rather than rejected — the section inventories F5 schema APIs, and
+    imposing that format on every other operation would be a contract this
+    compiler has no business enforcing.
+    """
+    paths = {
+        "/api/config/a": {"post": _operation("delete_lb")},
+        "/api/config/b": {"post": _operation("ves.io.schema.thing.API.Create")},
+    }
+    grouped = build_api_operations(paths)
+    assert [entry["apiIdentity"] for entry in grouped] == ["ves.io.schema.thing"]
+
+
+def test_non_operation_keys_are_ignored():
+    """`parameters` and `$ref` sit beside methods in a path item and are not operations."""
+    paths = {
+        "/api/config/a": {
+            "parameters": [{"name": "x", "in": "query"}],
+            "post": _operation("ves.io.schema.thing.API.Create"),
+        },
+    }
+    grouped = build_api_operations(paths)
+    assert len(grouped) == 1
+    assert len(grouped[0]["operations"]) == 1
+
+
+def test_output_is_deterministic():
+    first = json.dumps(build_api_operations(_sample_paths()), sort_keys=False)
+    second = json.dumps(build_api_operations(_sample_paths()), sort_keys=False)
+    assert first == second
+
+
+# --------------------------------------------------------------------------- #
+# apiExclusions
+# --------------------------------------------------------------------------- #
+
+
+def test_exclusions_are_empty_without_a_configuration(tmp_path):
+    """Absent configuration means nothing is deliberately withheld — not unknown."""
+    assert build_api_exclusions(tmp_path / "missing.yaml", {"ves.io.schema.thing"}) == []
+
+
+def test_exclusions_are_read_from_configuration(tmp_path):
+    config = tmp_path / "api_exclusions.yaml"
+    config.write_text(
+        "exclusions:\n"
+        "  - apiIdentity: ves.io.schema.internal_thing\n"
+        "    classification: internal\n"
+        "    reason: Internal control-plane API, not tenant-facing\n",
+    )
+    exclusions = build_api_exclusions(config, {"ves.io.schema.thing"})
+    assert exclusions == [
+        {
+            "apiIdentity": "ves.io.schema.internal_thing",
+            "classification": "internal",
+            "reason": "Internal control-plane API, not tenant-facing",
+        },
+    ]
+
+
+def test_exclusion_that_is_also_published_is_rejected(tmp_path):
+    """The two sections must partition identities, or 'excluded' means nothing."""
+    config = tmp_path / "api_exclusions.yaml"
+    config.write_text(
+        "exclusions:\n"
+        "  - apiIdentity: ves.io.schema.thing\n"
+        "    classification: internal\n"
+        "    reason: contradictory\n",
+    )
+    with pytest.raises(ValueError, match="both published and excluded"):
+        build_api_exclusions(config, {"ves.io.schema.thing"})
+
+
+def test_exclusions_require_a_classification_and_reason(tmp_path):
+    config = tmp_path / "api_exclusions.yaml"
+    config.write_text("exclusions:\n  - apiIdentity: ves.io.schema.internal_thing\n")
+    with pytest.raises(ValueError, match="classification"):
+        build_api_exclusions(config, set())
+
+
+def test_exclusions_are_sorted_and_deduplicated(tmp_path):
+    config = tmp_path / "api_exclusions.yaml"
+    config.write_text(
+        "exclusions:\n"
+        "  - apiIdentity: ves.io.schema.zzz\n"
+        "    classification: internal\n"
+        "    reason: z\n"
+        "  - apiIdentity: ves.io.schema.aaa\n"
+        "    classification: internal\n"
+        "    reason: a\n",
+    )
+    exclusions = build_api_exclusions(config, set())
+    assert [e["apiIdentity"] for e in exclusions] == ["ves.io.schema.aaa", "ves.io.schema.zzz"]
+
+    config.write_text(
+        "exclusions:\n"
+        "  - apiIdentity: ves.io.schema.aaa\n"
+        "    classification: internal\n"
+        "    reason: a\n"
+        "  - apiIdentity: ves.io.schema.aaa\n"
+        "    classification: internal\n"
+        "    reason: again\n",
+    )
+    with pytest.raises(ValueError, match="duplicate"):
+        build_api_exclusions(config, set())
+
+
+# --------------------------------------------------------------------------- #
+# Catalog integration
+# --------------------------------------------------------------------------- #
+
+
+def test_catalog_publishes_both_sections_and_they_partition_identities():
+    catalog = compile_catalog({"paths": _sample_paths(), "components": {"schemas": {}}})
+    assert "apiOperations" in catalog
+    assert "apiExclusions" in catalog
+
+    published = {entry["apiIdentity"] for entry in catalog["apiOperations"]}
+    excluded = {entry["apiIdentity"] for entry in catalog["apiExclusions"]}
+    assert published == {
+        "ves.io.schema.alert",
+        "ves.io.schema.api_sec.api_crawler",
+        "ves.io.schema.upgrade_status",
+    }
+    assert not published & excluded, "an identity is both published and excluded"
+
+
+def test_catalog_sections_are_byte_identical_across_runs():
+    spec = {"paths": _sample_paths(), "components": {"schemas": {}}}
+    first = compile_catalog(spec)
+    second = compile_catalog(spec)
+    assert json.dumps(first["apiOperations"]) == json.dumps(second["apiOperations"])
+    assert json.dumps(first["apiExclusions"]) == json.dumps(second["apiExclusions"])
+
+
+# --------------------------------------------------------------------------- #
+# Path collisions
+# --------------------------------------------------------------------------- #
+#
+# Two source specifications can claim the same path and method with different
+# operationIds. Merging is last-writer-wins by filename sort order, so one identity
+# used to disappear from the catalog on alphabetical accident alone — measured:
+# ves.io.schema.discovery_cloud lost /api/discovery/namespaces/{namespace}/
+# suggest-values to ves.io.schema.discovered_service, leaving 282 of 283 identities.
+#
+# A silent loss is the one outcome this section exists to prevent, so the loser is
+# published as an exclusion instead: still absent from apiOperations, but now stated,
+# with the winner named.
+
+
+def _spec_file(tmp_path, name, path, method, operation_id):
+    spec = {"openapi": "3.0.3", "paths": {path: {method: _operation(operation_id)}}}
+    (tmp_path / name).write_text(json.dumps(spec))
+
+
+def test_merge_records_a_collision_when_operation_ids_differ(tmp_path):
+    from scripts.compile_catalog import merge_spec_files
+
+    _spec_file(tmp_path, "aaa.json", "/api/x/y", "post", "ves.io.schema.first.CustomAPI.Do")
+    _spec_file(tmp_path, "zzz.json", "/api/x/y", "post", "ves.io.schema.second.CustomAPI.Do")
+
+    merged = merge_spec_files(tmp_path)
+    collisions = merged["x-f5xc-path-collisions"]
+    assert len(collisions) == 1
+    collision = collisions[0]
+    # Later filename wins the merge, so the earlier one is the loser.
+    assert collision["losingOperationId"] == "ves.io.schema.first.CustomAPI.Do"
+    assert collision["winningOperationId"] == "ves.io.schema.second.CustomAPI.Do"
+    assert collision["path"] == "/api/x/y"
+    assert collision["method"] == "POST"
+
+
+def test_merge_records_no_collision_for_an_identical_duplicate(tmp_path):
+    """The same operation declared twice is harmless — nothing is lost."""
+    from scripts.compile_catalog import merge_spec_files
+
+    _spec_file(tmp_path, "aaa.json", "/api/x/y", "post", "ves.io.schema.same.CustomAPI.Do")
+    _spec_file(tmp_path, "zzz.json", "/api/x/y", "post", "ves.io.schema.same.CustomAPI.Do")
+
+    assert merge_spec_files(tmp_path).get("x-f5xc-path-collisions", []) == []
+
+
+def test_collision_loser_is_published_as_an_exclusion(tmp_path):
+    from scripts.compile_catalog import merge_spec_files
+
+    _spec_file(tmp_path, "aaa.json", "/api/x/y", "post", "ves.io.schema.first.CustomAPI.Do")
+    _spec_file(tmp_path, "zzz.json", "/api/x/y", "post", "ves.io.schema.second.CustomAPI.Do")
+
+    catalog = compile_catalog(merge_spec_files(tmp_path))
+    published = {e["apiIdentity"] for e in catalog["apiOperations"]}
+    excluded = {e["apiIdentity"] for e in catalog["apiExclusions"]}
+
+    assert published == {"ves.io.schema.second"}
+    assert excluded == {"ves.io.schema.first"}
+    assert not published & excluded
+
+    entry = catalog["apiExclusions"][0]
+    assert entry["classification"] == "path-collision"
+    # The reason has to name the winner, or the exclusion is unactionable.
+    assert "ves.io.schema.second" in entry["reason"]
+    assert "/api/x/y" in entry["reason"]
+
+
+def test_collision_loser_that_also_wins_elsewhere_stays_published(tmp_path):
+    """An identity losing one path but owning another is not excluded.
+
+    Excluding it would claim the whole API is unavailable when only one operation
+    was displaced.
+    """
+    from scripts.compile_catalog import merge_spec_files
+
+    _spec_file(tmp_path, "aaa.json", "/api/x/y", "post", "ves.io.schema.first.CustomAPI.Do")
+    _spec_file(tmp_path, "bbb.json", "/api/x/other", "get", "ves.io.schema.first.CustomAPI.List")
+    _spec_file(tmp_path, "zzz.json", "/api/x/y", "post", "ves.io.schema.second.CustomAPI.Do")
+
+    catalog = compile_catalog(merge_spec_files(tmp_path))
+    published = {e["apiIdentity"] for e in catalog["apiOperations"]}
+    excluded = {e["apiIdentity"] for e in catalog["apiExclusions"]}
+    assert published == {"ves.io.schema.first", "ves.io.schema.second"}
+    assert excluded == set()


### PR DESCRIPTION
## Publish `apiOperations` and `apiExclusions` in api-catalog.json

`api-catalog.json` now states, for every `ves.io.schema` identity, the exact operations the API exposes:

```json
{
  "apiIdentity": "ves.io.schema.api_sec.api_crawler",
  "operations": [
    {
      "method": "POST",
      "path": "/api/config/namespaces/{namespace}/api_crawlers",
      "operationId": "ves.io.schema.api_sec.api_crawler.API.Create",
      "surface": "config",
      "requestSchema": "api_crawlerCreateRequest"
    }
  ]
}
```

A consumer reads method and path verbatim instead of inferring them from an operation name. Measured on the published specifications: **282 identities, 1851 operations, 33 surfaces, 1108 request schemas**.

### Publishing the identity is the point, and it is not the trivial parse it looks like

The specifications use **58 distinct RPC container names**, and four spell it `Api` rather than `API`: `UpgradeStatusCustomApi`, `SoftwareVersionOsImageCustomApi`, `WafSignatureChangelogCustomApi`, `SignatureCustomApi`.

While measuring this I got the identity count wrong three times on unchanged data — 91 absent, then 3, then 0 — each time because my own pattern missed a container spelling. A generated consumer would make exactly the same mistake, silently, and lose seven operations across three identities. The container is now matched structurally rather than by looking for the letters `API`, and every spelling above is a test case.

An operationId that *claims* to be schema-qualified and does not parse is a hard error — that is precisely the bug class this section removes, and skipping it is how a contract ends up looking complete while missing an API. An operationId that makes no such claim is simply not an F5 schema API, so it is not inventoried; imposing that format on every operation is a contract this compiler has no business enforcing.

### `apiExclusions` states what is deliberately absent

So a consumer can distinguish that from an API that merely went missing. It reads `config/api_exclusions.yaml` when present, and records identities displaced by a path collision.

**That collision was a live defect.** Two specifications claim `POST /api/discovery/namespaces/{namespace}/suggest-values` with different operationIds — `ves.io.schema.discovered_service` and `ves.io.schema.discovery_cloud`. Merging is last-writer-wins over a filename sort, so `discovery_cloud` disappeared from the catalog on alphabetical accident alone, leaving 282 of 283 identities with nothing recording the 283rd.

The merge still resolves the same way, because an OpenAPI document cannot hold two operations on one path and method, but the displacement is now published:

```json
{
  "apiIdentity": "ves.io.schema.discovery_cloud",
  "classification": "path-collision",
  "reason": "POST /api/discovery/namespaces/{namespace}/suggest-values is claimed by both this API and ves.io.schema.discovered_service, which owns it in the published specification"
}
```

So the two sections partition the identity space exactly: **282 published + 1 excluded = 283** in the source specifications. An identity that loses one path but still owns another stays published, because excluding it would claim the whole API is unavailable when one operation was displaced.

### Determinism

Both sections are totally ordered — identities sorted, operations by `(method, path)`, exclusions by `(apiIdentity, classification)` — so output does not depend on filesystem traversal order. Duplicate operationIds are rejected.

### Deliberately not published

Terraform resource names, `kind`, `manageability`, and create/get/replace schema-key **roles**. Those are consumer decisions. Asking this repository for them would bake one consumer's vocabulary into a specification that serves any of them — an SDK generator, a CLI, a documentation build.

This is the narrowed contract agreed on #1321; my original request for a full resource contract is withdrawn there, because satisfying it would have meant reimplementing ~3,671 lines of Go naming rules in Python and maintaining one set of rules in two languages.

### Two of my own errors, fixed here rather than shipped

- Blanket strictness that rejected legitimate non-F5 operationIds and broke 11 existing tests.
- A `surface` rule that assumed every path starts with `/api/`, when `/no_auth/namespaces/system/billing/plan_transition` does not.

Synthetic RPC method names in the fixtures are spelled out (`CreateFirst`, not `CreateA`) because codespell reads a trailing capital as a misspelling of the verb — renaming the fixture is cheaper than teaching the dictionary an exception.

### Verification

- 40 new tests plus the 62 existing compile-catalog tests — **102 passing**
- `ruff` clean and formatted
- Real-specification run reproduces every count above and the partition property

Closes #1321
Refs #1331
Refs f5-sales-demo/terraform-provider-xcsh#1460
