### PR TITLE
fix(ci): authorize stable exact-caller branches

### DIFF
--- a/scripts/verify_governance.py
+++ b/scripts/verify_governance.py
@@ -39,7 +39,7 @@ DEFAULT_GOVERNANCE_JSON = Path(".claude/governance.json")
 # ownership proven by GitHub's pull-request event receipt.
 AUTHORIZED_AUTOMATION_BRANCH = re.compile(
     r"(?:governance/sync-managed-files(?:-[0-9a-f]{12}-[1-9][0-9]*-[1-9][0-9]*)?|"
-    r"sync/exact-caller-[0-9a-f]{12}-[1-9][0-9]*-[1-9][0-9]*)",
+    r"sync/exact-caller-[0-9a-f]{120})",
 )
 
 

--- a/tests/test_verify_governance.py
+++ b/tests/test_verify_governance.py
@@ -22,6 +22,13 @@ from scripts.verify_governance import (
     verify,
 )
 
+STABLE_EXACT_CALLER_BRANCH = (
+    "sync/exact-caller-"
+    "0123456789abcdef0123456789abcdef01234567"
+    "89abcdef0123456789abcdef0123456789abcdef"
+    "fedcba9876543210fedcba9876543210fedcba98"
+)
+
 if TYPE_CHECKING:
     from pathlib import Path
 
@@ -224,7 +231,7 @@ class TestMain:
         [
             "governance/sync-managed-files",
             "governance/sync-managed-files-05b3aea603b7-30784318975-1",
-            "sync/exact-caller-0123456789ab-123-4",
+            STABLE_EXACT_CALLER_BRANCH,
         ],
     )
     def test_same_repository_automation_branch_is_authorized(
@@ -257,7 +264,7 @@ class TestMain:
         "head_ref",
         [
             "governance/sync-managed-files",
-            "sync/exact-caller-0123456789ab-123-4",
+            STABLE_EXACT_CALLER_BRANCH,
         ],
     )
     def test_same_ref_fork_is_not_authorized(
@@ -295,9 +302,10 @@ class TestMain:
         "head_ref",
         [
             "governance/sync-managed-files-lookalike",
-            "sync/exact-caller-0123456789ab-0-1",
-            "sync/exact-caller-0123456789ab-1-0",
-            "sync/exact-caller-0123456789ab-1-1-extra",
+            "sync/exact-caller-0123456789ab-123-4",
+            STABLE_EXACT_CALLER_BRANCH[:-1],
+            f"{STABLE_EXACT_CALLER_BRANCH}0",
+            f"{STABLE_EXACT_CALLER_BRANCH[:-1]}g",
         ],
     )
     def test_lookalike_automation_branch_is_not_authorized(


### PR DESCRIPTION
## Summary

- replace the retired run-scoped exact-caller branch pattern with the stable receipt contract
- require exactly three complete 40-hex Git blob receipts
- preserve same-repository pull-request receipt validation and fail closed for forks and malformed near matches

Closes #1336

## Verification

- `python -m pytest tests/test_verify_governance.py -q` — 28 passed; verifier coverage 100%
- `python -m pytest -q` with refreshed upstream seed — 2,366 passed, 6 skipped, 1 expected xfail
- `ruff check scripts/verify_governance.py tests/test_verify_governance.py` — passed
- `ruff format --check scripts/verify_governance.py tests/test_verify_governance.py` — passed
- pre-commit enrichment pipeline, Spectral, repository hooks, hygiene, security, and secrets checks — passed
- `bash scripts/agy-pre-push-review.sh` — passed with no findings