### PR TITLE
fix(workflow): avoid template expansion in release shell

### DIFF
--- a/.github/workflows/sync-and-enrich.yml
+++ b/.github/workflows/sync-and-enrich.yml
@@ -143,8 +143,8 @@ jobs:
     # push all authenticate with VERSION_BUMP_PAT instead, so no pull-requests
     # scope is required here.
     permissions:
-      contents: write
-      statuses: write
+      contents: write # Publish the generated release and its tag with the workflow token.
+      statuses: write # Post the required linked-issue status on the release pull request head.
     outputs:
       version: ${{ steps.version.outputs.new_version }}
       has_changes: ${{ steps.detect.outputs.has_changes }}
@@ -569,6 +569,7 @@ jobs:
           RELEASE_STATUS_TOKEN: ${{ github.token }}
           VERSION: ${{ steps.version.outputs.new_version }}
           BUMP_TYPE: ${{ steps.version.outputs.bump_type }}
+          REPOSITORY: ${{ github.repository }}
         run: |
           set -e
 
@@ -576,7 +577,7 @@ jobs:
           git config --local user.name "github-actions[bot]"
 
           # Configure git to use VERSION_BUMP_PAT for authentication
-          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${REPOSITORY}.git"
 
           BRANCH="release/v${VERSION}"
 
@@ -796,8 +797,8 @@ jobs:
     # actions/deploy-pages needs both of these; id-token is for its OIDC exchange.
     permissions:
       contents: read
-      pages: write
-      id-token: write
+      pages: write # Publish the generated documentation artifact to GitHub Pages.
+      id-token: write # Exchange an OIDC token with the GitHub Pages deployment service.
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -915,22 +916,28 @@ jobs:
     # both as GITHUB_TOKEN.
     permissions:
       contents: read
-      issues: write
+      issues: write # Create or update the repository issue that records workflow failures.
     steps:
       - name: Check for failures
         id: check_failure
+        env:
+          CHECK_UPDATES_RESULT: ${{ needs.check-updates.result }}
+          SYNC_AND_ENRICH_RESULT: ${{ needs.sync-and-enrich.result }}
+          DEPLOY_DOCS_RESULT: ${{ needs.deploy-docs.result }}
+          BUILD_DOWNSTREAM_MATRIX_RESULT: ${{ needs.build-downstream-matrix.result }}
+          NOTIFY_DOWNSTREAM_RESULT: ${{ needs.notify-downstream.result }}
         run: |
           # Check if any job failed or was cancelled
-          if [ "${{ needs.check-updates.result }}" = "failure" ] || \
-            [ "${{ needs.sync-and-enrich.result }}" = "failure" ] || \
-            [ "${{ needs.deploy-docs.result }}" = "failure" ] || \
-            [ "${{ needs.build-downstream-matrix.result }}" = "failure" ] || \
-            [ "${{ needs.notify-downstream.result }}" = "failure" ] || \
-            [ "${{ needs.check-updates.result }}" = "cancelled" ] || \
-            [ "${{ needs.sync-and-enrich.result }}" = "cancelled" ] || \
-            [ "${{ needs.deploy-docs.result }}" = "cancelled" ] || \
-            [ "${{ needs.build-downstream-matrix.result }}" = "cancelled" ] || \
-            [ "${{ needs.notify-downstream.result }}" = "cancelled" ]; then
+          if [ "$CHECK_UPDATES_RESULT" = "failure" ] || \
+            [ "$SYNC_AND_ENRICH_RESULT" = "failure" ] || \
+            [ "$DEPLOY_DOCS_RESULT" = "failure" ] || \
+            [ "$BUILD_DOWNSTREAM_MATRIX_RESULT" = "failure" ] || \
+            [ "$NOTIFY_DOWNSTREAM_RESULT" = "failure" ] || \
+            [ "$CHECK_UPDATES_RESULT" = "cancelled" ] || \
+            [ "$SYNC_AND_ENRICH_RESULT" = "cancelled" ] || \
+            [ "$DEPLOY_DOCS_RESULT" = "cancelled" ] || \
+            [ "$BUILD_DOWNSTREAM_MATRIX_RESULT" = "cancelled" ] || \
+            [ "$NOTIFY_DOWNSTREAM_RESULT" = "cancelled" ]; then
             echo "has_failure=true" >> "$GITHUB_OUTPUT"
             echo "::warning::Workflow failure detected - will create issue"
           else

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -70,7 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
+      pull-requests: write # Comment when the contract-diff gate detects a change.
     steps:
       - name: Checkout repository
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0


### PR DESCRIPTION
## Summary

- move repository and job-result GitHub expressions out of shell `run:` bodies into step environment variables
- document all explicit write permissions inline for deterministic workflow auditing
- preserve release, deployment, downstream dispatch, and monitoring behavior

## Verification

- `uv run --extra dev pytest tests/test_workflow_action_pins.py tests/shell/test_detect_release_changes.py tests/shell/test_dispatch_downstream.py` (44 passed)
- `actionlint .github/workflows/sync-and-enrich.yml .github/workflows/tests.yml`
- `yamllint .github/workflows/sync-and-enrich.yml .github/workflows/tests.yml`
- `zizmor==1.29.0 --no-config --no-ignores --persona=auditor`: zero `template-injection` and zero `undocumented-permissions` findings
- exact-HEAD Antigravity reviewer and verifier approved

Closes #1470