### PR TITLE
fix: complete response operation artifacts

### DIFF
--- a/config/operation_descriptions.yaml
+++ b/config/operation_descriptions.yaml
@@ -5,6 +5,11 @@ operations:
     medium: Signed Customer Edge image and checksum URLs for a requested deployment platform
     long: 'Read-only Customer Edge image lookup returning signed download URLs for the platform image
       and its MD5 checksum without changing tenant configuration'
+  ves.io.schema.token.CustomAPI.GetCloudInitConfig:
+    short: Issue site-scoped Customer Edge cloud-init
+    medium: Issue Customer Edge cloud-init containing a one-time node token for a Secure Mesh v2 site
+    long: 'Secure Mesh v2 credential issuance returning Customer Edge cloud-init with a new,
+      site-scoped one-time node token'
 resources:
   # ===========================================================================
   # virtual domain - Load Balancing & Traffic Management

--- a/config/operation_metadata.yaml
+++ b/config/operation_metadata.yaml
@@ -54,6 +54,14 @@ query_operations:
     rationale: Returns signed Customer Edge image URLs without changing tenant state
     required_fields: [provider]
 
+# Operations that issue a new credential. These are not reads: consumers must
+# persist the first response and must not refresh the operation on every plan.
+issuance_operations:
+  ves.io.schema.token.CustomAPI.GetCloudInitConfig:
+    rationale: Issues site-scoped Customer Edge cloud-init with a one-time node token
+    required_fields: [provider, site_name]
+    creates: [site_node_token]
+
 # Operation Metadata Extensions:
 # ===============================
 #

--- a/config/schema_overrides.yaml
+++ b/config/schema_overrides.yaml
@@ -68,6 +68,22 @@ overrides:
               Complete cloud-init containing the site-scoped one-time node
               token.
 
+  secret_payloads:
+    upstream_issue: "f5-sales-demo/api-specs-enriched#1492"
+    description: >-
+      Secret URL fields carry either Base64 plaintext or a sealed secret
+      envelope. Mark both forms sensitive so generated Terraform providers do
+      not render credential material in plans or diagnostics.
+    schemas:
+      - pattern: "^schemaClearSecretInfoType$"
+        set_property_extensions:
+          url:
+            x-f5xc-sensitive: true
+      - pattern: "^schemaBlindfoldSecretInfoType$"
+        set_property_extensions:
+          location:
+            x-f5xc-sensitive: true
+
   registration_approval:
     upstream_issue: "f5-sales-demo/terraform-provider-xcsh#1206"
     description: >-

--- a/config/schema_overrides.yaml
+++ b/config/schema_overrides.yaml
@@ -40,8 +40,33 @@ overrides:
         set_property_extensions:
           image_download_url:
             x-f5xc-sensitive: true
+            x-f5xc-description-medium: >-
+              Signed URL for the requested Customer Edge image.
           image_md5_download_url:
             x-f5xc-sensitive: true
+            x-f5xc-description-medium: >-
+              Signed URL for the requested Customer Edge image MD5 checksum.
+
+  token_cloud_init:
+    upstream_issue: "f5-sales-demo/api-specs-enriched#1485"
+    description: >-
+      Secure Mesh v2 cloud-init contains a one-time site node token. Mark the
+      response sensitive and publish it as a generated create-once Terraform
+      resource.
+    schemas:
+      - pattern: "^tokenGetCloudInitConfigResp$"
+        inject_extensions:
+          x-f5xc-terraform-resource: "xcsh_site_cloud_init"
+          x-f5xc-category: "Sites"
+          x-f5xc-description-medium: >-
+            Site-scoped Customer Edge cloud-init containing a one-time Secure
+            Mesh v2 node registration token.
+        set_property_extensions:
+          cloud_init_config:
+            x-f5xc-sensitive: true
+            x-f5xc-description-medium: >-
+              Complete cloud-init containing the site-scoped one-time node
+              token.
 
   registration_approval:
     upstream_issue: "f5-sales-demo/terraform-provider-xcsh#1206"

--- a/docs/specifications/api/api.json
+++ b/docs/specifications/api/api.json
@@ -14138,6 +14138,7 @@
               "ves.io.schema.rules.message.required": "true",
               "ves.io.schema.rules.string.uri_ref": "true"
             },
+            "x-f5xc-sensitive": true,
             "x-f5xc-example": "string:///U2VjcmV0SW5mb3JtYXRpb24=",
             "x-validation-rules": {
               "ves.io.schema.rules.message.required": "true",
@@ -14281,6 +14282,7 @@
               "ves.io.schema.rules.string.max_bytes": "131072",
               "ves.io.schema.rules.string.uri_ref": "true"
             },
+            "x-f5xc-sensitive": true,
             "x-f5xc-example": "string:///U2VjcmV0SW5mb3JtYXRpb24=",
             "x-validation-rules": {
               "ves.io.schema.rules.message.required": "true",

--- a/docs/specifications/api/bigip.json
+++ b/docs/specifications/api/bigip.json
@@ -14662,6 +14662,7 @@
               "ves.io.schema.rules.message.required": "true",
               "ves.io.schema.rules.string.uri_ref": "true"
             },
+            "x-f5xc-sensitive": true,
             "x-f5xc-example": "string:///U2VjcmV0SW5mb3JtYXRpb24=",
             "x-validation-rules": {
               "ves.io.schema.rules.message.required": "true",
@@ -14805,6 +14806,7 @@
               "ves.io.schema.rules.string.max_bytes": "131072",
               "ves.io.schema.rules.string.uri_ref": "true"
             },
+            "x-f5xc-sensitive": true,
             "x-f5xc-example": "string:///U2VjcmV0SW5mb3JtYXRpb24=",
             "x-validation-rules": {
               "ves.io.schema.rules.message.required": "true",

--- a/docs/specifications/api/blindfold.json
+++ b/docs/specifications/api/blindfold.json
@@ -11284,6 +11284,7 @@
               "ves.io.schema.rules.message.required": "true",
               "ves.io.schema.rules.string.uri_ref": "true"
             },
+            "x-f5xc-sensitive": true,
             "x-f5xc-example": "string:///U2VjcmV0SW5mb3JtYXRpb24=",
             "x-validation-rules": {
               "ves.io.schema.rules.message.required": "true",
@@ -11427,6 +11428,7 @@
               "ves.io.schema.rules.string.max_bytes": "131072",
               "ves.io.schema.rules.string.uri_ref": "true"
             },
+            "x-f5xc-sensitive": true,
             "x-f5xc-example": "string:///U2VjcmV0SW5mb3JtYXRpb24=",
             "x-validation-rules": {
               "ves.io.schema.rules.message.required": "true",

--- a/docs/specifications/api/cdn.json
+++ b/docs/specifications/api/cdn.json
@@ -38376,6 +38376,7 @@
               "ves.io.schema.rules.message.required": "true",
               "ves.io.schema.rules.string.uri_ref": "true"
             },
