### PR TITLE
feat: publish SMSv2 CE automation contract

### DIFF
--- a/config/interface_contracts.yaml
+++ b/config/interface_contracts.yaml
@@ -1,76 +1,95 @@
 # Evidence-backed interface contracts for resources whose guest interface names
 # are not stable configuration identities.
-version: "1.0.0"
+version: "2.0.0"
 
 contracts:
   securemesh_site_v2:
     schema_patterns:
       - "^viewssecuremesh_site_v2(?:Create|Replace|Get)SpecType$"
     contract:
-      version: "1.0.0"
+      version: "2.0.0"
+      contract_id: "f5xc-ce-automation/v1"
       resource: "securemesh_site_v2"
-      cloud: "azure"
-      stable_identity:
-        required_fields:
-          - "node_hostname"
-          - "cloud_nic_position"
-          - "nic_mac"
-          - "ip_configuration"
-          - "subnet"
-          - "control_plane_interface_reference"
-      roles:
-        - name: "slo"
-          required: true
-          bindable: true
-          network_option: "site_local_network"
-          vrf: "site_local_outside"
-          configuration_path: "azure.not_managed.node_list[].interface_list[]"
-          identity_fields:
-            - "node_hostname"
-            - "cloud_nic_position"
-            - "nic_mac"
-            - "ip_configuration"
-            - "subnet"
-            - "control_plane_interface_reference"
-        - name: "external"
-          required: false
-          bindable: false
-          network_option: null
-          vrf: null
-          configuration_path: null
-          identity_fields:
-            - "node_hostname"
-            - "cloud_nic_position"
-            - "nic_mac"
-            - "ip_configuration"
-            - "subnet"
-            - "control_plane_interface_reference"
-        - name: "sli"
-          required: false
-          bindable: false
-          network_option: null
-          vrf: null
-          configuration_path: null
-          identity_fields:
-            - "node_hostname"
-            - "cloud_nic_position"
-            - "nic_mac"
-            - "ip_configuration"
-            - "subnet"
-            - "control_plane_interface_reference"
-      invariants:
-        first_azure_nic_is_slo_anchor: true
-        macs_unique_per_node: true
-        role_bindings_unique_per_node: true
-        homogeneous_ha_role_vrf_shape: true
-        bgp_bindable_roles:
-          - "slo"
-      runtime_evidence:
-        guest_interface_names: "observational_only"
-        minimum_mapping_confidence: "authoritative"
-        provenance_required: true
-        replacement_observation_required: true
-      change_risk:
-        maintenance_window_required: true
-        restarts_ce_data_plane_services: true
-        adding_or_removing_interfaces_disruptive: true
+      api:
+        collection_path: "/api/config/namespaces/{namespace}/securemesh_site_v2s"
+        item_path: "/api/config/namespaces/{namespace}/securemesh_site_v2s/{name}"
+        namespace: "system"
+      providers:
+        # The wire schema is present. No AWS automation profile or one-use
+        # bootstrap API is published with sufficient evidence to enable apply.
+        aws:
+          availability: "schema_only"
+          node_list_path: "aws.not_managed.node_list[]"
+          interface_list_path: "aws.not_managed.node_list[].interface_list[]"
+          unavailable_capabilities:
+            - "bootstrap_checkout"
+            - "direct-eni"
+            - "nlb-ingress"
+            - "tgw-static"
+            - "tgw-connect"
+        azure:
+          availability: "evidence_backed"
+          stable_identity:
+            required_fields:
+              - "node_hostname"
+              - "cloud_nic_position"
+              - "nic_mac"
+              - "ip_configuration"
+              - "subnet"
+              - "control_plane_interface_reference"
+          roles:
+            - name: "slo"
+              required: true
+              bindable: true
+              network_option: "site_local_network"
+              vrf: "site_local_outside"
+              configuration_path: "azure.not_managed.node_list[].interface_list[]"
+              identity_fields:
+                - "node_hostname"
+                - "cloud_nic_position"
+                - "nic_mac"
+                - "ip_configuration"
+                - "subnet"
+                - "control_plane_interface_reference"
+            - name: "external"
+              required: false
+              bindable: false
+              network_option: null
+              vrf: null
+              configuration_path: null
+              identity_fields:
+                - "node_hostname"
+                - "cloud_nic_position"
+                - "nic_mac"
+                - "ip_configuration"
+                - "subnet"
+                - "control_plane_interface_reference"
+            - name: "sli"
+              required: false
+              bindable: false
+              network_option: null
+              vrf: null
+              configuration_path: null
+              identity_fields:
+                - "node_hostname"
+                - "cloud_nic_position"
+                - "nic_mac"
+                - "ip_configuration"
+                - "subnet"
+                - "control_plane_interface_reference"
+          invariants:
+            first_azure_nic_is_slo_anchor: true
+            macs_unique_per_node: true
+            role_bindings_unique_per_node: true
+            homogeneous_ha_role_vrf_shape: true
+            bgp_bindable_roles:
+              - "slo"
+          runtime_evidence:
+            guest_interface_names: "observational_only"
+            minimum_mapping_confidence: "authoritative"
+            provenance_required: true
+            replacement_observation_required: true
+          change_risk:
+            maintenance_window_required: true
+            restarts_ce_data_plane_services: true
+            adding_or_removing_interfaces_disruptive: true

