### PR TITLE
feat: publish versioned resource coverage contract

### DIFF
--- a/.github/workflows/sync-and-enrich.yml
+++ b/.github/workflows/sync-and-enrich.yml
@@ -137,6 +137,7 @@ jobs:
     needs: check-updates
     if: needs.check-updates.outputs.has_updates == 'true'
     runs-on: ubuntu-latest
+    environment: release
     # `gh release create` runs as GITHUB_TOKEN and needs contents: write. The
     # release-branch exemption below posts the existing required linked-issue
     # context with GITHUB_TOKEN. Branch pushes, PR create/merge/close and tag
@@ -250,12 +251,9 @@ jobs:
           node-version: '22'
 
       - name: Install Spectral CLI
-        # Pinned: an unpinned `npm install -g` takes whatever was published at run
-        # time, which is the supply-chain exposure zizmor's adhoc-packages audit
-        # flags. Pre-existing; surfaced when a workflow file was next staged.
-        # zizmor: ignore[adhoc-packages] — a global CLI with no project lockfile to
-        # install from; pinning the version is the available mitigation.
-        run: npm install -g @stoplight/spectral-cli@6.16.2
+        run: |
+          npm ci --ignore-scripts
+          echo "$PWD/node_modules/.bin" >> "$GITHUB_PATH"
 
       - name: Check for Discovery Data
         id: check-discovery
@@ -873,6 +871,7 @@ jobs:
     needs: [sync-and-enrich, build-downstream-matrix]
     if: needs.build-downstream-matrix.outputs.has_targets == 'true'
     runs-on: ubuntu-latest
+    environment: downstream-dispatch
     strategy:
       matrix: ${{ fromJSON(needs.build-downstream-matrix.outputs.matrix) }}
       fail-fast: false

--- a/config/namespace_profile.yaml
+++ b/config/namespace_profile.yaml
@@ -1999,3 +1999,31 @@ resources:
     classification:
       category: "observability"
       multi_tenant_pattern: "none"
+
+  # Canonical creates discovered from qualified operation identities. These
+  # entries make the profile explicit while namespace CRUD evidence is pending;
+  # restricted status keeps the classification advisory downstream.
+  addon_subscription: &qualified_create_default
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: operation_identity_default_deny, date: "2026-08-15"}
+    recommendation:
+      primary: "system"
+      rationale: "Canonical create identity pending namespace CRUD verification"
+    classification:
+      category: "application"
+      multi_tenant_pattern: "none"
+  alert_gen_policy: *qualified_create_default
+  alert_template: *qualified_create_default
+  allowed_tenant: *qualified_create_default
+  application_profiles: *qualified_create_default
+  bot_infrastructure: *qualified_create_default
+  child_tenant: *qualified_create_default
+  child_tenant_manager: *qualified_create_default
+  code_base_integration: *qualified_create_default
+  irule: *qualified_create_default
+  managed_tenant: *qualified_create_default
+  mobile_base_config: *qualified_create_default
+  receiver: *qualified_create_default
+  tenant_profile: *qualified_create_default
+  ticket_tracking_system: *qualified_create_default

--- a/config/resource_coverage.yaml
+++ b/config/resource_coverage.yaml
@@ -1,0 +1,47 @@
+# Versioned policy inputs for the generated resource coverage contract.
+#
+# Canonical resources are discovered automatically from exact
+# ves.io.schema.<qualified-resource>.API.Create identities on namespace collection
+# routes. Profile-only resources are excluded automatically with
+# no_canonical_create. Only intentionally supported downstream overrides belong
+# here, and each must name a real GET collection path from the same spec corpus.
+
+version: 1
+
+manual:
+  api_credential:
+    path: "/api/web/namespaces/{namespace}/api_credentials"
+  api_group:
+    path: "/api/web/namespaces/{namespace}/api_groups"
+  bigip_virtual_server:
+    path: "/api/config/namespaces/{namespace}/bigip_virtual_servers"
+  bot_allowlist_policy:
+    path: "/api/shape/bot/namespaces/{namespace}/bot_allowlist_policys"
+  bot_detection_rule:
+    path: "/api/shape/bot/namespaces/{namespace}/bot_detection_rules"
+  bot_endpoint_policy:
+    path: "/api/shape/bot/namespaces/{namespace}/bot_endpoint_policys"
+  bot_network_policy:
+    path: "/api/shape/bot/namespaces/{namespace}/bot_network_policys"
+  discovered_service:
+    path: "/api/discovery/namespaces/{namespace}/discovered_services"
+  flow_anomaly:
+    path: "/api/config/namespaces/{namespace}/flow_anomalys"
+  infraprotect_firewall_ruleset:
+    path: "/api/infraprotect/namespaces/{namespace}/infraprotect_firewall_rulesets"
+  lma_region:
+    path: "/api/config/namespaces/{namespace}/lma_regions"
+  nginx_csg:
+    path: "/api/config/namespaces/{namespace}/nginx_csgs"
+  nginx_instance:
+    path: "/api/config/namespaces/{namespace}/nginx_instances"
+  nginx_server:
+    path: "/api/config/namespaces/{namespace}/nginx_servers"
+  service_credential:
+    path: "/api/web/namespaces/{namespace}/service_credentials"
+  shape_bot_defense_instance:
+    path: "/api/config/namespaces/{namespace}/shape_bot_defense_instances"
+  user:
+    path: "/api/web/custom/namespaces/{namespace}/user_roles"
+
+exclusions: {}

--- a/docs/specifications/api/api.json
+++ b/docs/specifications/api/api.json
@@ -38540,12 +38540,12 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
-            "category": "security",
+            "category": "application",
             "multi_tenant_pattern": "none"
           }
         }
@@ -38626,12 +38626,12 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
-            "category": "security",
+            "category": "application",
             "multi_tenant_pattern": "none"
           }
         }
@@ -38766,12 +38766,12 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
-            "category": "security",
+            "category": "application",
             "multi_tenant_pattern": "none"
           }
         }
@@ -38962,12 +38962,12 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
-            "category": "security",
+            "category": "application",
             "multi_tenant_pattern": "none"
           }
         }
@@ -39027,12 +39027,12 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
-            "category": "security",
+            "category": "application",
             "multi_tenant_pattern": "none"
           }
         }
@@ -39104,12 +39104,12 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
-            "category": "security",
+            "category": "application",
             "multi_tenant_pattern": "none"
           }
         }
@@ -39157,12 +39157,12 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
-            "category": "security",
+            "category": "application",
             "multi_tenant_pattern": "none"
           }
         }
@@ -39298,12 +39298,12 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
-            "category": "security",
+            "category": "application",
             "multi_tenant_pattern": "none"
           }
         }
@@ -39481,12 +39481,12 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
-            "category": "security",
+            "category": "application",
             "multi_tenant_pattern": "none"
           }
         }
@@ -39609,12 +39609,12 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
-            "category": "security",
+            "category": "application",
             "multi_tenant_pattern": "none"
           }
         }
@@ -39737,12 +39737,12 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
-            "category": "security",
+            "category": "application",
             "multi_tenant_pattern": "none"
           }
         }
@@ -39838,12 +39838,12 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
-            "category": "security",
+            "category": "application",
             "multi_tenant_pattern": "none"
           }
         }
@@ -39887,12 +39887,12 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
-            "category": "security",
+            "category": "application",
             "multi_tenant_pattern": "none"
           }
         }
@@ -39976,12 +39976,12 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
-            "category": "security",
+            "category": "application",
             "multi_tenant_pattern": "none"
           }
         }
@@ -40021,12 +40021,12 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
-            "category": "security",
+            "category": "application",
             "multi_tenant_pattern": "none"
           }
         }
@@ -40096,12 +40096,12 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
-            "category": "security",
+            "category": "application",
             "multi_tenant_pattern": "none"
           }
         }
@@ -40178,12 +40178,12 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
-            "category": "security",
+            "category": "application",
             "multi_tenant_pattern": "none"
           }
         }
@@ -40529,12 +40529,12 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
-            "category": "security",
+            "category": "application",
             "multi_tenant_pattern": "none"
           }
         }
@@ -40594,12 +40594,12 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
-            "category": "security",
+            "category": "application",
             "multi_tenant_pattern": "none"
           }
         }
@@ -40623,12 +40623,12 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
-            "category": "security",
+            "category": "application",
             "multi_tenant_pattern": "none"
           }
         }
@@ -40673,12 +40673,12 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
-            "category": "security",
+            "category": "application",
             "multi_tenant_pattern": "none"
           }
         }
@@ -40756,12 +40756,12 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
-            "category": "security",
+            "category": "application",
             "multi_tenant_pattern": "none"
           }
         }

--- a/docs/specifications/api/bigip.json
+++ b/docs/specifications/api/bigip.json
@@ -15852,9 +15852,9 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
@@ -15917,9 +15917,9 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
@@ -15994,9 +15994,9 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
@@ -16119,9 +16119,9 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
@@ -16191,9 +16191,9 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
@@ -16332,9 +16332,9 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
@@ -16493,9 +16493,9 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
@@ -16611,9 +16611,9 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
@@ -16987,9 +16987,9 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
@@ -17477,9 +17477,9 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
@@ -17559,9 +17559,9 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
@@ -17893,9 +17893,9 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
@@ -17958,9 +17958,9 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
@@ -17987,9 +17987,9 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
@@ -18106,9 +18106,9 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
@@ -18322,9 +18322,9 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
@@ -18508,9 +18508,9 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
@@ -19214,9 +19214,9 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
@@ -27705,9 +27705,9 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
@@ -27782,9 +27782,9 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
@@ -27899,9 +27899,9 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
@@ -28040,9 +28040,9 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
@@ -28201,9 +28201,9 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
@@ -28313,9 +28313,9 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
@@ -28395,9 +28395,9 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
@@ -28727,9 +28727,9 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
@@ -28792,9 +28792,9 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
@@ -28821,9 +28821,9 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
@@ -28933,9 +28933,9 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",

--- a/docs/specifications/api/data_intelligence.json
+++ b/docs/specifications/api/data_intelligence.json
@@ -73,20 +73,18 @@
     "x-f5xc-namespace-profile": {
       "constraint": {
         "allowed": [
-          "custom",
-          "default",
-          "shared"
+          "system"
         ],
         "enforced": false
       },
       "recommendation": {
-        "primary": "custom",
+        "primary": "system",
         "alternatives": [],
-        "rationale": "Standard tenant resource"
+        "rationale": "Canonical create identity pending namespace CRUD verification"
       },
       "classification": {
         "category": "application",
-        "multi_tenant_pattern": "per-tenant"
+        "multi_tenant_pattern": "none"
       }
     }
   },
@@ -3604,20 +3602,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -3820,20 +3816,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -3907,20 +3901,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -3959,20 +3951,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -4085,20 +4075,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -4298,20 +4286,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -4371,20 +4357,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -4438,20 +4422,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -4517,20 +4499,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -4729,20 +4709,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -4916,20 +4894,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -5059,20 +5035,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -5192,20 +5166,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -5377,20 +5349,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -5717,20 +5687,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -5911,20 +5879,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -5997,20 +5963,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -6081,20 +6045,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -6432,20 +6394,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -6499,20 +6459,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -6530,20 +6488,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -6736,20 +6692,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -6926,20 +6880,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -7081,20 +7033,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -7166,20 +7116,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -7263,20 +7211,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -7471,20 +7417,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -7730,20 +7674,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -7970,20 +7912,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -8018,20 +7958,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -8110,20 +8048,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -8193,20 +8129,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -8263,20 +8197,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -8506,20 +8438,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -8752,20 +8682,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -8996,20 +8924,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -9306,20 +9232,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -9347,20 +9271,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -9463,20 +9385,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -9803,20 +9723,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -9995,20 +9913,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -10179,20 +10095,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -10268,20 +10182,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -10437,20 +10349,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -10560,20 +10470,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -10735,20 +10643,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -10823,20 +10729,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -10878,20 +10782,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -10932,20 +10834,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -11013,20 +10913,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -11067,20 +10965,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -11120,20 +11016,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -11348,20 +11242,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -11433,20 +11325,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -11533,20 +11423,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -11717,20 +11605,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -11840,20 +11726,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -11925,20 +11809,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -11966,20 +11848,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -12095,20 +11975,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -12216,20 +12094,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -12660,20 +12536,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -12700,20 +12574,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },

--- a/docs/specifications/api/marketplace.json
+++ b/docs/specifications/api/marketplace.json
@@ -13008,20 +13008,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -13075,20 +13073,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -13154,20 +13150,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -13256,20 +13250,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -13399,20 +13391,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -13562,20 +13552,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -13659,20 +13647,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -13743,20 +13729,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -14079,20 +14063,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -14153,20 +14135,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -14220,20 +14200,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -14251,20 +14229,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -14348,20 +14324,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -14439,20 +14413,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },

--- a/docs/specifications/api/namespace_profiles.json
+++ b/docs/specifications/api/namespace_profiles.json
@@ -22,6 +22,28 @@
     }
   },
   "resources": {
+    "addon_subscription": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": false
+      },
+      "recommendation": {
+        "primary": "system",
+        "alternatives": [],
+        "rationale": "Canonical create identity pending namespace CRUD verification"
+      },
+      "classification": {
+        "category": "application",
+        "multi_tenant_pattern": "none"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "restricted",
+        "method": "operation_identity_default_deny"
+      }
+    },
     "address_allocator": {
       "constraint": {
         "allowed": [
@@ -132,6 +154,28 @@
         "method": "conservative_default"
       }
     },
+    "alert_gen_policy": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": false
+      },
+      "recommendation": {
+        "primary": "system",
+        "alternatives": [],
+        "rationale": "Canonical create identity pending namespace CRUD verification"
+      },
+      "classification": {
+        "category": "application",
+        "multi_tenant_pattern": "none"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "restricted",
+        "method": "operation_identity_default_deny"
+      }
+    },
     "alert_policy": {
       "constraint": {
         "allowed": [
@@ -202,6 +246,28 @@
         "method": "crud"
       }
     },
+    "alert_template": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": false
+      },
+      "recommendation": {
+        "primary": "system",
+        "alternatives": [],
+        "rationale": "Canonical create identity pending namespace CRUD verification"
+      },
+      "classification": {
+        "category": "application",
+        "multi_tenant_pattern": "none"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "restricted",
+        "method": "operation_identity_default_deny"
+      }
+    },
     "allowed_domain": {
       "constraint": {
         "allowed": [
@@ -222,6 +288,28 @@
         "explicit": true,
         "verification": "restricted",
         "method": "conservative_default"
+      }
+    },
+    "allowed_tenant": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": false
+      },
+      "recommendation": {
+        "primary": "system",
+        "alternatives": [],
+        "rationale": "Canonical create identity pending namespace CRUD verification"
+      },
+      "classification": {
+        "category": "application",
+        "multi_tenant_pattern": "none"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "restricted",
+        "method": "operation_identity_default_deny"
       }
     },
     "analytics_query": {
@@ -541,6 +629,28 @@
         "explicit": true,
         "verification": "unverified",
         "method": ""
+      }
+    },
+    "application_profiles": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": false
+      },
+      "recommendation": {
+        "primary": "system",
+        "alternatives": [],
+        "rationale": "Canonical create identity pending namespace CRUD verification"
+      },
+      "classification": {
+        "category": "application",
+        "multi_tenant_pattern": "none"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "restricted",
+        "method": "operation_identity_default_deny"
       }
     },
     "audit_log": {
@@ -1007,6 +1117,28 @@
         "method": "conservative_default"
       }
     },
+    "bot_infrastructure": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": false
+      },
+      "recommendation": {
+        "primary": "system",
+        "alternatives": [],
+        "rationale": "Canonical create identity pending namespace CRUD verification"
+      },
+      "classification": {
+        "category": "application",
+        "multi_tenant_pattern": "none"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "restricted",
+        "method": "operation_identity_default_deny"
+      }
+    },
     "bot_network_policy": {
       "constraint": {
         "allowed": [
@@ -1215,6 +1347,50 @@
         "method": "crud"
       }
     },
+    "child_tenant": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": false
+      },
+      "recommendation": {
+        "primary": "system",
+        "alternatives": [],
+        "rationale": "Canonical create identity pending namespace CRUD verification"
+      },
+      "classification": {
+        "category": "application",
+        "multi_tenant_pattern": "none"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "restricted",
+        "method": "operation_identity_default_deny"
+      }
+    },
+    "child_tenant_manager": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": false
+      },
+      "recommendation": {
+        "primary": "system",
+        "alternatives": [],
+        "rationale": "Canonical create identity pending namespace CRUD verification"
+      },
+      "classification": {
+        "category": "application",
+        "multi_tenant_pattern": "none"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "restricted",
+        "method": "operation_identity_default_deny"
+      }
+    },
     "cloud_connect": {
       "constraint": {
         "allowed": [
@@ -1347,6 +1523,28 @@
         "explicit": true,
         "verification": "restricted",
         "method": "default_deny"
+      }
+    },
+    "code_base_integration": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": false
+      },
+      "recommendation": {
+        "primary": "system",
+        "alternatives": [],
+        "rationale": "Canonical create identity pending namespace CRUD verification"
+      },
+      "classification": {
+        "category": "application",
+        "multi_tenant_pattern": "none"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "restricted",
+        "method": "operation_identity_default_deny"
       }
     },
     "contact": {
@@ -2583,6 +2781,28 @@
         "method": ""
       }
     },
