### PR TITLE
fix(release): emit canonical downstream delivery identities

### DIFF
--- a/.github/workflows/sync-and-enrich.yml
+++ b/.github/workflows/sync-and-enrich.yml
@@ -149,6 +149,7 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.new_version }}
       has_changes: ${{ steps.detect.outputs.has_changes }}
+      target_commit: ${{ steps.release.outputs.target_commit }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -562,6 +563,7 @@ jobs:
           biome format --write docs/specifications/api/ docs/api-reference/ || true
 
       - name: Commit and tag release
+        id: release
         if: steps.detect.outputs.has_changes == 'true'
         env:
           GH_TOKEN: ${{ secrets.VERSION_BUMP_PAT }}
@@ -665,7 +667,9 @@ jobs:
             # rather than re-deriving it in a later step where main may already have
             # moved on — a receipt naming the wrong commit is rejected downstream
             # after the release is immutable and can no longer be corrected.
-            echo "release_commit=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
+            TARGET_COMMIT=$(git rev-parse HEAD)
+            echo "release_commit=${TARGET_COMMIT}" >> "$GITHUB_ENV"
+            echo "target_commit=${TARGET_COMMIT}" >> "$GITHUB_OUTPUT"
 
             echo "::notice::Released v${VERSION} via PR merge + tag"
           else
@@ -896,8 +900,7 @@ jobs:
           EVENT_TYPE: ${{ matrix.downstream.event_type }}
           VERSION: ${{ needs.sync-and-enrich.outputs.version }}
           SOURCE_REPOSITORY: ${{ github.repository }}
-          SOURCE_UPDATED_AT: ${{ github.event.repository.updated_at }}
-          SOURCE_RUN_ID: ${{ github.run_id }}
+          SOURCE_TARGET_COMMIT: ${{ needs.sync-and-enrich.outputs.target_commit }}
         run: bash scripts/release/dispatch-downstream.sh
 
       - name: Log dispatch result

--- a/config/downstream_repos.yaml
+++ b/config/downstream_repos.yaml
@@ -10,6 +10,7 @@
 #    with the matching event_type
 # 3. The DOWNSTREAM_DISPATCH_TOKEN secret must have write access to the repo
 
+---
 downstream_repositories:
   # F5 XC Shell (xcsh) - CLI tool for F5 XC
   - owner: f5-sales-demo
@@ -39,12 +40,14 @@ downstream_repositories:
     enabled: true
     description: Schema-driven inventory of the F5 XC console UI
 
-# Payload sent to downstream repositories (for documentation):
+# Canonical client_payload sent to downstream repositories (for documentation):
+# delivery_id is target-specific: SHA-256 of compact, key-sorted JSON containing
+# {commit, event_type, source, tag, target, version}, where target is owner/repo.
 # {
-#   "version": "1.0.82",
-#   "release_tag": "v1.0.82",
-#   "release_url": "https://github.com/f5-sales-demo/api-specs-enriched/releases/tag/v1.0.82",
-#   "timestamp": "2025-01-01T00:00:00Z",
+#   "delivery_id": "<64-character lowercase SHA-256>",
+#   "release_tag": "v2.1.220",
+#   "release_url": "https://github.com/f5-sales-demo/api-specs-enriched/releases/tag/v2.1.220",
+#   "target_commit": "b3130b919b421a60b3f527c1cea686aebdd59bc3",
 #   "trigger_source": "f5-sales-demo/api-specs-enriched",
-#   "run_id": "12345678"
+#   "version": "2.1.220"
 # }

--- a/scripts/release/dispatch-downstream.sh
+++ b/scripts/release/dispatch-downstream.sh
@@ -10,8 +10,7 @@ required=(
   EVENT_TYPE
   VERSION
   SOURCE_REPOSITORY
-  SOURCE_UPDATED_AT
-  SOURCE_RUN_ID
+  SOURCE_TARGET_COMMIT
 )
 
 for name in "${required[@]}"; do
@@ -41,12 +40,8 @@ if [[ ! "$SOURCE_REPOSITORY" =~ ^[A-Za-z0-9-]+/[A-Za-z0-9._-]+$ ]]; then
   echo "[ERROR] SOURCE_REPOSITORY is malformed" >&2
   exit 2
 fi
-if [[ ! "$SOURCE_UPDATED_AT" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]]; then
-  echo "[ERROR] SOURCE_UPDATED_AT is malformed" >&2
-  exit 2
-fi
-if [[ ! "$SOURCE_RUN_ID" =~ ^[1-9][0-9]*$ ]]; then
-  echo "[ERROR] SOURCE_RUN_ID is malformed" >&2
+if [[ ! "$SOURCE_TARGET_COMMIT" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "[ERROR] SOURCE_TARGET_COMMIT is malformed" >&2
   exit 2
 fi
 
@@ -56,23 +51,43 @@ if ! command -v "$dispatch_gh" >/dev/null 2>&1; then
   exit 2
 fi
 
+release_tag="v${VERSION}"
+target="${TARGET_OWNER}/${TARGET_REPO}"
+identity=$(jq -cnS \
+  --arg commit "$SOURCE_TARGET_COMMIT" \
+  --arg event_type "$EVENT_TYPE" \
+  --arg source "$SOURCE_REPOSITORY" \
+  --arg tag "$release_tag" \
+  --arg target "$target" \
+  --arg version "$VERSION" \
+  '{
+    commit: $commit,
+    event_type: $event_type,
+    source: $source,
+    tag: $tag,
+    target: $target,
+    version: $version
+  }')
+delivery_id=$(printf '%s' "$identity" | sha256sum | awk '{print $1}')
+
 jq -cn \
   --arg event_type "$EVENT_TYPE" \
+  --arg delivery_id "$delivery_id" \
   --arg version "$VERSION" \
   --arg source_repository "$SOURCE_REPOSITORY" \
-  --arg timestamp "$SOURCE_UPDATED_AT" \
-  --arg run_id "$SOURCE_RUN_ID" \
+  --arg release_tag "$release_tag" \
+  --arg target_commit "$SOURCE_TARGET_COMMIT" \
   '{
     event_type: $event_type,
     client_payload: {
-      version: $version,
-      release_tag: ("v" + $version),
+      delivery_id: $delivery_id,
+      release_tag: $release_tag,
       release_url: (
-        "https://github.com/" + $source_repository + "/releases/tag/v" + $version
+        "https://github.com/" + $source_repository + "/releases/tag/" + $release_tag
       ),
-      timestamp: $timestamp,
+      target_commit: $target_commit,
       trigger_source: $source_repository,
-      run_id: $run_id
+      version: $version
     }
   }' |
   "$dispatch_gh" api --method POST \

--- a/tests/shell/test_dispatch_downstream.py
+++ b/tests/shell/test_dispatch_downstream.py
@@ -18,13 +18,35 @@ _WORKFLOW = _ROOT / ".github" / "workflows" / "sync-and-enrich.yml"
 _REQUIRED_ENV = {
     "GH_TOKEN": "test-token",
     "TARGET_OWNER": "f5-sales-demo",
-    "TARGET_REPO": "terraform-provider-xcsh",
+    "TARGET_REPO": "xcsh",
     "EVENT_TYPE": "enriched-specs-updated",
-    "VERSION": "2.1.211",
+    "VERSION": "2.1.220",
     "SOURCE_REPOSITORY": "f5-sales-demo/api-specs-enriched",
-    "SOURCE_UPDATED_AT": "2026-08-03T03:10:54Z",
-    "SOURCE_RUN_ID": "30781155338",
+    "SOURCE_TARGET_COMMIT": "b3130b919b421a60b3f527c1cea686aebdd59bc3",
 }
+
+_EXPECTED_DELIVERIES = [
+    (
+        "xcsh",
+        "enriched-specs-updated",
+        "c49ba43a076c3d2ed9ba1145807988c7b5dd60630e590199ddc392a5752c0933",
+    ),
+    (
+        "vscode-xcsh",
+        "enriched-specs-updated",
+        "4365baedb6569423277a419da3b91a63f7bd6923541fcb0c118fb1e770e43679",
+    ),
+    (
+        "terraform-provider-xcsh",
+        "enriched-specs-updated",
+        "efd8880c11be1d07c73da28125adbe15dc0ec0c97d8aeed93bcf462dffbc27db",
+    ),
+    (
+        "console",
+        "upstream-enrichment-changed",
+        "255c767bcbc7bb5bd8921760cbf9699f2c14d294cd2bcba11a7f87deba6dfa0f",
+    ),
+]
 
 
 def _fake_gh(tmp_path: Path) -> tuple[Path, Path, Path]:
@@ -72,31 +94,51 @@ def _run(
     return result, args_path, input_path
 
 
-def test_dispatch_uses_exact_endpoint_and_payload(tmp_path: Path) -> None:
-    result, args_path, input_path = _run(tmp_path)
+@pytest.mark.parametrize(("target_repo", "event_type", "delivery_id"), _EXPECTED_DELIVERIES)
+def test_dispatch_uses_exact_endpoint_payload_and_delivery_identity(
+    tmp_path: Path, target_repo: str, event_type: str, delivery_id: str
+) -> None:
+    result, args_path, input_path = _run(
+        tmp_path,
+        overrides={"TARGET_REPO": target_repo, "EVENT_TYPE": event_type},
+    )
 
     assert result.returncode == 0, result.stderr
     assert args_path.read_text().splitlines() == [
         "api",
         "--method",
         "POST",
-        "repos/f5-sales-demo/terraform-provider-xcsh/dispatches",
+        f"repos/f5-sales-demo/{target_repo}/dispatches",
         "--input",
         "-",
     ]
     assert json.loads(input_path.read_text()) == {
-        "event_type": "enriched-specs-updated",
+        "event_type": event_type,
         "client_payload": {
-            "version": "2.1.211",
-            "release_tag": "v2.1.211",
+            "delivery_id": delivery_id,
+            "release_tag": "v2.1.220",
             "release_url": (
-                "https://github.com/f5-sales-demo/api-specs-enriched/releases/tag/v2.1.211"
+                "https://github.com/f5-sales-demo/api-specs-enriched/releases/tag/v2.1.220"
             ),
-            "timestamp": "2026-08-03T03:10:54Z",
+            "target_commit": "b3130b919b421a60b3f527c1cea686aebdd59bc3",
             "trigger_source": "f5-sales-demo/api-specs-enriched",
-            "run_id": "30781155338",
+            "version": "2.1.220",
         },
     }
+
+
+def test_delivery_identity_changes_with_target_or_event_type(tmp_path: Path) -> None:
+    ids = set()
+    for overrides in (
+        {},
+        {"TARGET_REPO": "vscode-xcsh"},
+        {"EVENT_TYPE": "upstream-enrichment-changed"},
+    ):
+        result, _, input_path = _run(tmp_path, overrides=overrides)
+        assert result.returncode == 0, result.stderr
+        ids.add(json.loads(input_path.read_text())["client_payload"]["delivery_id"])
+
+    assert len(ids) == 3
 
 
 @pytest.mark.parametrize("name", sorted(_REQUIRED_ENV))
@@ -114,10 +156,10 @@ def test_dispatch_fails_closed_when_input_is_missing(tmp_path: Path, name: str) 
         ("TARGET_OWNER", "f5-sales-demo/escape"),
         ("TARGET_REPO", "../escape"),
         ("EVENT_TYPE", "invalid event"),
-        ("VERSION", "2.1.211/escape"),
+        ("VERSION", "2.1.220/escape"),
         ("SOURCE_REPOSITORY", "missing-slash"),
-        ("SOURCE_UPDATED_AT", "not-a-timestamp"),
-        ("SOURCE_RUN_ID", "not-a-run-id"),
+        ("SOURCE_TARGET_COMMIT", "not-a-commit"),
+        ("SOURCE_TARGET_COMMIT", "B3130B919B421A60B3F527C1CEA686AEBDD59BC3"),
     ],
 )
 def test_dispatch_rejects_malformed_input(tmp_path: Path, name: str, value: str) -> None:

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -35,3 +35,31 @@ def test_downstream_matrix_sets_up_python_before_installing_pyyaml() -> None:
     assert "python-version: ${{ env.PYTHON_VERSION }}" in job
     assert install in job
     assert job.index(setup_python) < job.index(install)
+
+
+def test_tag_commit_is_exposed_and_supplied_to_dispatch() -> None:
+    """Downstream delivery must identify the immutable annotated-tag commit."""
+
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    release_job = workflow.split("\n  sync-and-enrich:\n", maxsplit=1)[1].split(
+        "\n  deploy-docs:\n", maxsplit=1
+    )[0]
+    notify_job = workflow.split("\n  notify-downstream:\n", maxsplit=1)[1].split(
+        "\n  # ==========================================================================",
+        maxsplit=1,
+    )[0]
+
+    push_tag = 'git push origin "v${VERSION}"'
+    resolve_commit = "TARGET_COMMIT=$(git rev-parse HEAD)"
+    expose_step = 'echo "target_commit=${TARGET_COMMIT}" >> "$GITHUB_OUTPUT"'
+    expose_job = "target_commit: ${{ steps.release.outputs.target_commit }}"
+    supply_dispatch = "SOURCE_TARGET_COMMIT: ${{ needs.sync-and-enrich.outputs.target_commit }}"
+
+    assert "id: release" in release_job
+    assert release_job.index(push_tag) < release_job.index(resolve_commit)
+    assert release_job.index(resolve_commit) < release_job.index(expose_step)
+    assert expose_job in release_job
+    assert supply_dispatch in notify_job
+    assert notify_job.index(supply_dispatch) < notify_job.index(
+        "run: bash scripts/release/dispatch-downstream.sh"
+    )


### PR DESCRIPTION
## Summary

Emit the canonical target-specific release dispatch contract for every configured downstream consumer.

## Related Issue

Closes #1502

## Changes

- expose the immutable annotated-tag commit as the sync-and-enrich target_commit output
- replace timestamp and run_id dispatcher inputs with validated SOURCE_TARGET_COMMIT
- hash compact key-sorted identity JSON per target and configured event type
- emit exactly the canonical six-field client_payload
- document the contract and cover all four v2.1.220 delivery identities

## Verification evidence

- focused dispatcher and workflow contracts: 24 passed
- changed-file pre-commit: all hooks passed
- shellcheck and git diff --check: passed
- full suite with the required upstream corpus: 2359 passed, 72 skipped, 1 xfailed
- exact expected delivery IDs verified for xcsh, vscode-xcsh, terraform-provider-xcsh, and console

## Delivery evidence

- CI and squash auto-merge will be monitored through MERGED
- after merge, v2.1.220 will be replayed at b3130b919b421a60b3f527c1cea686aebdd59bc3 and all four recipient workflows will be monitored
- worktree and branch cleanup will be recorded after delivery completes

## Checklist

- [x] Linked to a detailed issue with Closes #1502
- [x] Feature-complete and verified
- [x] Contract tests cover the acceptance criteria and pass
- [x] Verified locally with focused, pre-commit, shell, and full-suite checks
- [ ] Pending, failed, behind, or conflicted states repaired through MERGED
- [ ] Worktree and confirmed-merged branch cleaned
- [x] Follows project conventions and style guides