### PR TITLE
feat: add Secure Mesh interface contract

### DIFF
--- a/config/best_practices.yaml
+++ b/config/best_practices.yaml
@@ -226,14 +226,20 @@ domains:
         message: "Site not responding"
         resolution: "Check site connectivity and agent status"
         prevention: "Configure monitoring for site health"
+      - code: 400
+        message: "Expanded Secure Mesh interfaces lack authoritative evidence"
+        resolution: "Keep optional roles unconfigured and collect the sanitized CE evidence matrix"
+        prevention: "Bind roles by Azure NIC position, MAC, IP configuration, subnet, and control-plane reference; never by guest interface name"
     security_notes:
       - "Rotate site tokens after initial registration"
       - "Configure site-level firewall policies"
       - "Enable audit logging for site operations"
+      - "Treat guest interface names as diagnostics only; they are not stable configuration identities"
     performance_tips:
       - "Deploy sites close to workloads for low latency"
       - "Configure appropriate resource allocation"
       - "Use site mesh for efficient inter-site communication"
+      - "Schedule interface additions or removals in a maintenance window because CE data-plane services restart"
 
   authentication:
     common_errors:

--- a/config/guided_workflows.yaml
+++ b/config/guided_workflows.yaml
@@ -402,6 +402,50 @@ workflows:
             - "Tunnel connectivity established"
             - "Services deployed successfully"
 
+    - id: evidence_gated_secure_mesh_interfaces
+      name: Configure Evidence-Gated Secure Mesh Site v2 Interfaces
+      description: Configure the mandatory SLO first and enable optional interface roles only after authoritative Azure and CE evidence agrees.
+      complexity: high
+      estimated_steps: 5
+      prerequisites:
+        - "Three-node HA topology with identical declared role and VRF shape"
+        - "Sanitized Azure and CE evidence including a replacement registration observation"
+        - "Approved maintenance window for any interface addition or removal"
+      steps:
+        - order: 1
+          action: inventory_cloud_nics
+          name: Inventory Azure NICs
+          description: Record each node hostname, NIC position, MAC, IP configuration, subnet, and control-plane interface reference.
+          resource: securemesh_site_v2
+        - order: 2
+          action: collect_runtime_evidence
+          name: Collect CE Evidence
+          description: Normalize supported CE diagnostics by MAC, IP, subnet, and control-plane role without using guest interface names as keys.
+          resource: securemesh_site_v2
+          depends_on: [1]
+        - order: 3
+          action: validate_role_mapping
+          name: Validate Role Mapping
+          description: Require authoritative mapping confidence and provenance before optional roles become bindable.
+          resource: securemesh_site_v2
+          depends_on: [2]
+        - order: 4
+          action: configure_slo
+          name: Configure SLO
+          description: Bind the first Azure NIC to the required Site Local Outside role; BGP may bind only to this role.
+          resource: securemesh_site_v2
+          depends_on: [3]
+        - order: 5
+          action: enable_optional_roles
+          name: Enable Approved Optional Roles
+          description: During the maintenance window, configure external or SLI only where the approved contract declares their network option and VRF.
+          resource: securemesh_site_v2
+          depends_on: [4]
+          verification:
+            - "Every HA node has the same role and VRF shape"
+            - "BGP binds only to the SLO role"
+            - "Evidence provenance is retained without credentials or raw diagnostics"
+
   authentication:
     - id: create_and_use_api_token
       name: Create and Use an API Token

--- a/config/interface_contracts.yaml
+++ b/config/interface_contracts.yaml
@@ -1,0 +1,76 @@
+# Evidence-backed interface contracts for resources whose guest interface names
+# are not stable configuration identities.
+version: "1.0.0"
+
+contracts:
+  securemesh_site_v2:
+    schema_patterns:
+      - "^viewssecuremesh_site_v2(?:Create|Replace|Get)SpecType$"
+    contract:
+      version: "1.0.0"
+      resource: "securemesh_site_v2"
+      cloud: "azure"
+      stable_identity:
+        required_fields:
+          - "node_hostname"
+          - "cloud_nic_position"
+          - "nic_mac"
+          - "ip_configuration"
+          - "subnet"
+          - "control_plane_interface_reference"
+      roles:
+        - name: "slo"
+          required: true
+          bindable: true
+          network_option: "site_local_network"
+          vrf: "site_local_outside"
+          configuration_path: "azure.not_managed.node_list[].interface_list[]"
+          identity_fields:
+            - "node_hostname"
+            - "cloud_nic_position"
+            - "nic_mac"
+            - "ip_configuration"
+            - "subnet"
+            - "control_plane_interface_reference"
+        - name: "external"
+          required: false
+          bindable: false
+          network_option: null
+          vrf: null
+          configuration_path: null
+          identity_fields:
+            - "node_hostname"
+            - "cloud_nic_position"
+            - "nic_mac"
+            - "ip_configuration"
+            - "subnet"
+            - "control_plane_interface_reference"
+        - name: "sli"
+          required: false
+          bindable: false
+          network_option: null
+          vrf: null
+          configuration_path: null
+          identity_fields:
+            - "node_hostname"
+            - "cloud_nic_position"
+            - "nic_mac"
+            - "ip_configuration"
+            - "subnet"
+            - "control_plane_interface_reference"
+      invariants:
+        first_azure_nic_is_slo_anchor: true
+        macs_unique_per_node: true
+        role_bindings_unique_per_node: true
+        homogeneous_ha_role_vrf_shape: true
+        bgp_bindable_roles:
+          - "slo"
+      runtime_evidence:
+        guest_interface_names: "observational_only"
+        minimum_mapping_confidence: "authoritative"
+        provenance_required: true
+        replacement_observation_required: true
+      change_risk:
+        maintenance_window_required: true
+        restarts_ce_data_plane_services: true
+        adding_or_removing_interfaces_disruptive: true