+    "irule": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": false
+      },
+      "recommendation": {
+        "primary": "system",
+        "alternatives": [],
+        "rationale": "Canonical create identity pending namespace CRUD verification"
+      },
+      "classification": {
+        "category": "application",
+        "multi_tenant_pattern": "none"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "restricted",
+        "method": "operation_identity_default_deny"
+      }
+    },
     "k8s_cluster": {
       "constraint": {
         "allowed": [
@@ -2895,6 +3115,28 @@
         "method": "crud"
       }
     },
+    "managed_tenant": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": false
+      },
+      "recommendation": {
+        "primary": "system",
+        "alternatives": [],
+        "rationale": "Canonical create identity pending namespace CRUD verification"
+      },
+      "classification": {
+        "category": "application",
+        "multi_tenant_pattern": "none"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "restricted",
+        "method": "operation_identity_default_deny"
+      }
+    },
     "marketplace_item": {
       "constraint": {
         "allowed": [
@@ -3005,6 +3247,28 @@
         "explicit": true,
         "verification": "restricted",
         "method": "conservative_default"
+      }
+    },
+    "mobile_base_config": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": false
+      },
+      "recommendation": {
+        "primary": "system",
+        "alternatives": [],
+        "rationale": "Canonical create identity pending namespace CRUD verification"
+      },
+      "classification": {
+        "category": "application",
+        "multi_tenant_pattern": "none"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "restricted",
+        "method": "operation_identity_default_deny"
       }
     },
     "namespace": {
@@ -3818,6 +4082,28 @@
         "method": "crud"
       }
     },