+            "x-f5xc-sensitive": true,
             "x-f5xc-example": "string:///U2VjcmV0SW5mb3JtYXRpb24=",
             "x-validation-rules": {
               "ves.io.schema.rules.message.required": "true",
@@ -40034,6 +40035,7 @@
               "ves.io.schema.rules.string.max_bytes": "131072",
               "ves.io.schema.rules.string.uri_ref": "true"
             },
+            "x-f5xc-sensitive": true,
             "x-f5xc-example": "string:///U2VjcmV0SW5mb3JtYXRpb24=",
             "x-validation-rules": {
               "ves.io.schema.rules.message.required": "true",

--- a/docs/specifications/api/ce_management.json
+++ b/docs/specifications/api/ce_management.json
@@ -15537,6 +15537,7 @@
               "ves.io.schema.rules.message.required": "true",
               "ves.io.schema.rules.string.uri_ref": "true"
             },
+            "x-f5xc-sensitive": true,
             "x-f5xc-example": "string:///U2VjcmV0SW5mb3JtYXRpb24=",
             "x-validation-rules": {
               "ves.io.schema.rules.message.required": "true",
@@ -15680,6 +15681,7 @@
               "ves.io.schema.rules.string.max_bytes": "131072",
               "ves.io.schema.rules.string.uri_ref": "true"
             },