--- a/docs/en/extensions/catalog.md
+++ b/docs/en/extensions/catalog.md
@@ -294,6 +294,18 @@ stubby as long as the `### x-name` header exists and the
 - **Example:** `"x-f5xc-action": "approve"`
 - **Pass-through from upstream:** no
 
+### x-f5xc-interface-contract
+
+- **Applied at:** schema
+- **Purpose:** Evidence-backed cloud NIC and control-plane role contract for Secure Mesh Site v2; guest interface names remain observational only.
+- **Consumers:** Terraform, CLI, MCP, IDE, documentation
+- **Value type:** object
+- **Value schema:** `{"type":"object","required":["version","stable_identity","roles","invariants","runtime_evidence","change_risk"]}`
+- **Injected by:** scripts/utils/interface_contract_enricher.py
+- **Driven by config:** config/interface_contracts.yaml
+- **Example:** `"x-f5xc-interface-contract":{"version":"1.0.0","roles":[{"name":"slo","bindable":true}]}`
+- **Pass-through from upstream:** no
+
 ## Injected — property-level
 
 ### x-f5xc-description

--- a/docs/specifications/api/index.json
+++ b/docs/specifications/api/index.json
@@ -4234,7 +4234,7 @@
   },
   "x-f5xc-guided-workflows": {
     "version": "1.0.0",
-    "total_workflows": 9,
+    "total_workflows": 10,
     "domains": [
       "virtual",
       "waf",
@@ -4531,6 +4531,73 @@
               "Site shows online status",
               "Tunnel connectivity established",
               "Services deployed successfully"
+            ]
+          }
+        ],
+        "domain": "sites"
+      },
+      {
+        "id": "evidence_gated_secure_mesh_interfaces",
+        "name": "Configure Evidence-Gated Secure Mesh Site v2 Interfaces",
+        "description": "Configure the mandatory SLO first and enable optional interface roles only after authoritative Azure and CE evidence agrees.",
+        "complexity": "high",
+        "estimated_steps": 5,
+        "prerequisites": [
+          "Three-node HA topology with identical declared role and VRF shape",
+          "Sanitized Azure and CE evidence including a replacement registration observation",
+          "Approved maintenance window for any interface addition or removal"
+        ],
+        "steps": [
+          {
+            "order": 1,
+            "action": "inventory_cloud_nics",
+            "name": "Inventory Azure NICs",
+            "description": "Record each node hostname, NIC position, MAC, IP configuration, subnet, and control-plane interface reference.",
+            "resource": "securemesh_site_v2"
+          },
+          {
+            "order": 2,
+            "action": "collect_runtime_evidence",
+            "name": "Collect CE Evidence",
+            "description": "Normalize supported CE diagnostics by MAC, IP, subnet, and control-plane role without using guest interface names as keys.",
+            "resource": "securemesh_site_v2",
+            "depends_on": [
+              1
+            ]
+          },
+          {
+            "order": 3,
+            "action": "validate_role_mapping",
+            "name": "Validate Role Mapping",
+            "description": "Require authoritative mapping confidence and provenance before optional roles become bindable.",
+            "resource": "securemesh_site_v2",
+            "depends_on": [
+              2
+            ]
+          },
+          {
+            "order": 4,
+            "action": "configure_slo",
+            "name": "Configure SLO",
+            "description": "Bind the first Azure NIC to the required Site Local Outside role; BGP may bind only to this role.",
+            "resource": "securemesh_site_v2",
+            "depends_on": [
+              3
+            ]
+          },
+          {
+            "order": 5,
+            "action": "enable_optional_roles",
+            "name": "Enable Approved Optional Roles",
+            "description": "During the maintenance window, configure external or SLI only where the approved contract declares their network option and VRF.",
+            "resource": "securemesh_site_v2",
+            "depends_on": [
+              4
+            ],
+            "verification": [
+              "Every HA node has the same role and VRF shape",
+              "BGP binds only to the SLO role",
+              "Evidence provenance is retained without credentials or raw diagnostics"
             ]
           }
         ],

--- a/docs/specifications/api/sites.json
+++ b/docs/specifications/api/sites.json
@@ -33,17 +33,25 @@
           "message": "Site not responding",
           "resolution": "Check site connectivity and agent status",
           "prevention": "Configure monitoring for site health"
+        },
+        {
+          "code": 400,
+          "message": "Expanded Secure Mesh interfaces lack authoritative evidence",
+          "resolution": "Keep optional roles unconfigured and collect the sanitized CE evidence matrix",
+          "prevention": "Bind roles by Azure NIC position, MAC, IP configuration, subnet, and control-plane reference; never by guest interface name"
         }
       ],
       "security_notes": [
         "Rotate site tokens after initial registration",
         "Configure site-level firewall policies",
-        "Enable audit logging for site operations"
+        "Enable audit logging for site operations",
+        "Treat guest interface names as diagnostics only; they are not stable configuration identities"
       ],
       "performance_tips": [
         "Deploy sites close to workloads for low latency",
         "Configure appropriate resource allocation",
-        "Use site mesh for efficient inter-site communication"
+        "Use site mesh for efficient inter-site communication",
+        "Schedule interface additions or removals in a maintenance window because CE data-plane services restart"
       ]
     },
     "x-f5xc-guided-workflows": [
@@ -114,6 +122,72 @@
               "Site shows online status",
               "Tunnel connectivity established",
               "Services deployed successfully"
+            ]
+          }
+        ]
+      },
+      {
+        "id": "evidence_gated_secure_mesh_interfaces",
+        "name": "Configure Evidence-Gated Secure Mesh Site v2 Interfaces",
+        "description": "Configure the mandatory SLO first and enable optional interface roles only after authoritative Azure and CE evidence agrees.",
+        "complexity": "high",
+        "estimated_steps": 5,
+        "prerequisites": [
+          "Three-node HA topology with identical declared role and VRF shape",
+          "Sanitized Azure and CE evidence including a replacement registration observation",
+          "Approved maintenance window for any interface addition or removal"
+        ],
+        "steps": [
+          {
+            "order": 1,
+            "action": "inventory_cloud_nics",
+            "name": "Inventory Azure NICs",
+            "description": "Record each node hostname, NIC position, MAC, IP configuration, subnet, and control-plane interface reference.",
+            "resource": "securemesh_site_v2"
+          },
+          {
+            "order": 2,
+            "action": "collect_runtime_evidence",
+            "name": "Collect CE Evidence",
+            "description": "Normalize supported CE diagnostics by MAC, IP, subnet, and control-plane role without using guest interface names as keys.",
+            "resource": "securemesh_site_v2",
+            "depends_on": [
+              1
+            ]
+          },
+          {
+            "order": 3,
+            "action": "validate_role_mapping",
+            "name": "Validate Role Mapping",
+            "description": "Require authoritative mapping confidence and provenance before optional roles become bindable.",
+            "resource": "securemesh_site_v2",
+            "depends_on": [
+              2
+            ]
+          },
+          {
+            "order": 4,
+            "action": "configure_slo",
+            "name": "Configure SLO",
+            "description": "Bind the first Azure NIC to the required Site Local Outside role; BGP may bind only to this role.",
+            "resource": "securemesh_site_v2",
+            "depends_on": [
+              3
+            ]
+          },
+          {
+            "order": 5,
+            "action": "enable_optional_roles",
+            "name": "Enable Approved Optional Roles",
+            "description": "During the maintenance window, configure external or SLI only where the approved contract declares their network option and VRF.",
+            "resource": "securemesh_site_v2",
+            "depends_on": [
+              4
+            ],
+            "verification": [
+              "Every HA node has the same role and VRF shape",
+              "BGP binds only to the SLO role",
+              "Evidence provenance is retained without credentials or raw diagnostics"
             ]
           }
         ]
@@ -101179,6 +101253,91 @@
           "forward_proxy_choice": "no_forward_proxy",
           "logs_receiver_choice": "logs_streaming_disabled"
         },