+    "receiver": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": false
+      },
+      "recommendation": {
+        "primary": "system",
+        "alternatives": [],
+        "rationale": "Canonical create identity pending namespace CRUD verification"
+      },
+      "classification": {
+        "category": "application",
+        "multi_tenant_pattern": "none"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "restricted",
+        "method": "operation_identity_default_deny"
+      }
+    },
     "registration": {
       "constraint": {
         "allowed": [
@@ -4627,6 +4913,28 @@
         "method": ""
       }
     },
+    "tenant_profile": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": false
+      },
+      "recommendation": {
+        "primary": "system",
+        "alternatives": [],
+        "rationale": "Canonical create identity pending namespace CRUD verification"
+      },
+      "classification": {
+        "category": "application",
+        "multi_tenant_pattern": "none"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "restricted",
+        "method": "operation_identity_default_deny"
+      }
+    },
     "tenant_settings": {
       "constraint": {
         "allowed": [
@@ -4691,6 +4999,28 @@
         "explicit": true,
         "verification": "restricted",
         "method": "conservative_default"
+      }
+    },
+    "ticket_tracking_system": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": false
+      },
+      "recommendation": {
+        "primary": "system",
+        "alternatives": [],
+        "rationale": "Canonical create identity pending namespace CRUD verification"
+      },
+      "classification": {
+        "category": "application",
+        "multi_tenant_pattern": "none"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "restricted",
+        "method": "operation_identity_default_deny"
       }
     },
     "token": {
@@ -5493,10 +5823,10 @@
     }
   },
   "_coverage": {
-    "total_explicit": 242,
+    "total_explicit": 257,
     "verified": 74,
     "assumed": 10,
-    "unverified": 158,
+    "unverified": 173,
     "default_deny_worklist_count": 17,
     "default_deny_worklist": [
       "address_allocator",

--- a/docs/specifications/api/resource_coverage.json
+++ b/docs/specifications/api/resource_coverage.json
@@ -1,0 +1,1200 @@
+{
+  "version": "2.1.220",
+  "contract_version": 1,
+  "source": "api-specs-enriched/config/resource_coverage.yaml",
+  "resources": {
+    "addon_subscription": {
+      "disposition": "generated",
+      "path": "/api/web/namespaces/{metadata.namespace}/addon_subscriptions",
+      "operation_id": "ves.io.schema.pbac.addon_subscription.API.Create"
+    },
+    "address_allocator": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/address_allocators",
+      "operation_id": "ves.io.schema.address_allocator.API.Create"
+    },
+    "advertise_policy": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/advertise_policys",
+      "operation_id": "ves.io.schema.advertise_policy.API.Create"
+    },
+    "ai_gateway": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "ai_policy": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "alert": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "alert_gen_policy": {
+      "disposition": "generated",
+      "path": "/api/shape/alerts/namespaces/{metadata.namespace}/alert_gen_policys",
+      "operation_id": "ves.io.schema.shape.brmalerts.alert_gen_policy.API.Create"
+    },
+    "alert_policy": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/alert_policys",
+      "operation_id": "ves.io.schema.alert_policy.API.Create"
+    },
+    "alert_policy_set": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "alert_receiver": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/alert_receivers",
+      "operation_id": "ves.io.schema.alert_receiver.API.Create"
+    },
+    "alert_template": {
+      "disposition": "generated",
+      "path": "/api/shape/alerts/namespaces/{metadata.namespace}/alert_templates",
+      "operation_id": "ves.io.schema.shape.brmalerts.alert_template.API.Create"
+    },
+    "allowed_domain": {
+      "disposition": "generated",
+      "path": "/api/shape/csd/namespaces/{metadata.namespace}/allowed_domains",
+      "operation_id": "ves.io.schema.shape.client_side_defense.allowed_domain.API.Create"
+    },
+    "allowed_tenant": {
+      "disposition": "generated",
+      "path": "/api/web/namespaces/{metadata.namespace}/allowed_tenants",
+      "operation_id": "ves.io.schema.tenant_management.allowed_tenant.API.Create"
+    },
+    "analytics_query": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "api_crawler": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/api_crawlers",
+      "operation_id": "ves.io.schema.api_sec.api_crawler.API.Create"
+    },
+    "api_credential": {
+      "disposition": "manual",
+      "path": "/api/web/namespaces/{namespace}/api_credentials"
+    },
+    "api_credential_api_token": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "api_definition": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/api_definitions",
+      "operation_id": "ves.io.schema.views.api_definition.API.Create"
+    },
+    "api_discovery": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/api_discoverys",
+      "operation_id": "ves.io.schema.api_sec.api_discovery.API.Create"
+    },
+    "api_endpoint": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "api_group": {
+      "disposition": "manual",
+      "path": "/api/web/namespaces/{namespace}/api_groups"
+    },
+    "api_rate_limit": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "api_testing": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/api_testings",
+      "operation_id": "ves.io.schema.api_sec.api_testing.API.Create"
+    },
+    "app_api_group": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/app_api_groups",
+      "operation_id": "ves.io.schema.views.app_api_group.API.Create"
+    },
+    "app_firewall": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/app_firewalls",
+      "operation_id": "ves.io.schema.app_firewall.API.Create"
+    },
+    "app_setting": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/app_settings",
+      "operation_id": "ves.io.schema.app_setting.API.Create"
+    },
+    "app_type": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/app_types",
+      "operation_id": "ves.io.schema.app_type.API.Create"
+    },
+    "application_profiles": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/application_profiless",
+      "operation_id": "ves.io.schema.bigcne.application_profiles.API.Create"
+    },
+    "audit_log": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "authentication": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/authentications",
+      "operation_id": "ves.io.schema.authentication.API.Create"
+    },
+    "authentication_policy": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "authorization_server": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/authorization_servers",
+      "operation_id": "ves.io.schema.authorization_server.API.Create"
+    },
+    "aws_tgw_site": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/aws_tgw_sites",
+      "operation_id": "ves.io.schema.views.aws_tgw_site.API.Create"
+    },
+    "aws_vpc_site": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/aws_vpc_sites",
+      "operation_id": "ves.io.schema.views.aws_vpc_site.API.Create"
+    },
+    "azure_vnet_site": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/azure_vnet_sites",
+      "operation_id": "ves.io.schema.views.azure_vnet_site.API.Create"
+    },
+    "bgp": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/bgps",
+      "operation_id": "ves.io.schema.bgp.API.Create"
+    },
+    "bgp_asn_set": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/bgp_asn_sets",
+      "operation_id": "ves.io.schema.bgp_asn_set.API.Create"
+    },
+    "bgp_routing_policy": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/bgp_routing_policys",
+      "operation_id": "ves.io.schema.bgp_routing_policy.API.Create"
+    },
+    "bigip_device": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "bigip_http_proxy": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/bigip_http_proxys",
+      "operation_id": "ves.io.schema.views.bigip_http_proxy.API.Create"
+    },
+    "bigip_irule": {
+      "disposition": "generated",
+      "path": "/api/bigipconnector/namespaces/{metadata.namespace}/bigip_irules",
+      "operation_id": "ves.io.schema.bigip_irule.API.Create"
+    },
+    "bigip_pool": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "bigip_virtual_server": {
+      "disposition": "manual",
+      "path": "/api/config/namespaces/{namespace}/bigip_virtual_servers"
+    },
+    "blindfold_secret": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "bot_allowlist_policy": {
+      "disposition": "manual",
+      "path": "/api/shape/bot/namespaces/{namespace}/bot_allowlist_policys"
+    },
+    "bot_defense_app_infrastructure": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/bot_defense_app_infrastructures",
+      "operation_id": "ves.io.schema.views.bot_defense_app_infrastructure.API.Create"
+    },
+    "bot_defense_instance": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "bot_detection_rule": {
+      "disposition": "manual",
+      "path": "/api/shape/bot/namespaces/{namespace}/bot_detection_rules"
+    },
+    "bot_endpoint_policy": {
+      "disposition": "manual",
+      "path": "/api/shape/bot/namespaces/{namespace}/bot_endpoint_policys"
+    },
+    "bot_infrastructure": {
+      "disposition": "generated",
+      "path": "/api/shape/bot/namespaces/{metadata.namespace}/bot_infrastructures",
+      "operation_id": "ves.io.schema.shape.bot_defense.bot_infrastructure.API.Create"
+    },
+    "bot_network_policy": {
+      "disposition": "manual",
+      "path": "/api/shape/bot/namespaces/{namespace}/bot_network_policys"
+    },
+    "bucket": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "ca_certificate": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "cdn_cache_rule": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/cdn_cache_rules",
+      "operation_id": "ves.io.schema.cdn_cache_rule.API.Create"
+    },
+    "cdn_loadbalancer": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/cdn_loadbalancers",
+      "operation_id": "ves.io.schema.views.cdn_loadbalancer.API.Create"
+    },
+    "cdn_origin_pool": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "cdn_purge_command": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/cdn_purge_commands",
+      "operation_id": "ves.io.schema.cdn_purge_command.API.Create"
+    },
+    "certificate": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/certificates",
+      "operation_id": "ves.io.schema.certificate.API.Create"
+    },
+    "certificate_chain": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/certificate_chains",
+      "operation_id": "ves.io.schema.certificate_chain.API.Create"
+    },
+    "child_tenant": {
+      "disposition": "generated",
+      "path": "/api/web/namespaces/{metadata.namespace}/child_tenants",
+      "operation_id": "ves.io.schema.tenant_management.child_tenant.API.Create"
+    },
+    "child_tenant_manager": {
+      "disposition": "generated",
+      "path": "/api/web/namespaces/{metadata.namespace}/child_tenant_managers",
+      "operation_id": "ves.io.schema.tenant_management.child_tenant_manager.API.Create"
+    },
+    "cloud_connect": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/cloud_connects",
+      "operation_id": "ves.io.schema.cloud_connect.API.Create"
+    },
+    "cloud_credentials": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/cloud_credentialss",
+      "operation_id": "ves.io.schema.cloud_credentials.API.Create"
+    },
+    "cloud_elastic_ip": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/cloud_elastic_ips",
+      "operation_id": "ves.io.schema.cloud_elastic_ip.API.Create"
+    },
+    "cloud_link": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/cloud_links",
+      "operation_id": "ves.io.schema.cloud_link.API.Create"
+    },
+    "cluster": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/clusters",
+      "operation_id": "ves.io.schema.cluster.API.Create"
+    },
+    "cminstance": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/cminstances",
+      "operation_id": "ves.io.schema.cminstance.API.Create"
+    },
+    "code_base_integration": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/code_base_integrations",
+      "operation_id": "ves.io.schema.api_sec.code_base_integration.API.Create"
+    },
+    "contact": {
+      "disposition": "generated",
+      "path": "/api/web/namespaces/{metadata.namespace}/contacts",
+      "operation_id": "ves.io.schema.contact.API.Create"
+    },
+    "container_registry": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/container_registrys",
+      "operation_id": "ves.io.schema.container_registry.API.Create"
+    },
+    "crl": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/crls",
+      "operation_id": "ves.io.schema.crl.API.Create"
+    },
+    "customer_support": {
+      "disposition": "generated",
+      "path": "/api/web/namespaces/{metadata.namespace}/customer_supports",
+      "operation_id": "ves.io.schema.customer_support.API.Create"
+    },
+    "dashboard": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "data_classification": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "data_export": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "data_group": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/data_groups",
+      "operation_id": "ves.io.schema.bigcne.data_group.API.Create"
+    },
+    "data_type": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/data_types",
+      "operation_id": "ves.io.schema.data_type.API.Create"
+    },
+    "dc_cluster_group": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/dc_cluster_groups",
+      "operation_id": "ves.io.schema.dc_cluster_group.API.Create"
+    },
+    "ddos_mitigation_rule": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "ddos_protection": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "discovered_service": {
+      "disposition": "manual",
+      "path": "/api/discovery/namespaces/{namespace}/discovered_services"
+    },
+    "discovery": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/discoverys",
+      "operation_id": "ves.io.schema.discovery.API.Create"
+    },
+    "dns_compliance_checks": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/dns_compliance_checkss",
+      "operation_id": "ves.io.schema.dns_compliance_checks.API.Create"
+    },
+    "dns_domain": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/dns_domains",
+      "operation_id": "ves.io.schema.dns_domain.API.Create"
+    },
+    "dns_lb_health_check": {
+      "disposition": "generated",
+      "path": "/api/config/dns/namespaces/{metadata.namespace}/dns_lb_health_checks",
+      "operation_id": "ves.io.schema.dns_lb_health_check.API.Create"
+    },
+    "dns_lb_pool": {
+      "disposition": "generated",
+      "path": "/api/config/dns/namespaces/{metadata.namespace}/dns_lb_pools",
+      "operation_id": "ves.io.schema.dns_lb_pool.API.Create"
+    },
+    "dns_load_balancer": {
+      "disposition": "generated",
+      "path": "/api/config/dns/namespaces/{metadata.namespace}/dns_load_balancers",
+      "operation_id": "ves.io.schema.dns_load_balancer.API.Create"
+    },
+    "dns_proxy": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/dns_proxys",
+      "operation_id": "ves.io.schema.dns_proxy.API.Create"
+    },
+    "dns_zone": {
+      "disposition": "generated",
+      "path": "/api/config/dns/namespaces/{metadata.namespace}/dns_zones",
+      "operation_id": "ves.io.schema.dns_zone.API.Create"
+    },
+    "endpoint": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/endpoints",
+      "operation_id": "ves.io.schema.endpoint.API.Create"
+    },
+    "enhanced_firewall_policy": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/enhanced_firewall_policys",
+      "operation_id": "ves.io.schema.enhanced_firewall_policy.API.Create"
+    },
+    "external_connector": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/external_connectors",
+      "operation_id": "ves.io.schema.views.external_connector.API.Create"
+    },
+    "fast_acl": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/fast_acls",
+      "operation_id": "ves.io.schema.fast_acl.API.Create"
+    },
+    "fast_acl_rule": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/fast_acl_rules",
+      "operation_id": "ves.io.schema.fast_acl_rule.API.Create"
+    },
+    "filter_set": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/filter_sets",
+      "operation_id": "ves.io.schema.filter_set.API.Create"
+    },
+    "fleet": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/fleets",
+      "operation_id": "ves.io.schema.fleet.API.Create"
+    },
+    "fleet_config": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "flow_anomaly": {
+      "disposition": "manual",
+      "path": "/api/config/namespaces/{namespace}/flow_anomalys"
+    },
+    "forward_proxy_policy": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/forward_proxy_policys",
+      "operation_id": "ves.io.schema.views.forward_proxy_policy.API.Create"
+    },
+    "forwarding_class": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/forwarding_classs",
+      "operation_id": "ves.io.schema.forwarding_class.API.Create"
+    },
+    "gcp_vpc_site": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/gcp_vpc_sites",
+      "operation_id": "ves.io.schema.views.gcp_vpc_site.API.Create"
+    },
+    "geo_location_set": {
+      "disposition": "generated",
+      "path": "/api/config/dns/namespaces/{metadata.namespace}/geo_location_sets",
+      "operation_id": "ves.io.schema.geo_location_set.API.Create"
+    },
+    "global_log_receiver": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/global_log_receivers",
+      "operation_id": "ves.io.schema.global_log_receiver.API.Create"
+    },
+    "global_network": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "healthcheck": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/healthchecks",
+      "operation_id": "ves.io.schema.healthcheck.API.Create"
+    },
+    "http_loadbalancer": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/http_loadbalancers",
+      "operation_id": "ves.io.schema.views.http_loadbalancer.API.Create"
+    },
+    "ike1": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/ike1s",
+      "operation_id": "ves.io.schema.ike1.API.Create"
+    },
+    "ike2": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/ike2s",
+      "operation_id": "ves.io.schema.ike2.API.Create"
+    },
+    "ike_phase1_profile": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/ike_phase1_profiles",
+      "operation_id": "ves.io.schema.views.ike_phase1_profile.API.Create"
+    },
+    "ike_phase2_profile": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/ike_phase2_profiles",
+      "operation_id": "ves.io.schema.views.ike_phase2_profile.API.Create"
+    },
+    "infraprotect_asn": {
+      "disposition": "generated",
+      "path": "/api/infraprotect/namespaces/{metadata.namespace}/infraprotect_asns",
+      "operation_id": "ves.io.schema.infraprotect_asn.API.Create"
+    },
+    "infraprotect_asn_prefix": {
+      "disposition": "generated",
+      "path": "/api/infraprotect/namespaces/{metadata.namespace}/infraprotect_asn_prefixs",
+      "operation_id": "ves.io.schema.infraprotect_asn_prefix.API.Create"
+    },
+    "infraprotect_deny_list_rule": {
+      "disposition": "generated",
+      "path": "/api/infraprotect/namespaces/{metadata.namespace}/infraprotect_deny_list_rules",
+      "operation_id": "ves.io.schema.infraprotect_deny_list_rule.API.Create"
+    },
+    "infraprotect_firewall_rule": {
+      "disposition": "generated",
+      "path": "/api/infraprotect/namespaces/{metadata.namespace}/infraprotect_firewall_rules",
+      "operation_id": "ves.io.schema.infraprotect_firewall_rule.API.Create"
+    },
+    "infraprotect_firewall_rule_group": {
+      "disposition": "generated",
+      "path": "/api/infraprotect/namespaces/{metadata.namespace}/infraprotect_firewall_rule_groups",
+      "operation_id": "ves.io.schema.infraprotect_firewall_rule_group.API.Create"
+    },
+    "infraprotect_firewall_ruleset": {
+      "disposition": "manual",
+      "path": "/api/infraprotect/namespaces/{namespace}/infraprotect_firewall_rulesets"
+    },
+    "infraprotect_internet_prefix_advertisement": {
+      "disposition": "generated",
+      "path": "/api/infraprotect/namespaces/{metadata.namespace}/infraprotect_internet_prefix_advertisements",
+      "operation_id": "ves.io.schema.infraprotect_internet_prefix_advertisement.API.Create"
+    },
+    "infraprotect_packet_capture": {
+      "disposition": "generated",
+      "path": "/api/infraprotect/namespaces/{metadata.namespace}/infraprotect_packet_captures",
+      "operation_id": "ves.io.schema.infraprotect_packet_capture.API.Create"
+    },
+    "infraprotect_tunnel": {
+      "disposition": "generated",
+      "path": "/api/infraprotect/namespaces/{metadata.namespace}/infraprotect_tunnels",
+      "operation_id": "ves.io.schema.infraprotect_tunnel.API.Create"
+    },
+    "insight_query": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "interface": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "ip_prefix_set": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/ip_prefix_sets",
+      "operation_id": "ves.io.schema.ip_prefix_set.API.Create"
+    },
+    "irule": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/irules",
+      "operation_id": "ves.io.schema.bigcne.irule.API.Create"
+    },
+    "k8s_cluster": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/k8s_clusters",
+      "operation_id": "ves.io.schema.k8s_cluster.API.Create"
+    },
+    "k8s_cluster_role": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/k8s_cluster_roles",
+      "operation_id": "ves.io.schema.k8s_cluster_role.API.Create"
+    },
+    "k8s_cluster_role_binding": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/k8s_cluster_role_bindings",
+      "operation_id": "ves.io.schema.k8s_cluster_role_binding.API.Create"
+    },
+    "k8s_pod_security_admission": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/k8s_pod_security_admissions",
+      "operation_id": "ves.io.schema.k8s_pod_security_admission.API.Create"
+    },
+    "k8s_pod_security_policy": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/k8s_pod_security_policys",
+      "operation_id": "ves.io.schema.k8s_pod_security_policy.API.Create"
+    },
+    "known_label": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "known_label_key": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "label": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "label_group": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "lma_region": {
+      "disposition": "manual",
+      "path": "/api/config/namespaces/{namespace}/lma_regions"
+    },
+    "log_receiver": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/log_receivers",
+      "operation_id": "ves.io.schema.log_receiver.API.Create"
+    },
+    "malicious_user_detection": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "malicious_user_mitigation": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/malicious_user_mitigations",
+      "operation_id": "ves.io.schema.malicious_user_mitigation.API.Create"
+    },
+    "malicious_user_rule": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "managed_tenant": {
+      "disposition": "generated",
+      "path": "/api/web/namespaces/{metadata.namespace}/managed_tenants",
+      "operation_id": "ves.io.schema.tenant_management.managed_tenant.API.Create"
+    },
+    "marketplace_item": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "metrics_receiver": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "mitigated_domain": {
+      "disposition": "generated",
+      "path": "/api/shape/csd/namespaces/{metadata.namespace}/mitigated_domains",
+      "operation_id": "ves.io.schema.shape.client_side_defense.mitigated_domain.API.Create"
+    },
+    "mitigation_policy": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "mk8s_cluster": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "mobile_base_config": {
+      "disposition": "generated",
+      "path": "/api/mobile/security/namespaces/{metadata.namespace}/mobile_base_configs",
+      "operation_id": "ves.io.schema.shape.bot_defense.mobile_base_config.API.Create"
+    },
+    "namespace": {
+      "disposition": "generated",
+      "path": "/api/web/namespaces",
+      "operation_id": "ves.io.schema.namespace.API.Create"
+    },
+    "namespace_role": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "namespace_role_binding": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "nat_policy": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/nat_policys",
+      "operation_id": "ves.io.schema.nat_policy.API.Create"
+    },
+    "network_connector": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/network_connectors",
+      "operation_id": "ves.io.schema.network_connector.API.Create"
+    },
+    "network_firewall": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/network_firewalls",
+      "operation_id": "ves.io.schema.network_firewall.API.Create"
+    },
+    "network_interface": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/network_interfaces",
+      "operation_id": "ves.io.schema.network_interface.API.Create"
+    },
+    "network_policy": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/network_policys",
+      "operation_id": "ves.io.schema.network_policy.API.Create"
+    },
+    "network_policy_rule": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/network_policy_rules",
+      "operation_id": "ves.io.schema.network_policy_rule.API.Create"
+    },
+    "network_policy_set": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "network_policy_view": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/network_policy_views",
+      "operation_id": "ves.io.schema.views.network_policy_view.API.Create"
+    },
+    "nfv_service": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/nfv_services",
+      "operation_id": "ves.io.schema.nfv_service.API.Create"
+    },
+    "nginx_config": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "nginx_csg": {
+      "disposition": "manual",
+      "path": "/api/config/namespaces/{namespace}/nginx_csgs"
+    },
+    "nginx_instance": {
+      "disposition": "manual",
+      "path": "/api/config/namespaces/{namespace}/nginx_instances"
+    },
+    "nginx_server": {
+      "disposition": "manual",
+      "path": "/api/config/namespaces/{namespace}/nginx_servers"
+    },
+    "nginx_service_discovery": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/nginx_service_discoverys",
+      "operation_id": "ves.io.schema.nginx.one.nginx_service_discovery.API.Create"
+    },
+    "nginx_upstream": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "node_config": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "object_store": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "origin_pool": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/origin_pools",
+      "operation_id": "ves.io.schema.views.origin_pool.API.Create"
+    },
+    "otp_policy": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "physical_k8s_site": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "pod_security_policy": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "policer": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/policers",
+      "operation_id": "ves.io.schema.policer.API.Create"
+    },
+    "policy_based_routing": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/policy_based_routings",
+      "operation_id": "ves.io.schema.views.policy_based_routing.API.Create"
+    },
+    "policy_document": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "protected_application": {
+      "disposition": "generated",
+      "path": "/api/shape/bot/namespaces/{metadata.namespace}/protected_applications",
+      "operation_id": "ves.io.schema.shape.bot_defense.protected_application.API.Create"
+    },
+    "protected_domain": {
+      "disposition": "generated",
+      "path": "/api/shape/csd/namespaces/{metadata.namespace}/protected_domains",
+      "operation_id": "ves.io.schema.shape.client_side_defense.protected_domain.API.Create"
+    },
+    "protocol_inspection": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/protocol_inspections",
+      "operation_id": "ves.io.schema.protocol_inspection.API.Create"
+    },
+    "protocol_policer": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/protocol_policers",
+      "operation_id": "ves.io.schema.protocol_policer.API.Create"
+    },
+    "proxy": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/proxys",
+      "operation_id": "ves.io.schema.views.proxy.API.Create"
+    },
+    "quota": {
+      "disposition": "generated",
+      "path": "/api/web/namespaces/{metadata.namespace}/quotas",
+      "operation_id": "ves.io.schema.quota.API.Create"
+    },
+    "rate_limit_threshold": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "rate_limiter": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/rate_limiters",
+      "operation_id": "ves.io.schema.rate_limiter.API.Create"
+    },
+    "rate_limiter_policy": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/rate_limiter_policys",
+      "operation_id": "ves.io.schema.views.rate_limiter_policy.API.Create"
+    },
+    "receiver": {
+      "disposition": "generated",
+      "path": "/api/data-intelligence/namespaces/{metadata.namespace}/receivers",
+      "operation_id": "ves.io.schema.shape.data_delivery.receiver.API.Create"
+    },
+    "registration": {
+      "disposition": "generated",
+      "path": "/api/register/namespaces/{metadata.namespace}/registrations",
+      "operation_id": "ves.io.schema.registration.API.Create"
+    },
+    "registration_token": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "report_config": {
+      "disposition": "generated",
+      "path": "/api/report/namespaces/{metadata.namespace}/report_configs",
+      "operation_id": "ves.io.schema.report_config.API.Create"
+    },
+    "role": {
+      "disposition": "generated",
+      "path": "/api/web/namespaces/{metadata.namespace}/roles",
+      "operation_id": "ves.io.schema.role.API.Create"
+    },
+    "route": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/routes",
+      "operation_id": "ves.io.schema.route.API.Create"
+    },
+    "saved_query": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "secret": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "secret_management_access": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/secret_management_accesss",
+      "operation_id": "ves.io.schema.secret_management_access.API.Create"
+    },
+    "secret_policy": {
+      "disposition": "generated",
+      "path": "/api/secret_management/namespaces/{metadata.namespace}/secret_policys",
+      "operation_id": "ves.io.schema.secret_policy.API.Create"
+    },
+    "secret_policy_rule": {
+      "disposition": "generated",
+      "path": "/api/secret_management/namespaces/{metadata.namespace}/secret_policy_rules",
+      "operation_id": "ves.io.schema.secret_policy_rule.API.Create"
+    },
+    "securemesh_site": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/securemesh_sites",
+      "operation_id": "ves.io.schema.views.securemesh_site.API.Create"
+    },
+    "securemesh_site_v2": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/securemesh_site_v2s",
+      "operation_id": "ves.io.schema.views.securemesh_site_v2.API.Create"
+    },
+    "segment": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/segments",
+      "operation_id": "ves.io.schema.segment.API.Create"
+    },
+    "sensitive_data_policy": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/sensitive_data_policys",
+      "operation_id": "ves.io.schema.sensitive_data_policy.API.Create"
+    },
+    "service_credential": {
+      "disposition": "manual",
+      "path": "/api/web/namespaces/{namespace}/service_credentials"
+    },
+    "service_discovery": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "service_policy": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/service_policys",
+      "operation_id": "ves.io.schema.service_policy.API.Create"
+    },
+    "service_policy_rule": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/service_policy_rules",
+      "operation_id": "ves.io.schema.service_policy_rule.API.Create"
+    },
+    "session": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "shape_app_firewall": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "shape_bot_defense_instance": {
+      "disposition": "manual",
+      "path": "/api/config/namespaces/{namespace}/shape_bot_defense_instances"
+    },
+    "shape_recognizer": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "site": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "site_config": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "site_mesh": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "site_mesh_group": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/site_mesh_groups",
+      "operation_id": "ves.io.schema.site_mesh_group.API.Create"
+    },
+    "software_version": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "srv6_network_slice": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/srv6_network_slices",
+      "operation_id": "ves.io.schema.srv6_network_slice.API.Create"
+    },
+    "static_asset": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "subnet": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/subnets",
+      "operation_id": "ves.io.schema.subnet.API.Create"
+    },
+    "subscription": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "support_case": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "tcp_loadbalancer": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/tcp_loadbalancers",
+      "operation_id": "ves.io.schema.views.tcp_loadbalancer.API.Create"
+    },
+    "telemetry_receiver": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "tenant": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "tenant_configuration": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/tenant_configurations",
+      "operation_id": "ves.io.schema.views.tenant_configuration.API.Create"
+    },
+    "tenant_profile": {
+      "disposition": "generated",
+      "path": "/api/web/namespaces/{metadata.namespace}/tenant_profiles",
+      "operation_id": "ves.io.schema.tenant_management.tenant_profile.API.Create"
+    },
+    "tenant_settings": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "threat_campaign_policy": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "threat_category": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "ticket_tracking_system": {
+      "disposition": "generated",
+      "path": "/api/web/namespaces/{metadata.namespace}/ticket_tracking_systems",
+      "operation_id": "ves.io.schema.ticket_management.ticket_tracking_system.API.Create"
+    },
+    "token": {
+      "disposition": "generated",
+      "path": "/api/register/namespaces/{metadata.namespace}/tokens",
+      "operation_id": "ves.io.schema.token.API.Create"
+    },
+    "tpm_api_key": {
+      "disposition": "generated",
+      "path": "/api/tpm/namespaces/{metadata.namespace}/tpm_api_keys",
+      "operation_id": "ves.io.schema.tpm_api_key.API.Create"
+    },
+    "tpm_category": {
+      "disposition": "generated",
+      "path": "/api/tpm/namespaces/{metadata.namespace}/tpm_categorys",
+      "operation_id": "ves.io.schema.tpm_category.API.Create"
+    },
+    "tpm_manager": {
+      "disposition": "generated",
+      "path": "/api/tpm/namespaces/{metadata.namespace}/tpm_managers",
+      "operation_id": "ves.io.schema.tpm_manager.API.Create"
+    },
+    "trusted_ca_list": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/trusted_ca_lists",
+      "operation_id": "ves.io.schema.trusted_ca_list.API.Create"
+    },
+    "tunnel": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/tunnels",
+      "operation_id": "ves.io.schema.tunnel.API.Create"
+    },
+    "udp_loadbalancer": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/udp_loadbalancers",
+      "operation_id": "ves.io.schema.views.udp_loadbalancer.API.Create"
+    },
+    "ui_component": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "upgrade_os": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "usage_report": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "usb_policy": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/usb_policys",
+      "operation_id": "ves.io.schema.usb_policy.API.Create"
+    },
+    "user": {
+      "disposition": "manual",
+      "path": "/api/web/custom/namespaces/{namespace}/user_roles"
+    },
+    "user_identification": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/user_identifications",
+      "operation_id": "ves.io.schema.user_identification.API.Create"
+    },
+    "user_profile": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "user_role": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "v1_dns_monitor": {
+      "disposition": "generated",
+      "path": "/api/observability/synthetic_monitor/namespaces/{metadata.namespace}/v1_dns_monitors",
+      "operation_id": "ves.io.schema.observability.synthetic_monitor.v1_dns_monitor.API.Create"
+    },
+    "v1_http_monitor": {
+      "disposition": "generated",
+      "path": "/api/observability/synthetic_monitor/namespaces/{metadata.namespace}/v1_http_monitors",
+      "operation_id": "ves.io.schema.observability.synthetic_monitor.v1_http_monitor.API.Create"
+    },
+    "views_advertise_policy": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "views_aws_tgw_site": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "views_aws_vpc_site": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "views_azure_vnet_site": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "views_gcp_vpc_site": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "views_physical_k8s_site": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "views_voltstack_site": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "virtual_host": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/virtual_hosts",
+      "operation_id": "ves.io.schema.virtual_host.API.Create"
+    },
+    "virtual_k8s": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/virtual_k8ss",
+      "operation_id": "ves.io.schema.virtual_k8s.API.Create"
+    },
+    "virtual_network": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/virtual_networks",
+      "operation_id": "ves.io.schema.virtual_network.API.Create"
+    },
+    "virtual_site": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/virtual_sites",
+      "operation_id": "ves.io.schema.virtual_site.API.Create"
+    },
+    "voltshare_admin_policy": {
+      "disposition": "generated",
+      "path": "/api/secret_management/namespaces/{metadata.namespace}/voltshare_admin_policys",
+      "operation_id": "ves.io.schema.voltshare_admin_policy.API.Create"
+    },
+    "voltstack_site": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/voltstack_sites",
+      "operation_id": "ves.io.schema.views.voltstack_site.API.Create"
+    },
+    "vpm_config": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "waf": {
+      "disposition": "excluded",
+      "reason": "no_canonical_create"
+    },
+    "waf_exclusion_policy": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/waf_exclusion_policys",
+      "operation_id": "ves.io.schema.waf_exclusion_policy.API.Create"
+    },
+    "workload": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/workloads",
+      "operation_id": "ves.io.schema.views.workload.API.Create"
+    },
+    "workload_flavor": {
+      "disposition": "generated",
+      "path": "/api/config/namespaces/{metadata.namespace}/workload_flavors",
+      "operation_id": "ves.io.schema.workload_flavor.API.Create"
+    }
+  },
+  "coverage": {
+    "excluded": 81,
+    "generated": 159,
+    "manual": 17,
+    "total": 257
+  }
+}

