### PR TITLE
feat(release): add an audited force-release control

### DIFF
--- a/.github/workflows/sync-and-enrich.yml
+++ b/.github/workflows/sync-and-enrich.yml
@@ -22,6 +22,17 @@ on:
       - '.github/workflows/sync-and-enrich.yml'
       - 'docs/**/*.html'
   workflow_dispatch:
+    inputs:
+      force_release:
+        description: >-
+          Publish a release even when the enriched specifications are unchanged.
+          For changes to what this repository publishes ABOUT the specifications —
+          the api-catalog.json contract, the publication receipt — which produce no
+          diff under docs/specifications/api and so never trip the output-driven
+          gate. Generated output must still exist; this cannot publish an empty
+          bundle.
+        type: boolean
+        default: false
 
 # Read-only default; each job declares what it consumes. Traced per write:
 #   sync-and-enrich  contents: write   `gh release create` runs as GITHUB_TOKEN
@@ -300,6 +311,8 @@ jobs:
         id: detect
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Inert on every trigger except a dispatch that asks for it.
+          FORCE_RELEASE: ${{ inputs.force_release || false }}
         # Output-driven gate: compares the generated, tracked output in the
         # working tree against HEAD. Lives in a script so it can be unit
         # tested (tests/shell/test_detect_release_changes.py) — the inline
@@ -351,11 +364,11 @@ jobs:
               NEW_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))"
               BUMP_TYPE="patch"
             fi
-          elif [ "$CHANGE_TYPE" = "pipeline" ]; then
-            # Pipeline/config/dependency changes → patch bump
+          elif [ "$CHANGE_TYPE" = "pipeline" ] || [ "$CHANGE_TYPE" = "forced" ]; then
+            # Pipeline/config/dependency changes and explicit forced releases → patch bump
             NEW_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))"
             BUMP_TYPE="patch"
-            echo "::notice::Pipeline changes detected - patch bump"
+            echo "::notice::${CHANGE_TYPE^} release detected - patch bump"
           else
             # Fallback for unknown change types
             NEW_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))"

--- a/scripts/release/detect-release-changes.sh
+++ b/scripts/release/detect-release-changes.sh
@@ -6,9 +6,10 @@
 #
 # Writes to $GITHUB_OUTPUT:
 #   has_changes   true|false  Whether the run should publish a release.
-#   change_type   source|pipeline
+#   change_type   source|pipeline|forced
 #                 `source`   a new upstream api-specs release is in play.
 #                 `pipeline` output moved without a new upstream release.
+#                 `forced`   an operator explicitly requested publication.
 #                 Omitted when the pipeline produced no output at all.
 #
 # Environment:
@@ -98,6 +99,26 @@ done
 if [ ! -f "$INDEX_FILE" ]; then
   emit "has_changes=false"
   echo "No enriched specs generated (${INDEX_FILE} is missing)"
+  exit 0
+fi
+
+# Deliberate operator release.
+#
+# The gate is output-driven, which is right for the common case but leaves a real
+# hole: a change to what this repository *publishes about* the specifications,
+# rather than to the specifications themselves, produces no diff under
+# "$OUTPUT_DIR" and can therefore never be released. api-catalog.json is built
+# into release/ and is outside the signal path entirely, so the apiOperations and
+# apiExclusions contract added in #1332 could not reach a consumer until some
+# unrelated upstream spec change happened to cut a release.
+#
+# Rather than widen the signal to cover generated artifacts that legitimately
+# churn, this is an explicit, audited control: an operator asks for a release and
+# says so. It still requires generated output to exist, so it cannot publish an
+# empty or half-built bundle.
+if [ "${FORCE_RELEASE:-false}" = "true" ] || [ "${FORCE_RELEASE:-0}" = "1" ]; then
+  emit "has_changes=true" "change_type=forced"
+  echo "Release forced by operator request (FORCE_RELEASE)"
   exit 0
 fi
 