+        "x-f5xc-interface-contract": {
+          "version": "1.0.0",
+          "resource": "securemesh_site_v2",
+          "cloud": "azure",
+          "stable_identity": {
+            "required_fields": [
+              "node_hostname",
+              "cloud_nic_position",
+              "nic_mac",
+              "ip_configuration",
+              "subnet",
+              "control_plane_interface_reference"
+            ]
+          },
+          "roles": [
+            {
+              "name": "slo",
+              "required": true,
+              "bindable": true,
+              "network_option": "site_local_network",
+              "vrf": "site_local_outside",
+              "configuration_path": "azure.not_managed.node_list[].interface_list[]",
+              "identity_fields": [
+                "node_hostname",
+                "cloud_nic_position",
+                "nic_mac",
+                "ip_configuration",
+                "subnet",
+                "control_plane_interface_reference"
+              ]
+            },
+            {
+              "name": "external",
+              "required": false,
+              "bindable": false,
+              "network_option": null,
+              "vrf": null,
+              "configuration_path": null,
+              "identity_fields": [
+                "node_hostname",
+                "cloud_nic_position",
+                "nic_mac",
+                "ip_configuration",
+                "subnet",
+                "control_plane_interface_reference"
+              ]
+            },
+            {
+              "name": "sli",
+              "required": false,
+              "bindable": false,
+              "network_option": null,
+              "vrf": null,
+              "configuration_path": null,
+              "identity_fields": [
+                "node_hostname",
+                "cloud_nic_position",
+                "nic_mac",
+                "ip_configuration",
+                "subnet",
+                "control_plane_interface_reference"
+              ]
+            }
+          ],
+          "invariants": {
+            "first_azure_nic_is_slo_anchor": true,
+            "macs_unique_per_node": true,
+            "role_bindings_unique_per_node": true,
+            "homogeneous_ha_role_vrf_shape": true,
+            "bgp_bindable_roles": [
+              "slo"
+            ]
+          },
+          "runtime_evidence": {
+            "guest_interface_names": "observational_only",
+            "minimum_mapping_confidence": "authoritative",
+            "provenance_required": true,
+            "replacement_observation_required": true
+          },
+          "change_risk": {
+            "maintenance_window_required": true,
+            "restarts_ce_data_plane_services": true,
+            "adding_or_removing_interfaces_disruptive": true
+          }
+        },
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
@@ -102510,6 +102669,91 @@
           "forward_proxy_choice": "no_forward_proxy",
           "logs_receiver_choice": "logs_streaming_disabled"
         },