+            "x-f5xc-sensitive": true,
             "x-f5xc-example": "string:///U2VjcmV0SW5mb3JtYXRpb24=",
             "x-validation-rules": {
               "ves.io.schema.rules.message.required": "true",

--- a/docs/specifications/api/ce_management.json
+++ b/docs/specifications/api/ce_management.json
@@ -29874,6 +29874,7 @@
             "title": "Image Download Url",
             "x-displayname": "Image Download URL.",
             "x-f5xc-sensitive": true,
+            "x-f5xc-description-medium": "Signed URL for the requested Customer Edge image.",
             "maxLength": 1024,
             "x-f5xc-constraints": {
               "constraintType": "string",
@@ -29898,6 +29899,7 @@
             "title": "Image Md5 Download Url",
             "x-displayname": "Image Md5 Download URL.",
             "x-f5xc-sensitive": true,
+            "x-f5xc-description-medium": "Signed URL for the requested Customer Edge image MD5 checksum.",
             "maxLength": 1024,
             "x-f5xc-constraints": {
               "constraintType": "string",

--- a/docs/specifications/api/certificates.json
+++ b/docs/specifications/api/certificates.json
@@ -11112,6 +11112,7 @@
               "ves.io.schema.rules.message.required": "true",
               "ves.io.schema.rules.string.uri_ref": "true"
             },
+            "x-f5xc-sensitive": true,
             "x-f5xc-example": "string:///U2VjcmV0SW5mb3JtYXRpb24=",
             "x-validation-rules": {
               "ves.io.schema.rules.message.required": "true",
@@ -11434,6 +11435,7 @@
               "ves.io.schema.rules.string.max_bytes": "131072",
               "ves.io.schema.rules.string.uri_ref": "true"
             },
+            "x-f5xc-sensitive": true,
             "x-f5xc-example": "string:///U2VjcmV0SW5mb3JtYXRpb24=",
             "x-validation-rules": {
               "ves.io.schema.rules.message.required": "true",

--- a/docs/specifications/api/cloud_infrastructure.json
+++ b/docs/specifications/api/cloud_infrastructure.json
@@ -25120,6 +25120,7 @@
               "ves.io.schema.rules.message.required": "true",
               "ves.io.schema.rules.string.uri_ref": "true"
             },
+            "x-f5xc-sensitive": true,
             "x-f5xc-example": "string:///U2VjcmV0SW5mb3JtYXRpb24=",
             "x-validation-rules": {
               "ves.io.schema.rules.message.required": "true",
@@ -25263,6 +25264,7 @@
               "ves.io.schema.rules.string.max_bytes": "131072",
               "ves.io.schema.rules.string.uri_ref": "true"
             },
+            "x-f5xc-sensitive": true,
             "x-f5xc-example": "string:///U2VjcmV0SW5mb3JtYXRpb24=",
             "x-validation-rules": {
               "ves.io.schema.rules.message.required": "true",

--- a/docs/specifications/api/container_services.json
+++ b/docs/specifications/api/container_services.json
@@ -11570,6 +11570,7 @@
               "ves.io.schema.rules.message.required": "true",
               "ves.io.schema.rules.string.uri_ref": "true"
             },
+            "x-f5xc-sensitive": true,
             "x-f5xc-example": "string:///U2VjcmV0SW5mb3JtYXRpb24=",
             "x-validation-rules": {
               "ves.io.schema.rules.message.required": "true",
@@ -11713,6 +11714,7 @@
               "ves.io.schema.rules.string.max_bytes": "131072",
               "ves.io.schema.rules.string.uri_ref": "true"
             },
+            "x-f5xc-sensitive": true,
             "x-f5xc-example": "string:///U2VjcmV0SW5mb3JtYXRpb24=",
             "x-validation-rules": {
               "ves.io.schema.rules.message.required": "true",

--- a/docs/specifications/api/data_and_privacy_security.json
+++ b/docs/specifications/api/data_and_privacy_security.json
@@ -9633,6 +9633,7 @@
               "ves.io.schema.rules.message.required": "true",
               "ves.io.schema.rules.string.uri_ref": "true"
             },
+            "x-f5xc-sensitive": true,
             "x-f5xc-example": "string:///U2VjcmV0SW5mb3JtYXRpb24=",
             "x-validation-rules": {
               "ves.io.schema.rules.message.required": "true",
@@ -9776,6 +9777,7 @@
               "ves.io.schema.rules.string.max_bytes": "131072",
               "ves.io.schema.rules.string.uri_ref": "true"
             },
+            "x-f5xc-sensitive": true,
             "x-f5xc-example": "string:///U2VjcmV0SW5mb3JtYXRpb24=",
             "x-validation-rules": {
               "ves.io.schema.rules.message.required": "true",

--- a/docs/specifications/api/data_intelligence.json
+++ b/docs/specifications/api/data_intelligence.json
@@ -7478,6 +7478,7 @@
               "ves.io.schema.rules.message.required": "true",
               "ves.io.schema.rules.string.uri_ref": "true"
             },
+            "x-f5xc-sensitive": true,
             "x-f5xc-example": "string:///U2VjcmV0SW5mb3JtYXRpb24=",
             "x-validation-rules": {
               "ves.io.schema.rules.message.required": "true",
@@ -7621,6 +7622,7 @@
               "ves.io.schema.rules.string.max_bytes": "131072",
               "ves.io.schema.rules.string.uri_ref": "true"
             },
+            "x-f5xc-sensitive": true,
             "x-f5xc-example": "string:///U2VjcmV0SW5mb3JtYXRpb24=",
             "x-validation-rules": {
               "ves.io.schema.rules.message.required": "true",

--- a/docs/specifications/api/ddos.json
+++ b/docs/specifications/api/ddos.json
@@ -42036,6 +42036,7 @@
               "ves.io.schema.rules.message.required": "true",
               "ves.io.schema.rules.string.uri_ref": "true"
             },
+            "x-f5xc-sensitive": true,
             "x-f5xc-example": "string:///U2VjcmV0SW5mb3JtYXRpb24=",
             "x-validation-rules": {
               "ves.io.schema.rules.message.required": "true",
@@ -42179,6 +42180,7 @@
               "ves.io.schema.rules.string.max_bytes": "131072",
               "ves.io.schema.rules.string.uri_ref": "true"
             },
+            "x-f5xc-sensitive": true,
             "x-f5xc-example": "string:///U2VjcmV0SW5mb3JtYXRpb24=",
             "x-validation-rules": {
               "ves.io.schema.rules.message.required": "true",

--- a/docs/specifications/api/dns.json
+++ b/docs/specifications/api/dns.json
@@ -46746,6 +46746,7 @@
               "ves.io.schema.rules.message.required": "true",
               "ves.io.schema.rules.string.uri_ref": "true"
             },
+            "x-f5xc-sensitive": true,
             "x-f5xc-example": "string:///U2VjcmV0SW5mb3JtYXRpb24=",
             "x-validation-rules": {
               "ves.io.schema.rules.message.required": "true",
@@ -46889,6 +46890,7 @@
               "ves.io.schema.rules.string.max_bytes": "131072",
               "ves.io.schema.rules.string.uri_ref": "true"
             },
+            "x-f5xc-sensitive": true,
             "x-f5xc-example": "string:///U2VjcmV0SW5mb3JtYXRpb24=",
             "x-validation-rules": {
               "ves.io.schema.rules.message.required": "true",

--- a/docs/specifications/api/managed_kubernetes.json
+++ b/docs/specifications/api/managed_kubernetes.json
@@ -7594,6 +7594,7 @@
               "ves.io.schema.rules.message.required": "true",
               "ves.io.schema.rules.string.uri_ref": "true"
             },
+            "x-f5xc-sensitive": true,
             "x-f5xc-example": "string:///U2VjcmV0SW5mb3JtYXRpb24=",
             "x-validation-rules": {
               "ves.io.schema.rules.message.required": "true",
@@ -7737,6 +7738,7 @@
               "ves.io.schema.rules.string.max_bytes": "131072",
               "ves.io.schema.rules.string.uri_ref": "true"
             },
+            "x-f5xc-sensitive": true,
             "x-f5xc-example": "string:///U2VjcmV0SW5mb3JtYXRpb24=",
             "x-validation-rules": {
               "ves.io.schema.rules.message.required": "true",

--- a/docs/specifications/api/marketplace.json
+++ b/docs/specifications/api/marketplace.json
@@ -16972,6 +16972,7 @@
               "ves.io.schema.rules.message.required": "true",
               "ves.io.schema.rules.string.uri_ref": "true"
             },
+            "x-f5xc-sensitive": true,
             "x-f5xc-example": "string:///U2VjcmV0SW5mb3JtYXRpb24=",
             "x-validation-rules": {
               "ves.io.schema.rules.message.required": "true",
@@ -17115,6 +17116,7 @@
               "ves.io.schema.rules.string.max_bytes": "131072",
               "ves.io.schema.rules.string.uri_ref": "true"
             },
+            "x-f5xc-sensitive": true,
             "x-f5xc-example": "string:///U2VjcmV0SW5mb3JtYXRpb24=",
             "x-validation-rules": {
               "ves.io.schema.rules.message.required": "true",

--- a/docs/specifications/api/network.json
+++ b/docs/specifications/api/network.json
@@ -28341,6 +28341,7 @@
               "ves.io.schema.rules.message.required": "true",
               "ves.io.schema.rules.string.uri_ref": "true"
             },
+            "x-f5xc-sensitive": true,
             "x-f5xc-example": "string:///U2VjcmV0SW5mb3JtYXRpb24=",
             "x-validation-rules": {
               "ves.io.schema.rules.message.required": "true",
@@ -28484,6 +28485,7 @@
               "ves.io.schema.rules.string.max_bytes": "131072",
               "ves.io.schema.rules.string.uri_ref": "true"
             },
+            "x-f5xc-sensitive": true,
             "x-f5xc-example": "string:///U2VjcmV0SW5mb3JtYXRpb24=",
             "x-validation-rules": {
               "ves.io.schema.rules.message.required": "true",

--- a/docs/specifications/api/service_mesh.json
+++ b/docs/specifications/api/service_mesh.json
@@ -29853,6 +29853,7 @@
               "ves.io.schema.rules.message.required": "true",
               "ves.io.schema.rules.string.uri_ref": "true"
             },
+            "x-f5xc-sensitive": true,
             "x-f5xc-example": "string:///U2VjcmV0SW5mb3JtYXRpb24=",
             "x-validation-rules": {
               "ves.io.schema.rules.message.required": "true",
@@ -29996,6 +29997,7 @@
               "ves.io.schema.rules.string.max_bytes": "131072",
               "ves.io.schema.rules.string.uri_ref": "true"
             },
+            "x-f5xc-sensitive": true,
             "x-f5xc-example": "string:///U2VjcmV0SW5mb3JtYXRpb24=",
             "x-validation-rules": {
               "ves.io.schema.rules.message.required": "true",

--- a/docs/specifications/api/shape.json
+++ b/docs/specifications/api/shape.json
@@ -120419,6 +120419,7 @@
               "ves.io.schema.rules.message.required": "true",
               "ves.io.schema.rules.string.uri_ref": "true"
             },
+            "x-f5xc-sensitive": true,
             "x-f5xc-example": "string:///U2VjcmV0SW5mb3JtYXRpb24=",
             "x-validation-rules": {
               "ves.io.schema.rules.message.required": "true",
@@ -120562,6 +120563,7 @@
               "ves.io.schema.rules.string.max_bytes": "131072",
               "ves.io.schema.rules.string.uri_ref": "true"
             },
+            "x-f5xc-sensitive": true,
             "x-f5xc-example": "string:///U2VjcmV0SW5mb3JtYXRpb24=",
             "x-validation-rules": {
               "ves.io.schema.rules.message.required": "true",

--- a/docs/specifications/api/sites.json
+++ b/docs/specifications/api/sites.json
@@ -39799,6 +39799,7 @@
               "ves.io.schema.rules.message.required": "true",
               "ves.io.schema.rules.string.uri_ref": "true"
             },
+            "x-f5xc-sensitive": true,
             "x-f5xc-example": "string:///U2VjcmV0SW5mb3JtYXRpb24=",
             "x-validation-rules": {
               "ves.io.schema.rules.message.required": "true",
@@ -39942,6 +39943,7 @@
               "ves.io.schema.rules.string.max_bytes": "131072",
               "ves.io.schema.rules.string.uri_ref": "true"
             },
+            "x-f5xc-sensitive": true,
             "x-f5xc-example": "string:///U2VjcmV0SW5mb3JtYXRpb24=",
             "x-validation-rules": {
               "ves.io.schema.rules.message.required": "true",

--- a/docs/specifications/api/statistics.json
+++ b/docs/specifications/api/statistics.json
@@ -28530,6 +28530,7 @@
               "ves.io.schema.rules.message.required": "true",
               "ves.io.schema.rules.string.uri_ref": "true"
             },
+            "x-f5xc-sensitive": true,
             "x-f5xc-example": "string:///U2VjcmV0SW5mb3JtYXRpb24=",
             "x-validation-rules": {
               "ves.io.schema.rules.message.required": "true",
@@ -28673,6 +28674,7 @@
               "ves.io.schema.rules.string.max_bytes": "131072",
               "ves.io.schema.rules.string.uri_ref": "true"
             },
+            "x-f5xc-sensitive": true,
             "x-f5xc-example": "string:///U2VjcmV0SW5mb3JtYXRpb24=",
             "x-validation-rules": {
               "ves.io.schema.rules.message.required": "true",

--- a/docs/specifications/api/support.json
+++ b/docs/specifications/api/support.json
@@ -22084,6 +22084,7 @@
               "ves.io.schema.rules.message.required": "true",
               "ves.io.schema.rules.string.uri_ref": "true"
             },
+            "x-f5xc-sensitive": true,
             "x-f5xc-example": "string:///U2VjcmV0SW5mb3JtYXRpb24=",
             "x-validation-rules": {
               "ves.io.schema.rules.message.required": "true",
@@ -22227,6 +22228,7 @@
               "ves.io.schema.rules.string.max_bytes": "131072",
               "ves.io.schema.rules.string.uri_ref": "true"
             },
+            "x-f5xc-sensitive": true,
             "x-f5xc-example": "string:///U2VjcmV0SW5mb3JtYXRpb24=",
             "x-validation-rules": {
               "ves.io.schema.rules.message.required": "true",

--- a/docs/specifications/api/tenant_and_identity.json
+++ b/docs/specifications/api/tenant_and_identity.json
@@ -55612,6 +55612,7 @@
               "ves.io.schema.rules.message.required": "true",
               "ves.io.schema.rules.string.uri_ref": "true"
             },
+            "x-f5xc-sensitive": true,
             "x-f5xc-example": "string:///U2VjcmV0SW5mb3JtYXRpb24=",
             "x-validation-rules": {
               "ves.io.schema.rules.message.required": "true",
@@ -55755,6 +55756,7 @@
               "ves.io.schema.rules.string.max_bytes": "131072",
               "ves.io.schema.rules.string.uri_ref": "true"
             },
+            "x-f5xc-sensitive": true,
             "x-f5xc-example": "string:///U2VjcmV0SW5mb3JtYXRpb24=",
             "x-validation-rules": {
               "ves.io.schema.rules.message.required": "true",

--- a/docs/specifications/api/users.json
+++ b/docs/specifications/api/users.json
@@ -1889,18 +1889,28 @@
           "register"
         ],
         "x-f5xc-operation-metadata": {
-          "purpose": "Resource retrieval operation",
-          "required_fields": [],
+          "purpose": "Issue site-scoped Customer Edge cloud-init",
+          "required_fields": [
+            "provider",
+            "site_name"
+          ],
           "optional_fields": [],
           "field_docs": {},
           "conditions": {
             "prerequisites": [
               "Active namespace"
             ],
-            "postconditions": []
+            "postconditions": [
+              "One-time site node token issued",
+              "Credential returned only in the response"
+            ]
           },
-          "side_effects": {},
-          "danger_level": "low",
+          "side_effects": {
+            "creates": [
+              "site_node_token"
+            ]
+          },
+          "danger_level": "medium",
           "confirmation_required": false,
           "common_errors": [
             {
@@ -1939,7 +1949,17 @@
             "resource_usage": "moderate"
           }
         },
-        "x-f5xc-danger-level": "low",
+        "x-f5xc-operation-role": "issuance",
+        "x-f5xc-required-fields": [
+          "provider",
+          "site_name"
+        ],
+        "x-f5xc-danger-level": "medium",
+        "x-f5xc-side-effects": {
+          "creates": [
+            "site_node_token"
+          ]
+        },
         "x-discovered-response-time-ms": 153.29,
         "x-discovered-sample-size": 1,
         "x-f5xc-discovered-response-time": {
@@ -8264,6 +8284,8 @@
             "description": "Cloud-init config.",
             "title": "cloud-init config",
             "x-displayname": "Cloud-init config.",
+            "x-f5xc-sensitive": true,
+            "x-f5xc-description-medium": "Complete cloud-init containing the site-scoped one-time node token.",
             "maxLength": 1024,
             "x-f5xc-constraints": {
               "constraintType": "string",
@@ -8296,6 +8318,9 @@
           "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {\n    \"cloud_init_config\": \"value\"\n  }\n}"
         },
         "x-f5xc-cli-domain": "users",
+        "x-f5xc-terraform-resource": "xcsh_site_cloud_init",
+        "x-f5xc-category": "Sites",
+        "x-f5xc-description-medium": "Site-scoped Customer Edge cloud-init containing a one-time Secure Mesh v2 node registration token.",
         "x-f5xc-namespace-profile": {
           "constraint": {
             "allowed": [

--- a/docs/specifications/api/virtual.json
+++ b/docs/specifications/api/virtual.json
@@ -62068,6 +62068,7 @@
               "ves.io.schema.rules.message.required": "true",
               "ves.io.schema.rules.string.uri_ref": "true"
             },
+            "x-f5xc-sensitive": true,
             "x-f5xc-example": "string:///U2VjcmV0SW5mb3JtYXRpb24=",
             "x-validation-rules": {
               "ves.io.schema.rules.message.required": "true",
@@ -62211,6 +62212,7 @@
               "ves.io.schema.rules.string.max_bytes": "131072",
               "ves.io.schema.rules.string.uri_ref": "true"
             },
+            "x-f5xc-sensitive": true,
             "x-f5xc-example": "string:///U2VjcmV0SW5mb3JtYXRpb24=",
             "x-validation-rules": {
               "ves.io.schema.rules.message.required": "true",

--- a/release/api-catalog.json
+++ b/release/api-catalog.json
@@ -60130,7 +60130,7 @@
               "recommendation": {
                 "primary": "system",
                 "alternatives": [],
-                "rationale": "DNS LB health check is a DNS object — system namespace enforced by API"
+                "rationale": "DNS LB health check is a DNS object \u2014 system namespace enforced by API"
               },
               "classification": {
                 "category": "networking",
@@ -60272,7 +60272,7 @@
               "recommendation": {
                 "primary": "system",
                 "alternatives": [],
-                "rationale": "DNS LB health check is a DNS object — system namespace enforced by API"
+                "rationale": "DNS LB health check is a DNS object \u2014 system namespace enforced by API"
               },
               "classification": {
                 "category": "networking",
@@ -60529,7 +60529,7 @@
               "recommendation": {
                 "primary": "system",
                 "alternatives": [],
-                "rationale": "DNS LB health check is a DNS object — system namespace enforced by API"
+                "rationale": "DNS LB health check is a DNS object \u2014 system namespace enforced by API"
               },
               "classification": {
                 "category": "networking",
@@ -64204,7 +64204,7 @@
               "recommendation": {
                 "primary": "system",
                 "alternatives": [],
-                "rationale": "DNS proxy is a DNS object — system namespace enforced by API"
+                "rationale": "DNS proxy is a DNS object \u2014 system namespace enforced by API"
               },
               "classification": {
                 "category": "networking",
@@ -64346,7 +64346,7 @@
               "recommendation": {
                 "primary": "system",
                 "alternatives": [],
-                "rationale": "DNS proxy is a DNS object — system namespace enforced by API"
+                "rationale": "DNS proxy is a DNS object \u2014 system namespace enforced by API"
               },
               "classification": {
                 "category": "networking",
@@ -64603,7 +64603,7 @@
               "recommendation": {
                 "primary": "system",
                 "alternatives": [],
-                "rationale": "DNS proxy is a DNS object — system namespace enforced by API"
+                "rationale": "DNS proxy is a DNS object \u2014 system namespace enforced by API"
               },
               "classification": {
                 "category": "networking",
@@ -64916,7 +64916,7 @@
               "recommendation": {
                 "primary": "system",
                 "alternatives": [],
-                "rationale": "DNS load balancing requires system namespace — API enforces restriction"
+                "rationale": "DNS load balancing requires system namespace \u2014 API enforces restriction"
               },
               "classification": {
                 "category": "networking",
@@ -118041,7 +118041,7 @@
             "properties": {
               "x_amzn_marketplace_token": {
                 "type": "string",
-                "description": "AWS customer’s registration token.",
+                "description": "AWS customer\u2019s registration token.",
                 "title": "x-amzn-marketplace-token",
                 "x-displayname": "X-amzn-marketplace-token.",
                 "x-ves-example": "X-amzn-marketplace-token=<token val>",
@@ -118122,7 +118122,7 @@
           "fieldMetadata": {
             "x_amzn_marketplace_token": {
               "type": "string",
-              "description": "AWS customer’s registration token.",
+              "description": "AWS customer\u2019s registration token.",
               "constraints": {
                 "constraintType": "string",
                 "category": "general",
@@ -261526,7 +261526,7 @@
               }
             },
             "x-f5xc-minimum-configuration": {
-              "description": "Label-based site selector for grouping RE and CE sites — used as advertise_where target for HTTP LBs",
+              "description": "Label-based site selector for grouping RE and CE sites \u2014 used as advertise_where target for HTTP LBs",
               "required_fields": [
                 "metadata.name",
                 "metadata.namespace",
@@ -261583,7 +261583,7 @@
               "spec.site_type",
               "spec.site_selector"
             ],
-            "description": "Label-based site selector for grouping RE and CE sites — used as advertise_where target for HTTP LBs"
+            "description": "Label-based site selector for grouping RE and CE sites \u2014 used as advertise_where target for HTTP LBs"
           },
           "fieldMetadata": {
             "metadata": {
@@ -261681,7 +261681,7 @@
               }
             },
             "x-f5xc-minimum-configuration": {
-              "description": "Label-based site selector for grouping RE and CE sites — used as advertise_where target for HTTP LBs",
+              "description": "Label-based site selector for grouping RE and CE sites \u2014 used as advertise_where target for HTTP LBs",
               "required_fields": [
                 "metadata.name",
                 "metadata.namespace",
@@ -261737,7 +261737,7 @@
               "spec.site_type",
               "spec.site_selector"
             ],
-            "description": "Label-based site selector for grouping RE and CE sites — used as advertise_where target for HTTP LBs"
+            "description": "Label-based site selector for grouping RE and CE sites \u2014 used as advertise_where target for HTTP LBs"
           },
           "fieldMetadata": {
             "metadata": {
@@ -279541,7 +279541,8 @@
           "path": "/api/register/namespaces/system/get-cloud-init-config",
           "operationId": "ves.io.schema.token.CustomAPI.GetCloudInitConfig",
           "surface": "register",
-          "responseSchema": "tokenGetCloudInitConfigResp"
+          "responseSchema": "tokenGetCloudInitConfigResp",
+          "role": "issuance"
         },
         {
           "method": "GET",

--- a/scripts/compile_catalog.py
+++ b/scripts/compile_catalog.py
@@ -825,18 +825,44 @@ def build_api_operations(paths: dict[str, Any]) -> list[dict[str, Any]]:
                 entry["responseSchema"] = response_schema
             operation_role = operation.get("x-f5xc-operation-role")
             if operation_role is not None:
-                if operation_role != "query":
+                if operation_role not in {"query", "issuance"}:
                     raise ValueError(
                         f"{operation_id} has unsupported x-f5xc-operation-role {operation_role!r}"
                     )
-                if request_schema is None or response_schema is None:
+                method_upper = method.upper()
+                has_query_parameters = any(
+                    isinstance(parameter, dict) and parameter.get("in") == "query"
+                    for parameter in operation.get("parameters", [])
+                )
+                if response_schema is None:
                     raise ValueError(
-                        f"query operation {operation_id} requires request and response schemas"
+                        f"{operation_role} operation {operation_id} requires a response schema"
                     )
-                if operation.get("x-f5xc-danger-level") != "low":
-                    raise ValueError(f"query operation {operation_id} must have low danger")
-                if operation.get("x-f5xc-side-effects"):
-                    raise ValueError(f"query operation {operation_id} must not have side effects")
+                if method_upper == "POST" and request_schema is None:
+                    raise ValueError(
+                        f"POST {operation_role} operation {operation_id} requires a request schema"
+                    )
+                if method_upper == "GET" and not has_query_parameters:
+                    raise ValueError(
+                        f"GET {operation_role} operation {operation_id} requires query parameters"
+                    )
+                if method_upper not in {"GET", "POST"}:
+                    raise ValueError(
+                        f"{operation_role} operation {operation_id} must use GET or POST, got {method_upper}"
+                    )
+                if operation_role == "query":
+                    if operation.get("x-f5xc-danger-level") != "low":
+                        raise ValueError(f"query operation {operation_id} must have low danger")
+                    if operation.get("x-f5xc-side-effects"):
+                        raise ValueError(f"query operation {operation_id} must not have side effects")
+                else:
+                    if operation.get("x-f5xc-danger-level") != "medium":
+                        raise ValueError(f"issuance operation {operation_id} must have medium danger")
+                    creates = (operation.get("x-f5xc-side-effects") or {}).get("creates", [])
+                    if not creates:
+                        raise ValueError(
+                            f"issuance operation {operation_id} must declare a created credential"
+                        )
                 entry["role"] = operation_role
             grouped.setdefault(identity, []).append(entry)
 

--- a/scripts/compile_catalog.py
+++ b/scripts/compile_catalog.py
@@ -854,10 +854,14 @@ def build_api_operations(paths: dict[str, Any]) -> list[dict[str, Any]]:
                     if operation.get("x-f5xc-danger-level") != "low":
                         raise ValueError(f"query operation {operation_id} must have low danger")
                     if operation.get("x-f5xc-side-effects"):
-                        raise ValueError(f"query operation {operation_id} must not have side effects")
+                        raise ValueError(
+                            f"query operation {operation_id} must not have side effects"
+                        )
                 else:
                     if operation.get("x-f5xc-danger-level") != "medium":
-                        raise ValueError(f"issuance operation {operation_id} must have medium danger")
+                        raise ValueError(
+                            f"issuance operation {operation_id} must have medium danger"
+                        )
                     creates = (operation.get("x-f5xc-side-effects") or {}).get("creates", [])
                     if not creates:
                         raise ValueError(

--- a/scripts/utils/operation_metadata_enricher.py
+++ b/scripts/utils/operation_metadata_enricher.py
@@ -67,6 +67,7 @@ class OperationMetadataEnricher:
         self.danger_levels: dict[str, Any] = {}
         self.required_fields_config: dict[str, Any] = {}
         self.query_operations: dict[str, Any] = {}
+        self.issuance_operations: dict[str, Any] = {}
         self.extension_prefix = "x-f5xc"
         self.stats = OperationEnrichmentStats()
 
@@ -85,6 +86,7 @@ class OperationMetadataEnricher:
             self.danger_levels = config.get("danger_levels", {})
             self.required_fields_config = config.get("required_fields", {})
             self.query_operations = config.get("query_operations", {})
+            self.issuance_operations = config.get("issuance_operations", {})
             self.extension_prefix = config.get("extension_prefix", "x-f5xc")
         except Exception:
             self._use_default_config()
@@ -124,6 +126,7 @@ class OperationMetadataEnricher:
             "standard_create_fields": ["metadata.name", "metadata.namespace"],
         }
         self.query_operations = {}
+        self.issuance_operations = {}
 
         self.extension_prefix = "x-f5xc"
 
@@ -185,20 +188,32 @@ class OperationMetadataEnricher:
         self.stats.operations_enriched += 1
         operation_id = operation.get("operationId", "")
         is_query = operation_id in self.query_operations
-        query_contract = self.query_operations.get(operation_id, {})
-        if is_query:
-            if method != "POST":
-                raise ValueError(f"query operation {operation_id} must use POST, got {method}")
-            if not self._request_schema_ref(operation):
-                raise ValueError(f"query operation {operation_id} must have a request schema")
+        is_issuance = operation_id in self.issuance_operations
+        if is_query and is_issuance:
+            raise ValueError(f"operation {operation_id} cannot be both query and issuance")
+        special_contract = self.query_operations.get(
+            operation_id, self.issuance_operations.get(operation_id, {})
+        )
+        if is_query or is_issuance:
+            if method not in {"GET", "POST"}:
+                raise ValueError(
+                    f"{('query' if is_query else 'issuance')} operation {operation_id} "
+                    f"must use GET or POST, got {method}"
+                )
+            if method == "POST" and not self._request_schema_ref(operation):
+                raise ValueError(f"POST operation {operation_id} must have a request schema")
+            if method == "GET" and not self._query_parameters(operation):
+                raise ValueError(f"GET operation {operation_id} must have query parameters")
             if not self._response_schema_refs(operation):
-                raise ValueError(f"query operation {operation_id} must have a response schema")
-            operation[f"{self.extension_prefix}-operation-role"] = "query"
+                raise ValueError(f"operation {operation_id} must have a response schema")
+            operation[f"{self.extension_prefix}-operation-role"] = (
+                "query" if is_query else "issuance"
+            )
 
         # Extract and add required fields
         required_fields = (
-            list(query_contract.get("required_fields", []))
-            if is_query
+            list(special_contract.get("required_fields", []))
+            if is_query or is_issuance
             else self._extract_required_fields(operation, method)
         )
         if required_fields:
@@ -206,7 +221,13 @@ class OperationMetadataEnricher:
             self.stats.required_fields_added += 1
 
         # Calculate and assign danger level
-        danger_level = "low" if is_query else self._calculate_danger_level(method, path, operation)
+        danger_level = (
+            "low"
+            if is_query
+            else "medium"
+            if is_issuance
+            else self._calculate_danger_level(method, path, operation)
+        )
         operation[f"{self.extension_prefix}-danger-level"] = danger_level
         self.stats.danger_levels_assigned += 1
 
@@ -215,7 +236,13 @@ class OperationMetadataEnricher:
             operation[f"{self.extension_prefix}-confirmation-required"] = True
 
         # Determine and add side effects
-        side_effects = {} if is_query else self._determine_side_effects(method, path, operation)
+        side_effects = (
+            {}
+            if is_query
+            else {"creates": list(special_contract.get("creates", []))}
+            if is_issuance
+            else self._determine_side_effects(method, path, operation)
+        )
         if side_effects:
             operation[f"{self.extension_prefix}-side-effects"] = side_effects
             self.stats.side_effects_documented += 1
@@ -233,6 +260,11 @@ class OperationMetadataEnricher:
             comprehensive_metadata["conditions"]["postconditions"] = [
                 "Requested data returned",
                 "Tenant state unchanged",
+            ]
+        elif is_issuance:
+            comprehensive_metadata["conditions"]["postconditions"] = [
+                "One-time site node token issued",
+                "Credential returned only in the response",
             ]
         if comprehensive_metadata:
             operation[f"{self.extension_prefix}-operation-metadata"] = comprehensive_metadata
@@ -259,6 +291,14 @@ class OperationMetadataEnricher:
             if isinstance(ref, str) and ref:
                 refs.add(ref)
         return refs
+
+    @staticmethod
+    def _query_parameters(operation: dict[str, Any]) -> list[dict[str, Any]]:
+        return [
+            parameter
+            for parameter in operation.get("parameters", [])
+            if isinstance(parameter, dict) and parameter.get("in") == "query"
+        ]
 
     def _build_comprehensive_metadata(
         self,

--- a/tests/test_api_operations.py
+++ b/tests/test_api_operations.py
@@ -306,9 +306,9 @@ def test_get_issuance_role_uses_parameters_without_inventing_a_request_schema():
         }
     )
 
-    query = build_api_operations({"/api/register/cloud-init": {"get": operation}})[0][
-        "operations"
-    ][0]
+    query = build_api_operations({"/api/register/cloud-init": {"get": operation}})[0]["operations"][
+        0
+    ]
     assert query == {
         "method": "GET",
         "path": "/api/register/cloud-init",
@@ -347,9 +347,7 @@ def test_issuance_role_requires_mutating_metadata(danger, side_effects, message)
         "ves.io.schema.token.CustomAPI.GetCloudInitConfig",
         response_ref="#/components/schemas/CloudInitResp",
     )
-    operation["parameters"] = [
-        {"name": "site_name", "in": "query", "schema": {"type": "string"}}
-    ]
+    operation["parameters"] = [{"name": "site_name", "in": "query", "schema": {"type": "string"}}]
     operation["x-f5xc-operation-role"] = "issuance"
     operation["x-f5xc-danger-level"] = danger
     if side_effects is not None:

--- a/tests/test_api_operations.py
+++ b/tests/test_api_operations.py
@@ -289,6 +289,76 @@ def test_query_role_requires_read_only_metadata_and_schema_pair():
         build_api_operations({"/api/register/query": {"post": operation}})
 
 
+def test_get_issuance_role_uses_parameters_without_inventing_a_request_schema():
+    operation = _operation(
+        "ves.io.schema.token.CustomAPI.GetCloudInitConfig",
+        response_ref="#/components/schemas/CloudInitResp",
+    )
+    operation["parameters"] = [
+        {"name": "provider", "in": "query", "schema": {"type": "string"}},
+        {"name": "site_name", "in": "query", "schema": {"type": "string"}},
+    ]
+    operation.update(
+        {
+            "x-f5xc-operation-role": "issuance",
+            "x-f5xc-danger-level": "medium",
+            "x-f5xc-side-effects": {"creates": ["site_node_token"]},
+        }
+    )
+
+    query = build_api_operations({"/api/register/cloud-init": {"get": operation}})[0][
+        "operations"
+    ][0]
+    assert query == {
+        "method": "GET",
+        "path": "/api/register/cloud-init",
+        "operationId": "ves.io.schema.token.CustomAPI.GetCloudInitConfig",
+        "surface": "register",
+        "responseSchema": "CloudInitResp",
+        "role": "issuance",
+    }
+
+
+def test_get_issuance_role_requires_query_parameters():
+    operation = _operation(
+        "ves.io.schema.token.CustomAPI.GetCloudInitConfig",
+        response_ref="#/components/schemas/CloudInitResp",
+    )
+    operation.update(
+        {
+            "x-f5xc-operation-role": "issuance",
+            "x-f5xc-danger-level": "medium",
+            "x-f5xc-side-effects": {"creates": ["site_node_token"]},
+        }
+    )
+    with pytest.raises(ValueError, match="requires query parameters"):
+        build_api_operations({"/api/register/cloud-init": {"get": operation}})
+
+
+@pytest.mark.parametrize(
+    ("danger", "side_effects", "message"),
+    [
+        ("low", {"creates": ["site_node_token"]}, "must have medium danger"),
+        ("medium", None, "must declare a created credential"),
+    ],
+)
+def test_issuance_role_requires_mutating_metadata(danger, side_effects, message):
+    operation = _operation(
+        "ves.io.schema.token.CustomAPI.GetCloudInitConfig",
+        response_ref="#/components/schemas/CloudInitResp",
+    )
+    operation["parameters"] = [
+        {"name": "site_name", "in": "query", "schema": {"type": "string"}}
+    ]
+    operation["x-f5xc-operation-role"] = "issuance"
+    operation["x-f5xc-danger-level"] = danger
+    if side_effects is not None:
+        operation["x-f5xc-side-effects"] = side_effects
+
+    with pytest.raises(ValueError, match=message):
+        build_api_operations({"/api/register/cloud-init": {"get": operation}})
+
+
 def test_unknown_operation_role_is_rejected():
     operation = _operation("ves.io.schema.registration.CustomAPI.Query")
     operation["x-f5xc-operation-role"] = "lookup"

--- a/tests/test_operation_description_enricher.py
+++ b/tests/test_operation_description_enricher.py
@@ -76,9 +76,7 @@ class TestOperationDescriptionEnricherBasics:
 
     def test_cloud_init_issuance_has_an_issuance_description(self, enricher):
         assert (
-            enricher.get_operation_description(
-                "ves.io.schema.token.CustomAPI.GetCloudInitConfig"
-            )
+            enricher.get_operation_description("ves.io.schema.token.CustomAPI.GetCloudInitConfig")
             == "Issue site-scoped Customer Edge cloud-init"
         )
 

--- a/tests/test_operation_description_enricher.py
+++ b/tests/test_operation_description_enricher.py
@@ -74,6 +74,14 @@ class TestOperationDescriptionEnricherBasics:
             == "Retrieve signed Customer Edge image download URLs"
         )
 
+    def test_cloud_init_issuance_has_an_issuance_description(self, enricher):
+        assert (
+            enricher.get_operation_description(
+                "ves.io.schema.token.CustomAPI.GetCloudInitConfig"
+            )
+            == "Issue site-scoped Customer Edge cloud-init"
+        )
+
     def test_disabled_enricher(self, tmp_path):
         """Test enricher respects enabled flag."""
         config_path = tmp_path / "disabled_config.yaml"

--- a/tests/test_operation_metadata_enricher.py
+++ b/tests/test_operation_metadata_enricher.py
@@ -391,6 +391,45 @@ class TestSpecEnrichment:
             "Tenant state unchanged",
         ]
 
+    def test_curated_get_issuance_records_credential_side_effect(self, enricher):
+        operation_id = "ves.io.schema.token.CustomAPI.GetCloudInitConfig"
+        spec = {
+            "paths": {
+                "/api/register/namespaces/system/get-cloud-init-config": {
+                    "get": {
+                        "operationId": operation_id,
+                        "parameters": [
+                            {"name": "provider", "in": "query", "schema": {"type": "string"}},
+                            {"name": "site_name", "in": "query", "schema": {"type": "string"}},
+                        ],
+                        "responses": {
+                            "200": {
+                                "content": {
+                                    "application/json": {
+                                        "schema": {
+                                            "$ref": "#/components/schemas/tokenGetCloudInitConfigResp"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                    }
+                }
+            }
+        }
+
+        operation = enricher.enrich_spec(spec)["paths"][
+            "/api/register/namespaces/system/get-cloud-init-config"
+        ]["get"]
+        assert operation["x-f5xc-operation-role"] == "issuance"
+        assert operation["x-f5xc-danger-level"] == "medium"
+        assert operation["x-f5xc-required-fields"] == ["provider", "site_name"]
+        assert operation["x-f5xc-side-effects"] == {"creates": ["site_node_token"]}
+        assert operation["x-f5xc-operation-metadata"]["conditions"]["postconditions"] == [
+            "One-time site node token issued",
+            "Credential returned only in the response",
+        ]
+
     @pytest.mark.parametrize("missing", ["requestBody", "responses"])
     def test_curated_query_requires_request_and_response_schemas(self, enricher, missing):
         operation = {
@@ -411,6 +450,20 @@ class TestSpecEnrichment:
         operation.pop(missing)
         with pytest.raises(ValueError, match=r"must have a .* schema"):
             enricher.enrich_spec({"paths": {"/api/register/query": {"post": operation}}})
+
+    def test_curated_get_issuance_requires_query_parameters(self, enricher):
+        operation = {
+            "operationId": "ves.io.schema.token.CustomAPI.GetCloudInitConfig",
+            "responses": {
+                "200": {
+                    "content": {
+                        "application/json": {"schema": {"$ref": "#/components/schemas/QueryResp"}}
+                    }
+                }
+            },
+        }
+        with pytest.raises(ValueError, match="must have query parameters"):
+            enricher.enrich_spec({"paths": {"/api/register/query": {"get": operation}}})
 
 
 class TestEdgeCases:

--- a/tests/test_registration_image_query_specs.py
+++ b/tests/test_registration_image_query_specs.py
@@ -7,8 +7,10 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).parent.parent
 SPEC_PATH = REPO_ROOT / "docs" / "specifications" / "api" / "ce_management.json"
+TOKEN_SPEC_PATH = REPO_ROOT / "docs" / "specifications" / "api" / "users.json"
 CATALOG_PATH = REPO_ROOT / "release" / "api-catalog.json"
 OPERATION_ID = "ves.io.schema.registration.CustomAPI.GetImageDownloadUrl"
+CLOUD_INIT_OPERATION_ID = "ves.io.schema.token.CustomAPI.GetCloudInitConfig"
 
 
 def test_image_download_operation_is_a_read_only_query() -> None:
@@ -63,4 +65,45 @@ def test_release_catalog_publishes_the_query_schema_pair() -> None:
         "requestSchema": "registrationGetImageDownloadUrlReq",
         "responseSchema": "registrationGetImageDownloadUrlResp",
         "role": "query",
+    }
+
+
+def test_cloud_init_operation_is_a_site_scoped_sensitive_issuance() -> None:
+    spec = json.loads(TOKEN_SPEC_PATH.read_text())
+    operation = spec["paths"]["/api/register/namespaces/system/get-cloud-init-config"]["get"]
+    response = spec["components"]["schemas"]["tokenGetCloudInitConfigResp"]
+
+    assert operation["operationId"] == CLOUD_INIT_OPERATION_ID
+    assert operation["x-f5xc-operation-role"] == "issuance"
+    assert operation["x-f5xc-required-fields"] == ["provider", "site_name"]
+    assert operation["x-f5xc-danger-level"] == "medium"
+    assert operation["x-f5xc-side-effects"] == {"creates": ["site_node_token"]}
+    assert response["x-f5xc-terraform-resource"] == "xcsh_site_cloud_init"
+    assert response["x-f5xc-category"] == "Sites"
+    assert response["properties"]["cloud_init_config"]["x-f5xc-sensitive"] is True
+    assert response["properties"]["cloud_init_config"]["x-f5xc-description-medium"] == (
+        "Complete cloud-init containing the site-scoped one-time node token."
+    )
+
+
+def test_release_catalog_publishes_the_cloud_init_issuance() -> None:
+    catalog = json.loads(CATALOG_PATH.read_text())
+    token = next(
+        identity
+        for identity in catalog["apiOperations"]
+        if identity["apiIdentity"] == "ves.io.schema.token"
+    )
+    query = next(
+        operation
+        for operation in token["operations"]
+        if operation["operationId"] == CLOUD_INIT_OPERATION_ID
+    )
+
+    assert query == {
+        "method": "GET",
+        "path": "/api/register/namespaces/system/get-cloud-init-config",
+        "operationId": CLOUD_INIT_OPERATION_ID,
+        "surface": "register",
+        "responseSchema": "tokenGetCloudInitConfigResp",
+        "role": "issuance",
     }

--- a/tests/test_schema_override_enricher.py
+++ b/tests/test_schema_override_enricher.py
@@ -124,6 +124,28 @@ class TestSchemaOverrideEnricher:
         assert schema["properties"]["image_download_url"]["x-f5xc-sensitive"] is True
         assert schema["properties"]["image_md5_download_url"]["x-f5xc-sensitive"] is True
 
+    def test_marks_clear_and_blindfold_secret_payloads_sensitive(self, enricher):
+        spec = {
+            "components": {
+                "schemas": {
+                    "schemaClearSecretInfoType": {
+                        "type": "object",
+                        "properties": {"url": {"type": "string"}},
+                    },
+                    "schemaBlindfoldSecretInfoType": {
+                        "type": "object",
+                        "properties": {"location": {"type": "string"}},
+                    },
+                }
+            }
+        }
+        schemas = enricher.enrich_spec(spec)["components"]["schemas"]
+        assert schemas["schemaClearSecretInfoType"]["properties"]["url"]["x-f5xc-sensitive"] is True
+        assert (
+            schemas["schemaBlindfoldSecretInfoType"]["properties"]["location"]["x-f5xc-sensitive"]
+            is True
+        )
+
     def test_updates_oneof_extension_array(self, synthetic_enricher, test_spec):
         result = synthetic_enricher.enrich_spec(test_spec)
         for schema_name in ["testResourceCreateSpecType", "testResourceGetSpecType"]:


### PR DESCRIPTION
## Summary

- publish exact query and issuance roles from the enriched API contract
- describe and protect signed CE image URLs and issued cloud-init content
- mark clear-secret URLs and blindfold secret locations sensitive at the authoritative schema layer
- compile deterministic response-operation metadata into the version 2.1.220 catalog
- cover GET/POST request wiring, compiler output, generation roles, and downstream secret handling

## Verification

- full generation pipeline: completed successfully across all inputs
- complete pytest suite: 2,419 passed, 6 skipped, 1 xfailed
- Spectral: 39 files passed with zero findings
- focused schema, operation, issuance, and catalog suite: 152 passed
- authored source/tests PII enforcement: clean
- generated aggregate and domain sensitivity assertions: passed
- `git diff --check`: clean

Closes #1492