--- a/docs/specifications/api/shape.json
+++ b/docs/specifications/api/shape.json
@@ -69588,13 +69588,13 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
-            "category": "observability",
-            "multi_tenant_pattern": "per-tenant"
+            "category": "application",
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -69731,13 +69731,13 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
-            "category": "observability",
-            "multi_tenant_pattern": "per-tenant"
+            "category": "application",
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -69763,13 +69763,13 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
-            "category": "observability",
-            "multi_tenant_pattern": "per-tenant"
+            "category": "application",
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -69828,13 +69828,13 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
-            "category": "observability",
-            "multi_tenant_pattern": "per-tenant"
+            "category": "application",
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -69905,13 +69905,13 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
-            "category": "observability",
-            "multi_tenant_pattern": "per-tenant"
+            "category": "application",
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -70046,13 +70046,13 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
-            "category": "observability",
-            "multi_tenant_pattern": "per-tenant"
+            "category": "application",
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -70229,13 +70229,13 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
-            "category": "observability",
-            "multi_tenant_pattern": "per-tenant"
+            "category": "application",
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -70311,13 +70311,13 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
-            "category": "observability",
-            "multi_tenant_pattern": "per-tenant"
+            "category": "application",
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -70662,13 +70662,13 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
-            "category": "observability",
-            "multi_tenant_pattern": "per-tenant"
+            "category": "application",
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -70814,13 +70814,13 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
-            "category": "observability",
-            "multi_tenant_pattern": "per-tenant"
+            "category": "application",
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -70879,13 +70879,13 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
-            "category": "observability",
-            "multi_tenant_pattern": "per-tenant"
+            "category": "application",
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -70908,13 +70908,13 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
-            "category": "observability",
-            "multi_tenant_pattern": "per-tenant"
+            "category": "application",
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -70992,13 +70992,13 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
-            "category": "observability",
-            "multi_tenant_pattern": "per-tenant"
+            "category": "application",
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -73855,13 +73855,13 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
-            "category": "observability",
-            "multi_tenant_pattern": "per-tenant"
+            "category": "application",
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -73916,13 +73916,13 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
-            "category": "observability",
-            "multi_tenant_pattern": "per-tenant"
+            "category": "application",
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -73981,13 +73981,13 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
-            "category": "observability",
-            "multi_tenant_pattern": "per-tenant"
+            "category": "application",
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -74058,13 +74058,13 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
-            "category": "observability",
-            "multi_tenant_pattern": "per-tenant"
+            "category": "application",
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -74199,13 +74199,13 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
-            "category": "observability",
-            "multi_tenant_pattern": "per-tenant"
+            "category": "application",
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -74367,13 +74367,13 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
-            "category": "observability",
-            "multi_tenant_pattern": "per-tenant"
+            "category": "application",
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -74449,13 +74449,13 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
-            "category": "observability",
-            "multi_tenant_pattern": "per-tenant"
+            "category": "application",
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -74799,13 +74799,13 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
-            "category": "observability",
-            "multi_tenant_pattern": "per-tenant"
+            "category": "application",
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -74883,13 +74883,13 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
-            "category": "observability",
-            "multi_tenant_pattern": "per-tenant"
+            "category": "application",
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -78010,20 +78010,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -78051,20 +78049,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -91017,20 +91013,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -91196,20 +91190,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -91278,20 +91270,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -91377,20 +91367,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -91419,20 +91407,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -91470,20 +91456,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -91537,20 +91521,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -91616,20 +91598,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -91710,20 +91690,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -91781,20 +91759,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -91976,20 +91952,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -92078,20 +92052,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -92198,20 +92170,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -92497,20 +92467,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -92801,20 +92769,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -92856,20 +92822,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -92909,20 +92873,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -92952,20 +92914,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -92993,20 +92953,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -93117,20 +93075,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -93210,20 +93166,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -93331,20 +93285,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -93516,20 +93468,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -93650,20 +93600,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -93859,20 +93807,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -93963,20 +93909,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -94135,20 +94079,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -94219,20 +94161,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -94572,20 +94512,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -94693,20 +94631,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -94735,20 +94671,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -94837,20 +94771,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -94904,20 +94836,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -94935,20 +94865,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -95126,20 +95054,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -95212,20 +95138,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -95300,20 +95224,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -95457,20 +95379,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -95526,20 +95446,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -116974,20 +116892,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -117100,20 +117016,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -117313,20 +117227,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -117386,20 +117298,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -117453,20 +117363,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -117532,20 +117440,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -117744,20 +117650,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -117931,20 +117835,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -118074,20 +117976,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -118207,20 +118107,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -118392,20 +118290,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -118732,20 +118628,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -118926,20 +118820,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -119012,20 +118904,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -119096,20 +118986,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -119447,20 +119335,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -119514,20 +119400,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -119545,20 +119429,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -119751,20 +119633,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -119941,20 +119821,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -120096,20 +119974,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -120181,20 +120057,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -120278,20 +120152,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -120486,20 +120358,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -125136,20 +125006,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -125215,20 +125083,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -125314,20 +125180,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -125457,20 +125321,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -125620,20 +125482,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -125741,20 +125601,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -125825,20 +125683,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -126161,20 +126017,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -126268,20 +126122,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -126310,20 +126162,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -126377,20 +126227,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -126408,20 +126256,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -126503,20 +126349,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },

--- a/docs/specifications/api/support.json
+++ b/docs/specifications/api/support.json
@@ -29363,13 +29363,13 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -29440,13 +29440,13 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -29493,13 +29493,13 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -29634,13 +29634,13 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -29795,13 +29795,13 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -29846,13 +29846,13 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -30002,13 +30002,13 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -30051,13 +30051,13 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -30110,13 +30110,13 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -30186,13 +30186,13 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -30268,13 +30268,13 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -30603,13 +30603,13 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -30668,13 +30668,13 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -30697,13 +30697,13 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -30748,13 +30748,13 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -30800,13 +30800,13 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -30855,13 +30855,13 @@
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },

--- a/docs/specifications/api/tenant_and_identity.json
+++ b/docs/specifications/api/tenant_and_identity.json
@@ -73,20 +73,18 @@
     "x-f5xc-namespace-profile": {
       "constraint": {
         "allowed": [
-          "custom",
-          "default",
-          "shared"
+          "system"
         ],
         "enforced": false
       },
       "recommendation": {
-        "primary": "custom",
+        "primary": "system",
         "alternatives": [],
-        "rationale": "Standard tenant resource"
+        "rationale": "Canonical create identity pending namespace CRUD verification"
       },
       "classification": {
         "category": "application",
-        "multi_tenant_pattern": "per-tenant"
+        "multi_tenant_pattern": "none"
       }
     }
   },
@@ -49207,20 +49205,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -49350,20 +49346,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -49402,20 +49396,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -49491,20 +49483,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -49558,20 +49548,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -49589,20 +49577,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -49704,20 +49690,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -49756,20 +49740,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -49808,20 +49790,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -49842,20 +49822,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -50058,20 +50036,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -50145,20 +50121,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -50385,20 +50359,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -50433,20 +50405,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -50525,20 +50495,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -50608,20 +50576,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -50678,20 +50644,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -50921,20 +50885,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -51167,20 +51129,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -51411,20 +51371,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -51650,20 +51608,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -51691,20 +51647,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -51807,20 +51761,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -52147,20 +52099,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -52339,20 +52289,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -52523,20 +52471,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -53845,20 +53791,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -53912,20 +53856,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -53991,20 +53933,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -54061,20 +54001,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -54204,20 +54142,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -54389,20 +54325,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -54455,20 +54389,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -54592,20 +54524,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -54626,20 +54556,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -54710,20 +54638,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -55062,20 +54988,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -55230,20 +55154,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -55387,20 +55309,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -55454,20 +55374,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -55485,20 +55403,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -55551,20 +55467,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -55637,20 +55551,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -55896,20 +55808,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -56034,20 +55944,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -56113,20 +56021,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -56192,20 +56098,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -56335,20 +56239,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -56520,20 +56422,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -56638,20 +56538,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -56722,20 +56620,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -57075,20 +56971,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -57142,20 +57036,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -57173,20 +57065,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -57250,20 +57140,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -57293,20 +57181,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -57379,20 +57265,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -57507,20 +57391,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -57542,20 +57424,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -57758,20 +57638,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -57858,20 +57736,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -58038,20 +57914,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -58181,20 +58055,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -58292,20 +58164,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -58346,20 +58216,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -58457,20 +58325,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -58524,20 +58390,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -58555,20 +58419,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -58597,20 +58459,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -58748,20 +58608,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -58800,20 +58658,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -58852,20 +58708,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -59096,20 +58950,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -59148,20 +59000,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -59200,20 +59050,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -59252,20 +59100,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -59320,20 +59166,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -59363,20 +59207,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -59410,20 +59252,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -59457,20 +59297,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -59522,20 +59360,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -59570,20 +59406,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -59604,20 +59438,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -59892,20 +59724,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -59959,20 +59789,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -60038,20 +59866,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -60402,20 +60228,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -60447,20 +60271,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -61006,20 +60828,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -61359,20 +61179,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -61444,20 +61262,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -63979,20 +63795,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -64121,20 +63935,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -64228,20 +64040,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -64578,20 +64388,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -64721,20 +64529,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -64806,20 +64612,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -64913,20 +64717,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -65024,20 +64826,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -65091,20 +64891,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -65122,20 +64920,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -65226,20 +65022,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -66334,20 +66128,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -66530,20 +66322,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -66572,20 +66362,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -66669,20 +66457,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -66758,20 +66544,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -66825,20 +66609,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -66904,20 +66686,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -67189,20 +66969,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -67332,20 +67110,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -67517,20 +67293,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -67795,20 +67569,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -67879,20 +67651,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -68230,20 +68000,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -68297,20 +68065,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -68328,20 +68094,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -68606,20 +68370,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -68691,20 +68453,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -68834,20 +68594,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -68961,20 +68719,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -69084,20 +68840,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -69238,20 +68992,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -69305,20 +69057,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -69336,20 +69086,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -81207,20 +80955,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -81291,20 +81037,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -81643,20 +81387,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -81703,20 +81445,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -81789,20 +81529,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -81865,20 +81603,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -84319,20 +84055,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -84876,20 +84610,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -85349,20 +85081,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -85401,20 +85131,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -85537,20 +85265,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -85614,20 +85340,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -86115,20 +85839,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -86469,20 +86191,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -86513,20 +86233,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -86556,20 +86274,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -86705,20 +86421,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -86758,20 +86472,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -86834,20 +86546,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -86986,20 +86696,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -87151,20 +86859,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -87270,20 +86976,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -87519,20 +87223,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -87625,20 +87327,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -87761,20 +87461,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -87895,20 +87593,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -87938,20 +87634,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -87990,20 +87684,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -88157,20 +87849,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -88224,20 +87914,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -88424,20 +88112,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -88506,20 +88192,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -88558,20 +88242,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -88628,20 +88310,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -88662,20 +88342,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -88703,20 +88381,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -88748,20 +88424,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -89213,20 +88887,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -89269,20 +88941,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -89898,20 +89568,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -90344,20 +90012,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -90452,20 +90118,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -90526,20 +90190,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -90594,20 +90256,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -90649,20 +90309,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -90718,20 +90376,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -90800,20 +90456,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -90910,20 +90564,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -90945,20 +90597,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -90996,20 +90646,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -91105,20 +90753,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -91241,20 +90887,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -91385,20 +91029,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -91470,20 +91112,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -91601,20 +91241,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -91671,20 +91309,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -91762,20 +91398,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -92065,20 +91699,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -92341,20 +91973,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -92452,20 +92082,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -92548,20 +92176,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -92774,20 +92400,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -92866,20 +92490,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -93035,20 +92657,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -93223,20 +92843,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -93434,20 +93052,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -93629,20 +93245,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -93751,20 +93365,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -93866,20 +93478,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -93988,20 +93598,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -94215,20 +93823,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -94322,20 +93928,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -94498,20 +94102,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -94705,20 +94307,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -94765,20 +94365,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -95126,20 +94724,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -95215,20 +94811,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -99876,20 +99470,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -100083,10 +99675,10 @@
           "recommendation": {
             "primary": "system",
             "alternatives": [],
-            "rationale": "Tenant object is platform-level administration"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
-            "category": "infrastructure",
+            "category": "application",
             "multi_tenant_pattern": "none"
           }
         }
@@ -100160,10 +99752,10 @@
           "recommendation": {
             "primary": "system",
             "alternatives": [],
-            "rationale": "Tenant object is platform-level administration"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
-            "category": "infrastructure",
+            "category": "application",
             "multi_tenant_pattern": "none"
           }
         }
@@ -100342,10 +99934,10 @@
           "recommendation": {
             "primary": "system",
             "alternatives": [],
-            "rationale": "Tenant object is platform-level administration"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
-            "category": "infrastructure",
+            "category": "application",
             "multi_tenant_pattern": "none"
           }
         }
@@ -100483,10 +100075,10 @@
           "recommendation": {
             "primary": "system",
             "alternatives": [],
-            "rationale": "Tenant object is platform-level administration"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
-            "category": "infrastructure",
+            "category": "application",
             "multi_tenant_pattern": "none"
           }
         }
@@ -100644,10 +100236,10 @@
           "recommendation": {
             "primary": "system",
             "alternatives": [],
-            "rationale": "Tenant object is platform-level administration"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
-            "category": "infrastructure",
+            "category": "application",
             "multi_tenant_pattern": "none"
           }
         }
@@ -100818,10 +100410,10 @@
           "recommendation": {
             "primary": "system",
             "alternatives": [],
-            "rationale": "Tenant object is platform-level administration"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
-            "category": "infrastructure",
+            "category": "application",
             "multi_tenant_pattern": "none"
           }
         }
@@ -100948,10 +100540,10 @@
           "recommendation": {
             "primary": "system",
             "alternatives": [],
-            "rationale": "Tenant object is platform-level administration"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
-            "category": "infrastructure",
+            "category": "application",
             "multi_tenant_pattern": "none"
           }
         }
@@ -101030,10 +100622,10 @@
           "recommendation": {
             "primary": "system",
             "alternatives": [],
-            "rationale": "Tenant object is platform-level administration"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
-            "category": "infrastructure",
+            "category": "application",
             "multi_tenant_pattern": "none"
           }
         }
@@ -101363,10 +100955,10 @@
           "recommendation": {
             "primary": "system",
             "alternatives": [],
-            "rationale": "Tenant object is platform-level administration"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
-            "category": "infrastructure",
+            "category": "application",
             "multi_tenant_pattern": "none"
           }
         }
@@ -101428,10 +101020,10 @@
           "recommendation": {
             "primary": "system",
             "alternatives": [],
-            "rationale": "Tenant object is platform-level administration"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
-            "category": "infrastructure",
+            "category": "application",
             "multi_tenant_pattern": "none"
           }
         }
@@ -101457,10 +101049,10 @@
           "recommendation": {
             "primary": "system",
             "alternatives": [],
-            "rationale": "Tenant object is platform-level administration"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
-            "category": "infrastructure",
+            "category": "application",
             "multi_tenant_pattern": "none"
           }
         }
@@ -101631,10 +101223,10 @@
           "recommendation": {
             "primary": "system",
             "alternatives": [],
-            "rationale": "Tenant object is platform-level administration"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
-            "category": "infrastructure",
+            "category": "application",
             "multi_tenant_pattern": "none"
           }
         }
