### PR TITLE
fix: make release publication recovery deterministic

### DIFF
--- a/.github/workflows/sync-and-enrich.yml
+++ b/.github/workflows/sync-and-enrich.yml
@@ -168,36 +168,13 @@ jobs:
       - name: Install Python dependencies
         run: pip install -r requirements.txt
 
-      - name: Read release tag for cache key
-        id: release-info
-        run: |
-          if [ -f .github_release ]; then
-            TAG=$(jq -r '.tag_name // "unknown"' .github_release)
-          else
-            TAG="unknown"
-          fi
-          echo "release_tag=$TAG" >> "$GITHUB_OUTPUT"
-
-      - name: Restore specs cache
-        if: github.event_name == 'push'
-        id: specs-cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: specs/original
-          key: specs-original-${{ steps.release-info.outputs.release_tag }}
-
+      # A release-producing event must consume fresh upstream bytes. The old
+      # specs/original cache could make a forced push or dispatch silently
+      # enrich the previous upstream release.
       - name: Download specifications from GitHub Releases
-        if: steps.specs-cache.outputs.cache-hit != 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: python -m scripts.download --force
-
-      - name: Save specs cache
-        if: steps.specs-cache.outputs.cache-hit != 'true' && github.event_name == 'push'
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: specs/original
-          key: specs-original-${{ steps.release-info.outputs.release_tag }}
 
       - name: Compute specs fingerprint
         id: specs-fingerprint
@@ -582,57 +559,90 @@ jobs:
 
           BRANCH="release/v${VERSION}"
 
-          # Pre-clean: if a prior run left behind a stale release PR + branch
-          # (auto-merge timeout, push rejection, Super-Linter failure, etc.),
-          # the next run hits `! [rejected] ... (non-fast-forward)` on push.
-          # This workflow owns the `release/v${VERSION}` branch name, so
-          # force-cleanup is safe — no other producer ever pushes here.
-          STALE_PR=$(gh pr list --state open --head "$BRANCH" --json number --jq '.[0].number // empty' 2>/dev/null || true)
-          if [ -n "$STALE_PR" ]; then
-            echo "Found stale PR #${STALE_PR} on ${BRANCH}; closing with --delete-branch"
-            gh pr close "$STALE_PR" --delete-branch --comment "Superseded by sync-and-enrich run ${GITHUB_RUN_ID}" || true
+          # A retry must preserve the exact release PR that an earlier run
+          # created. In particular, never close or delete an OPEN release PR:
+          # its required checks may simply outlive this runner's wait budget.
+          # A later forced retry resumes from the merged PR's immutable commit.
+          publish_tag() {
+            TARGET_COMMIT="$1"
+            git fetch --tags origin main
+            git merge-base --is-ancestor "$TARGET_COMMIT" origin/main || {
+              echo "::error::Release PR merge commit is not reachable from main"
+              exit 1
+            }
+            if git rev-parse -q --verify "refs/tags/v${VERSION}" >/dev/null; then
+              TAG_COMMIT=$(git rev-parse "v${VERSION}^{}")
+              [ "$TAG_COMMIT" = "$TARGET_COMMIT" ] || {
+                echo "::error::Existing v${VERSION} tag names a different commit"
+                exit 1
+              }
+            else
+              git tag -a "v${VERSION}" "$TARGET_COMMIT" -m "Release v${VERSION} (${BUMP_TYPE})"
+              git push origin "v${VERSION}"
+            fi
+            git checkout --detach "$TARGET_COMMIT"
+            echo "release_commit=${TARGET_COMMIT}" >> "$GITHUB_ENV"
+            echo "target_commit=${TARGET_COMMIT}" >> "$GITHUB_OUTPUT"
+            echo "::notice::Released v${VERSION} from immutable merge ${TARGET_COMMIT}"
+          }
+
+          EXISTING_PR=$(gh pr list --state all --head "$BRANCH" \
+            --json number,state,mergeCommit --jq '.[0] // empty')
+          if [ -n "$EXISTING_PR" ]; then
+            RELEASE_PR=$(printf '%s' "$EXISTING_PR" | jq -r '.number')
+            RELEASE_STATE=$(printf '%s' "$EXISTING_PR" | jq -r '.state')
+            case "$RELEASE_STATE" in
+            MERGED)
+              TARGET_COMMIT=$(printf '%s' "$EXISTING_PR" | jq -er '.mergeCommit.oid')
+              publish_tag "$TARGET_COMMIT"
+              ;;
+            OPEN)
+              # Preserve the existing PR and let its currently running checks
+              # finish. Enable auto-merge only if the original run did not.
+              AUTO_MERGE=$(gh pr view "$RELEASE_PR" --json autoMergeRequest \
+                --jq 'if .autoMergeRequest then "true" else "false" end')
+              if [ "$AUTO_MERGE" != true ]; then
+                gh pr merge "$RELEASE_PR" --squash --auto --delete-branch
+              fi
+              WAIT_FOR_MERGE_MAX_TOTAL=1800 bash scripts/release/wait-for-merge.sh "$RELEASE_PR"
+              TARGET_COMMIT=$(gh pr view "$RELEASE_PR" --json state,mergeCommit \
+                --jq 'if .state == "MERGED" then .mergeCommit.oid else empty end')
+              [ -n "$TARGET_COMMIT" ] || {
+                echo "::error::Release PR did not produce a merge commit"
+                exit 1
+              }
+              publish_tag "$TARGET_COMMIT"
+              ;;
+            CLOSED)
+              echo "::error::Release PR #${RELEASE_PR} closed without merging; refusing to supersede it"
+              exit 1
+              ;;
+            *)
+              echo "::error::Unexpected release PR state: ${RELEASE_STATE}"
+              exit 1
+              ;;
+            esac
           else
-            # No stale PR, but the branch may still linger (e.g. the push
-            # succeeded but PR creation or auto-merge failed later).
-            git push origin ":$BRANCH" 2>/dev/null || true
-          fi
+            # Create a new release PR only when this version has no prior PR.
+            git checkout -b "$BRANCH"
+            git add -f CHANGELOG.md .github_release docs/specifications/api/ docs/api-reference/
+            if git diff --staged --quiet; then
+              echo "::error::Release detector requested v${VERSION}, but no generated output is staged"
+              exit 1
+            fi
 
