### PR TITLE
fix(release): set up Python for downstream matrix

### DIFF
--- a/.github/workflows/sync-and-enrich.yml
+++ b/.github/workflows/sync-and-enrich.yml
@@ -839,8 +839,13 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
       - name: Install PyYAML
-        run: pip install pyyaml
+        run: python -m pip install pyyaml
 
       - name: Build matrix from config
         id: matrix

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -18,3 +18,22 @@ def test_release_pr_create_is_non_interactive() -> None:
         '--body "Automated release v${VERSION} (${BUMP_TYPE}). Created by the sync-and-enrich workflow."'
         in command
     )
+
+
+def test_downstream_matrix_sets_up_python_before_installing_pyyaml() -> None:
+    """The minimal release runner must not rely on a system ``pip`` binary."""
+
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    job = workflow.split("\n  build-downstream-matrix:\n", maxsplit=1)[1].split(
+        "\n  notify-downstream:\n", maxsplit=1
+    )[0]
+
+    setup_python = (
+        "uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97"
+    )
+    install = "run: python -m pip install pyyaml"
+
+    assert setup_python in job
+    assert "python-version: ${{ env.PYTHON_VERSION }}" in job
+    assert install in job
+    assert job.index(setup_python) < job.index(install)

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -28,9 +28,7 @@ def test_downstream_matrix_sets_up_python_before_installing_pyyaml() -> None:
         "\n  notify-downstream:\n", maxsplit=1
     )[0]
 
-    setup_python = (
-        "uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97"
-    )
+    setup_python = "uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97"
     install = "run: python -m pip install pyyaml"
 
     assert setup_python in job


### PR DESCRIPTION
Closes #1500

## Summary
- set up the repository-pinned Python runtime before building the downstream matrix
- invoke pip through that interpreter instead of relying on a runner-provided executable
- add a regression test that enforces setup ordering and the configured Python version

## Verification
- `python -m pytest -q` after seeding `specs/original` (2,355 passed, 72 skipped, 1 xfailed)
- `pytest -q tests/test_release_workflow.py tests/test_workflow_action_pins.py tests/shell/test_dispatch_downstream.py` (24 passed)
- `ruff format --check tests/test_release_workflow.py`
- `pre-commit run --files .github/workflows/sync-and-enrich.yml tests/test_release_workflow.py`
- `git diff --check`