### PR TITLE
fix(lint): allow managed validator CLI filename

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -249,6 +249,8 @@ ignore = [
 
 # Per-file rule ignores
 [tool.ruff.lint.per-file-ignores]
+"scripts/workflow-security-validator.py" = ["N999"]
+
 # Tests can use assert, magic values, and don't need docstrings
 "tests/**/*.py" = [
     "S101",    # assert allowed in tests


### PR DESCRIPTION
## Summary

- allow Ruff `N999` only for the centrally managed `scripts/workflow-security-validator.py` CLI filename
- retain naming enforcement for every other Python module
- unblock managed-file PR #1467

## Verification

- failing reproduction before the change
- passing managed-filename reproduction after the change
- control filename still fails `N999`
- full repository `uvx --from ruff==0.15.17 ruff check .` passes with the exact Super-Linter Ruff version
- `git diff --check`
- exact-HEAD Antigravity semantic review passed with no critical/high findings

Closes #1468