--- a/tests/shell/test_detect_release_changes.py
+++ b/tests/shell/test_detect_release_changes.py
@@ -168,7 +168,11 @@ def _setup_repo(
     return repo
 
 
-def _run(repo: Path, fake_gh: Path) -> tuple[subprocess.CompletedProcess[str], dict[str, str]]:
+def _run(
+    repo: Path,
+    fake_gh: Path,
+    extra_env: dict[str, str] | None = None,
+) -> tuple[subprocess.CompletedProcess[str], dict[str, str]]:
     """Run the detector inside ``repo`` and parse its ``$GITHUB_OUTPUT``."""
     script_copy = repo / _SCRIPT_RELATIVE
     script_copy.parent.mkdir(parents=True, exist_ok=True)
@@ -181,6 +185,7 @@ def _run(repo: Path, fake_gh: Path) -> tuple[subprocess.CompletedProcess[str], d
         **os.environ,
         "GITHUB_OUTPUT": str(output_file),
         "DETECT_RELEASE_GH": str(fake_gh),
+        **(extra_env or {}),
     }
     proc = subprocess.run(
         ["bash", _SCRIPT_RELATIVE],
@@ -485,3 +490,56 @@ def test_workflow_delegates_to_the_detector() -> None:
     body = _WORKFLOW.read_text()
     assert _SCRIPT_RELATIVE in body, "the workflow must call the detector script"
     assert "HEAD~1 HEAD" not in body, "no step may gate on a HEAD~1..HEAD comparison"
+
+
+# A change to what this repository publishes *about* the specifications — the
+# api-catalog.json contract, the publication receipt — produces no diff under
+# docs/specifications/api, so the output-driven gate can never release it. That is
+# how the apiOperations/apiExclusions contract from #1332 landed on main with no way
+# to reach a consumer short of an unrelated upstream spec change.
+#
+# FORCE_RELEASE is the explicit operator control for exactly that case. It is
+# audited (a dispatch input), it still requires generated output to exist, and it
+# reports its own change_type so a release built this way is distinguishable.
+
+
+def test_force_release_publishes_an_unchanged_tree(tmp_path: Path) -> None:
+    repo = _setup_repo(tmp_path)
+    proc, outputs = _run(repo, _write_fake_gh(tmp_path, release_lines=1), {"FORCE_RELEASE": "true"})
+    assert proc.returncode == 0, proc.stderr
+    assert outputs["has_changes"] == "true"
+    assert outputs["change_type"] == "forced"
+
+
+def test_workflow_versions_forced_releases_without_an_unknown_type_warning() -> None:
+    body = _WORKFLOW.read_text()
+    assert 'elif [ "$CHANGE_TYPE" = "pipeline" ] || [ "$CHANGE_TYPE" = "forced" ]; then' in body
+
+
+def test_force_release_accepts_the_numeric_form(tmp_path: Path) -> None:
+    repo = _setup_repo(tmp_path)
+    _, outputs = _run(repo, _write_fake_gh(tmp_path, release_lines=1), {"FORCE_RELEASE": "1"})
+    assert outputs["has_changes"] == "true"
+
+
+def test_force_release_is_inert_when_unset_or_false(tmp_path: Path) -> None:
+    """The default must remain output-driven, or every dispatch would release."""
+    repo = _setup_repo(tmp_path)
+    _, unset = _run(repo, _write_fake_gh(tmp_path, release_lines=1))
+    assert unset["has_changes"] == "false"
+
+    second = tmp_path / "second"
+    second.mkdir()
+    repo_two = _setup_repo(second)
+    _, explicit_false = _run(
+        repo_two, _write_fake_gh(tmp_path, release_lines=1), {"FORCE_RELEASE": "false"}
+    )
+    assert explicit_false["has_changes"] == "false"
+
+
+def test_force_release_cannot_publish_without_generated_output(tmp_path: Path) -> None:
+    """Forcing is not a licence to publish an empty or half-built bundle."""
+    repo = _setup_repo(tmp_path)
+    (repo / "docs" / "specifications" / "api" / "index.json").unlink()
+    _, outputs = _run(repo, _write_fake_gh(tmp_path, release_lines=1), {"FORCE_RELEASE": "true"})
+    assert outputs["has_changes"] == "false"


### PR DESCRIPTION
## Summary
- add an explicit force_release workflow-dispatch input
- allow the release detector to publish unchanged generated output only after verifying the output exists
- classify forced releases as patch releases without an unknown-type warning

## Verification
- uv run --frozen --extra dev pytest -q tests/shell/test_detect_release_changes.py (22 passed)
- repository pre-commit enrichment and Spectral pipeline passed
- shellcheck scripts/release/detect-release-changes.sh
- actionlint .github/workflows/sync-and-enrich.yml
- uv run --frozen --extra dev ruff check tests/shell/test_detect_release_changes.py
- mandatory local Antigravity review: no findings
- reviewer full-suite result: 2371 passed, 6 skipped, 1 xfailed

Closes #1334