+        "x-f5xc-interface-contract": {
+          "version": "1.0.0",
+          "resource": "securemesh_site_v2",
+          "cloud": "azure",
+          "stable_identity": {
+            "required_fields": [
+              "node_hostname",
+              "cloud_nic_position",
+              "nic_mac",
+              "ip_configuration",
+              "subnet",
+              "control_plane_interface_reference"
+            ]
+          },
+          "roles": [
+            {
+              "name": "slo",
+              "required": true,
+              "bindable": true,
+              "network_option": "site_local_network",
+              "vrf": "site_local_outside",
+              "configuration_path": "azure.not_managed.node_list[].interface_list[]",
+              "identity_fields": [
+                "node_hostname",
+                "cloud_nic_position",
+                "nic_mac",
+                "ip_configuration",
+                "subnet",
+                "control_plane_interface_reference"
+              ]
+            },
+            {
+              "name": "external",
+              "required": false,
+              "bindable": false,
+              "network_option": null,
+              "vrf": null,
+              "configuration_path": null,
+              "identity_fields": [
+                "node_hostname",
+                "cloud_nic_position",
+                "nic_mac",
+                "ip_configuration",
+                "subnet",
+                "control_plane_interface_reference"
+              ]
+            },
+            {
+              "name": "sli",
+              "required": false,
+              "bindable": false,
+              "network_option": null,
+              "vrf": null,
+              "configuration_path": null,
+              "identity_fields": [
+                "node_hostname",
+                "cloud_nic_position",
+                "nic_mac",
+                "ip_configuration",
+                "subnet",
+                "control_plane_interface_reference"
+              ]
+            }
+          ],
+          "invariants": {
+            "first_azure_nic_is_slo_anchor": true,
+            "macs_unique_per_node": true,
+            "role_bindings_unique_per_node": true,
+            "homogeneous_ha_role_vrf_shape": true,
+            "bgp_bindable_roles": [
+              "slo"
+            ]
+          },
+          "runtime_evidence": {
+            "guest_interface_names": "observational_only",
+            "minimum_mapping_confidence": "authoritative",
+            "provenance_required": true,
+            "replacement_observation_required": true
+          },
+          "change_risk": {
+            "maintenance_window_required": true,
+            "restarts_ce_data_plane_services": true,
+            "adding_or_removing_interfaces_disruptive": true
+          }
+        },
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
@@ -103783,6 +104027,91 @@
           "network_policy_choice": "no_network_policy",
           "forward_proxy_choice": "no_forward_proxy",
           "logs_receiver_choice": "logs_streaming_disabled"