--- a/docs/en/extensions/catalog.md
+++ b/docs/en/extensions/catalog.md
@@ -294,16 +294,17 @@ stubby as long as the `### x-name` header exists and the
 - **Example:** `"x-f5xc-action": "approve"`
 - **Pass-through from upstream:** no
 
-### x-f5xc-interface-contract
+### x-f5xc-ce-automation-contract
 
 - **Applied at:** schema
-- **Purpose:** Evidence-backed cloud NIC and control-plane role contract for Secure Mesh Site v2; guest interface names remain observational only.
+- **Purpose:** Checksum-bound Secure Mesh Site v2 automation contract. It identifies the real
+  collection and item paths, the required system namespace, and provider support evidence.
 - **Consumers:** Terraform, CLI, MCP, IDE, documentation
 - **Value type:** object
-- **Value schema:** `{"type":"object","required":["version","stable_identity","roles","invariants","runtime_evidence","change_risk"]}`
+- **Value schema:** `{"type":"object","required":["version","contract_id","resource","api","providers"]}`
 - **Injected by:** scripts/utils/interface_contract_enricher.py
 - **Driven by config:** config/interface_contracts.yaml
-- **Example:** `"x-f5xc-interface-contract":{"version":"1.0.0","roles":[{"name":"slo","bindable":true}]}`
+- **Example:** `"x-f5xc-ce-automation-contract":{"contract_id":"f5xc-ce-automation/v1","providers":{"aws":{"availability":"schema_only"}}}`
 - **Pass-through from upstream:** no
 
 ## Injected — property-level

--- a/docs/specifications/api/sites.json
+++ b/docs/specifications/api/sites.json
@@ -101255,89 +101255,111 @@
           "forward_proxy_choice": "no_forward_proxy",
           "logs_receiver_choice": "logs_streaming_disabled"
         },
