### PR TITLE
fix(governance): accept four-receipt bootstrap branches

### DIFF
--- a/scripts/verify_governance.py
+++ b/scripts/verify_governance.py
@@ -39,7 +39,7 @@ DEFAULT_GOVERNANCE_JSON = Path(".claude/governance.json")
 # ownership proven by GitHub's pull-request event receipt.
 AUTHORIZED_AUTOMATION_BRANCH = re.compile(
     r"(?:governance/sync-managed-files(?:-[0-9a-f]{12}-[1-9][0-9]*-[1-9][0-9]*)?|"
-    r"sync/exact-caller-[0-9a-f]{120})",
+    r"sync/exact-caller-[0-9a-f]{160})",
 )
 
 

--- a/tests/test_verify_governance.py
+++ b/tests/test_verify_governance.py
@@ -27,7 +27,9 @@ STABLE_EXACT_CALLER_BRANCH = (
     "0123456789abcdef0123456789abcdef01234567"
     "89abcdef0123456789abcdef0123456789abcdef"
     "fedcba9876543210fedcba9876543210fedcba98"
+    "00112233445566778899aabbccddeeff00112233"
 )
+LEGACY_THREE_RECEIPT_BRANCH = STABLE_EXACT_CALLER_BRANCH[:-40]
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -303,6 +305,7 @@ class TestMain:
         [
             "governance/sync-managed-files-lookalike",
             "sync/exact-caller-0123456789ab-123-4",
+            LEGACY_THREE_RECEIPT_BRANCH,
             STABLE_EXACT_CALLER_BRANCH[:-1],
             f"{STABLE_EXACT_CALLER_BRANCH}0",
             f"{STABLE_EXACT_CALLER_BRANCH[:-1]}g",


### PR DESCRIPTION
## Summary

Update the same-repository governance automation exemption to recognize the secure four-receipt exact-caller identity (160 lowercase hexadecimal characters) while explicitly rejecting the legacy three-receipt identity.

Closes #1414

## Verification

- TDD: focused suite initially failed for the new 160-hex identity and incorrectly accepted legacy 120-hex.
- `python -m pytest tests/test_verify_governance.py -q` — 29 passed.
- Python compile check, staged PII enforcement, and `git diff --check` passed.
- Same-repository ownership proof remains required; fork, malformed, truncated, overlong, and legacy identities remain rejected.