@@ -101857,20 +101449,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -101901,20 +101491,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -109783,20 +109371,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -109923,20 +109509,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -109976,20 +109560,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -110030,20 +109612,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -110094,20 +109674,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -110217,20 +109795,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -110300,20 +109876,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -110390,20 +109964,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -110453,20 +110025,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -110579,20 +110149,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -110634,20 +110202,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -110784,20 +110350,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -110927,20 +110491,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },
@@ -111026,20 +110588,18 @@
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [
-              "custom",
-              "default",
-              "shared"
+              "system"
             ],
             "enforced": false
           },
           "recommendation": {
-            "primary": "custom",
+            "primary": "system",
             "alternatives": [],
-            "rationale": "Standard tenant resource"
+            "rationale": "Canonical create identity pending namespace CRUD verification"
           },
           "classification": {
             "category": "application",
-            "multi_tenant_pattern": "per-tenant"
+            "multi_tenant_pattern": "none"
           }
         }
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3232 @@
+{
+  "name": "api-specs-enriched-ci",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "api-specs-enriched-ci",
+      "devDependencies": {
+        "@stoplight/spectral-cli": "6.16.2"
+      }
+    },
+    "node_modules/@asyncapi/specs": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-6.11.1.tgz",
+      "integrity": "sha512-A3WBLqAKGoJ2+6FWFtpjBlCQ1oFCcs4GxF7zsIGvNqp/klGUHjlA3aAcZ9XMMpLGE8zPeYDz2x9FmO6DSuKraQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.11"
+      }
+    },
+    "node_modules/@jsep-plugin/assignment": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/assignment/-/assignment-1.3.0.tgz",
+      "integrity": "sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
+    "node_modules/@jsep-plugin/regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/regex/-/regex-1.0.4.tgz",
+      "integrity": "sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
+    "node_modules/@jsep-plugin/ternary": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/ternary/-/ternary-1.1.4.tgz",
+      "integrity": "sha512-ck5wiqIbqdMX6WRQztBL7ASDty9YLgJ3sSAK5ZpBzXeySvFGCzIvM6UiAI4hTZ22fEcYQVV/zhUbNscggW+Ukg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@rollup/plugin-commonjs": {
+      "version": "22.0.2",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-22.0.2.tgz",
+      "integrity": "sha512-//NdP6iIwPbMTcazYsiBMbJW7gfmpHom33u1beiIoHDEM0Q9clvtQB1T0efvMqHeKsGohiHo97BCPCkBXdscwg==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/pluginutils": "^3.1.0",
+        "commondir": "^1.0.1",
+        "estree-walker": "^2.0.1",
+        "glob": "^7.1.6",
+        "is-reference": "^1.2.1",
+        "magic-string": "^0.25.7",
+        "resolve": "^1.17.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.68.0"
+      }
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+      "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "0.0.39",
+        "estree-walker": "^1.0.1",
+        "picomatch": "^2.2.2"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0"
+      }
+    },
+    "node_modules/@rollup/pluginutils/node_modules/estree-walker": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+      "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+      "dev": true
+    },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "dev": true,
+      "hasInstallScript": true
+    },
+    "node_modules/@stoplight/better-ajv-errors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@stoplight/better-ajv-errors/-/better-ajv-errors-1.0.3.tgz",
+      "integrity": "sha512-0p9uXkuB22qGdNfy3VeEhxkU5uwvp/KrBTAbrLBURv6ilxIVwanKwjMc41lQfIVgPGcOkmLbTolfFrSsueu7zA==",
+      "dev": true,
+      "dependencies": {
+        "jsonpointer": "^5.0.0",
+        "leven": "^3.1.0"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      },
+      "peerDependencies": {
+        "ajv": ">=8"
+      }
+    },
+    "node_modules/@stoplight/json": {
+      "version": "3.21.7",
+      "resolved": "https://registry.npmjs.org/@stoplight/json/-/json-3.21.7.tgz",
+      "integrity": "sha512-xcJXgKFqv/uCEgtGlPxy3tPA+4I+ZI4vAuMJ885+ThkTHFVkC+0Fm58lA9NlsyjnkpxFh4YiQWpH+KefHdbA0A==",
+      "dev": true,
+      "dependencies": {
+        "@stoplight/ordered-object-literal": "^1.0.3",
+        "@stoplight/path": "^1.3.2",
+        "@stoplight/types": "^13.6.0",
+        "jsonc-parser": "~2.2.1",
+        "lodash": "^4.17.21",
+        "safe-stable-stringify": "^1.1"
+      },
+      "engines": {
+        "node": ">=8.3.0"
+      }
+    },
+    "node_modules/@stoplight/json-ref-readers": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@stoplight/json-ref-readers/-/json-ref-readers-1.2.2.tgz",
+      "integrity": "sha512-nty0tHUq2f1IKuFYsLM4CXLZGHdMn+X/IwEUIpeSOXt0QjMUbL0Em57iJUDzz+2MkWG83smIigNZ3fauGjqgdQ==",
+      "dev": true,
+      "dependencies": {
+        "node-fetch": "^2.6.0",
+        "tslib": "^1.14.1"
+      },
+      "engines": {
+        "node": ">=8.3.0"
+      }
+    },
+    "node_modules/@stoplight/json-ref-readers/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
+    },
+    "node_modules/@stoplight/json-ref-resolver": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@stoplight/json-ref-resolver/-/json-ref-resolver-3.1.6.tgz",
+      "integrity": "sha512-YNcWv3R3n3U6iQYBsFOiWSuRGE5su1tJSiX6pAPRVk7dP0L7lqCteXGzuVRQ0gMZqUl8v1P0+fAKxF6PLo9B5A==",
+      "dev": true,
+      "dependencies": {
+        "@stoplight/json": "^3.21.0",
+        "@stoplight/path": "^1.3.2",
+        "@stoplight/types": "^12.3.0 || ^13.0.0",
+        "@types/urijs": "^1.19.19",
+        "dependency-graph": "~0.11.0",
+        "fast-memoize": "^2.5.2",
+        "immer": "^9.0.6",
+        "lodash": "^4.17.21",
+        "tslib": "^2.6.0",
+        "urijs": "^1.19.11"
+      },
+      "engines": {
+        "node": ">=8.3.0"
+      }
+    },
+    "node_modules/@stoplight/ordered-object-literal": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@stoplight/ordered-object-literal/-/ordered-object-literal-1.0.5.tgz",
+      "integrity": "sha512-COTiuCU5bgMUtbIFBuyyh2/yVVzlr5Om0v5utQDgBCuQUOPgU1DwoffkTfg4UBQOvByi5foF4w4T+H9CoRe5wg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@stoplight/path": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@stoplight/path/-/path-1.3.2.tgz",
+      "integrity": "sha512-lyIc6JUlUA8Ve5ELywPC8I2Sdnh1zc1zmbYgVarhXIp9YeAB0ReeqmGEOWNtlHkbP2DAA1AL65Wfn2ncjK/jtQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@stoplight/spectral-cli": {
+      "version": "6.16.2",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-cli/-/spectral-cli-6.16.2.tgz",
+      "integrity": "sha512-1BwNCglpvCA2J+MpdXSPH56h69rARthf0QG/t2eeFbuqg12rcQEbGfAXs70mCRUAewiCzf1QqzeHF1tnabfS3A==",
+      "dev": true,
+      "dependencies": {
+        "@scarf/scarf": "^1.4.0",
+        "@stoplight/json": "~3.21.0",
+        "@stoplight/path": "1.3.2",
+        "@stoplight/spectral-core": "^1.19.5",
+        "@stoplight/spectral-formatters": "^1.4.1",
+        "@stoplight/spectral-parsers": "^1.0.4",
+        "@stoplight/spectral-ref-resolver": "^1.0.4",
+        "@stoplight/spectral-ruleset-bundler": "^1.6.0",
+        "@stoplight/spectral-ruleset-migrator": "^1.11.0",
+        "@stoplight/spectral-rulesets": ">=1",
+        "@stoplight/spectral-runtime": "^1.1.2",
+        "@stoplight/types": "^13.6.0",
+        "chalk": "4.1.2",
+        "fast-glob": "~3.2.12",
+        "hpagent": "~1.2.0",
+        "lodash": "^4.18.1",
+        "pony-cause": "^1.1.1",
+        "stacktracey": "^2.1.8",
+        "tslib": "^2.8.1",
+        "yargs": "~17.7.2"
+      },
+      "bin": {
+        "spectral": "dist/index.js"
+      },
+      "engines": {
+        "node": "^16.20 || ^18.18 || >= 20.17"
+      }
+    },
+    "node_modules/@stoplight/spectral-core": {
+      "version": "1.23.1",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-core/-/spectral-core-1.23.1.tgz",
+      "integrity": "sha512-VLC8OhpO/pMJKb6IHhurxJjXO1qB56Ng1unIb8b+hNxdw0+SEcASvmR+RpjfHYX/jv/DfSaA1x8QhFBJBmqBOQ==",
+      "dev": true,
+      "dependencies": {
+        "@scarf/scarf": "^1.4.0",
+        "@stoplight/better-ajv-errors": "1.0.3",
+        "@stoplight/json": "~3.21.0",
+        "@stoplight/path": "1.3.2",
+        "@stoplight/spectral-parsers": "^1.0.0",
+        "@stoplight/spectral-ref-resolver": "^1.0.4",
+        "@stoplight/spectral-runtime": "^1.1.2",
+        "@stoplight/types": "~13.6.0",
+        "@types/es-aggregate-error": "^1.0.2",
+        "@types/json-schema": "^7.0.11",
+        "ajv": "^8.18.0",
+        "ajv-errors": "~3.0.0",
+        "ajv-formats": "~2.1.1",
+        "es-aggregate-error": "^1.0.7",
+        "expr-eval-fork": "^3.0.1",
+        "jsonpath-plus": "^10.3.0",
+        "lodash": "^4.18.1",
+        "lodash.topath": "^4.5.2",
+        "minimatch": "^3.1.4",
+        "nimma": "0.2.3",
+        "pony-cause": "^1.1.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": "^16.20 || ^18.18 || >= 20.17"
+      }
+    },
+    "node_modules/@stoplight/spectral-core/node_modules/@stoplight/types": {
+      "version": "13.6.0",
+      "resolved": "https://registry.npmjs.org/@stoplight/types/-/types-13.6.0.tgz",
+      "integrity": "sha512-dzyuzvUjv3m1wmhPfq82lCVYGcXG0xUYgqnWfCq3PCVR4BKFhjdkHrnJ+jIDoMKvXb05AZP/ObQF6+NpDo29IQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.4",
+        "utility-types": "^3.10.0"
+      },
+      "engines": {
+        "node": "^12.20 || >=14.13"
+      }
+    },
+    "node_modules/@stoplight/spectral-formats": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-formats/-/spectral-formats-1.8.5.tgz",
+      "integrity": "sha512-xaC0rCH0p7/bzNJsz+JgLSj+Cp6uwYGWpePQxdLkF2G6a8Zyp3OyS7umkGYNiimEwKrOjvCNNTFJpeuiENZSBA==",
+      "dev": true,
+      "dependencies": {
+        "@scarf/scarf": "^1.4.0",
+        "@stoplight/json": "^3.17.0",
+        "@stoplight/spectral-core": "^1.23.0",
+        "@types/json-schema": "^7.0.7",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": "^16.20 || ^18.18 || >= 20.17"
+      }
+    },
+    "node_modules/@stoplight/spectral-formatters": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-formatters/-/spectral-formatters-1.5.1.tgz",
+      "integrity": "sha512-mGXaiIrPglPokSnbFqbkWN3DoozIbwrZAA6OgqSIl+djeD5+e6PMELg0g6r3ot3ZzntO+6/GXaDnxEQ/p9M/EQ==",
+      "dev": true,
+      "dependencies": {
+        "@stoplight/path": "^1.3.2",
+        "@stoplight/spectral-core": "^1.19.4",
+        "@stoplight/spectral-runtime": "^1.1.2",
+        "@stoplight/types": "^13.15.0",
+        "@types/markdown-escape": "^1.1.3",
+        "chalk": "4.1.2",
+        "cliui": "7.0.4",
+        "lodash": "^4.18.1",
+        "markdown-escape": "^2.0.0",
+        "node-sarif-builder": "^2.0.3",
+        "strip-ansi": "6.0",
+        "text-table": "^0.2.0",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": "^16.20 || ^18.18 || >= 20.17"
+      }
+    },
+    "node_modules/@stoplight/spectral-functions": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-functions/-/spectral-functions-1.10.5.tgz",
+      "integrity": "sha512-vDCd0NJ93715bcUpZZ5vNHiyxd4cgHF6tuXsDiXOXKAByg+I1fR5/dMijEo6Ce1Lz95a+RZ22JKYhF1YuzVvuA==",
+      "dev": true,
+      "dependencies": {
+        "@scarf/scarf": "^1.4.0",
+        "@stoplight/better-ajv-errors": "1.0.3",
+        "@stoplight/json": "^3.17.1",
+        "@stoplight/spectral-core": "^1.23.0",
+        "@stoplight/spectral-formats": "^1.8.1",
+        "@stoplight/spectral-runtime": "^1.1.2",
+        "ajv": "^8.18.0",
+        "ajv-draft-04": "~1.0.0",
+        "ajv-errors": "~3.0.0",
+        "ajv-formats": "~2.1.1",
+        "lodash": "^4.18.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": "^16.20 || ^18.18 || >= 20.17"
+      }
+    },
+    "node_modules/@stoplight/spectral-parsers": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-parsers/-/spectral-parsers-1.0.5.tgz",
+      "integrity": "sha512-ANDTp2IHWGvsQDAY85/jQi9ZrF4mRrA5bciNHX+PUxPr4DwS6iv4h+FVWJMVwcEYdpyoIdyL+SRmHdJfQEPmwQ==",
+      "dev": true,
+      "dependencies": {
+        "@stoplight/json": "~3.21.0",
+        "@stoplight/types": "^14.1.1",
+        "@stoplight/yaml": "~4.3.0",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": "^16.20 || ^18.18 || >= 20.17"
+      }
+    },
+    "node_modules/@stoplight/spectral-parsers/node_modules/@stoplight/types": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/@stoplight/types/-/types-14.1.1.tgz",
+      "integrity": "sha512-/kjtr+0t0tjKr+heVfviO9FrU/uGLc+QNX3fHJc19xsCNYqU7lVhaXxDmEID9BZTjG+/r9pK9xP/xU02XGg65g==",
+      "dev": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.4",
+        "utility-types": "^3.10.0"
+      },
+      "engines": {
+        "node": "^12.20 || >=14.13"
+      }
+    },
+    "node_modules/@stoplight/spectral-ref-resolver": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-ref-resolver/-/spectral-ref-resolver-1.0.5.tgz",
+      "integrity": "sha512-gj3TieX5a9zMW29z3mBlAtDOCgN3GEc1VgZnCVlr5irmR4Qi5LuECuFItAq4pTn5Zu+sW5bqutsCH7D4PkpyAA==",
+      "dev": true,
+      "dependencies": {
+        "@stoplight/json-ref-readers": "1.2.2",
+        "@stoplight/json-ref-resolver": "~3.1.6",
+        "@stoplight/spectral-runtime": "^1.1.2",
+        "dependency-graph": "0.11.0",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": "^16.20 || ^18.18 || >= 20.17"
+      }
+    },
+    "node_modules/@stoplight/spectral-ruleset-bundler": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-ruleset-bundler/-/spectral-ruleset-bundler-1.7.0.tgz",
+      "integrity": "sha512-PpIdj5Wje0T7ktxY8EUzBWLU0+mGGQHznT8nlQxTMnRhWLNYsm6HvSZDXLtMi+86yqvTuf7loJy6JvLBDzHGAA==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/plugin-commonjs": "~22.0.2",
+        "@stoplight/path": "1.3.2",
+        "@stoplight/spectral-core": ">=1",
+        "@stoplight/spectral-formats": "^1.8.1",
+        "@stoplight/spectral-functions": ">=1",
+        "@stoplight/spectral-parsers": ">=1",
+        "@stoplight/spectral-ref-resolver": "^1.0.4",
+        "@stoplight/spectral-ruleset-migrator": "^1.9.6",
+        "@stoplight/spectral-rulesets": ">=1",
+        "@stoplight/spectral-runtime": "^1.1.2",
+        "@stoplight/types": "^13.6.0",
+        "@types/node": "*",
+        "pony-cause": "1.1.1",
+        "rollup": "~2.80.0",
+        "tslib": "^2.8.1",
+        "validate-npm-package-name": "3.0.0"
+      },
+      "engines": {
+        "node": "^16.20 || ^18.18 || >= 20.17"
+      }
+    },
+    "node_modules/@stoplight/spectral-ruleset-migrator": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-ruleset-migrator/-/spectral-ruleset-migrator-1.12.2.tgz",
+      "integrity": "sha512-9hTcyXnBGppM1kMA8vVvY6aWzF3vXbU7+mZvvd9wdPE8QdHj9NO//1s+A/TfiWOKdH9GOERC5NITCnVvbEYEWg==",
+      "dev": true,
+      "dependencies": {
+        "@stoplight/json": "~3.21.0",
+        "@stoplight/ordered-object-literal": "~1.0.4",
+        "@stoplight/path": "1.3.2",
+        "@stoplight/spectral-functions": "^1.9.1",
+        "@stoplight/spectral-runtime": "^1.1.2",
+        "@stoplight/types": "^13.6.0",
+        "@stoplight/yaml": "~4.2.3",
+        "@types/node": "*",
+        "ajv": "^8.18.0",
+        "ast-types": "0.14.2",
+        "astring": "^1.9.0",
+        "reserved": "0.1.2",
+        "tslib": "^2.8.1",
+        "validate-npm-package-name": "3.0.0"
+      },
+      "engines": {
+        "node": "^16.20 || ^18.18 || >= 20.17"
+      }
+    },
+    "node_modules/@stoplight/spectral-ruleset-migrator/node_modules/@stoplight/yaml": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@stoplight/yaml/-/yaml-4.2.3.tgz",
+      "integrity": "sha512-Mx01wjRAR9C7yLMUyYFTfbUf5DimEpHMkRDQ1PKLe9dfNILbgdxyrncsOXM3vCpsQ1Hfj4bPiGl+u4u6e9Akqw==",
+      "dev": true,
+      "dependencies": {
+        "@stoplight/ordered-object-literal": "^1.0.1",
+        "@stoplight/types": "^13.0.0",
+        "@stoplight/yaml-ast-parser": "0.0.48",
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=10.8"
+      }
+    },
+    "node_modules/@stoplight/spectral-ruleset-migrator/node_modules/@stoplight/yaml-ast-parser": {
+      "version": "0.0.48",
+      "resolved": "https://registry.npmjs.org/@stoplight/yaml-ast-parser/-/yaml-ast-parser-0.0.48.tgz",
+      "integrity": "sha512-sV+51I7WYnLJnKPn2EMWgS4EUfoP4iWEbrWwbXsj0MZCB/xOK8j6+C9fntIdOM50kpx45ZLC3s6kwKivWuqvyg==",
+      "dev": true
+    },
+    "node_modules/@stoplight/spectral-rulesets": {
+      "version": "1.22.7",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-rulesets/-/spectral-rulesets-1.22.7.tgz",
+      "integrity": "sha512-cT1B6Ly21923lvr235lu7iIgmcnoCTJaN3ANOyTqr4D5GA/4p2k0+yhjhdfj/1ks/Os3kUzSFnFkzpWH7WszFA==",
+      "dev": true,
+      "dependencies": {
+        "@asyncapi/specs": "6.11.1",
+        "@scarf/scarf": "^1.4.0",
+        "@stoplight/better-ajv-errors": "1.0.3",
+        "@stoplight/json": "^3.17.0",
+        "@stoplight/spectral-core": "^1.23.0",
+        "@stoplight/spectral-formats": "^1.8.1",
+        "@stoplight/spectral-functions": "^1.9.1",
+        "@stoplight/spectral-runtime": "^1.1.2",
+        "@stoplight/types": "^13.6.0",
+        "@types/json-schema": "^7.0.7",
+        "ajv": "^8.18.0",
+        "ajv-formats": "~2.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "leven": "3.1.0",
+        "lodash": "^4.18.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": "^16.20 || ^18.18 || >= 20.17"
+      }
+    },
+    "node_modules/@stoplight/spectral-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-runtime/-/spectral-runtime-1.1.6.tgz",
+      "integrity": "sha512-Y8rEDyMN4bSMJCrDs2shdcVHYyCnH3FvXRP4dBhha4Z8iJv+JPp7KqOV/hwVB/hWFC209upiwj2oDmLfR0qCDg==",
+      "dev": true,
+      "dependencies": {
+        "@stoplight/json": "^3.20.1",
+        "@stoplight/path": "^1.3.2",
+        "@stoplight/types": "^13.6.0",
+        "lodash": "^4.18.1",
+        "node-fetch": "^2.7.0",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": "^16.20 || ^18.18 || >= 20.17"
+      }
+    },
+    "node_modules/@stoplight/types": {
+      "version": "13.20.0",
+      "resolved": "https://registry.npmjs.org/@stoplight/types/-/types-13.20.0.tgz",
+      "integrity": "sha512-2FNTv05If7ib79VPDA/r9eUet76jewXFH2y2K5vuge6SXbRHtWBhcaRmu+6QpF4/WRNoJj5XYRSwLGXDxysBGA==",
+      "dev": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.4",
+        "utility-types": "^3.10.0"
+      },
+      "engines": {
+        "node": "^12.20 || >=14.13"
+      }
+    },
+    "node_modules/@stoplight/yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@stoplight/yaml/-/yaml-4.3.0.tgz",
+      "integrity": "sha512-JZlVFE6/dYpP9tQmV0/ADfn32L9uFarHWxfcRhReKUnljz1ZiUM5zpX+PH8h5CJs6lao3TuFqnPm9IJJCEkE2w==",
+      "dev": true,
+      "dependencies": {
+        "@stoplight/ordered-object-literal": "^1.0.5",
+        "@stoplight/types": "^14.1.1",
+        "@stoplight/yaml-ast-parser": "0.0.50",
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=10.8"
+      }
+    },
+    "node_modules/@stoplight/yaml-ast-parser": {
+      "version": "0.0.50",
+      "resolved": "https://registry.npmjs.org/@stoplight/yaml-ast-parser/-/yaml-ast-parser-0.0.50.tgz",
+      "integrity": "sha512-Pb6M8TDO9DtSVla9yXSTAxmo9GVEouq5P40DWXdOie69bXogZTkgvopCq+yEvTMA0F6PEvdJmbtTV3ccIp11VQ==",
+      "dev": true
+    },
+    "node_modules/@stoplight/yaml/node_modules/@stoplight/types": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/@stoplight/types/-/types-14.1.1.tgz",
+      "integrity": "sha512-/kjtr+0t0tjKr+heVfviO9FrU/uGLc+QNX3fHJc19xsCNYqU7lVhaXxDmEID9BZTjG+/r9pK9xP/xU02XGg65g==",
+      "dev": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.4",
+        "utility-types": "^3.10.0"
+      },
+      "engines": {
+        "node": "^12.20 || >=14.13"
+      }
+    },
+    "node_modules/@types/es-aggregate-error": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@types/es-aggregate-error/-/es-aggregate-error-1.0.6.tgz",
+      "integrity": "sha512-qJ7LIFp06h1QE1aVxbVd+zJP2wdaugYXYfd6JxsyRMrYHaxb6itXPogW2tz+ylUJ1n1b+JF1PHyYCfYHm0dvUg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+      "dev": true
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true
+    },
+    "node_modules/@types/markdown-escape": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@types/markdown-escape/-/markdown-escape-1.1.3.tgz",
+      "integrity": "sha512-JIc1+s3y5ujKnt/+N+wq6s/QdL2qZ11fP79MijrVXsAAnzSxCbT2j/3prHRouJdZ2yFLN3vkP0HytfnoCczjOw==",
+      "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
+      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@types/sarif": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@types/sarif/-/sarif-2.1.7.tgz",
+      "integrity": "sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ==",
+      "dev": true
+    },
+    "node_modules/@types/urijs": {
+      "version": "1.19.26",
+      "resolved": "https://registry.npmjs.org/@types/urijs/-/urijs-1.19.26.tgz",
+      "integrity": "sha512-wkXrVzX5yoqLnndOwFsieJA7oKM8cNkOKJtf/3vVGSUFkWDKZvFHpIl9Pvqb/T9UsawBBFMTTD8xu7sK5MWuvg==",
+      "dev": true
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-draft-04": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+      "dev": true,
+      "peerDependencies": {
+        "ajv": "^8.5.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-errors": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-3.0.0.tgz",
+      "integrity": "sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ==",
+      "dev": true,
+      "peerDependencies": {
+        "ajv": "^8.0.1"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "is-array-buffer": "^3.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/arraybuffer.prototype.slice": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+      "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
+      "dev": true,
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.1",
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "is-array-buffer": "^3.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/as-table": {
+      "version": "1.0.55",
+      "resolved": "https://registry.npmjs.org/as-table/-/as-table-1.0.55.tgz",
+      "integrity": "sha512-xvsWESUJn0JN421Xb9MQw6AsMHRCUknCe0Wjlxvjud80mU4E6hQf1A6NzQKcYNmYw62MfzEtXc+badstZP3JpQ==",
+      "dev": true,
+      "dependencies": {
+        "printable-characters": "^1.0.42"
+      }
+    },
+    "node_modules/ast-types": {
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.14.2.tgz",
+      "integrity": "sha512-O0yuUDnZeQDL+ncNGlJ78BiO4jnYI3bvMsD5prT0/nsgijG/LpNBIr63gTjVTNsiGkgQhiyCShTgxt8oXOrklA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/astring": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/astring/-/astring-1.9.0.tgz",
+      "integrity": "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==",
+      "dev": true,
+      "bin": {
+        "astring": "bin/astring"
+      }
+    },
+    "node_modules/async-function": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
+      "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dev": true,
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/builtins": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
+      "integrity": "sha512-uYBjakWipfaO/bXI7E8rq6kpwHRZK5cNYrUv2OzZSI/FvmdMyXJ2tG9dKcjEC5YHmHpUAwsargWIZNWdxb/bnQ==",
+      "dev": true
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+      "dev": true
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-2.0.2.tgz",
+      "integrity": "sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA==",
+      "dev": true
+    },
+    "node_modules/data-view-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+      "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/data-view-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+      "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/inspect-js"
+      }
+    },
+    "node_modules/data-view-byte-offset": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+      "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/dependency-graph": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-0.11.0.tgz",
+      "integrity": "sha512-JeMq7fEshyepOWDfcfHK06N3MhyPhz++vtqWhMT5O9A3K42rdsEDpfdVqjaqaAhsw6a+ZqeDvQVtD0hFHQWrzg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/es-abstract": {
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.2.tgz",
+      "integrity": "sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==",
+      "dev": true,
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.2",
+        "arraybuffer.prototype.slice": "^1.0.4",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "data-view-buffer": "^1.0.2",
+        "data-view-byte-length": "^1.0.2",
+        "data-view-byte-offset": "^1.0.1",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "es-set-tostringtag": "^2.1.0",
+        "es-to-primitive": "^1.3.0",
+        "function.prototype.name": "^1.1.8",
+        "get-intrinsic": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "get-symbol-description": "^1.1.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "internal-slot": "^1.1.0",
+        "is-array-buffer": "^3.0.5",
+        "is-callable": "^1.2.7",
+        "is-data-view": "^1.0.2",
+        "is-negative-zero": "^2.0.3",
+        "is-regex": "^1.2.1",
+        "is-set": "^2.0.3",
+        "is-shared-array-buffer": "^1.0.4",
+        "is-string": "^1.1.1",
+        "is-typed-array": "^1.1.15",
+        "is-weakref": "^1.1.1",
+        "math-intrinsics": "^1.1.0",
+        "object-inspect": "^1.13.4",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.7",
+        "own-keys": "^1.0.1",
+        "regexp.prototype.flags": "^1.5.4",
+        "safe-array-concat": "^1.1.3",
+        "safe-push-apply": "^1.0.0",
+        "safe-regex-test": "^1.1.0",
+        "set-proto": "^1.0.0",
+        "stop-iteration-iterator": "^1.1.0",
+        "string.prototype.trim": "^1.2.10",
+        "string.prototype.trimend": "^1.0.9",
+        "string.prototype.trimstart": "^1.0.8",
+        "typed-array-buffer": "^1.0.3",
+        "typed-array-byte-length": "^1.0.3",
+        "typed-array-byte-offset": "^1.0.4",
+        "typed-array-length": "^1.0.7",
+        "unbox-primitive": "^1.1.0",
+        "which-typed-array": "^1.1.19"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-abstract-get": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-abstract-get/-/es-abstract-get-1.0.0.tgz",
+      "integrity": "sha512-6PMWXpdhshVvFp+FoWYs1EvG1Nj0tvk0dZM+XcK0xMEM1czRVcP6ohqPWHy6qPagSpC8j4+p89WXlT+xXJs/fg==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.2",
+        "is-callable": "^1.2.7",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-aggregate-error": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/es-aggregate-error/-/es-aggregate-error-1.0.14.tgz",
+      "integrity": "sha512-3YxX6rVb07B5TV11AV5wsL7nQCHXNwoHPsQC8S4AmBiqYhyNCJ5BRKXkXyDJvs8QzXN20NgRtxe3dEEQD9NLHA==",
+      "dev": true,
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.0",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "globalthis": "^1.0.4",
+        "has-property-descriptors": "^1.0.2",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-to-primitive": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.4.tgz",
+      "integrity": "sha512-yPDz7wqpg1/mmHLmS3tcfTfbw5f1eryXvyghYBffGdERwe+mV7ZcWzTR8LR17Kvqt3qfPurjlonmnq3MKXIOXw==",
+      "dev": true,
+      "dependencies": {
+        "es-abstract-get": "^1.0.0",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "is-callable": "^1.2.7",
+        "is-date-object": "^1.1.0",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true
+    },
+    "node_modules/expr-eval-fork": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/expr-eval-fork/-/expr-eval-fork-3.0.3.tgz",
+      "integrity": "sha512-BhC+hbc5lIVjygr840n5DEkW3MQq7H9o+mc1/N7Z5uIiCFVyESLL5DIE7LNq4CYUNxy+XjA+3jRrL/h0Kt2xcg==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
+    "node_modules/fast-glob": {
+      "version": "3.2.12",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
+      "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-memoize": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/fast-memoize/-/fast-memoize-2.5.2.tgz",
+      "integrity": "sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw==",
+      "dev": true
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ]
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dev": true,
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/function.prototype.name": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.2.0.tgz",
+      "integrity": "sha512-jObKIik1P2QjPHP5nz5BaOtUlfgS0fWo8IUByNXkM+o+02sJOi94em77GwJKQSJ3gfPHdgzLNrHc1uokV4P/ew==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2",
+        "hasown": "^2.0.4",
+        "is-callable": "^1.2.7",
+        "is-document.all": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generator-function": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-source": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/get-source/-/get-source-2.0.12.tgz",
+      "integrity": "sha512-X5+4+iD+HoSeEED+uwrQ07BOQr0kEDFMVqqpBuI+RaZBpBpHCuXxo70bjar6f0b0u/DQJsJ7ssurpP0V60Az+w==",
+      "dev": true,
+      "dependencies": {
+        "data-uri-to-buffer": "^2.0.0",
+        "source-map": "^0.6.1"
+      }
+    },
+    "node_modules/get-symbol-description": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+      "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "dev": true,
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true
+    },
+    "node_modules/has-bigints": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-proto": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
+      "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
+      "dev": true,
+      "dependencies": {
+        "dunder-proto": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hpagent": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-1.2.0.tgz",
+      "integrity": "sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/immer": {
+      "version": "9.0.21",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.21.tgz",
+      "integrity": "sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "node_modules/internal-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-async-function": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
+      "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
+      "dev": true,
+      "dependencies": {
+        "async-function": "^1.0.0",
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bigint": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
+      "dev": true,
+      "dependencies": {
+        "has-bigints": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-boolean-object": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+      "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-data-view": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
+      "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-document.all": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-document.all/-/is-document.all-1.0.0.tgz",
+      "integrity": "sha512-+XSoyS05OdBbhFuELhgTCpFNHkpBOJqtsZfUFFpe5QTw+9Sjbh8zitxhQkYAo6wV7e1Vb8cAPvpCk9jGam/82g==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-finalizationregistry": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+      "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.4",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-negative-zero": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-number-object": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-reference": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
+      "integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-set": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-string": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dev": true,
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakmap": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
+      "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true
+    },
+    "node_modules/jsep": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
+      "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.16.0"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true
+    },
+    "node_modules/jsonc-parser": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.2.1.tgz",
+      "integrity": "sha512-o6/yDBYccGvTz1+QFevz6l6OBZ2+fMVu2JZ9CIhzsYRX4mjaK5IyX9eldUdCmga16zlgQxyrj5pt9kzuj2C02w==",
+      "dev": true
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonpath-plus": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.4.0.tgz",
+      "integrity": "sha512-T92WWatJXmhBbKsgH/0hl+jxjdXrifi5IKeMY02DWggRxX0UElcbVzPlmgLTbvsPeW1PasQ6xE2Q75stkhGbsA==",
+      "dev": true,
+      "dependencies": {
+        "@jsep-plugin/assignment": "^1.3.0",
+        "@jsep-plugin/regex": "^1.0.4",
+        "jsep": "^1.4.0"
+      },
+      "bin": {
+        "jsonpath": "bin/jsonpath-cli.js",
+        "jsonpath-plus": "bin/jsonpath-cli.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/jsonpointer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
+      "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/leven": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true
+    },
+    "node_modules/lodash.topath": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/lodash.topath/-/lodash.topath-4.5.2.tgz",
+      "integrity": "sha512-1/W4dM+35DwvE/iEd1M9ekewOSTlpFekhw9mhAtrwjVqUr83/ilQiyAvmg4tVX7Unkcfl1KC+i9WdaT4B6aQcg==",
+      "dev": true
+    },
+    "node_modules/magic-string": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+      "dev": true,
+      "dependencies": {
+        "sourcemap-codec": "^1.4.8"
+      }
+    },
+    "node_modules/markdown-escape": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-escape/-/markdown-escape-2.0.0.tgz",
+      "integrity": "sha512-Trz4v0+XWlwy68LJIyw3bLbsJiC8XAbRCKF9DbEtZjyndKOGVx6n+wNB0VfoRmY2LKboQLeniap3xrb6LGSJ8A==",
+      "dev": true
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/nimma": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/nimma/-/nimma-0.2.3.tgz",
+      "integrity": "sha512-1ZOI8J+1PKKGceo/5CT5GfQOG6H8I2BencSK06YarZ2wXwH37BSSUWldqJmMJYA5JfqDqffxDXynt6f11AyKcA==",
+      "dev": true,
+      "dependencies": {
+        "@jsep-plugin/regex": "^1.0.1",
+        "@jsep-plugin/ternary": "^1.0.2",
+        "astring": "^1.8.1",
+        "jsep": "^1.2.0"
+      },
+      "engines": {
+        "node": "^12.20 || >=14.13"
+      },
+      "optionalDependencies": {
+        "jsonpath-plus": "^6.0.1 || ^10.1.0",
+        "lodash.topath": "^4.5.2"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-sarif-builder": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/node-sarif-builder/-/node-sarif-builder-2.0.3.tgz",
+      "integrity": "sha512-Pzr3rol8fvhG/oJjIq2NTVB0vmdNNlz22FENhhPojYRZ4/ee08CfK4YuKmuL54V9MLhI1kpzxfOJ/63LzmZzDg==",
+      "dev": true,
+      "dependencies": {
+        "@types/sarif": "^2.1.4",
+        "fs-extra": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/own-keys": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.2.tgz",
+      "integrity": "sha512-19YVAg7T+WTrxggPukVq7DjTv6+PJ867TmhCvBsYwmbFCsZd344rq2Ld1p0wo8f8Qrrhgp82c6FJRqdXWtSEhg==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.4",
+        "get-intrinsic": "^1.3.0",
+        "object-keys": "^1.1.1",
+        "safe-push-apply": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pony-cause": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pony-cause/-/pony-cause-1.1.1.tgz",
+      "integrity": "sha512-PxkIc/2ZpLiEzQXu5YRDOUgBlfGYBY8156HY5ZcRAwwonMk5W/MrJP2LLkG/hF7GEQzaHo2aS7ho6ZLCOvf+6g==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/printable-characters": {
+      "version": "1.0.42",
+      "resolved": "https://registry.npmjs.org/printable-characters/-/printable-characters-1.0.42.tgz",
+      "integrity": "sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ==",
+      "dev": true
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/reflect.getprototypeof": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+      "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.7",
+        "get-proto": "^1.0.1",
+        "which-builtin-type": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/reserved": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/reserved/-/reserved-0.1.2.tgz",
+      "integrity": "sha512-/qO54MWj5L8WCBP9/UNe2iefJc+L9yETbH32xO/ft/EYPOTCR5k+azvDUgdCOKwZH8hXwPd0b8XBL78Nn2U69g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "2.80.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.80.0.tgz",
+      "integrity": "sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ==",
+      "dev": true,
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/safe-array-concat": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.4.tgz",
+      "integrity": "sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "get-intrinsic": "^1.3.0",
+        "has-symbols": "^1.1.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-push-apply": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+      "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-1.1.1.tgz",
+      "integrity": "sha512-ERq4hUjKDbJfE4+XtZLFPCDi8Vb1JqaxAPTxWFLBx8XcAlf9Bda/ZJdVezs/NAfsMQScyIlUMx+Yeu7P7rx5jw==",
+      "dev": true
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "dev": true,
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-proto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
+      "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
+      "dev": true,
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "deprecated": "Please use @jridgewell/sourcemap-codec instead",
+      "dev": true
+    },
+    "node_modules/stacktracey": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/stacktracey/-/stacktracey-2.2.0.tgz",
+      "integrity": "sha512-ETyQEz+CzXiLjEbyJqpbp+/T79RQD/6wqFucRBIlVNZfYq2Ay7wbretD4cxpbymZlaPWx58aIhPEY1Cr8DlVvg==",
+      "dev": true,
+      "dependencies": {
+        "as-table": "^1.0.36",
+        "get-source": "^2.0.12"
+      }
+    },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "internal-slot": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string.prototype.trim": {
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.11.tgz",
+      "integrity": "sha512-PwvK7BU+CMTJGYQCTZb5RWXIML92lftJLhQz1tBzgKiqGxJaMlBAa48POXaNAC2s4y8jr3EFqrkF9+44neS46w==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "define-data-property": "^1.1.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.2",
+        "es-object-atoms": "^1.1.2",
+        "has-property-descriptors": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.10.tgz",
+      "integrity": "sha512-2+3aDAOmPTmuFwjDnmJG2ctEkQKVki7vOSqaxkv42Mowj1V6PnvuwFCRrR5lChUux1TBskPjfkeTOhqczDMxTw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimstart": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+      "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true
+    },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/typed-array-byte-length": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+      "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-byte-offset": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+      "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
+      "dev": true,
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "reflect.getprototypeof": "^1.0.9"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-length": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.8.tgz",
+      "integrity": "sha512-phPGCwqr2+Qo0fwniCE8e4pKnGu/yFb5nD5Y8bf0EEeiI5GklnACYA9GFy/DrAeRrKHXvHn+1SUsOWgJp6RO+g==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "for-each": "^0.3.5",
+        "gopd": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "possible-typed-array-names": "^1.1.0",
+        "reflect.getprototypeof": "^1.0.10"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/unbox-primitive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+      "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "which-boxed-primitive": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/urijs": {
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.11.tgz",
+      "integrity": "sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ==",
+      "dev": true
+    },
+    "node_modules/utility-types": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.11.0.tgz",
+      "integrity": "sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/validate-npm-package-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
+      "integrity": "sha512-M6w37eVCMMouJ9V/sdPGnC5H4uDr73/+xdq0FBLO3TFFX1+7wiUY6Es328NN+y43tmY+doUdN9g9J21vqB7iLw==",
+      "dev": true,
+      "dependencies": {
+        "builtins": "^1.0.3"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
+      "dev": true,
+      "dependencies": {
+        "is-bigint": "^1.1.0",
+        "is-boolean-object": "^1.2.1",
+        "is-number-object": "^1.1.1",
+        "is-string": "^1.1.1",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-builtin-type": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+      "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "function.prototype.name": "^1.1.6",
+        "has-tostringtag": "^1.0.2",
+        "is-async-function": "^2.0.0",
+        "is-date-object": "^1.1.0",
+        "is-finalizationregistry": "^1.1.0",
+        "is-generator-function": "^1.0.10",
+        "is-regex": "^1.2.1",
+        "is-weakref": "^1.0.2",
+        "isarray": "^2.0.5",
+        "which-boxed-primitive": "^1.1.0",
+        "which-collection": "^1.0.2",
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+      "dev": true,
+      "dependencies": {
+        "is-map": "^2.0.3",
+        "is-set": "^2.0.3",
+        "is-weakmap": "^2.0.2",
+        "is-weakset": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.22",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+      "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
+      "dev": true,
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "api-specs-enriched-ci",
+  "private": true,
+  "devDependencies": {
+    "@stoplight/spectral-cli": "6.16.2"
+  }
+}

--- a/scripts/audit_namespace_profiles.py
+++ b/scripts/audit_namespace_profiles.py
@@ -61,7 +61,12 @@ def mine_description_signals(specs_dir: Path) -> dict[str, list[dict[str, str]]]
 
     for entry in sorted(specs_dir.iterdir()):
         fname = entry.name
-        if not fname.endswith(".json") or fname in ("index.json", "namespace_profiles.json"):
+        if not fname.endswith(".json") or fname in (
+            "index.json",
+            "namespace_profiles.json",
+            "resource_coverage.json",
+            "validation.json",
+        ):
             continue
         with (specs_dir / fname).open() as f:
             spec = json.load(f)
@@ -142,7 +147,12 @@ def mine_example_signals(specs_dir: Path) -> dict[str, list[dict[str, str]]]:
 
     for entry in sorted(specs_dir.iterdir()):
         fname = entry.name
-        if not fname.endswith(".json") or fname in ("index.json", "namespace_profiles.json"):
+        if not fname.endswith(".json") or fname in (
+            "index.json",
+            "namespace_profiles.json",
+            "resource_coverage.json",
+            "validation.json",
+        ):
             continue
         with (specs_dir / fname).open() as f:
             spec = json.load(f)

--- a/scripts/build_dependency_graph.py
+++ b/scripts/build_dependency_graph.py
@@ -126,7 +126,12 @@ def main() -> int:
     specs_dir = Path("docs/specifications/api")
     specs: list[dict[str, Any]] = []
     for f in sorted(specs_dir.glob("*.json")):
-        if f.name == "index.json":
+        if f.name in {
+            "index.json",
+            "namespace_profiles.json",
+            "resource_coverage.json",
+            "validation.json",
+        }:
             continue
         try:
             specs.append(json.loads(f.read_text()))

--- a/scripts/classify_namespace_scope.py
+++ b/scripts/classify_namespace_scope.py
@@ -73,6 +73,7 @@ def _system_path_resources(specs_dir: Path) -> set[str]:
         if spec_path.name in {
             "index.json",
             "namespace_profiles.json",
+            "resource_coverage.json",
             "openapi.json",
             "minimal-export-defaults.json",
         }:
@@ -108,6 +109,7 @@ def _nl_system_resources(specs_dir: Path) -> set[str]:
         if spec_path.name in {
             "index.json",
             "namespace_profiles.json",
+            "resource_coverage.json",
             "openapi.json",
             "minimal-export-defaults.json",
         }:

--- a/scripts/compile_catalog.py
+++ b/scripts/compile_catalog.py
@@ -42,6 +42,13 @@ def merge_spec_files(dir_path: Path) -> dict[str, Any]:
     collisions: list[dict[str, Any]] = []
 
     for spec_file in sorted(dir_path.glob("*.json")):
+        if spec_file.name in {
+            "index.json",
+            "namespace_profiles.json",
+            "resource_coverage.json",
+            "validation.json",
+        }:
+            continue
         try:
             with spec_file.open() as f:
                 spec = json.load(f)

--- a/scripts/contract_diff.py
+++ b/scripts/contract_diff.py
@@ -298,7 +298,13 @@ def _load_specs_from_dir(spec_dir: Path) -> list[tuple[str, dict]]:
     """
     loaded: list[tuple[str, dict]] = []
     for path in sorted(spec_dir.glob("*.json")):
-        if path.name in {"manifest.json", "index.json"}:
+        if path.name in {
+            "manifest.json",
+            "index.json",
+            "namespace_profiles.json",
+            "resource_coverage.json",
+            "validation.json",
+        }:
             continue
         try:
             doc = json.loads(path.read_text())

--- a/scripts/discover.py
+++ b/scripts/discover.py
@@ -110,7 +110,13 @@ def extract_endpoints_from_specs(specs_dir: Path) -> list[dict[str, Any]]:
         return endpoints
 
     for spec_file in sorted(specs_dir.glob("*.json")):
-        if spec_file.name in ("index.json", "openapi.json"):
+        if spec_file.name in (
+            "index.json",
+            "namespace_profiles.json",
+            "resource_coverage.json",
+            "validation.json",
+            "openapi.json",
+        ):
             continue
 
         try:

--- a/scripts/discover_namespace_crud.py
+++ b/scripts/discover_namespace_crud.py
@@ -67,6 +67,7 @@ def build_create_path_index(specs_dir: Path) -> dict[str, dict[str, str]]:
         if spec_path.name in {
             "index.json",
             "namespace_profiles.json",
+            "resource_coverage.json",
             "openapi.json",
             "minimal-export-defaults.json",
         }:

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -255,6 +255,7 @@ def lint_all_specs(
         "validation.json",
         "minimal-export-defaults.json",
         "namespace_profiles.json",
+        "resource_coverage.json",
     }
     spec_files = sorted(f for f in input_dir.glob("*.json") if f.name not in non_openapi_files)
     if not spec_files:

--- a/scripts/pipeline.py
+++ b/scripts/pipeline.py
@@ -135,6 +135,7 @@ from scripts.utils.json_writer import write_json_file
 from scripts.utils.memory_profiler import MemoryProfiler
 from scripts.utils.minimal_defaults_exporter import MinimalDefaultsExporter
 from scripts.utils.namespace_profiles_exporter import NamespaceProfilesExporter
+from scripts.utils.resource_coverage_exporter import ResourceCoverageExporter
 from scripts.utils.server_variables import ServerVariableHelper
 
 console = Console()
@@ -1964,18 +1965,30 @@ def run_pipeline(
             # scope map consumed by downstream tree filtering (vscode-xcsh, xcsh).
             # Rides alongside the domain specs (like validation.json) and is read by
             # the consumer via an explicit path, not parsed as a domain spec.
-            try:
-                np_profiles_exporter = NamespaceProfilesExporter()
-                np_profiles_artifact = np_profiles_exporter.export(
-                    output_dir / "namespace_profiles.json",
-                    version=version,
-                )
-                console.print(
-                    f"[green]Exported namespace_profiles.json: "
-                    f"{len(np_profiles_artifact['resources'])} resource overrides + default[/green]",
-                )
-            except Exception as e:
-                console.print(f"[yellow]Warning: Failed to export namespace profiles: {e}[/yellow]")
+            np_profiles_exporter = NamespaceProfilesExporter()
+            np_profiles_artifact = np_profiles_exporter.export(
+                output_dir / "namespace_profiles.json",
+                version=version,
+            )
+            console.print(
+                f"[green]Exported namespace_profiles.json: "
+                f"{len(np_profiles_artifact['resources'])} resource overrides + default[/green]",
+            )
+
+            # Publish the fail-closed resource coverage contract only after the
+            # canonical candidates and namespace profiles can be proven complete.
+            coverage_artifact = ResourceCoverageExporter().export(
+                domain_specs.values(),
+                np_profiles_artifact,
+                output_dir / "resource_coverage.json",
+                version=version,
+            )
+            console.print(
+                f"[green]Exported resource_coverage.json: "
+                f"{coverage_artifact['coverage']['generated']} generated, "
+                f"{coverage_artifact['coverage']['manual']} manual, "
+                f"{coverage_artifact['coverage']['excluded']} excluded[/green]",
+            )
 
             console.print(f"[green]Created {len(domain_specs)} domain specs + master spec[/green]")
 

--- a/scripts/utils/resource_coverage_exporter.py
+++ b/scripts/utils/resource_coverage_exporter.py
@@ -1,0 +1,324 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+"""Build the versioned resource coverage contract for downstream generators."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import yaml
+
+from scripts.utils.json_writer import write_json_file
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+CONTRACT_VERSION = 1
+ALLOWED_EXCLUSION_REASONS = frozenset({"no_canonical_create"})
+_CREATE_OPERATION = re.compile(r"^ves\.io\.schema\.(?P<identity>[a-zA-Z0-9_.]+)\.API\.Create$")
+
+
+class ResourceCoverageError(ValueError):
+    """Raised when resource coverage cannot be proven complete."""
+
+
+@dataclass(frozen=True)
+class CanonicalResource:
+    """A canonical create identity and its collection route."""
+
+    resource_key: str
+    path: str
+    operation_id: str
+
+
+def _is_collection_path(path: str, resource_key: str) -> bool:
+    """Return whether *path* has canonical namespace collection semantics."""
+    segments = path.strip("/").split("/")
+    if len(segments) < 3 or segments[0] != "api":
+        return False
+
+    namespace_indexes = [index for index, value in enumerate(segments) if value == "namespaces"]
+    if not namespace_indexes:
+        return False
+
+    index = namespace_indexes[-1]
+    # Namespace itself is the one tenant-level resource whose collection route
+    # ends at /namespaces rather than below a selected namespace.
+    if index == len(segments) - 1:
+        return resource_key == "namespace"
+
+    # All other canonical routes select one namespace and then one collection.
+    if len(segments) != index + 3:
+        return False
+    namespace = segments[index + 1]
+    collection = segments[index + 2]
+    return bool(namespace and collection and not collection.startswith("{"))
+
+
+def discover_canonical_resources(
+    documents: Iterable[dict[str, Any]],
+) -> dict[str, CanonicalResource]:
+    """Discover canonical resources from exact create identity plus route semantics.
+
+    The last schema-identity segment is the canonical resource key. This handles
+    both ``views.<resource>`` and other qualified identities without guessing a
+    singular name from the route.
+    """
+    candidates: dict[str, CanonicalResource] = {}
+    for document in documents:
+        paths = document.get("paths", {})
+        if not isinstance(paths, dict):
+            continue
+        for api_path in sorted(paths):
+            path_item = paths[api_path]
+            if not isinstance(path_item, dict):
+                continue
+            post = path_item.get("post")
+            if not isinstance(post, dict):
+                continue
+            operation_id = post.get("operationId")
+            if not isinstance(operation_id, str):
+                continue
+            match = _CREATE_OPERATION.fullmatch(operation_id)
+            if not match:
+                continue
+            resource_key = match.group("identity").split(".")[-1]
+            if not _is_collection_path(api_path, resource_key):
+                continue
+
+            candidate = CanonicalResource(resource_key, api_path, operation_id)
+            existing = candidates.get(resource_key)
+            if existing and existing != candidate:
+                raise ResourceCoverageError(
+                    f"canonical resource {resource_key!r} has conflicting create routes: "
+                    f"{existing.path!r} and {api_path!r}"
+                )
+            candidates[resource_key] = candidate
+
+    return dict(sorted(candidates.items()))
+
+
+class ResourceCoverageExporter:
+    """Validate and export generated, manual, and excluded resource coverage."""
+
+    def __init__(self, config_path: Path | None = None) -> None:
+        """Load and validate the curated manual and exclusion policy."""
+        self.config_path = config_path or Path("config/resource_coverage.yaml")
+        try:
+            raw = yaml.safe_load(self.config_path.read_text()) or {}
+        except (OSError, yaml.YAMLError) as exc:
+            raise ResourceCoverageError(
+                f"failed to load resource coverage config {self.config_path}: {exc}"
+            ) from exc
+        if not isinstance(raw, dict):
+            raise ResourceCoverageError("resource coverage config must be an object")
+        if raw.get("version") != CONTRACT_VERSION:
+            raise ResourceCoverageError(
+                f"unsupported contract config version {raw.get('version')!r}; "
+                f"expected {CONTRACT_VERSION}"
+            )
+
+        manual = raw.get("manual", {})
+        if not isinstance(manual, dict):
+            raise ResourceCoverageError("manual must be an object")
+        parsed_manual: dict[str, str] = {}
+        for resource_key, entry in manual.items():
+            if not isinstance(resource_key, str) or not isinstance(entry, dict):
+                raise ResourceCoverageError("each manual resource must be an object")
+            manual_path = entry.get("path")
+            if not isinstance(manual_path, str) or not manual_path.startswith("/api/"):
+                raise ResourceCoverageError(
+                    f"manual resource {resource_key!r} must declare an absolute API path"
+                )
+            if not _is_collection_path(manual_path, resource_key):
+                raise ResourceCoverageError(
+                    f"manual path {manual_path!r} for {resource_key!r} is not a collection route"
+                )
+            parsed_manual[resource_key] = manual_path
+        self.manual = dict(sorted(parsed_manual.items()))
+
+        exclusions = raw.get("exclusions", {})
+        if not isinstance(exclusions, dict):
+            raise ResourceCoverageError("exclusions must be an object")
+        for resource_key, reason in exclusions.items():
+            if reason not in ALLOWED_EXCLUSION_REASONS:
+                raise ResourceCoverageError(
+                    f"invalid exclusion reason {reason!r} for {resource_key!r}"
+                )
+        self.exclusions: dict[str, str] = dict(sorted(exclusions.items()))
+
+    @property
+    def manual_resource_keys(self) -> set[str]:
+        """Return explicitly supported downstream manual resource keys."""
+        return set(self.manual)
+
+    def build(
+        self,
+        documents: Iterable[dict[str, Any]],
+        namespace_profiles: dict[str, Any],
+        *,
+        version: str,
+    ) -> dict[str, Any]:
+        """Build and validate a complete deterministic coverage artifact."""
+        documents = list(documents)
+        candidates = discover_canonical_resources(documents)
+        profile_version = namespace_profiles.get("version")
+        if profile_version is not None and profile_version != version:
+            raise ResourceCoverageError(
+                f"namespace profile version {profile_version!r} does not match {version!r}"
+            )
+        profiles = namespace_profiles.get("resources")
+        if not isinstance(profiles, dict):
+            raise ResourceCoverageError("namespace_profiles resources must be an object")
+        profile_keys = set(profiles)
+
+        missing_profiles = sorted(set(candidates) - profile_keys)
+        if missing_profiles:
+            raise ResourceCoverageError(
+                "canonical candidates lack explicit namespace profiles: "
+                + ", ".join(missing_profiles)
+            )
+        missing_manual_profiles = sorted(set(self.manual) - profile_keys)
+        if missing_manual_profiles:
+            raise ResourceCoverageError(
+                "manual resources lack explicit namespace profiles: "
+                + ", ".join(missing_manual_profiles)
+            )
+
+        overlap = sorted(set(candidates) & set(self.manual))
+        if overlap:
+            raise ResourceCoverageError(
+                "canonical resources must be generated, not manual: " + ", ".join(overlap)
+            )
+
+        path_items: dict[str, dict[str, Any]] = {}
+        for document in documents:
+            paths = document.get("paths", {})
+            if isinstance(paths, dict):
+                path_items.update(
+                    (key, value) for key, value in paths.items() if isinstance(value, dict)
+                )
+        for resource_key, manual_path in self.manual.items():
+            path_item = path_items.get(manual_path)
+            if path_item is None:
+                raise ResourceCoverageError(
+                    f"manual path {manual_path!r} for {resource_key!r} does not exist"
+                )
+            if not isinstance(path_item.get("get"), dict):
+                raise ResourceCoverageError(
+                    f"manual path {manual_path!r} for {resource_key!r} has no GET list operation"
+                )
+
+        unknown_exclusions = sorted(set(self.exclusions) - profile_keys)
+        if unknown_exclusions:
+            raise ResourceCoverageError(
+                "configured exclusions lack namespace profiles: " + ", ".join(unknown_exclusions)
+            )
+        invalid_exclusions = sorted(set(self.exclusions) & set(candidates))
+        if invalid_exclusions:
+            raise ResourceCoverageError(
+                "canonical resources cannot be excluded: " + ", ".join(invalid_exclusions)
+            )
+
+        resources: dict[str, dict[str, Any]] = {}
+        counts = {"excluded": 0, "generated": 0, "manual": 0}
+        for resource_key in sorted(profile_keys):
+            candidate = candidates.get(resource_key)
+            if candidate:
+                resources[resource_key] = {
+                    "disposition": "generated",
+                    "path": candidate.path,
+                    "operation_id": candidate.operation_id,
+                }
+                counts["generated"] += 1
+            elif resource_key in self.manual:
+                resources[resource_key] = {
+                    "disposition": "manual",
+                    "path": self.manual[resource_key],
+                }
+                counts["manual"] += 1
+            else:
+                reason = self.exclusions.get(resource_key, "no_canonical_create")
+                if reason not in ALLOWED_EXCLUSION_REASONS:
+                    raise ResourceCoverageError(
+                        f"invalid exclusion reason {reason!r} for {resource_key!r}"
+                    )
+                resources[resource_key] = {"disposition": "excluded", "reason": reason}
+                counts["excluded"] += 1
+
+        return {
+            "version": version,
+            "contract_version": CONTRACT_VERSION,
+            "source": "api-specs-enriched/config/resource_coverage.yaml",
+            "resources": resources,
+            "coverage": {**counts, "total": len(resources)},
+        }
+
+    def export(
+        self,
+        documents: Iterable[dict[str, Any]],
+        namespace_profiles: dict[str, Any],
+        output_path: Path,
+        *,
+        version: str,
+    ) -> dict[str, Any]:
+        """Build, validate, and write the resource coverage artifact."""
+        artifact = self.build(documents, namespace_profiles, version=version)
+        write_json_file(artifact, output_path, indent=2, ensure_ascii=False)
+        return artifact
+
+
+def _load_documents(input_dir: Path) -> list[dict[str, Any]]:
+    metadata = {
+        "index.json",
+        "minimal-export-defaults.json",
+        "namespace_profiles.json",
+        "resource_coverage.json",
+        "validation.json",
+    }
+    return [
+        json.loads(path.read_text())
+        for path in sorted(input_dir.glob("*.json"))
+        if path.name not in metadata
+    ]
+
+
+def main() -> int:
+    """Export resource coverage from an existing generated-spec directory."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input-dir", type=Path, default=Path("docs/specifications/api"))
+    parser.add_argument("--profiles", type=Path, default=None)
+    parser.add_argument("--config", type=Path, default=None)
+    parser.add_argument("--output", type=Path, default=None)
+    parser.add_argument("--version", required=True)
+    args = parser.parse_args()
+    profiles_path = args.profiles or args.input_dir / "namespace_profiles.json"
+    output_path = args.output or args.input_dir / "resource_coverage.json"
+    try:
+        exporter = ResourceCoverageExporter(config_path=args.config)
+        artifact = exporter.export(
+            _load_documents(args.input_dir),
+            json.loads(profiles_path.read_text()),
+            output_path,
+            version=args.version,
+        )
+    except (OSError, json.JSONDecodeError, ResourceCoverageError) as exc:
+        print(f"Error exporting resource coverage: {exc}", file=sys.stderr)
+        return 1
+    print(
+        f"Resource coverage exported to {output_path}: "
+        f"{artifact['coverage']['generated']} generated, "
+        f"{artifact['coverage']['manual']} manual, "
+        f"{artifact['coverage']['excluded']} excluded"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -459,7 +459,16 @@ async def validate_all_specs(
     """Validate all specification files in a directory."""
     stats = ValidationStats()
 
-    spec_files = sorted(specs_dir.glob("*.json"))
+    metadata_files = {
+        "index.json",
+        "minimal-export-defaults.json",
+        "namespace_profiles.json",
+        "resource_coverage.json",
+        "validation.json",
+    }
+    spec_files = sorted(
+        path for path in specs_dir.glob("*.json") if path.name not in metadata_files
+    )
     if not spec_files:
         console.print(f"[yellow]No specification files found in {specs_dir}[/yellow]")
         return stats
@@ -667,7 +676,16 @@ def main() -> int:
     if args.dry_run:
         # Just list endpoints without validation
         console.print("\n[blue]Dry run - listing endpoints without validation[/blue]")
-        spec_files = sorted(args.specs_dir.glob("*.json"))
+        metadata_files = {
+            "index.json",
+            "minimal-export-defaults.json",
+            "namespace_profiles.json",
+            "resource_coverage.json",
+            "validation.json",
+        }
+        spec_files = sorted(
+            path for path in args.specs_dir.glob("*.json") if path.name not in metadata_files
+        )
         total_endpoints = 0
         for spec_file in spec_files:
             with spec_file.open() as f:

--- a/tests/test_all_endpoints_enrichment.py
+++ b/tests/test_all_endpoints_enrichment.py
@@ -39,7 +39,16 @@ def discover_all_endpoints() -> list[tuple[str, str, str, dict]]:
             allow_module_level=True,
         )
 
-    for spec_file in sorted(SPECS_DIR.glob("*.json")):
+    metadata_files = {
+        "index.json",
+        "minimal-export-defaults.json",
+        "namespace_profiles.json",
+        "resource_coverage.json",
+        "validation.json",
+    }
+    for spec_file in sorted(
+        path for path in SPECS_DIR.glob("*.json") if path.name not in metadata_files
+    ):
         try:
             with spec_file.open() as f:
                 spec = json.load(f)

--- a/tests/test_extension_catalog.py
+++ b/tests/test_extension_catalog.py
@@ -47,7 +47,12 @@ def _walk_x_keys(obj, acc: set[str]) -> None:
 def _enriched_x_keys() -> set[str]:
     keys: set[str] = set()
     for p in ENRICHED_DIR.glob("*.json"):
-        if p.name == "index.json":
+        if p.name in {
+            "index.json",
+            "namespace_profiles.json",
+            "resource_coverage.json",
+            "validation.json",
+        }:
             continue
         _walk_x_keys(json.loads(p.read_text()), keys)
     return keys

--- a/tests/test_naming_constraints_specs.py
+++ b/tests/test_naming_constraints_specs.py
@@ -26,7 +26,14 @@ pytestmark = pytest.mark.skipif(
 
 
 def _domain_specs() -> list[Path]:
-    skip = {"index.json", "validation.json", "minimal-export-defaults.json", "other.json"}
+    skip = {
+        "index.json",
+        "validation.json",
+        "minimal-export-defaults.json",
+        "namespace_profiles.json",
+        "resource_coverage.json",
+        "other.json",
+    }
     return [p for p in sorted(SPECS_DIR.glob("*.json")) if p.name not in skip]
 
 

--- a/tests/test_resource_coverage_exporter.py
+++ b/tests/test_resource_coverage_exporter.py
@@ -1,0 +1,230 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+"""Tests for the versioned resource coverage contract."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from scripts.utils.namespace_profiles_exporter import NamespaceProfilesExporter
+from scripts.utils.resource_coverage_exporter import (
+    ResourceCoverageError,
+    ResourceCoverageExporter,
+    discover_canonical_resources,
+)
+
+
+def operation(operation_id: str) -> dict[str, str]:
+    return {"operationId": operation_id}
+
+
+def spec(paths: dict[str, Any]) -> dict[str, Any]:
+    return {"openapi": "3.0.3", "info": {"version": "1.2.3"}, "paths": paths}
+
+
+def profile() -> dict[str, Any]:
+    return {
+        "constraint": {"allowed": ["custom"], "enforced": False},
+        "recommendation": {"primary": "custom", "rationale": "test"},
+        "classification": {"category": "application", "multi_tenant_pattern": "per-tenant"},
+    }
+
+
+def test_discovers_standard_qualified_and_views_create_identities() -> None:
+    document = spec(
+        {
+            "/api/config/namespaces/{metadata.namespace}/widgets": {
+                "post": operation("ves.io.schema.widget.API.Create")
+            },
+            "/api/data/namespaces/{metadata.namespace}/receivers": {
+                "post": operation("ves.io.schema.shape.data_delivery.receiver.API.Create")
+            },
+            "/api/config/namespaces/{metadata.namespace}/applications": {
+                "post": operation("ves.io.schema.views.application.API.Create")
+            },
+        }
+    )
+
+    candidates = discover_canonical_resources([document])
+
+    assert list(candidates) == ["application", "receiver", "widget"]
+    assert candidates["receiver"].operation_id == (
+        "ves.io.schema.shape.data_delivery.receiver.API.Create"
+    )
+    assert candidates["application"].path.endswith("/applications")
+
+
+def test_ignores_actions_aggregates_metadata_and_nested_create_routes() -> None:
+    document = spec(
+        {
+            "/api/config/namespaces/{namespace}/widgets/{name}/activate": {
+                "post": operation("ves.io.schema.widget.API.Create")
+            },
+            "/api/data/namespaces/{namespace}/widgets/aggregation": {
+                "post": operation("ves.io.schema.widget.CustomAPI.Aggregate")
+            },
+            "/api/config/namespaces/{namespace}/widgets/{name}/rotate": {
+                "post": operation("ves.io.schema.widget.CustomAPI.CreateToken")
+            },
+            "/metadata/resources": {"post": operation("ves.io.schema.metadata.API.Create")},
+        }
+    )
+
+    assert discover_canonical_resources([document]) == {}
+
+
+def test_build_assigns_one_disposition_to_every_profile(tmp_path: Path) -> None:
+    manual_config = tmp_path / "resource_coverage.yaml"
+    manual_config.write_text(
+        """\
+version: 1
+manual:
+  report:
+    path: /api/data/namespaces/{namespace}/reports
+"""
+    )
+    document = spec(
+        {
+            "/api/config/namespaces/{metadata.namespace}/widgets": {
+                "post": operation("ves.io.schema.views.widget.API.Create")
+            },
+            "/api/data/namespaces/{namespace}/reports": {
+                "get": operation("ves.io.schema.report.API.List")
+            },
+        }
+    )
+    profiles = {"resources": {key: profile() for key in ("widget", "report", "legacy")}}
+
+    artifact = ResourceCoverageExporter(config_path=manual_config).build(
+        [document], profiles, version="1.2.3"
+    )
+
+    assert artifact["version"] == "1.2.3"
+    assert list(artifact["resources"]) == ["legacy", "report", "widget"]
+    assert artifact["resources"]["widget"] == {
+        "disposition": "generated",
+        "path": "/api/config/namespaces/{metadata.namespace}/widgets",
+        "operation_id": "ves.io.schema.views.widget.API.Create",
+    }
+    assert artifact["resources"]["report"] == {
+        "disposition": "manual",
+        "path": "/api/data/namespaces/{namespace}/reports",
+    }
+    assert artifact["resources"]["legacy"] == {
+        "disposition": "excluded",
+        "reason": "no_canonical_create",
+    }
+    assert artifact["coverage"] == {"excluded": 1, "generated": 1, "manual": 1, "total": 3}
+
+
+def test_build_is_deterministic(tmp_path: Path) -> None:
+    config = tmp_path / "resource_coverage.yaml"
+    config.write_text("version: 1\nmanual: {}\n")
+    document = spec(
+        {
+            "/api/config/namespaces/{metadata.namespace}/zebras": {
+                "post": operation("ves.io.schema.zebra.API.Create")
+            },
+            "/api/config/namespaces/{metadata.namespace}/apples": {
+                "post": operation("ves.io.schema.apple.API.Create")
+            },
+        }
+    )
+    profiles = {"resources": {"zebra": profile(), "apple": profile()}}
+    exporter = ResourceCoverageExporter(config_path=config)
+
+    first = exporter.build([document], profiles, version="1.2.3")
+    second = exporter.build([document], profiles, version="1.2.3")
+
+    assert json.dumps(first, sort_keys=False) == json.dumps(second, sort_keys=False)
+    assert list(first["resources"]) == ["apple", "zebra"]
+
+
+def test_rejects_candidate_without_explicit_profile(tmp_path: Path) -> None:
+    config = tmp_path / "resource_coverage.yaml"
+    config.write_text("version: 1\nmanual: {}\n")
+    document = spec(
+        {
+            "/api/config/namespaces/{metadata.namespace}/widgets": {
+                "post": operation("ves.io.schema.widget.API.Create")
+            }
+        }
+    )
+
+    with pytest.raises(ResourceCoverageError, match=r"lack explicit namespace profiles.*widget"):
+        ResourceCoverageExporter(config_path=config).build(
+            [document], {"resources": {}}, version="1.2.3"
+        )
+
+
+@pytest.mark.parametrize(
+    ("config_text", "message"),
+    [
+        ("version: 2\nmanual: {}\n", "unsupported contract config version"),
+        ("version: 1\nmanual: []\n", "manual must be an object"),
+        (
+            "version: 1\nmanual: {}\nexclusions:\n  legacy: unsupported_guess\n",
+            "invalid exclusion reason",
+        ),
+    ],
+)
+def test_rejects_malformed_contract_config(tmp_path: Path, config_text: str, message: str) -> None:
+    config = tmp_path / "resource_coverage.yaml"
+    config.write_text(config_text)
+
+    with pytest.raises(ResourceCoverageError, match=message):
+        ResourceCoverageExporter(config_path=config)
+
+
+def test_rejects_stale_manual_path(tmp_path: Path) -> None:
+    config = tmp_path / "resource_coverage.yaml"
+    config.write_text(
+        """\
+version: 1
+manual:
+  report:
+    path: /api/data/namespaces/{namespace}/old_reports
+"""
+    )
+    document = spec(
+        {
+            "/api/data/namespaces/{namespace}/reports": {
+                "get": operation("ves.io.schema.report.API.List")
+            }
+        }
+    )
+    profiles = {"resources": {"report": profile()}}
+
+    with pytest.raises(ResourceCoverageError, match=r"manual path.*does not exist"):
+        ResourceCoverageExporter(config_path=config).build([document], profiles, version="1.2.3")
+
+
+def test_real_corpus_has_complete_profile_and_coverage_contract() -> None:
+    specs_dir = Path("docs/specifications/api")
+    domain_paths = sorted(
+        path
+        for path in specs_dir.glob("*.json")
+        if path.name
+        not in {
+            "index.json",
+            "minimal-export-defaults.json",
+            "namespace_profiles.json",
+            "resource_coverage.json",
+            "validation.json",
+        }
+    )
+    if not domain_paths:
+        pytest.skip("specs not available")
+
+    documents = [json.loads(path.read_text()) for path in domain_paths]
+    profiles = NamespaceProfilesExporter().build(version="test-corpus")
+    artifact = ResourceCoverageExporter().build(documents, profiles, version="test-corpus")
+
+    assert set(artifact["resources"]) == set(profiles["resources"])
+    assert artifact["coverage"]["generated"] > 0
+    assert artifact["coverage"]["manual"] > 0
+    assert artifact["coverage"]["excluded"] > 0

--- a/tests/test_stamp_release_version.py
+++ b/tests/test_stamp_release_version.py
@@ -5,12 +5,9 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING
+from pathlib import Path
 
 from scripts.stamp_release_version import stamp_directory, stamp_document
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 
 def test_stamp_document_uses_openapi_info_version() -> None:
@@ -54,13 +51,27 @@ def test_stamp_directory_updates_only_build_version_artifacts(tmp_path: Path) ->
         "domain.json": {"openapi": "3.0.3", "info": {"version": "1.0.0"}},
         "index.json": {"version": "1.0.0"},
         "validation.json": {"$schema": "example", "version": "2.1.0"},
+        "resource_coverage.json": {"version": "1.0.0", "resources": {}},
         "unversioned.json": {"resources": {}},
     }
     for name, document in fixtures.items():
         (tmp_path / name).write_text(json.dumps(document))
 
-    assert stamp_directory(tmp_path, "2.0.0") == 2
+    assert stamp_directory(tmp_path, "2.0.0") == 3
     assert json.loads((tmp_path / "domain.json").read_text())["info"]["version"] == "2.0.0"
     assert json.loads((tmp_path / "index.json").read_text())["version"] == "2.0.0"
     assert json.loads((tmp_path / "validation.json").read_text()) == fixtures["validation.json"]
+    assert json.loads((tmp_path / "resource_coverage.json").read_text())["version"] == "2.0.0"
     assert json.loads((tmp_path / "unversioned.json").read_text()) == fixtures["unversioned.json"]
+
+
+def test_release_bundle_copies_resource_coverage_metadata() -> None:
+    workflow = Path(".github/workflows/sync-and-enrich.yml").read_text()
+
+    assert "for spec_file in docs/specifications/api/*.json" in workflow
+    assert (
+        '"resource_coverage.json"'
+        not in workflow.split("# Copy domain specifications", 1)[1].split(
+            "# Copy metadata index", 1
+        )[0]
+    )


### PR DESCRIPTION
## Summary

- publish deterministic `resource_coverage.json` metadata from canonical create identities and route semantics
- require explicit namespace profiles and classify every profile as generated, manual, or excluded
- validate curated manual routes and treat coverage metadata as non-OpenAPI throughout tooling
- include and version-stamp the contract in immutable release bundles

## Verification

- `uv run --frozen ruff check` on all changed Python files
- `uv run --frozen ruff format --check` on all changed Python files
- focused tests: 173 passed, 14 skipped
- full suite: 2329 passed, 72 skipped, 1 xfailed
- real corpus: 159 generated, 17 manual, 81 excluded; repeat export byte-identical

Closes #1479