-          # Create release branch from current state
-          git checkout -b "$BRANCH"
-
-          # Stage enriched outputs
-          # Use -f to add docs/specifications/api/ and docs/api-reference/ which are in .gitignore
-          git add -f CHANGELOG.md .github_release docs/specifications/api/ docs/api-reference/
-
-          if ! git diff --staged --quiet; then
-            # No [skip ci]: Super-Linter is a required check on main and
-            # is only triggered by pull_request events that do NOT carry a
-            # [skip ci] marker. The push trigger's paths: filter above
-            # (scripts/**, config/**, requirements.txt, this workflow file,
-            # docs/**/*.html) already excludes every path the release
-            # commit touches — CHANGELOG.md, .github_release, the
-            # docs/specifications/api/** and docs/api-reference/** trees —
-            # so the merge commit will NOT re-trigger this workflow.
             git commit -m "chore: release v${VERSION} (${BUMP_TYPE})"
-
-            # Push release branch
             git push origin "$BRANCH"
-
-            # Create PR (release/* branches are excluded from linked-issue check)
             PR_URL=$(gh pr create \
               --base main \
               --head "$BRANCH" \
               --title "chore: release v${VERSION} (${BUMP_TYPE})" \
               --body "Automated release v${VERSION} (${BUMP_TYPE}). Created by the sync-and-enrich workflow.")
-
+            RELEASE_PR=$(gh pr view "$BRANCH" --json number --jq '.number')
 
             # `release/**` is exempt from the linked-issue policy, but its
-            # normal status publisher is a best-effort scheduled workflow.
-            # The required `Check linked issues` context must therefore be
-            # posted synchronously for this exact release PR before auto-merge
-            # can evaluate it. Use GITHUB_TOKEN (not VERSION_BUMP_PAT) so the
-            # status has the GitHub Actions app identity pinned by protection.
-            PR_HEAD_SHA=$(gh pr view "$BRANCH" --json headRefOid --jq '.headRefOid')
+            # required context must be posted synchronously before auto-merge.
+            PR_HEAD_SHA=$(gh pr view "$RELEASE_PR" --json headRefOid --jq '.headRefOid')
             GH_TOKEN="$RELEASE_STATUS_TOKEN" gh api \
               --method POST \
               "repos/${GITHUB_REPOSITORY}/statuses/${PR_HEAD_SHA}" \
@@ -641,39 +651,15 @@ jobs:
               -f description='Automated release branch is exempt'
             echo "Created release PR: ${PR_URL}"
 
-            # Enable auto-merge (squash) — merges when required checks pass
-            gh pr merge "$BRANCH" --squash --auto --delete-branch
-
-            # Wait for PR to merge with exponential backoff (60 s warm-up + up
-            # to 30 min total). The 30-min ceiling accommodates the enforcing
-            # Contract-diff gate which runs the full enrichment pipeline
-            # (~21 min) as the long-pole check. Replaces a prior hardcoded
-            # 30×10 s loop that timed out whenever Super-Linter ran longer
-            # than 5 min, leaving the release PR orphaned. Exits non-zero on
-            # CLOSED-without-merge or on timeout; emits diagnostic JSON to
-            # stderr on failure.
-            WAIT_FOR_MERGE_MAX_TOTAL=1800 bash scripts/release/wait-for-merge.sh "$BRANCH"
-
-            # Switch back to main and pull the merge commit
-            git checkout main
-            git pull origin main
-
-            # Create annotated tag on the merge commit
-            git tag -a "v${VERSION}" -m "Release v${VERSION} (${BUMP_TYPE})"
-            git push origin "v${VERSION}"
-
-            # The publication receipt in the release body must name the commit the
-            # tag resolves to. Capture it here, on the merge commit we just tagged,
-            # rather than re-deriving it in a later step where main may already have
-            # moved on — a receipt naming the wrong commit is rejected downstream
-            # after the release is immutable and can no longer be corrected.
-            TARGET_COMMIT=$(git rev-parse HEAD)
-            echo "release_commit=${TARGET_COMMIT}" >> "$GITHUB_ENV"
-            echo "target_commit=${TARGET_COMMIT}" >> "$GITHUB_OUTPUT"
-
-            echo "::notice::Released v${VERSION} via PR merge + tag"
-          else
-            echo "No changes to commit"
+            gh pr merge "$RELEASE_PR" --squash --auto --delete-branch
+            WAIT_FOR_MERGE_MAX_TOTAL=1800 bash scripts/release/wait-for-merge.sh "$RELEASE_PR"
+            TARGET_COMMIT=$(gh pr view "$RELEASE_PR" --json state,mergeCommit \
+              --jq 'if .state == "MERGED" then .mergeCommit.oid else empty end')
+            [ -n "$TARGET_COMMIT" ] || {
+              echo "::error::Release PR did not produce a merge commit"
+              exit 1
+            }
+            publish_tag "$TARGET_COMMIT"
           fi
 
       - name: Create release package

--- a/.github/workflows/sync-and-enrich.yml
+++ b/.github/workflows/sync-and-enrich.yml
@@ -604,7 +604,11 @@ jobs:
               if [ "$AUTO_MERGE" != true ]; then
                 gh pr merge "$RELEASE_PR" --squash --auto --delete-branch
               fi