+        },
+        "x-f5xc-interface-contract": {
+          "version": "1.0.0",
+          "resource": "securemesh_site_v2",
+          "cloud": "azure",
+          "stable_identity": {
+            "required_fields": [
+              "node_hostname",
+              "cloud_nic_position",
+              "nic_mac",
+              "ip_configuration",
+              "subnet",
+              "control_plane_interface_reference"
+            ]
+          },
+          "roles": [
+            {
+              "name": "slo",
+              "required": true,
+              "bindable": true,
+              "network_option": "site_local_network",
+              "vrf": "site_local_outside",
+              "configuration_path": "azure.not_managed.node_list[].interface_list[]",
+              "identity_fields": [
+                "node_hostname",
+                "cloud_nic_position",
+                "nic_mac",
+                "ip_configuration",
+                "subnet",
+                "control_plane_interface_reference"
+              ]
+            },
+            {
+              "name": "external",
+              "required": false,
+              "bindable": false,
+              "network_option": null,
+              "vrf": null,
+              "configuration_path": null,
+              "identity_fields": [
+                "node_hostname",
+                "cloud_nic_position",
+                "nic_mac",
+                "ip_configuration",
+                "subnet",
+                "control_plane_interface_reference"
+              ]
+            },
+            {
+              "name": "sli",
+              "required": false,
+              "bindable": false,
+              "network_option": null,
+              "vrf": null,
+              "configuration_path": null,
+              "identity_fields": [
+                "node_hostname",
+                "cloud_nic_position",
+                "nic_mac",
+                "ip_configuration",
+                "subnet",
+                "control_plane_interface_reference"
+              ]
+            }
+          ],
+          "invariants": {
+            "first_azure_nic_is_slo_anchor": true,
+            "macs_unique_per_node": true,
+            "role_bindings_unique_per_node": true,
+            "homogeneous_ha_role_vrf_shape": true,
+            "bgp_bindable_roles": [
+              "slo"
+            ]
+          },
+          "runtime_evidence": {
+            "guest_interface_names": "observational_only",
+            "minimum_mapping_confidence": "authoritative",
+            "provenance_required": true,
+            "replacement_observation_required": true
+          },
+          "change_risk": {
+            "maintenance_window_required": true,
+            "restarts_ce_data_plane_services": true,
+            "adding_or_removing_interfaces_disruptive": true
+          }
         },
         "x-f5xc-namespace-profile": {
           "constraint": {

--- a/scripts/pipeline.py
+++ b/scripts/pipeline.py
@@ -90,6 +90,7 @@ from scripts.utils import (
     FieldDescriptionEnricher,
     GrammarImprover,
     GuidedWorkflowEnricher,
+    InterfaceContractEnricher,
     MinimumConfigurationEnricher,
     NamespaceProfileEnricher,
     OperationDescriptionEnricher,
@@ -1245,6 +1246,7 @@ def merge_specs_by_domain(
         "conflicts_with_added": 0,
         "schema_overrides_applied": 0,
         "namespace_profiles_added": 0,
+        "interface_contracts_applied": 0,
     }
 
     # Load description enricher for domain-specific descriptions
@@ -1279,6 +1281,9 @@ def merge_specs_by_domain(
     # Load schema override enricher (Issue #294)
     # Injects missing oneOf variants from schema_overrides.yaml before conflicts-with
     schema_override_enricher = SchemaOverrideEnricher()
+
+    # Add evidence-backed roles without making guest interface names configuration keys.
+    interface_contract_enricher = InterfaceContractEnricher()
 
     for domain, spec_list in sorted(domain_specs.items()):
         domain_title = domain.replace("_", " ").title()
@@ -1447,6 +1452,12 @@ def merge_specs_by_domain(
         so_stats = schema_override_enricher.get_stats()
         stats["schema_overrides_applied"] += so_stats.get("properties_injected", 0)
         schema_override_enricher.reset_stats()
+
+        # Interface contracts run before downstream code-generation consumers inspect schemas.
+        merged_spec = interface_contract_enricher.enrich_spec(merged_spec)
+        ic_stats = interface_contract_enricher.get_stats()
+        stats["interface_contracts_applied"] += ic_stats["contracts_applied"]
+        interface_contract_enricher.reset_stats()
 
         # Conflicts-with: auto-derive mutual exclusivity from x-ves-oneof-field-* (Issue #494)
         merged_spec = conflicts_with_enricher.enrich_spec(merged_spec)

--- a/scripts/utils/__init__.py
+++ b/scripts/utils/__init__.py
@@ -27,6 +27,7 @@ from .field_description_enricher import FieldDescriptionEnricher
 from .field_metadata_enricher import FieldMetadataEnricher
 from .grammar import GrammarImprover
 from .guided_workflow_enricher import GuidedWorkflowEnricher
+from .interface_contract_enricher import InterfaceContractEnricher
 from .minimum_configuration_enricher import MinimumConfigurationEnricher
 from .namespace_profile_enricher import NamespaceProfileEnricher
 from .operation_description_enricher import OperationDescriptionEnricher
@@ -77,6 +78,7 @@ __all__ = [
     "FieldMetadataEnricher",
     "GrammarImprover",
     "GuidedWorkflowEnricher",
+    "InterfaceContractEnricher",
     "MinimumConfigurationEnricher",
     "NamespaceProfileEnricher",
     "OperationDescriptionEnricher",

--- a/scripts/utils/extension_constants.py
+++ b/scripts/utils/extension_constants.py
@@ -55,6 +55,9 @@ X_F5XC_TERRAFORM_RESOURCE = "x-f5xc-terraform-resource"
 X_F5XC_DISPLAY_NAME = "x-f5xc-display-name"
 X_F5XC_ACTION = "x-f5xc-action"
 
+# Evidence-backed multi-interface role contract (Issue #1441)
+X_F5XC_INTERFACE_CONTRACT = "x-f5xc-interface-contract"
+
 # Console UI enrichment (Issue #679)
 X_F5XC_CONSOLE = "x-f5xc-console"
 
@@ -227,6 +230,7 @@ VALID_X_F5XC_EXTENSIONS = frozenset(
         X_F5XC_TERRAFORM_RESOURCE,
         X_F5XC_DISPLAY_NAME,
         X_F5XC_ACTION,
+        X_F5XC_INTERFACE_CONTRACT,
         # Property-level
         X_F5XC_DESCRIPTION,
         X_F5XC_VALIDATION,

--- a/scripts/utils/interface_contract_enricher.py
+++ b/scripts/utils/interface_contract_enricher.py
@@ -1,0 +1,278 @@
+"""Emit and validate evidence-backed Secure Mesh interface contracts."""
+
+from __future__ import annotations
+
+import copy
+import re
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from .extension_constants import X_F5XC_INTERFACE_CONTRACT
+
+CONFIG_PATH = Path(__file__).parent.parent.parent / "config" / "interface_contracts.yaml"
+SUPPORTED_ROLES = frozenset({"slo", "external", "sli"})
+STABLE_IDENTITY_FIELDS = frozenset(
+    {
+        "node_hostname",
+        "cloud_nic_position",
+        "nic_mac",
+        "ip_configuration",
+        "subnet",
+        "control_plane_interface_reference",
+    }
+)
+
+
+class InterfaceContractValidationError(ValueError):
+    """Raised when an interface contract would be unsafe to publish."""
+
+
+@dataclass
+class InterfaceContractStats:
+    """Track schema-level interface-contract enrichment."""
+
+    schemas_processed: int = 0
+    schemas_matched: int = 0
+    contracts_applied: int = 0
+
+    def to_dict(self) -> dict[str, int]:
+        """Return stable serializable statistics."""
+        return asdict(self)
+
+
+class InterfaceContractEnricher:
+    """Inject validated ``x-f5xc-interface-contract`` schema extensions.
+
+    The contract intentionally describes cloud and control-plane identities,
+    never Linux guest interface names. An optional role can only become bindable
+    when the contract revision records authoritative evidence provenance.
+    """
+
+    def __init__(self, config_path: Path | None = None) -> None:
+        """Load and validate the configured schema-level contracts."""
+        self.config_path = Path(config_path) if config_path else CONFIG_PATH
+        self.contracts = self._load_contracts()
+        self.stats = InterfaceContractStats()
+
+    def _load_contracts(self) -> list[tuple[tuple[re.Pattern[str], ...], dict[str, Any]]]:
+        if not self.config_path.exists():
+            raise InterfaceContractValidationError(
+                f"interface contract configuration is missing: {self.config_path}"
+            )
+        with self.config_path.open() as config_file:
+            config = yaml.safe_load(config_file) or {}
+
+        contracts = config.get("contracts")
+        if not isinstance(contracts, dict) or not contracts:
+            raise InterfaceContractValidationError(
+                "interface contract configuration has no contracts"
+            )
+
+        loaded: list[tuple[tuple[re.Pattern[str], ...], dict[str, Any]]] = []
+        for resource, entry in sorted(contracts.items()):
+            if not isinstance(entry, dict):
+                raise InterfaceContractValidationError(
+                    f"{resource}: contract entry must be an object"
+                )
+            patterns = entry.get("schema_patterns")
+            contract = entry.get("contract")
+            if (
+                not isinstance(patterns, list)
+                or not patterns
+                or not all(isinstance(pattern, str) for pattern in patterns)
+            ):
+                raise InterfaceContractValidationError(
+                    f"{resource}: schema_patterns must be a non-empty string list"
+                )
+            if not isinstance(contract, dict):
+                raise InterfaceContractValidationError(f"{resource}: contract must be an object")
+            self._validate_contract(resource, contract)
+            try:
+                compiled = tuple(re.compile(pattern) for pattern in patterns)
+            except re.error as error:
+                raise InterfaceContractValidationError(
+                    f"{resource}: invalid schema pattern: {error}"
+                ) from error
+            loaded.append((compiled, copy.deepcopy(contract)))
+        return loaded
+
+    @staticmethod
+    def _required_object(contract: dict[str, Any], field: str, *, resource: str) -> dict[str, Any]:
+        value = contract.get(field)
+        if not isinstance(value, dict):
+            raise InterfaceContractValidationError(f"{resource}: {field} must be an object")
+        return value
+
+    def _validate_contract(self, resource: str, contract: dict[str, Any]) -> None:
+        if contract.get("version") != "1.0.0":
+            raise InterfaceContractValidationError(f"{resource}: unsupported contract version")
+        if contract.get("resource") != resource:
+            raise InterfaceContractValidationError(
+                f"{resource}: resource identity must match its key"
+            )
+        if contract.get("cloud") != "azure":
+            raise InterfaceContractValidationError(f"{resource}: cloud profile must be azure")
+
+        stable_identity = self._required_object(contract, "stable_identity", resource=resource)
+        fields = stable_identity.get("required_fields")
+        if not isinstance(fields, list) or set(fields) != STABLE_IDENTITY_FIELDS:
+            raise InterfaceContractValidationError(
+                f"{resource}: stable_identity.required_fields is incomplete"
+            )
+        if len(fields) != len(set(fields)):
+            raise InterfaceContractValidationError(
+                f"{resource}: stable_identity.required_fields contains duplicates"
+            )
+
+        roles = contract.get("roles")
+        if not isinstance(roles, list) or not roles:
+            raise InterfaceContractValidationError(f"{resource}: roles must be a non-empty list")
+        names: list[str] = []
+        runtime_evidence = self._required_object(contract, "runtime_evidence", resource=resource)
+        for role in roles:
+            if not isinstance(role, dict):
+                raise InterfaceContractValidationError(f"{resource}: role must be an object")
+            name = role.get("name")
+            if name not in SUPPORTED_ROLES:
+                raise InterfaceContractValidationError(f"{resource}: unknown role {name!r}")
+            names.append(name)
+            if not isinstance(role.get("required"), bool) or not isinstance(
+                role.get("bindable"), bool
+            ):
+                raise InterfaceContractValidationError(
+                    f"{resource}: role {name} must declare required and bindable booleans"
+                )
+            identity_fields = role.get("identity_fields")
+            if (
+                not isinstance(identity_fields, list)
+                or set(identity_fields) != STABLE_IDENTITY_FIELDS
+            ):
+                raise InterfaceContractValidationError(
+                    f"{resource}: role {name} lacks the complete stable identity"
+                )
+            if len(identity_fields) != len(set(identity_fields)):
+                raise InterfaceContractValidationError(
+                    f"{resource}: role {name} repeats a stable identity field"
+                )
+            for field in ("network_option", "vrf", "configuration_path"):
+                if field not in role:
+                    raise InterfaceContractValidationError(f"{resource}: role {name} lacks {field}")
+            if name == "slo":
+                if not role["required"] or not role["bindable"]:
+                    raise InterfaceContractValidationError(
+                        f"{resource}: slo must be required and bindable"
+                    )
+                if role["network_option"] != "site_local_network":
+                    raise InterfaceContractValidationError(
+                        f"{resource}: slo must use site_local_network"
+                    )
+                if role["vrf"] != "site_local_outside" or not isinstance(
+                    role["configuration_path"], str
+                ):
+                    raise InterfaceContractValidationError(
+                        f"{resource}: slo must declare its VRF and configuration path"
+                    )
+            elif role["required"]:
+                raise InterfaceContractValidationError(f"{resource}: {name} must remain optional")
+            elif role["bindable"]:
+                required_mapping_fields = ("network_option", "vrf", "configuration_path")
+                if not all(
+                    isinstance(role[field], str) and role[field]
+                    for field in required_mapping_fields
+                ):
+                    raise InterfaceContractValidationError(
+                        f"{resource}: bindable {name} requires network option, VRF, and path"
+                    )
+                if runtime_evidence.get(
+                    "minimum_mapping_confidence"
+                ) != "authoritative" or not runtime_evidence.get("provenance_required"):
+                    raise InterfaceContractValidationError(
+                        f"{resource}: bindable {name} requires authoritative evidence provenance"
+                    )
+            elif any(
+                role[field] is not None for field in ("network_option", "vrf", "configuration_path")
+            ):
+                raise InterfaceContractValidationError(
+                    f"{resource}: unbindable {name} must not declare a configuration mapping"
+                )
+
+        if len(names) != len(set(names)):
+            raise InterfaceContractValidationError(f"{resource}: duplicate role")
+        if set(names) != SUPPORTED_ROLES:
+            raise InterfaceContractValidationError(
+                f"{resource}: roles must define slo, external, and sli"
+            )
+
+        invariants = self._required_object(contract, "invariants", resource=resource)
+        for invariant in (
+            "first_azure_nic_is_slo_anchor",
+            "macs_unique_per_node",
+            "role_bindings_unique_per_node",
+            "homogeneous_ha_role_vrf_shape",
+        ):
+            if invariants.get(invariant) is not True:
+                raise InterfaceContractValidationError(
+                    f"{resource}: invariant {invariant} is required"
+                )
+        if invariants.get("bgp_bindable_roles") != ["slo"]:
+            raise InterfaceContractValidationError(f"{resource}: BGP may bind only to slo")
+
+        if runtime_evidence.get("guest_interface_names") != "observational_only":
+            raise InterfaceContractValidationError(
+                f"{resource}: guest interface names must be observational only"
+            )
+        if runtime_evidence.get("minimum_mapping_confidence") != "authoritative":
+            raise InterfaceContractValidationError(
+                f"{resource}: authoritative mapping confidence is required"
+            )
+        if (
+            runtime_evidence.get("provenance_required") is not True
+            or runtime_evidence.get("replacement_observation_required") is not True
+        ):
+            raise InterfaceContractValidationError(f"{resource}: evidence provenance is required")
+
+        change_risk = self._required_object(contract, "change_risk", resource=resource)
+        for field in (
+            "maintenance_window_required",
+            "restarts_ce_data_plane_services",
+            "adding_or_removing_interfaces_disruptive",
+        ):
+            if change_risk.get(field) is not True:
+                raise InterfaceContractValidationError(
+                    f"{resource}: change-risk field {field} is required"
+                )
+
+    def enrich_spec(self, spec: dict[str, Any]) -> dict[str, Any]:
+        """Inject every matching interface contract at schema level."""
+        schemas = spec.get("components", {}).get("schemas", {})
+        if not isinstance(schemas, dict):
+            return spec
+        for schema_name, schema in schemas.items():
+            if not isinstance(schema, dict):
+                continue
+            self.stats.schemas_processed += 1
+            for patterns, contract in self.contracts:
+                if any(pattern.search(schema_name) for pattern in patterns):
+                    schema[X_F5XC_INTERFACE_CONTRACT] = copy.deepcopy(contract)
+                    self.stats.schemas_matched += 1
+                    self.stats.contracts_applied += 1
+                    break
+        return spec
+
+    def get_stats(self) -> dict[str, int]:
+        """Return enrichment statistics."""
+        return self.stats.to_dict()
+
+    def reset_stats(self) -> None:
+        """Reset per-spec statistics after pipeline accounting."""
+        self.stats = InterfaceContractStats()
+
+
+__all__ = [
+    "InterfaceContractEnricher",
+    "InterfaceContractStats",
+    "InterfaceContractValidationError",
+]

--- a/tests/test_interface_contract_enricher.py
+++ b/tests/test_interface_contract_enricher.py
@@ -1,0 +1,157 @@
+"""Tests for the evidence-backed Secure Mesh interface contract."""
+
+from __future__ import annotations
+
+import copy
+import json
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from scripts.utils.extension_constants import X_F5XC_INTERFACE_CONTRACT
+from scripts.utils.interface_contract_enricher import (
+    InterfaceContractEnricher,
+    InterfaceContractValidationError,
+)
+
+
+@pytest.fixture
+def contract_config() -> dict[str, Any]:
+    """Load the production contract configuration."""
+    config_path = Path(__file__).parent.parent / "config" / "interface_contracts.yaml"
+    with config_path.open() as source:
+        return yaml.safe_load(source)
+
+
+@pytest.fixture
+def sms_spec() -> dict[str, Any]:
+    """Return matching and nonmatching component schemas."""
+    return {
+        "components": {
+            "schemas": {
+                "viewssecuremesh_site_v2CreateSpecType": {"type": "object"},
+                "viewssecuremesh_site_v2GetSpecType": {"type": "object"},
+                "unrelatedSchema": {"type": "object"},
+            },
+        },
+    }
+
+
+def _write_config(tmp_path: Path, config: dict[str, Any]) -> Path:
+    path = tmp_path / "interface_contracts.yaml"
+    with path.open("w") as destination:
+        yaml.safe_dump(config, destination, sort_keys=False)
+    return path
+
+
+def _contract(config: dict[str, Any]) -> dict[str, Any]:
+    return config["contracts"]["securemesh_site_v2"]["contract"]
+
+
+def test_emits_contract_for_only_securemesh_request_schemas(sms_spec: dict[str, Any]) -> None:
+    enriched = InterfaceContractEnricher().enrich_spec(copy.deepcopy(sms_spec))
+    schemas = enriched["components"]["schemas"]
+    assert X_F5XC_INTERFACE_CONTRACT in schemas["viewssecuremesh_site_v2CreateSpecType"]
+    assert X_F5XC_INTERFACE_CONTRACT in schemas["viewssecuremesh_site_v2GetSpecType"]
+    assert X_F5XC_INTERFACE_CONTRACT not in schemas["unrelatedSchema"]
+
+
+def test_contract_is_deterministic_and_guest_names_are_not_authoritative(
+    sms_spec: dict[str, Any],
+) -> None:
+    enricher = InterfaceContractEnricher()
+    once = enricher.enrich_spec(copy.deepcopy(sms_spec))
+    twice = enricher.enrich_spec(copy.deepcopy(sms_spec))
+    create_contract = once["components"]["schemas"]["viewssecuremesh_site_v2CreateSpecType"][
+        X_F5XC_INTERFACE_CONTRACT
+    ]
+    assert once == twice
+    assert create_contract["runtime_evidence"]["guest_interface_names"] == "observational_only"
+    assert "eth" not in json.dumps(create_contract).lower()
+
+
+def test_contract_defines_stable_identity_and_role_invariants() -> None:
+    enricher = InterfaceContractEnricher()
+    contract = enricher.contracts[0][1]
+    assert contract["stable_identity"]["required_fields"]
+    assert [role["name"] for role in contract["roles"]] == ["slo", "external", "sli"]
+    assert contract["invariants"]["bgp_bindable_roles"] == ["slo"]
+    assert contract["change_risk"]["maintenance_window_required"] is True
+    assert contract["change_risk"]["restarts_ce_data_plane_services"] is True
+
+
+Mutation = Callable[[dict[str, Any]], Any]
+
+
+@pytest.mark.parametrize(
+    ("mutate", "message"),
+    [
+        (
+            lambda config: config["contracts"]["securemesh_site_v2"].pop("contract"),
+            "contract must be an object",
+        ),
+        (
+            lambda config: _contract(config)["roles"].append(
+                copy.deepcopy(_contract(config)["roles"][0])
+            ),
+            "duplicate role",
+        ),
+        (
+            lambda config: _contract(config)["roles"][1].update({"name": "unknown"}),
+            "unknown role",
+        ),
+        (
+            lambda config: _contract(config)["roles"][2].pop("identity_fields"),
+            "lacks the complete stable identity",
+        ),
+        (
+            lambda config: _contract(config)["runtime_evidence"].update(
+                {"guest_interface_names": "authoritative"}
+            ),
+            "guest interface names must be observational only",
+        ),
+    ],
+)
+def test_rejects_unsafe_or_incomplete_contracts(
+    tmp_path: Path,
+    contract_config: dict[str, Any],
+    mutate: Mutation,
+    message: str,
+) -> None:
+    invalid = copy.deepcopy(contract_config)
+    mutate(invalid)
+    with pytest.raises(InterfaceContractValidationError, match=message):
+        InterfaceContractEnricher(_write_config(tmp_path, invalid))
+
+
+def test_rejects_bindable_optional_role_without_authoritative_evidence(
+    tmp_path: Path, contract_config: dict[str, Any]
+) -> None:
+    invalid = copy.deepcopy(contract_config)
+    external = _contract(invalid)["roles"][1]
+    external.update(
+        {
+            "bindable": True,
+            "network_option": "site_local_inside_network",
+            "vrf": "site_local_inside",
+            "configuration_path": "azure.not_managed.node_list[].interface_list[]",
+        }
+    )
+    _contract(invalid)["runtime_evidence"]["minimum_mapping_confidence"] = "advisory"
+    with pytest.raises(InterfaceContractValidationError, match="authoritative evidence provenance"):
+        InterfaceContractEnricher(_write_config(tmp_path, invalid))
+
+
+def test_site_guidance_describes_the_evidence_gate() -> None:
+    root = Path(__file__).parent.parent
+    best_practices = yaml.safe_load((root / "config" / "best_practices.yaml").read_text())
+    workflows = yaml.safe_load((root / "config" / "guided_workflows.yaml").read_text())
+    site_notes = best_practices["domains"]["sites"]["security_notes"]
+    site_workflows = workflows["workflows"]["sites"]
+    assert any("guest interface names" in note for note in site_notes)
+    assert any(
+        workflow["id"] == "evidence_gated_secure_mesh_interfaces" for workflow in site_workflows
+    )


### PR DESCRIPTION
## Summary

Adds the versioned, evidence-backed `x-f5xc-interface-contract` extension for Secure Mesh Site v2. It binds SLO to stable Azure identity and prevents external/SLI configuration until an authoritative evidence revision supplies their roles.

## Validation

- `pytest -q tests/test_interface_contract_enricher.py tests/test_extension_catalog.py tests/test_extension_naming.py`
- `ruff check` and `ruff format --check` on changed Python
- `python -m scripts.validate_configs`

Closes #1441