-        "x-f5xc-interface-contract": {
-          "version": "1.0.0",
+        "x-f5xc-ce-automation-contract": {
+          "version": "2.0.0",
+          "contract_id": "f5xc-ce-automation/v1",
           "resource": "securemesh_site_v2",
-          "cloud": "azure",
-          "stable_identity": {
-            "required_fields": [
-              "node_hostname",
-              "cloud_nic_position",
-              "nic_mac",
-              "ip_configuration",
-              "subnet",
-              "control_plane_interface_reference"
-            ]
+          "api": {
+            "collection_path": "/api/config/namespaces/{namespace}/securemesh_site_v2s",
+            "item_path": "/api/config/namespaces/{namespace}/securemesh_site_v2s/{name}",
+            "namespace": "system"
           },
-          "roles": [
-            {
-              "name": "slo",
-              "required": true,
-              "bindable": true,
-              "network_option": "site_local_network",
-              "vrf": "site_local_outside",
-              "configuration_path": "azure.not_managed.node_list[].interface_list[]",
-              "identity_fields": [
-                "node_hostname",
-                "cloud_nic_position",
-                "nic_mac",
-                "ip_configuration",
-                "subnet",
-                "control_plane_interface_reference"
+          "providers": {
+            "aws": {
+              "availability": "schema_only",
+              "node_list_path": "aws.not_managed.node_list[]",
+              "interface_list_path": "aws.not_managed.node_list[].interface_list[]",
+              "unavailable_capabilities": [
+                "bootstrap_checkout",
+                "direct-eni",
+                "nlb-ingress",
+                "tgw-static",
+                "tgw-connect"
               ]
             },
-            {
-              "name": "external",
-              "required": false,
-              "bindable": false,
-              "network_option": null,
-              "vrf": null,
-              "configuration_path": null,
-              "identity_fields": [
-                "node_hostname",
-                "cloud_nic_position",
-                "nic_mac",
-                "ip_configuration",
-                "subnet",
-                "control_plane_interface_reference"
-              ]
-            },
-            {
-              "name": "sli",
-              "required": false,
-              "bindable": false,
-              "network_option": null,
-              "vrf": null,
-              "configuration_path": null,
-              "identity_fields": [
-                "node_hostname",
-                "cloud_nic_position",
-                "nic_mac",
-                "ip_configuration",
-                "subnet",
-                "control_plane_interface_reference"
-              ]
+            "azure": {
+              "availability": "evidence_backed",
+              "stable_identity": {
+                "required_fields": [
+                  "node_hostname",
+                  "cloud_nic_position",
+                  "nic_mac",
+                  "ip_configuration",
+                  "subnet",
+                  "control_plane_interface_reference"
+                ]
+              },
+              "roles": [
+                {
+                  "name": "slo",
+                  "required": true,
+                  "bindable": true,
+                  "network_option": "site_local_network",
+                  "vrf": "site_local_outside",
+                  "configuration_path": "azure.not_managed.node_list[].interface_list[]",
+                  "identity_fields": [
+                    "node_hostname",
+                    "cloud_nic_position",
+                    "nic_mac",
+                    "ip_configuration",
+                    "subnet",
+                    "control_plane_interface_reference"
+                  ]
+                },
+                {
+                  "name": "external",
+                  "required": false,
+                  "bindable": false,
+                  "network_option": null,
+                  "vrf": null,
+                  "configuration_path": null,
+                  "identity_fields": [
+                    "node_hostname",
+                    "cloud_nic_position",
+                    "nic_mac",
+                    "ip_configuration",
+                    "subnet",
+                    "control_plane_interface_reference"
+                  ]
+                },
+                {
+                  "name": "sli",
+                  "required": false,
+                  "bindable": false,
+                  "network_option": null,
+                  "vrf": null,
+                  "configuration_path": null,
+                  "identity_fields": [
+                    "node_hostname",
+                    "cloud_nic_position",
+                    "nic_mac",
+                    "ip_configuration",
+                    "subnet",
+                    "control_plane_interface_reference"
+                  ]
+                }
+              ],
+              "invariants": {
+                "first_azure_nic_is_slo_anchor": true,
+                "macs_unique_per_node": true,
+                "role_bindings_unique_per_node": true,
+                "homogeneous_ha_role_vrf_shape": true,
+                "bgp_bindable_roles": [
+                  "slo"
+                ]
+              },
+              "runtime_evidence": {
+                "guest_interface_names": "observational_only",
+                "minimum_mapping_confidence": "authoritative",
+                "provenance_required": true,
+                "replacement_observation_required": true
+              },
+              "change_risk": {
+                "maintenance_window_required": true,
+                "restarts_ce_data_plane_services": true,
+                "adding_or_removing_interfaces_disruptive": true
+              }
             }
-          ],
-          "invariants": {
-            "first_azure_nic_is_slo_anchor": true,
-            "macs_unique_per_node": true,
-            "role_bindings_unique_per_node": true,
-            "homogeneous_ha_role_vrf_shape": true,
-            "bgp_bindable_roles": [
-              "slo"
-            ]
-          },
-          "runtime_evidence": {
-            "guest_interface_names": "observational_only",
-            "minimum_mapping_confidence": "authoritative",
-            "provenance_required": true,
-            "replacement_observation_required": true
-          },
-          "change_risk": {
-            "maintenance_window_required": true,
-            "restarts_ce_data_plane_services": true,
-            "adding_or_removing_interfaces_disruptive": true
           }
         },
         "x-f5xc-namespace-profile": {
@@ -102671,89 +102693,111 @@
           "forward_proxy_choice": "no_forward_proxy",
           "logs_receiver_choice": "logs_streaming_disabled"
         },
-        "x-f5xc-interface-contract": {
-          "version": "1.0.0",
+        "x-f5xc-ce-automation-contract": {
+          "version": "2.0.0",
+          "contract_id": "f5xc-ce-automation/v1",
           "resource": "securemesh_site_v2",
-          "cloud": "azure",
-          "stable_identity": {
-            "required_fields": [
-              "node_hostname",
-              "cloud_nic_position",
-              "nic_mac",
-              "ip_configuration",
-              "subnet",
-              "control_plane_interface_reference"
-            ]
+          "api": {
+            "collection_path": "/api/config/namespaces/{namespace}/securemesh_site_v2s",
+            "item_path": "/api/config/namespaces/{namespace}/securemesh_site_v2s/{name}",
+            "namespace": "system"
           },
-          "roles": [
-            {
-              "name": "slo",
-              "required": true,
-              "bindable": true,
-              "network_option": "site_local_network",
-              "vrf": "site_local_outside",
-              "configuration_path": "azure.not_managed.node_list[].interface_list[]",
-              "identity_fields": [
-                "node_hostname",
-                "cloud_nic_position",
-                "nic_mac",
-                "ip_configuration",
-                "subnet",
-                "control_plane_interface_reference"
+          "providers": {
+            "aws": {
+              "availability": "schema_only",
+              "node_list_path": "aws.not_managed.node_list[]",
+              "interface_list_path": "aws.not_managed.node_list[].interface_list[]",
+              "unavailable_capabilities": [
+                "bootstrap_checkout",
+                "direct-eni",
+                "nlb-ingress",
+                "tgw-static",
+                "tgw-connect"
               ]
             },
-            {
-              "name": "external",
-              "required": false,
-              "bindable": false,
-              "network_option": null,
-              "vrf": null,
-              "configuration_path": null,
-              "identity_fields": [
-                "node_hostname",
-                "cloud_nic_position",
-                "nic_mac",
-                "ip_configuration",
-                "subnet",
-                "control_plane_interface_reference"
-              ]
-            },
-            {
-              "name": "sli",
-              "required": false,
-              "bindable": false,
-              "network_option": null,
-              "vrf": null,
-              "configuration_path": null,
-              "identity_fields": [
-                "node_hostname",
-                "cloud_nic_position",
-                "nic_mac",
-                "ip_configuration",
-                "subnet",
-                "control_plane_interface_reference"
-              ]
+            "azure": {
+              "availability": "evidence_backed",
+              "stable_identity": {
+                "required_fields": [
+                  "node_hostname",
+                  "cloud_nic_position",
+                  "nic_mac",
+                  "ip_configuration",
+                  "subnet",
+                  "control_plane_interface_reference"
+                ]
+              },
+              "roles": [
+                {
+                  "name": "slo",
+                  "required": true,
+                  "bindable": true,
+                  "network_option": "site_local_network",
+                  "vrf": "site_local_outside",
+                  "configuration_path": "azure.not_managed.node_list[].interface_list[]",
+                  "identity_fields": [
+                    "node_hostname",
+                    "cloud_nic_position",
+                    "nic_mac",
+                    "ip_configuration",
+                    "subnet",
+                    "control_plane_interface_reference"
+                  ]
+                },
+                {
+                  "name": "external",
+                  "required": false,
+                  "bindable": false,
+                  "network_option": null,
+                  "vrf": null,
+                  "configuration_path": null,
+                  "identity_fields": [
+                    "node_hostname",
+                    "cloud_nic_position",
+                    "nic_mac",
+                    "ip_configuration",
+                    "subnet",
+                    "control_plane_interface_reference"
+                  ]
+                },
+                {
+                  "name": "sli",
+                  "required": false,
+                  "bindable": false,
+                  "network_option": null,
+                  "vrf": null,
+                  "configuration_path": null,
+                  "identity_fields": [
+                    "node_hostname",
+                    "cloud_nic_position",
+                    "nic_mac",
+                    "ip_configuration",
+                    "subnet",
+                    "control_plane_interface_reference"
+                  ]
+                }
+              ],
+              "invariants": {
+                "first_azure_nic_is_slo_anchor": true,
+                "macs_unique_per_node": true,
+                "role_bindings_unique_per_node": true,
+                "homogeneous_ha_role_vrf_shape": true,
+                "bgp_bindable_roles": [
+                  "slo"
+                ]
+              },
+              "runtime_evidence": {
+                "guest_interface_names": "observational_only",
+                "minimum_mapping_confidence": "authoritative",
+                "provenance_required": true,
+                "replacement_observation_required": true
+              },
+              "change_risk": {
+                "maintenance_window_required": true,
+                "restarts_ce_data_plane_services": true,
+                "adding_or_removing_interfaces_disruptive": true
+              }
             }
-          ],
-          "invariants": {
-            "first_azure_nic_is_slo_anchor": true,
-            "macs_unique_per_node": true,
-            "role_bindings_unique_per_node": true,
-            "homogeneous_ha_role_vrf_shape": true,
-            "bgp_bindable_roles": [
-              "slo"
-            ]
-          },
-          "runtime_evidence": {
-            "guest_interface_names": "observational_only",
-            "minimum_mapping_confidence": "authoritative",
-            "provenance_required": true,
-            "replacement_observation_required": true
-          },
-          "change_risk": {
-            "maintenance_window_required": true,
-            "restarts_ce_data_plane_services": true,
-            "adding_or_removing_interfaces_disruptive": true
           }
         },
         "x-f5xc-namespace-profile": {
@@ -104030,89 +104074,111 @@
           "forward_proxy_choice": "no_forward_proxy",
           "logs_receiver_choice": "logs_streaming_disabled"
         },
-        "x-f5xc-interface-contract": {
-          "version": "1.0.0",
+        "x-f5xc-ce-automation-contract": {
+          "version": "2.0.0",
+          "contract_id": "f5xc-ce-automation/v1",
           "resource": "securemesh_site_v2",
-          "cloud": "azure",
-          "stable_identity": {
-            "required_fields": [
-              "node_hostname",
-              "cloud_nic_position",
-              "nic_mac",
-              "ip_configuration",
-              "subnet",
-              "control_plane_interface_reference"
-            ]
+          "api": {
+            "collection_path": "/api/config/namespaces/{namespace}/securemesh_site_v2s",
+            "item_path": "/api/config/namespaces/{namespace}/securemesh_site_v2s/{name}",
+            "namespace": "system"
           },
-          "roles": [
-            {
-              "name": "slo",
-              "required": true,
-              "bindable": true,
-              "network_option": "site_local_network",
-              "vrf": "site_local_outside",
-              "configuration_path": "azure.not_managed.node_list[].interface_list[]",
-              "identity_fields": [
-                "node_hostname",
-                "cloud_nic_position",
-                "nic_mac",
-                "ip_configuration",
-                "subnet",
-                "control_plane_interface_reference"
+          "providers": {
+            "aws": {
+              "availability": "schema_only",
+              "node_list_path": "aws.not_managed.node_list[]",
+              "interface_list_path": "aws.not_managed.node_list[].interface_list[]",
+              "unavailable_capabilities": [
+                "bootstrap_checkout",
+                "direct-eni",
+                "nlb-ingress",
+                "tgw-static",
+                "tgw-connect"
               ]
             },
-            {
-              "name": "external",
-              "required": false,
-              "bindable": false,
-              "network_option": null,
-              "vrf": null,
-              "configuration_path": null,
-              "identity_fields": [
-                "node_hostname",
-                "cloud_nic_position",
-                "nic_mac",
-                "ip_configuration",
-                "subnet",
-                "control_plane_interface_reference"
-              ]
-            },
-            {
-              "name": "sli",
-              "required": false,
-              "bindable": false,
-              "network_option": null,
-              "vrf": null,
-              "configuration_path": null,
-              "identity_fields": [
-                "node_hostname",
-                "cloud_nic_position",
-                "nic_mac",
-                "ip_configuration",
-                "subnet",
-                "control_plane_interface_reference"
-              ]
+            "azure": {
+              "availability": "evidence_backed",
+              "stable_identity": {
+                "required_fields": [
+                  "node_hostname",
+                  "cloud_nic_position",
+                  "nic_mac",
+                  "ip_configuration",
+                  "subnet",
+                  "control_plane_interface_reference"
+                ]
+              },
+              "roles": [
+                {
+                  "name": "slo",
+                  "required": true,
+                  "bindable": true,
+                  "network_option": "site_local_network",
+                  "vrf": "site_local_outside",
+                  "configuration_path": "azure.not_managed.node_list[].interface_list[]",
+                  "identity_fields": [
+                    "node_hostname",
+                    "cloud_nic_position",
+                    "nic_mac",
+                    "ip_configuration",
+                    "subnet",
+                    "control_plane_interface_reference"
+                  ]
+                },
+                {
+                  "name": "external",
+                  "required": false,
+                  "bindable": false,
+                  "network_option": null,
+                  "vrf": null,
+                  "configuration_path": null,
+                  "identity_fields": [
+                    "node_hostname",
+                    "cloud_nic_position",
+                    "nic_mac",
+                    "ip_configuration",
+                    "subnet",
+                    "control_plane_interface_reference"
+                  ]
+                },
+                {
+                  "name": "sli",
+                  "required": false,
+                  "bindable": false,
+                  "network_option": null,
+                  "vrf": null,
+                  "configuration_path": null,
+                  "identity_fields": [
+                    "node_hostname",
+                    "cloud_nic_position",
+                    "nic_mac",
+                    "ip_configuration",
+                    "subnet",
+                    "control_plane_interface_reference"
+                  ]
+                }
+              ],
+              "invariants": {
+                "first_azure_nic_is_slo_anchor": true,
+                "macs_unique_per_node": true,
+                "role_bindings_unique_per_node": true,
+                "homogeneous_ha_role_vrf_shape": true,
+                "bgp_bindable_roles": [
+                  "slo"
+                ]
+              },
+              "runtime_evidence": {
+                "guest_interface_names": "observational_only",
+                "minimum_mapping_confidence": "authoritative",
+                "provenance_required": true,
+                "replacement_observation_required": true
+              },
+              "change_risk": {
+                "maintenance_window_required": true,
+                "restarts_ce_data_plane_services": true,
+                "adding_or_removing_interfaces_disruptive": true
+              }
             }
-          ],
-          "invariants": {
-            "first_azure_nic_is_slo_anchor": true,
-            "macs_unique_per_node": true,
-            "role_bindings_unique_per_node": true,
-            "homogeneous_ha_role_vrf_shape": true,
-            "bgp_bindable_roles": [
-              "slo"
-            ]
-          },
-          "runtime_evidence": {
-            "guest_interface_names": "observational_only",
-            "minimum_mapping_confidence": "authoritative",
-            "provenance_required": true,
-            "replacement_observation_required": true
-          },
-          "change_risk": {
-            "maintenance_window_required": true,
-            "restarts_ce_data_plane_services": true,
-            "adding_or_removing_interfaces_disruptive": true
           }
         },
         "x-f5xc-namespace-profile": {

--- a/scripts/utils/extension_constants.py
+++ b/scripts/utils/extension_constants.py
@@ -55,8 +55,8 @@ X_F5XC_TERRAFORM_RESOURCE = "x-f5xc-terraform-resource"
 X_F5XC_DISPLAY_NAME = "x-f5xc-display-name"
 X_F5XC_ACTION = "x-f5xc-action"
 
-# Evidence-backed multi-interface role contract (Issue #1441)
-X_F5XC_INTERFACE_CONTRACT = "x-f5xc-interface-contract"
+# Checksum-bound Secure Mesh Site v2 automation contract (Issue #1508)
+X_F5XC_CE_AUTOMATION_CONTRACT = "x-f5xc-ce-automation-contract"
 
 # Console UI enrichment (Issue #679)
 X_F5XC_CONSOLE = "x-f5xc-console"
@@ -232,7 +232,7 @@ VALID_X_F5XC_EXTENSIONS = frozenset(
         X_F5XC_TERRAFORM_RESOURCE,
         X_F5XC_DISPLAY_NAME,
         X_F5XC_ACTION,
-        X_F5XC_INTERFACE_CONTRACT,
+        X_F5XC_CE_AUTOMATION_CONTRACT,
         # Property-level
         X_F5XC_DESCRIPTION,
         X_F5XC_VALIDATION,

--- a/scripts/utils/interface_contract_enricher.py
+++ b/scripts/utils/interface_contract_enricher.py
@@ -10,7 +10,7 @@ from typing import Any
 
 import yaml
 
-from .extension_constants import X_F5XC_INTERFACE_CONTRACT
+from .extension_constants import X_F5XC_CE_AUTOMATION_CONTRACT
 
 CONFIG_PATH = Path(__file__).parent.parent.parent / "config" / "interface_contracts.yaml"
 SUPPORTED_ROLES = frozenset({"slo", "external", "sli"})
@@ -44,7 +44,7 @@ class InterfaceContractStats:
 
 
 class InterfaceContractEnricher:
-    """Inject validated ``x-f5xc-interface-contract`` schema extensions.
+    """Inject the validated Secure Mesh Site v2 automation contract.
 
     The contract intentionally describes cloud and control-plane identities,
     never Linux guest interface names. An optional role can only become bindable
@@ -107,14 +107,47 @@ class InterfaceContractEnricher:
         return value
 
     def _validate_contract(self, resource: str, contract: dict[str, Any]) -> None:
-        if contract.get("version") != "1.0.0":
+        if contract.get("version") != "2.0.0":
             raise InterfaceContractValidationError(f"{resource}: unsupported contract version")
         if contract.get("resource") != resource:
             raise InterfaceContractValidationError(
                 f"{resource}: resource identity must match its key"
             )
-        if contract.get("cloud") != "azure":
-            raise InterfaceContractValidationError(f"{resource}: cloud profile must be azure")
+        if contract.get("contract_id") != "f5xc-ce-automation/v1":
+            raise InterfaceContractValidationError(f"{resource}: invalid contract identity")
+        api = self._required_object(contract, "api", resource=resource)
+        if api != {
+            "collection_path": "/api/config/namespaces/{namespace}/securemesh_site_v2s",
+            "item_path": "/api/config/namespaces/{namespace}/securemesh_site_v2s/{name}",
+            "namespace": "system",
+        }:
+            raise InterfaceContractValidationError(f"{resource}: API paths must match SMSv2")
+        providers = self._required_object(contract, "providers", resource=resource)
+        if set(providers) != {"aws", "azure"}:
+            raise InterfaceContractValidationError(f"{resource}: providers must be aws and azure")
+        azure = providers["azure"]
+        aws = providers["aws"]
+        if not isinstance(azure, dict) or not isinstance(aws, dict):
+            raise InterfaceContractValidationError(f"{resource}: provider profiles must be objects")
+        self._validate_aws_profile(resource, aws)
+        self._validate_interface_profile(resource, azure)
+
+    def _validate_aws_profile(self, resource: str, profile: dict[str, Any]) -> None:
+        if profile.get("node_list_path") != "aws.not_managed.node_list[]":
+            raise InterfaceContractValidationError(f"{resource}: AWS node path is not schema-backed")
+        if profile.get("interface_list_path") != "aws.not_managed.node_list[].interface_list[]":
+            raise InterfaceContractValidationError(f"{resource}: AWS interface path is not schema-backed")
+        if profile.get("availability") != "schema_only":
+            raise InterfaceContractValidationError(f"{resource}: AWS availability must be schema_only")
+        unsupported = profile.get("unavailable_capabilities")
+        if unsupported != ["bootstrap_checkout", "direct-eni", "nlb-ingress", "tgw-static", "tgw-connect"]:
+            raise InterfaceContractValidationError(
+                f"{resource}: AWS unsupported capabilities must fail closed"
+            )
+
+    def _validate_interface_profile(self, resource: str, contract: dict[str, Any]) -> None:
+        if contract.get("availability") != "evidence_backed":
+            raise InterfaceContractValidationError(f"{resource}: Azure availability must be evidence_backed")
 
         stable_identity = self._required_object(contract, "stable_identity", resource=resource)
         fields = stable_identity.get("required_fields")
@@ -256,7 +289,7 @@ class InterfaceContractEnricher:
             self.stats.schemas_processed += 1
             for patterns, contract in self.contracts:
                 if any(pattern.search(schema_name) for pattern in patterns):
-                    schema[X_F5XC_INTERFACE_CONTRACT] = copy.deepcopy(contract)
+                    schema[X_F5XC_CE_AUTOMATION_CONTRACT] = copy.deepcopy(contract)
                     self.stats.schemas_matched += 1
                     self.stats.contracts_applied += 1
                     break

--- a/scripts/utils/interface_contract_enricher.py
+++ b/scripts/utils/interface_contract_enricher.py
@@ -134,20 +134,34 @@ class InterfaceContractEnricher:
 
     def _validate_aws_profile(self, resource: str, profile: dict[str, Any]) -> None:
         if profile.get("node_list_path") != "aws.not_managed.node_list[]":
-            raise InterfaceContractValidationError(f"{resource}: AWS node path is not schema-backed")
+            raise InterfaceContractValidationError(
+                f"{resource}: AWS node path is not schema-backed"
+            )
         if profile.get("interface_list_path") != "aws.not_managed.node_list[].interface_list[]":
-            raise InterfaceContractValidationError(f"{resource}: AWS interface path is not schema-backed")
+            raise InterfaceContractValidationError(
+                f"{resource}: AWS interface path is not schema-backed"
+            )
         if profile.get("availability") != "schema_only":
-            raise InterfaceContractValidationError(f"{resource}: AWS availability must be schema_only")
+            raise InterfaceContractValidationError(
+                f"{resource}: AWS availability must be schema_only"
+            )
         unsupported = profile.get("unavailable_capabilities")
-        if unsupported != ["bootstrap_checkout", "direct-eni", "nlb-ingress", "tgw-static", "tgw-connect"]:
+        if unsupported != [
+            "bootstrap_checkout",
+            "direct-eni",
+            "nlb-ingress",
+            "tgw-static",
+            "tgw-connect",
+        ]:
             raise InterfaceContractValidationError(
                 f"{resource}: AWS unsupported capabilities must fail closed"
             )
 
     def _validate_interface_profile(self, resource: str, contract: dict[str, Any]) -> None:
         if contract.get("availability") != "evidence_backed":
-            raise InterfaceContractValidationError(f"{resource}: Azure availability must be evidence_backed")
+            raise InterfaceContractValidationError(
+                f"{resource}: Azure availability must be evidence_backed"
+            )
 
         stable_identity = self._required_object(contract, "stable_identity", resource=resource)
         fields = stable_identity.get("required_fields")

--- a/tests/test_interface_contract_enricher.py
+++ b/tests/test_interface_contract_enricher.py
@@ -11,7 +11,7 @@ from typing import Any
 import pytest
 import yaml
 
-from scripts.utils.extension_constants import X_F5XC_INTERFACE_CONTRACT
+from scripts.utils.extension_constants import X_F5XC_CE_AUTOMATION_CONTRACT
 from scripts.utils.interface_contract_enricher import (
     InterfaceContractEnricher,
     InterfaceContractValidationError,
@@ -51,12 +51,17 @@ def _contract(config: dict[str, Any]) -> dict[str, Any]:
     return config["contracts"]["securemesh_site_v2"]["contract"]
 
 
+def _azure_contract(config: dict[str, Any]) -> dict[str, Any]:
+    return _contract(config)["providers"]["azure"]
+
+
 def test_emits_contract_for_only_securemesh_request_schemas(sms_spec: dict[str, Any]) -> None:
     enriched = InterfaceContractEnricher().enrich_spec(copy.deepcopy(sms_spec))
     schemas = enriched["components"]["schemas"]
-    assert X_F5XC_INTERFACE_CONTRACT in schemas["viewssecuremesh_site_v2CreateSpecType"]
-    assert X_F5XC_INTERFACE_CONTRACT in schemas["viewssecuremesh_site_v2GetSpecType"]
-    assert X_F5XC_INTERFACE_CONTRACT not in schemas["unrelatedSchema"]
+    assert X_F5XC_CE_AUTOMATION_CONTRACT in schemas["viewssecuremesh_site_v2CreateSpecType"]
+    assert X_F5XC_CE_AUTOMATION_CONTRACT in schemas["viewssecuremesh_site_v2GetSpecType"]
+    assert "x-f5xc-interface-contract" not in schemas["viewssecuremesh_site_v2CreateSpecType"]
+    assert X_F5XC_CE_AUTOMATION_CONTRACT not in schemas["unrelatedSchema"]
 
 
 def test_contract_is_deterministic_and_guest_names_are_not_authoritative(
@@ -65,22 +70,34 @@ def test_contract_is_deterministic_and_guest_names_are_not_authoritative(
     enricher = InterfaceContractEnricher()
     once = enricher.enrich_spec(copy.deepcopy(sms_spec))
     twice = enricher.enrich_spec(copy.deepcopy(sms_spec))
-    create_contract = once["components"]["schemas"]["viewssecuremesh_site_v2CreateSpecType"][
-        X_F5XC_INTERFACE_CONTRACT
-    ]
+    create_contract = once["components"]["schemas"]["viewssecuremesh_site_v2CreateSpecType"]
     assert once == twice
-    assert create_contract["runtime_evidence"]["guest_interface_names"] == "observational_only"
+    assert (
+        create_contract[X_F5XC_CE_AUTOMATION_CONTRACT]["providers"]["azure"]["runtime_evidence"][
+            "guest_interface_names"
+        ]
+        == "observational_only"
+    )
+    assert (
+        create_contract[X_F5XC_CE_AUTOMATION_CONTRACT]["contract_id"]
+        == "f5xc-ce-automation/v1"
+    )
     assert "eth" not in json.dumps(create_contract).lower()
 
 
 def test_contract_defines_stable_identity_and_role_invariants() -> None:
     enricher = InterfaceContractEnricher()
     contract = enricher.contracts[0][1]
-    assert contract["stable_identity"]["required_fields"]
-    assert [role["name"] for role in contract["roles"]] == ["slo", "external", "sli"]
-    assert contract["invariants"]["bgp_bindable_roles"] == ["slo"]
-    assert contract["change_risk"]["maintenance_window_required"] is True
-    assert contract["change_risk"]["restarts_ce_data_plane_services"] is True
+    azure = contract["providers"]["azure"]
+    assert contract["contract_id"] == "f5xc-ce-automation/v1"
+    assert contract["api"]["namespace"] == "system"
+    assert contract["providers"]["aws"]["availability"] == "schema_only"
+    assert "tgw-connect" in contract["providers"]["aws"]["unavailable_capabilities"]
+    assert azure["stable_identity"]["required_fields"]
+    assert [role["name"] for role in azure["roles"]] == ["slo", "external", "sli"]
+    assert azure["invariants"]["bgp_bindable_roles"] == ["slo"]
+    assert azure["change_risk"]["maintenance_window_required"] is True
+    assert azure["change_risk"]["restarts_ce_data_plane_services"] is True
 
 
 Mutation = Callable[[dict[str, Any]], Any]
@@ -94,21 +111,21 @@ Mutation = Callable[[dict[str, Any]], Any]
             "contract must be an object",
         ),
         (
-            lambda config: _contract(config)["roles"].append(
-                copy.deepcopy(_contract(config)["roles"][0])
+            lambda config: _azure_contract(config)["roles"].append(
+                copy.deepcopy(_azure_contract(config)["roles"][0])
             ),
             "duplicate role",
         ),
         (
-            lambda config: _contract(config)["roles"][1].update({"name": "unknown"}),
+            lambda config: _azure_contract(config)["roles"][1].update({"name": "unknown"}),
             "unknown role",
         ),
         (
-            lambda config: _contract(config)["roles"][2].pop("identity_fields"),
+            lambda config: _azure_contract(config)["roles"][2].pop("identity_fields"),
             "lacks the complete stable identity",
         ),
         (
-            lambda config: _contract(config)["runtime_evidence"].update(
+            lambda config: _azure_contract(config)["runtime_evidence"].update(
                 {"guest_interface_names": "authoritative"}
             ),
             "guest interface names must be observational only",
@@ -131,7 +148,7 @@ def test_rejects_bindable_optional_role_without_authoritative_evidence(
     tmp_path: Path, contract_config: dict[str, Any]
 ) -> None:
     invalid = copy.deepcopy(contract_config)
-    external = _contract(invalid)["roles"][1]
+    external = _azure_contract(invalid)["roles"][1]
     external.update(
         {
             "bindable": True,
@@ -140,8 +157,19 @@ def test_rejects_bindable_optional_role_without_authoritative_evidence(
             "configuration_path": "azure.not_managed.node_list[].interface_list[]",
         }
     )
-    _contract(invalid)["runtime_evidence"]["minimum_mapping_confidence"] = "advisory"
+    _azure_contract(invalid)["runtime_evidence"]["minimum_mapping_confidence"] = "advisory"
     with pytest.raises(InterfaceContractValidationError, match="authoritative evidence provenance"):
+        InterfaceContractEnricher(_write_config(tmp_path, invalid))
+
+
+def test_rejects_aws_profile_that_claims_unverified_automation(
+    tmp_path: Path, contract_config: dict[str, Any]
+) -> None:
+    invalid = copy.deepcopy(contract_config)
+    _contract(invalid)["providers"]["aws"]["availability"] = "supported"
+    with pytest.raises(
+        InterfaceContractValidationError, match="AWS availability must be schema_only"
+    ):
         InterfaceContractEnricher(_write_config(tmp_path, invalid))
 
 

--- a/tests/test_interface_contract_enricher.py
+++ b/tests/test_interface_contract_enricher.py
@@ -78,10 +78,7 @@ def test_contract_is_deterministic_and_guest_names_are_not_authoritative(
         ]
         == "observational_only"
     )
-    assert (
-        create_contract[X_F5XC_CE_AUTOMATION_CONTRACT]["contract_id"]
-        == "f5xc-ce-automation/v1"
-    )
+    assert create_contract[X_F5XC_CE_AUTOMATION_CONTRACT]["contract_id"] == "f5xc-ce-automation/v1"
     assert "eth" not in json.dumps(create_contract).lower()
 
 


### PR DESCRIPTION
## Summary

Publishes the clean-break `f5xc-ce-automation/v1` Secure Mesh Site v2 contract as a schema extension in the enriched API artifact.

## Why

Marketplace validation established that a parallel client payload and an undocumented tenant capability endpoint do not represent the live F5 XC SMSv2 API. The enriched spec must be the authoritative source consumed by Terraform and downstream automation.

## Changes

- Replaces the Azure-only interface extension with `x-f5xc-ce-automation-contract`.
- Binds the contract to the real system-namespace `securemesh_site_v2s` collection and item paths.
- Retains evidence-backed Azure NIC/role invariants.
- Models AWS typed node/interface schema paths, but marks bootstrap and every AWS routing profile unavailable until released evidence exists.
- Adds deterministic contract and fail-closed regression tests.

## Verification

- `python -m pytest tests/test_interface_contract_enricher.py tests/test_config_interdependencies.py -q`
- `python -m scripts.validate_configs`
- Full `python -m pytest` exercised the 2,415-test suite using global dependencies; the command-output transport truncated its final summary.
- `gitleaks protect --staged --redact`
- `git diff --check`

Closes #1508

## Downstream

Terraform contract consumer: f5-sales-demo/terraform-provider-xcsh#1646
Marketplace integration blocker: f5-sales-demo/marketplace#1194
Live-schema reconciliation: #1049