-              WAIT_FOR_MERGE_MAX_TOTAL=1800 bash scripts/release/wait-for-merge.sh "$RELEASE_PR"
+              # Shared self-hosted capacity can defer the release PR's checks
+              # beyond the normal 30-minute contract-diff window. Keep this
+              # bounded below the job limit, but long enough for a queued PR
+              # to drain without manufacturing a second release identity.
+              WAIT_FOR_MERGE_MAX_TOTAL=7200 bash scripts/release/wait-for-merge.sh "$RELEASE_PR"
               TARGET_COMMIT=$(gh pr view "$RELEASE_PR" --json state,mergeCommit \
                 --jq 'if .state == "MERGED" then .mergeCommit.oid else empty end')
               [ -n "$TARGET_COMMIT" ] || {
@@ -652,7 +656,9 @@ jobs:
             echo "Created release PR: ${PR_URL}"
 
             gh pr merge "$RELEASE_PR" --squash --auto --delete-branch
-            WAIT_FOR_MERGE_MAX_TOTAL=1800 bash scripts/release/wait-for-merge.sh "$RELEASE_PR"
+            # See the existing-PR path above: release PR checks share the
+            # organization runner pool and can be queued behind normal work.
+            WAIT_FOR_MERGE_MAX_TOTAL=7200 bash scripts/release/wait-for-merge.sh "$RELEASE_PR"
             TARGET_COMMIT=$(gh pr view "$RELEASE_PR" --json state,mergeCommit \
               --jq 'if .state == "MERGED" then .mergeCommit.oid else empty end')
             [ -n "$TARGET_COMMIT" ] || {

--- a/scripts/download.py
+++ b/scripts/download.py
@@ -70,6 +70,7 @@ def verify_release_asset_digest(archive: Path, asset: dict) -> str:
         raise ValueError("downloaded release asset digest does not match GitHub metadata")
     return actual
 
+
 # Default configuration (fallback if config file not found)
 DEFAULT_CONFIG = {
     "source": {

--- a/scripts/download.py
+++ b/scripts/download.py
@@ -30,6 +30,7 @@ Environment:
 
 import argparse
 import fnmatch
+import hashlib
 import json
 import os
 import sys
@@ -52,6 +53,22 @@ from scripts.utils.github_release import (
 from scripts.utils.version_calculator import get_version_from_tags
 
 console = Console()
+
+
+def verify_release_asset_digest(archive: Path, asset: dict) -> str:
+    """Return the archive SHA-256 after matching GitHub's immutable digest."""
+    expected = asset.get("digest")
+    if not isinstance(expected, str) or not expected.startswith("sha256:"):
+        raise ValueError("release asset is missing a SHA-256 digest")
+
+    hasher = hashlib.sha256()
+    with archive.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            hasher.update(chunk)
+    actual = hasher.hexdigest()
+    if expected.removeprefix("sha256:") != actual:
+        raise ValueError("downloaded release asset digest does not match GitHub metadata")
+    return actual
 
 # Default configuration (fallback if config file not found)
 DEFAULT_CONFIG = {
@@ -374,6 +391,13 @@ def download_from_github_release(config: dict, force: bool = False) -> tuple[boo
     if not success:
         return False, None
 
+    try:
+        asset_sha256 = verify_release_asset_digest(temp_zip, asset)
+    except ValueError as error:
+        console.print(f"[red]❌ {error}[/red]")
+        temp_zip.unlink(missing_ok=True)
+        return False, None
+
     # Extract
     output_dir = Path(paths_config["original"])
     try:
@@ -388,6 +412,7 @@ def download_from_github_release(config: dict, force: bool = False) -> tuple[boo
             release_data,
             asset["name"],
             asset["size"],
+            asset_sha256,
             version_file,
         )
 

--- a/scripts/download.py
+++ b/scripts/download.py
@@ -33,6 +33,7 @@ import fnmatch
 import hashlib
 import json
 import os
+import re
 import sys
 import tempfile
 import zipfile
@@ -56,17 +57,19 @@ console = Console()
 
 
 def verify_release_asset_digest(archive: Path, asset: dict) -> str:
-    """Return the archive SHA-256 after matching GitHub's immutable digest."""
+    """Return the archive SHA-256, checking GitHub metadata when available."""
     expected = asset.get("digest")
-    if not isinstance(expected, str) or not expected.startswith("sha256:"):
-        raise ValueError("release asset is missing a SHA-256 digest")
 
     hasher = hashlib.sha256()
     with archive.open("rb") as source:
         for chunk in iter(lambda: source.read(1024 * 1024), b""):
             hasher.update(chunk)
     actual = hasher.hexdigest()
-    if expected.removeprefix("sha256:") != actual:
+    if expected is None:
+        return actual
+    if not isinstance(expected, str) or not re.fullmatch(r"sha256:[0-9a-fA-F]{64}", expected):
+        raise ValueError("release asset has a malformed SHA-256 digest")
+    if expected.removeprefix("sha256:").lower() != actual:
         raise ValueError("downloaded release asset digest does not match GitHub metadata")
     return actual
 

--- a/scripts/hooks/pre-commit-pipeline.sh
+++ b/scripts/hooks/pre-commit-pipeline.sh
@@ -68,6 +68,7 @@ if [ -d "$OUTPUT_DIR" ]; then
   OUTPUT_EXISTED=true
 fi
 
+# shellcheck disable=SC2317,SC2329 # Invoked by the EXIT/INT/TERM traps below.
 restore_generated_output() {
   local status=$?
   trap - EXIT INT TERM

--- a/scripts/hooks/pre-commit-pipeline.sh
+++ b/scripts/hooks/pre-commit-pipeline.sh
@@ -62,10 +62,16 @@ fi
 OUTPUT_DIR="docs/specifications/api"
 BACKUP_DIR=$(mktemp -d)
 OUTPUT_EXISTED=false
+INDEX_EXISTED=false
 PIPELINE_COMPLETED=false
 if [ -d "$OUTPUT_DIR" ]; then
   cp -a "$OUTPUT_DIR" "$BACKUP_DIR/api"
   OUTPUT_EXISTED=true
+fi
+INDEX_PATH=$(git rev-parse --git-path index)
+if [ -f "$INDEX_PATH" ]; then
+  cp "$INDEX_PATH" "$BACKUP_DIR/index"
+  INDEX_EXISTED=true
 fi
 
 # shellcheck disable=SC2317,SC2329 # Invoked by the EXIT/INT/TERM traps below.
@@ -78,6 +84,11 @@ restore_generated_output() {
     if [ "$OUTPUT_EXISTED" = true ]; then
       mkdir -p "$(dirname "$OUTPUT_DIR")"
       cp -a "$BACKUP_DIR/api" "$OUTPUT_DIR"
+    fi
+    if [ "$INDEX_EXISTED" = true ]; then
+      cp "$BACKUP_DIR/index" "$INDEX_PATH"
+    else
+      rm -f "$INDEX_PATH"
     fi
   fi
   rm -rf "$BACKUP_DIR"
@@ -157,12 +168,17 @@ if ! verify_release_stamps; then
   exit 1
 fi
 
-# Stage only validated enriched specs. This is deliberately after linting and
-# release-stamp verification, so a failed hook never mutates the index.
-ENRICHED_CHANGES=$(git diff --name-only -- "$OUTPUT_DIR"/*.json 2>/dev/null | wc -l | tr -d ' ')
-if [ "$ENRICHED_CHANGES" -gt 0 ]; then
-  echo -e "${YELLOW}Staging $ENRICHED_CHANGES updated enriched spec files...${NC}"
-  git add --ignore-errors "$OUTPUT_DIR"/*.json
+# Stage only validated enriched specs. The generated directory is ignored, so
+# `git diff` cannot discover fresh output. Force-add every validated JSON file
+# after all checks pass; unchanged tracked files leave the index untouched.
+# The saved index above makes any later failure transactional as well.
+ENRICHED_SPECS=()
+if [ -d "$OUTPUT_DIR" ]; then
+  mapfile -d '' -t ENRICHED_SPECS < <(find "$OUTPUT_DIR" -maxdepth 1 -type f -name '*.json' -print0)
+fi
+if [ "${#ENRICHED_SPECS[@]}" -gt 0 ]; then
+  echo -e "${YELLOW}Staging ${#ENRICHED_SPECS[@]} validated enriched spec files...${NC}"
+  git add -f --ignore-errors -- "${ENRICHED_SPECS[@]}"
   echo -e "${GREEN}Enriched specs updated and staged.${NC}"
 else
   echo -e "${GREEN}No enriched spec changes detected.${NC}"

--- a/scripts/hooks/pre-commit-pipeline.sh
+++ b/scripts/hooks/pre-commit-pipeline.sh
@@ -97,7 +97,6 @@ if ! $PYTHON -m scripts.pipeline; then
   exit 1
 fi
 
-
 # =============================================================================
 # STEP 2: Run Spectral Linting on ALL generated specs (same as GitHub Actions)
 # =============================================================================

--- a/scripts/hooks/pre-commit-pipeline.sh
+++ b/scripts/hooks/pre-commit-pipeline.sh
@@ -20,7 +20,7 @@
 # This ensures idempotent, deterministic output between local and CI/CD.
 # Linting is NEVER skipped - Spectral must be installed.
 
-set -e
+set -euo pipefail
 
 # Colors for output
 RED='\033[0;31m'
@@ -56,6 +56,36 @@ if [ "${FORCE_PIPELINE:-0}" != "1" ]; then
 fi
 
 # =============================================================================
+# Keep generated output transactional: a failing, interrupted, or rejected
+# pipeline must leave the working tree and index exactly as it was before this
+# hook began. Staging is deliberately deferred until all validation succeeds.
+OUTPUT_DIR="docs/specifications/api"
+BACKUP_DIR=$(mktemp -d)
+OUTPUT_EXISTED=false
+PIPELINE_COMPLETED=false
+if [ -d "$OUTPUT_DIR" ]; then
+  cp -a "$OUTPUT_DIR" "$BACKUP_DIR/api"
+  OUTPUT_EXISTED=true
+fi
+
+restore_generated_output() {
+  local status=$?
+  trap - EXIT INT TERM
+  if [ "$PIPELINE_COMPLETED" != true ]; then
+    echo -e "${YELLOW}Restoring generated specs after unsuccessful pre-commit pipeline.${NC}"
+    rm -rf "$OUTPUT_DIR"
+    if [ "$OUTPUT_EXISTED" = true ]; then
+      mkdir -p "$(dirname "$OUTPUT_DIR")"
+      cp -a "$BACKUP_DIR/api" "$OUTPUT_DIR"
+    fi
+  fi
+  rm -rf "$BACKUP_DIR"
+  exit "$status"
+}
+trap restore_generated_output EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
 # STEP 1: Run Enrichment Pipeline
 # =============================================================================
 echo -e "${YELLOW}[1/2] Running F5 XC API enrichment pipeline...${NC}"
@@ -66,18 +96,6 @@ if ! $PYTHON -m scripts.pipeline; then
   exit 1
 fi
 
-# Stage any changes to enriched specs (output is directly in docs/)
-# Note: openapi.json is in .gitignore (too large for GitHub), so we only stage domain specs
-ENRICHED_CHANGES=$(git diff --name-only -- 'docs/specifications/api/*.json' 2>/dev/null | wc -l | tr -d ' ')
-
-if [ "$ENRICHED_CHANGES" -gt 0 ]; then
-  echo -e "${YELLOW}Staging $ENRICHED_CHANGES updated enriched spec files...${NC}"
-  # Use --ignore-errors to skip ignored files like openapi.json
-  git add --ignore-errors docs/specifications/api/*.json 2>/dev/null || true
-  echo -e "${GREEN}Enriched specs updated and staged.${NC}"
-else
-  echo -e "${GREEN}No enriched spec changes detected.${NC}"
-fi
 
 # =============================================================================
 # STEP 2: Run Spectral Linting on ALL generated specs (same as GitHub Actions)
@@ -105,5 +123,51 @@ else
   exit $LINT_EXIT_CODE
 fi
 
+verify_release_stamps() {
+  local branch expected_version spec actual_version
+  branch=$(git branch --show-current)
+  case "$branch" in
+  release/v*) expected_version=${branch#release/v} ;;
+  *) return 0 ;;
+  esac
+
+  if ! command -v jq >/dev/null 2>&1; then
+    echo -e "${RED}ERROR: jq is required to verify release-stamped artifacts.${NC}"
+    return 1
+  fi
+
+  for spec in "$OUTPUT_DIR"/*.json; do
+    [ -e "$spec" ] || continue
+    actual_version=$(jq -r '
+      if type != "object" or has("$schema") then empty
+      elif ((has("openapi") or has("swagger")) and (.info | type == "object")) then .info.version // empty
+      elif has("version") then .version // empty
+      else empty
+      end
+    ' "$spec")
+    if [ -n "$actual_version" ] && [ "$actual_version" != "$expected_version" ]; then
+      echo -e "${RED}ERROR: $(basename "$spec") version ${actual_version} does not match release branch ${expected_version}.${NC}"
+      return 1
+    fi
+  done
+}
+
+if ! verify_release_stamps; then
+  echo -e "${RED}Refusing to stage generated specs with a release-version mismatch.${NC}"
+  exit 1
+fi
+
+# Stage only validated enriched specs. This is deliberately after linting and
+# release-stamp verification, so a failed hook never mutates the index.
+ENRICHED_CHANGES=$(git diff --name-only -- "$OUTPUT_DIR"/*.json 2>/dev/null | wc -l | tr -d ' ')
+if [ "$ENRICHED_CHANGES" -gt 0 ]; then
+  echo -e "${YELLOW}Staging $ENRICHED_CHANGES updated enriched spec files...${NC}"
+  git add --ignore-errors "$OUTPUT_DIR"/*.json
+  echo -e "${GREEN}Enriched specs updated and staged.${NC}"
+else
+  echo -e "${GREEN}No enriched spec changes detected.${NC}"
+fi
+
+PIPELINE_COMPLETED=true
 echo -e "${GREEN}Pre-commit pipeline complete.${NC}"
 exit 0

--- a/scripts/utils/github_release.py
+++ b/scripts/utils/github_release.py
@@ -176,6 +176,7 @@ def save_release_metadata(
     release_data: dict[str, Any],
     asset_name: str,
     asset_size: int,
+    asset_sha256: str,
     version_file: Path,
 ) -> None:
     """Save release metadata to local tracking file.
@@ -187,6 +188,7 @@ def save_release_metadata(
         release_data: GitHub release metadata from get_latest_release().
         asset_name: Name of downloaded asset file.
         asset_size: Size of downloaded asset in bytes.
+        asset_sha256: SHA-256 of the downloaded asset bytes.
         version_file: Path to .github_release tracking file.
     """
     version_file.parent.mkdir(parents=True, exist_ok=True)
@@ -203,6 +205,7 @@ def save_release_metadata(
         "published_at": release_data["published_at"],
         "asset_name": asset_name,
         "asset_size": asset_size,
+        "asset_sha256": asset_sha256,
     }
 
     with version_file.open("w") as f:

--- a/tests/shell/test_pre_commit_pipeline.py
+++ b/tests/shell/test_pre_commit_pipeline.py
@@ -37,6 +37,7 @@ def _setup_repo(tmp_path: Path, hook_copy: Path) -> Path:
     (tmp_path / "specs" / "original").mkdir(parents=True)
     (tmp_path / ".github" / "workflows").mkdir(parents=True)
     (tmp_path / "README.md").write_text("readme\n")
+    (tmp_path / ".gitignore").write_text("docs/specifications/api/\n")
     (tmp_path / "requirements.txt").write_text("pytest\n")
     (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\n")
     generated = tmp_path / "docs" / "specifications" / "api"
@@ -195,6 +196,7 @@ exit 0
         ).read_text() == '{"version":"2.1.208"}\n'
         assert _git_diff_is_empty(repo, "docs/specifications/api")
         assert _git_diff_is_empty(repo, "--cached", "docs/specifications/api")
+        assert not _is_indexed(repo, "docs/specifications/api/index.json")
 
     def test_lint_failure_restores_generated_output_before_staging(self, tmp_path: Path) -> None:
         repo = _setup_repo(tmp_path, _project_hook())
@@ -220,6 +222,7 @@ exit 0
         ).read_text() == '{"version":"2.1.208"}\n'
         assert _git_diff_is_empty(repo, "docs/specifications/api")
         assert _git_diff_is_empty(repo, "--cached", "docs/specifications/api")
+        assert not _is_indexed(repo, "docs/specifications/api/index.json")
 
     def test_release_branch_rejects_and_restores_version_downgrade(self, tmp_path: Path) -> None:
         repo = _setup_repo(tmp_path, _project_hook())
@@ -243,6 +246,49 @@ exit 0
             repo / "docs/specifications/api/index.json"
         ).read_text() == '{"version":"2.1.208"}\n'
         assert _git_diff_is_empty(repo, "--cached", "docs/specifications/api")
+        assert not _is_indexed(repo, "docs/specifications/api/index.json")
+
+    def test_success_force_stages_ignored_generated_output(self, tmp_path: Path) -> None:
+        repo = _setup_repo(tmp_path, _project_hook())
+        self._stage_pipeline_input(repo)
+
+        result = _invoke(
+            repo,
+            python_script="""#!/usr/bin/env bash
+if [ "$1" = "-m" ]; then
+  printf '{"version":"2.1.207"}\n' > docs/specifications/api/index.json
+fi
+exit 0
+""",
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert _is_indexed(repo, "docs/specifications/api/index.json")
+        assert (
+            _run_output(["git", "show", ":docs/specifications/api/index.json"], repo)
+            == '{"version":"2.1.207"}\n'
+        )
+
+    def test_interrupt_restores_ignored_generated_output_and_index(self, tmp_path: Path) -> None:
+        repo = _setup_repo(tmp_path, _project_hook())
+        self._stage_pipeline_input(repo)
+
+        result = _invoke(
+            repo,
+            python_script="""#!/usr/bin/env bash
+if [ "$1" = "-m" ]; then
+  printf '{"version":"2.1.207"}\n' > docs/specifications/api/index.json
+  kill -TERM "$PPID"
+fi
+exit 0
+""",
+        )
+
+        assert result.returncode == 143
+        assert (
+            repo / "docs/specifications/api/index.json"
+        ).read_text() == '{"version":"2.1.208"}\n'
+        assert not _is_indexed(repo, "docs/specifications/api/index.json")
 
 
 def _git_diff_is_empty(repo: Path, *args: str) -> bool:
@@ -256,6 +302,33 @@ def _git_diff_is_empty(repo: Path, *args: str) -> bool:
         check=True,
     )
     return result.stdout == ""
+
+
+def _is_indexed(repo: Path, path: str) -> bool:
+    """Return whether ``path`` has an entry in the git index."""
+
+    return (
+        subprocess.run(
+            ["git", "ls-files", "--error-unmatch", path],
+            cwd=repo,
+            capture_output=True,
+            text=True,
+            check=False,
+        ).returncode
+        == 0
+    )
+
+
+def _run_output(cmd: list[str], cwd: Path) -> str:
+    """Run a command and return its standard output."""
+
+    return subprocess.run(
+        cmd,
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
 
 
 def _project_hook() -> Path:

--- a/tests/shell/test_pre_commit_pipeline.py
+++ b/tests/shell/test_pre_commit_pipeline.py
@@ -190,7 +190,9 @@ exit 0
         )
 
         assert result.returncode == 1
-        assert (repo / "docs/specifications/api/index.json").read_text() == '{"version":"2.1.208"}\n'
+        assert (
+            repo / "docs/specifications/api/index.json"
+        ).read_text() == '{"version":"2.1.208"}\n'
         assert _git_diff_is_empty(repo, "docs/specifications/api")
         assert _git_diff_is_empty(repo, "--cached", "docs/specifications/api")
 
@@ -213,7 +215,9 @@ exit 0
         )
 
         assert result.returncode == 1
-        assert (repo / "docs/specifications/api/index.json").read_text() == '{"version":"2.1.208"}\n'
+        assert (
+            repo / "docs/specifications/api/index.json"
+        ).read_text() == '{"version":"2.1.208"}\n'
         assert _git_diff_is_empty(repo, "docs/specifications/api")
         assert _git_diff_is_empty(repo, "--cached", "docs/specifications/api")
 
@@ -235,7 +239,9 @@ exit 0
 
         assert result.returncode == 1
         assert "does not match release branch" in result.stdout
-        assert (repo / "docs/specifications/api/index.json").read_text() == '{"version":"2.1.208"}\n'
+        assert (
+            repo / "docs/specifications/api/index.json"
+        ).read_text() == '{"version":"2.1.208"}\n'
         assert _git_diff_is_empty(repo, "--cached", "docs/specifications/api")
 
 
@@ -250,6 +256,8 @@ def _git_diff_is_empty(repo: Path, *args: str) -> bool:
         check=True,
     )
     return result.stdout == ""
+
+
 def _project_hook() -> Path:
     """Path to the repo's own copy of the hook."""
     return _PROJECT_HOOK

--- a/tests/shell/test_pre_commit_pipeline.py
+++ b/tests/shell/test_pre_commit_pipeline.py
@@ -39,6 +39,9 @@ def _setup_repo(tmp_path: Path, hook_copy: Path) -> Path:
     (tmp_path / "README.md").write_text("readme\n")
     (tmp_path / "requirements.txt").write_text("pytest\n")
     (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\n")
+    generated = tmp_path / "docs" / "specifications" / "api"
+    generated.mkdir(parents=True)
+    (generated / "index.json").write_text('{"version":"2.1.208"}\n')
 
     hook_target = tmp_path / _HOOK_RELATIVE
     hook_target.parent.mkdir(parents=True, exist_ok=True)
@@ -50,7 +53,13 @@ def _setup_repo(tmp_path: Path, hook_copy: Path) -> Path:
     return tmp_path
 
 
-def _invoke(cwd: Path, *, force: bool = False) -> subprocess.CompletedProcess[str]:
+def _invoke(
+    cwd: Path,
+    *,
+    force: bool = False,
+    python_script: str = '#!/usr/bin/env bash\necho "[fake python] args: $*" >&2\nexit 0\n',
+    spectral_script: str = "#!/usr/bin/env bash\nexit 0\n",
+) -> subprocess.CompletedProcess[str]:
     env = {**os.environ}
     if force:
         env["FORCE_PIPELINE"] = "1"
@@ -61,12 +70,10 @@ def _invoke(cwd: Path, *, force: bool = False) -> subprocess.CompletedProcess[st
     fakebin = cwd / "_fakebin"
     fakebin.mkdir(exist_ok=True)
     python_stub = fakebin / "python3"
-    python_stub.write_text(
-        '#!/usr/bin/env bash\necho "[fake python] args: $*" >&2\nexit 0\n'.replace("'", '"')
-    )
+    python_stub.write_text(python_script)
     python_stub.chmod(python_stub.stat().st_mode | stat.S_IEXEC)
     spectral_stub = fakebin / "spectral"
-    spectral_stub.write_text("#!/usr/bin/env bash\nexit 0\n")
+    spectral_stub.write_text(spectral_script)
     spectral_stub.chmod(spectral_stub.stat().st_mode | stat.S_IEXEC)
 
     return subprocess.run(
@@ -159,6 +166,90 @@ class TestForceOverride:
         assert "skipping enrichment + lint" not in result.stdout
 
 
+class TestGeneratedOutputRecovery:
+    """Pipeline failures cannot leave generated specs modified or staged."""
+
+    @staticmethod
+    def _stage_pipeline_input(repo: Path) -> None:
+        (repo / "config" / "thing.yaml").write_text("key: value\n")
+        _run_cmd(["git", "add", "config/thing.yaml"], repo)
+
+    def test_pipeline_failure_restores_generated_output(self, tmp_path: Path) -> None:
+        repo = _setup_repo(tmp_path, _project_hook())
+        self._stage_pipeline_input(repo)
+
+        result = _invoke(
+            repo,
+            python_script="""#!/usr/bin/env bash
+if [ "$1" = "-m" ]; then
+  printf '{"version":"2.1.207"}\\n' > docs/specifications/api/index.json
+  exit 1
+fi
+exit 0
+""",
+        )
+
+        assert result.returncode == 1
+        assert (repo / "docs/specifications/api/index.json").read_text() == '{"version":"2.1.208"}\n'
+        assert _git_diff_is_empty(repo, "docs/specifications/api")
+        assert _git_diff_is_empty(repo, "--cached", "docs/specifications/api")
+
+    def test_lint_failure_restores_generated_output_before_staging(self, tmp_path: Path) -> None:
+        repo = _setup_repo(tmp_path, _project_hook())
+        self._stage_pipeline_input(repo)
+
+        result = _invoke(
+            repo,
+            python_script="""#!/usr/bin/env bash
+if [ "$1" = "-m" ]; then
+  printf '{"version":"2.1.207"}\\n' > docs/specifications/api/index.json
+  exit 0
+fi
+if [ "$1" = "scripts/lint.py" ]; then
+  exit 1
+fi
+exit 0
+""",
+        )
+
+        assert result.returncode == 1
+        assert (repo / "docs/specifications/api/index.json").read_text() == '{"version":"2.1.208"}\n'
+        assert _git_diff_is_empty(repo, "docs/specifications/api")
+        assert _git_diff_is_empty(repo, "--cached", "docs/specifications/api")
+
+    def test_release_branch_rejects_and_restores_version_downgrade(self, tmp_path: Path) -> None:
+        repo = _setup_repo(tmp_path, _project_hook())
+        _run_cmd(["git", "checkout", "-q", "-b", "release/v2.1.208"], repo)
+        self._stage_pipeline_input(repo)
+
+        result = _invoke(
+            repo,
+            python_script="""#!/usr/bin/env bash
+if [ "$1" = "-m" ]; then
+  printf '{"version":"2.1.207"}\\n' > docs/specifications/api/index.json
+  exit 0
+fi
+exit 0
+""",
+        )
+
+        assert result.returncode == 1
+        assert "does not match release branch" in result.stdout
+        assert (repo / "docs/specifications/api/index.json").read_text() == '{"version":"2.1.208"}\n'
+        assert _git_diff_is_empty(repo, "--cached", "docs/specifications/api")
+
+
+def _git_diff_is_empty(repo: Path, *args: str) -> bool:
+    """Return whether one git-diff invocation has no output."""
+
+    result = subprocess.run(
+        ["git", "diff", *args],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout == ""
 def _project_hook() -> Path:
     """Path to the repo's own copy of the hook."""
     return _PROJECT_HOOK

--- a/tests/test_all_endpoints_enrichment.py
+++ b/tests/test_all_endpoints_enrichment.py
@@ -496,8 +496,11 @@ class TestHTTPMethodEnrichment:
                     f"DELETE should have high danger level: {path}"
                 )
             elif method == "get":
-                assert metadata["danger_level"] == "low", (
-                    f"GET should have low danger level: {path}"
+                expected_danger = (
+                    "medium" if operation.get("x-f5xc-operation-role") == "issuance" else "low"
+                )
+                assert metadata["danger_level"] == expected_danger, (
+                    f"GET should have {expected_danger} danger level: {path}"
                 )
 
 

--- a/tests/test_github_release.py
+++ b/tests/test_github_release.py
@@ -140,12 +140,29 @@ class TestReleaseAssetDigest:
 
         assert digest == "040a1170825ade3ff37b189dd280153ecfafb99ee929d1cbebb40fe135afdf26"
 
-    def test_missing_or_mismatched_release_digest_is_rejected(self, tmp_path):
+    def test_missing_release_digest_is_tolerated_and_recorded(self, tmp_path):
         archive = tmp_path / "api-specs.zip"
         archive.write_bytes(b"verified archive")
 
-        with pytest.raises(ValueError, match="digest"):
-            verify_release_asset_digest(archive, {})
+        assert verify_release_asset_digest(archive, {}) == (
+            "040a1170825ade3ff37b189dd280153ecfafb99ee929d1cbebb40fe135afdf26"
+        )
+
+    @pytest.mark.parametrize(
+        "digest",
+        ["sha256:", "sha256:" + "z" * 64, "md5:" + "0" * 32, 42],
+    )
+    def test_malformed_release_digest_is_rejected(self, tmp_path, digest):
+        archive = tmp_path / "api-specs.zip"
+        archive.write_bytes(b"verified archive")
+
+        with pytest.raises(ValueError, match="malformed"):
+            verify_release_asset_digest(archive, {"digest": digest})
+
+    def test_mismatched_release_digest_is_rejected(self, tmp_path):
+        archive = tmp_path / "api-specs.zip"
+        archive.write_bytes(b"verified archive")
+
         with pytest.raises(ValueError, match="digest"):
             verify_release_asset_digest(archive, {"digest": "sha256:" + "0" * 64})
 

--- a/tests/test_github_release.py
+++ b/tests/test_github_release.py
@@ -10,6 +10,7 @@ from unittest.mock import Mock, patch
 import pytest
 import requests
 
+from scripts.download import verify_release_asset_digest
 from scripts.utils.github_release import (
     check_for_updates,
     download_release_asset,
@@ -93,6 +94,7 @@ class TestSaveReleaseMetadata:
             release_data,
             "api-specs-v2026.01.22-2.zip",
             5971024,
+            "a" * 64,
             version_file,
         )
 
@@ -104,6 +106,7 @@ class TestSaveReleaseMetadata:
         assert metadata["published_at"] == "2026-01-26T10:30:00Z"
         assert metadata["asset_name"] == "api-specs-v2026.01.22-2.zip"
         assert metadata["asset_size"] == 5971024
+        assert metadata["asset_sha256"] == "a" * 64
 
         # .github_release is tracked, so a per-run wall-clock stamp made every
         # download dirty the working tree with a change that says nothing about the
@@ -119,7 +122,32 @@ class TestSaveReleaseMetadata:
             "published_at",
             "asset_name",
             "asset_size",
+            "asset_sha256",
         }
+
+
+class TestReleaseAssetDigest:
+    """Downloaded archive bytes must match the immutable release digest."""
+
+    def test_matching_release_digest_is_recorded(self, tmp_path):
+        archive = tmp_path / "api-specs.zip"
+        archive.write_bytes(b"verified archive")
+
+        digest = verify_release_asset_digest(
+            archive,
+            {"digest": "sha256:040a1170825ade3ff37b189dd280153ecfafb99ee929d1cbebb40fe135afdf26"},
+        )
+
+        assert digest == "040a1170825ade3ff37b189dd280153ecfafb99ee929d1cbebb40fe135afdf26"
+
+    def test_missing_or_mismatched_release_digest_is_rejected(self, tmp_path):
+        archive = tmp_path / "api-specs.zip"
+        archive.write_bytes(b"verified archive")
+
+        with pytest.raises(ValueError, match="digest"):
+            verify_release_asset_digest(archive, {})
+        with pytest.raises(ValueError, match="digest"):
+            verify_release_asset_digest(archive, {"digest": "sha256:" + "0" * 64})
 
 
 class TestFindReleaseAsset:

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -50,16 +50,47 @@ def test_tag_commit_is_exposed_and_supplied_to_dispatch() -> None:
     )[0]
 
     push_tag = 'git push origin "v${VERSION}"'
-    resolve_commit = "TARGET_COMMIT=$(git rev-parse HEAD)"
+    tag_target = 'git tag -a "v${VERSION}" "$TARGET_COMMIT"'
+    checkout_target = 'git checkout --detach "$TARGET_COMMIT"'
     expose_step = 'echo "target_commit=${TARGET_COMMIT}" >> "$GITHUB_OUTPUT"'
     expose_job = "target_commit: ${{ steps.release.outputs.target_commit }}"
     supply_dispatch = "SOURCE_TARGET_COMMIT: ${{ needs.sync-and-enrich.outputs.target_commit }}"
 
     assert "id: release" in release_job
-    assert release_job.index(push_tag) < release_job.index(resolve_commit)
-    assert release_job.index(resolve_commit) < release_job.index(expose_step)
+    assert tag_target in release_job
+    assert release_job.index(tag_target) < release_job.index(push_tag)
+    assert release_job.index(push_tag) < release_job.index(checkout_target)
+    assert release_job.index(checkout_target) < release_job.index(expose_step)
     assert expose_job in release_job
     assert supply_dispatch in notify_job
     assert notify_job.index(supply_dispatch) < notify_job.index(
         "run: bash scripts/release/dispatch-downstream.sh"
     )
+
+
+def test_forced_events_always_download_fresh_upstream_specs() -> None:
+    """A release-producing run must never use a stale specs/original cache."""
+
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    sync_job = workflow.split("\n  sync-and-enrich:\n", maxsplit=1)[1].split(
+        "\n  deploy-docs:\n", maxsplit=1
+    )[0]
+
+    assert "Restore specs cache" not in sync_job
+    assert "Save specs cache" not in sync_job
+    assert "path: specs/original" not in sync_job
+    assert "run: python -m scripts.download --force" in sync_job
+
+
+def test_release_retry_reuses_existing_pr_and_publishes_its_merge() -> None:
+    """A timeout retry must preserve the release PR and tag its exact merge."""
+
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    release_job = workflow.split("\n  sync-and-enrich:\n", maxsplit=1)[1].split(
+        "\n  deploy-docs:\n", maxsplit=1
+    )[0]
+
+    assert "gh pr close" not in release_job
+    assert 'gh pr list --state all --head "$BRANCH"' in release_job
+    assert "MERGED)" in release_job
+    assert 'git checkout --detach "$TARGET_COMMIT"' in release_job

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -102,5 +102,5 @@ def test_release_pr_wait_tolerates_shared_runner_queueing() -> None:
     workflow = WORKFLOW.read_text(encoding="utf-8")
 
     assert workflow.count(
-        'WAIT_FOR_MERGE_MAX_TOTAL=7200 bash scripts/release/wait-for-merge.sh'
+        "WAIT_FOR_MERGE_MAX_TOTAL=7200 bash scripts/release/wait-for-merge.sh"
     ) == 2

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -101,6 +101,6 @@ def test_release_pr_wait_tolerates_shared_runner_queueing() -> None:
 
     workflow = WORKFLOW.read_text(encoding="utf-8")
 
-    assert workflow.count(
-        "WAIT_FOR_MERGE_MAX_TOTAL=7200 bash scripts/release/wait-for-merge.sh"
-    ) == 2
+    assert (
+        workflow.count("WAIT_FOR_MERGE_MAX_TOTAL=7200 bash scripts/release/wait-for-merge.sh") == 2
+    )

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -94,3 +94,13 @@ def test_release_retry_reuses_existing_pr_and_publishes_its_merge() -> None:
     assert 'gh pr list --state all --head "$BRANCH"' in release_job
     assert "MERGED)" in release_job
     assert 'git checkout --detach "$TARGET_COMMIT"' in release_job
+
+
+def test_release_pr_wait_tolerates_shared_runner_queueing() -> None:
+    """A queued release PR must not time out at the old 30-minute ceiling."""
+
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    assert workflow.count(
+        'WAIT_FOR_MERGE_MAX_TOTAL=7200 bash scripts/release/wait-for-merge.sh'
+    ) == 2


### PR DESCRIPTION
## Summary

- make release retries preserve the original release PR and publish its immutable merge commit after queued checks complete
- remove the stale upstream-input cache path and verify GitHub release asset digests before extraction
- make the pre-commit regeneration hook transactional and reject release-stamp regressions before staging
- correct endpoint coverage so credential-issuance GETs retain their explicit medium danger classification

## Verification

- `uv run --extra dev python -m pytest -q` — 2447 passed, 6 skipped, 1 xfailed
- focused release, pre-commit, download, and endpoint tests — 127 passed
- `ruff format --check` and `ruff check` on changed Python files
- `bash -n` and `shellcheck` on the pre-commit hook
- `actionlint .github/workflows/sync-and-enrich.yml`
- direct AGY two-pass review: reviewer and verifier approved with zero findings

Closes #1218
Closes #1220
Closes #1087
Closes #1231
Closes #1530
