### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,33 @@ updates:
     cooldown:
       default-days: 7
 
+  # --- npm ---
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "chore(deps):"
+    labels:
+      - "dependencies"
+    open-pull-requests-limit: 10
+    groups:
+      # First-party @f5-sales-demo/* packages: track latest daily, all update types
+      # (auto-merged once CI is green) so internal deps never drift behind.
+      f5-internal:
+        patterns:
+          - "@f5-sales-demo/*"
+        update-types:
+          - "major"
+          - "minor"
+          - "patch"
+      npm-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    cooldown:
+      default-days: 7
+
   # --- pip ---
   - package-ecosystem: "pip"
     directory: "/"


### PR DESCRIPTION
Closes #1483

Synced managed files from `f5-sales-demo/docs-control` canonical source:

- .github/dependabot.yml