### PR TITLE
fix: map exclusive integer discovery bounds

### DIFF
--- a/config/constraint_patterns.yaml
+++ b/config/constraint_patterns.yaml
@@ -962,6 +962,16 @@ discovery_mapping:
       constraint_field: "maximum"
       description: "Maximum value for int64"
 
+    - ves_rule: "ves.io.schema.rules.int64.gt"
+      constraint_field: "minimum"
+      exclusive: true
+      description: "Minimum value for int64 (greater than)"
+
+    - ves_rule: "ves.io.schema.rules.int64.lt"
+      constraint_field: "maximum"
+      exclusive: true
+      description: "Maximum value for int64 (less than)"
+
     # Unsigned integer bounds. These carry the authoritative API contract
     # (source: api-probed) — the upstream x-ves-validation-rules are generated
     # straight from the F5 XC protobuf field validators.
@@ -975,6 +985,18 @@ discovery_mapping:
       source: "api-probed"
       description: "Maximum value for uint32 (less than or equal)"
 
+    - ves_rule: "ves.io.schema.rules.uint32.gt"
+      constraint_field: "minimum"
+      exclusive: true
+      source: "api-probed"
+      description: "Minimum value for uint32 (greater than)"
+
+    - ves_rule: "ves.io.schema.rules.uint32.lt"
+      constraint_field: "maximum"
+      exclusive: true
+      source: "api-probed"
+      description: "Maximum value for uint32 (less than)"
+
     - ves_rule: "ves.io.schema.rules.uint64.gte"
       constraint_field: "minimum"
       source: "api-probed"
@@ -984,6 +1006,18 @@ discovery_mapping:
       constraint_field: "maximum"
       source: "api-probed"
       description: "Maximum value for uint64 (less than or equal)"
+
+    - ves_rule: "ves.io.schema.rules.uint64.gt"
+      constraint_field: "minimum"
+      exclusive: true
+      source: "api-probed"
+      description: "Minimum value for uint64 (greater than)"
+
+    - ves_rule: "ves.io.schema.rules.uint64.lt"
+      constraint_field: "maximum"
+      exclusive: true
+      source: "api-probed"
+      description: "Maximum value for uint64 (less than)"
 
 # Reconciliation Rules
 # Priority: EXISTING > DISCOVERY > INFERRED

--- a/docs/specifications/api/api.json
+++ b/docs/specifications/api/api.json
@@ -33924,7 +33924,7 @@
             "x-f5xc-constraints": {
               "constraintType": "number",
               "category": "discovery",
-              "minimum": 0,
+              "minimum": 1,
               "maximum": 8192,
               "multipleOf": 1,
               "metadata": {

--- a/docs/specifications/api/cdn.json
+++ b/docs/specifications/api/cdn.json
@@ -15941,7 +15941,7 @@
             "x-f5xc-constraints": {
               "constraintType": "number",
               "category": "discovery",
-              "minimum": 0,
+              "minimum": 1,
               "maximum": 8192,
               "multipleOf": 1,
               "metadata": {
@@ -37550,6 +37550,7 @@
               "constraintType": "number",
               "category": "discovery",
               "maximum": 48,
+              "minimum": 1,
               "deterministic": true,
               "metadata": {
                 "source": "api-probed",
@@ -37625,6 +37626,7 @@
               "constraintType": "number",
               "category": "discovery",
               "maximum": 60,
+              "minimum": 1,
               "deterministic": true,
               "metadata": {
                 "source": "api-probed",
@@ -37700,6 +37702,7 @@
               "constraintType": "number",
               "category": "discovery",
               "maximum": 300,
+              "minimum": 1,
               "deterministic": true,
               "metadata": {
                 "source": "api-probed",
@@ -37935,6 +37938,7 @@
               "constraintType": "number",
               "category": "discovery",
               "maximum": 100,
+              "minimum": 1,
               "deterministic": true,
               "metadata": {
                 "source": "api-probed",
@@ -38059,6 +38063,7 @@
               "constraintType": "number",
               "category": "discovery",
               "maximum": 8192,
+              "minimum": 1,
               "deterministic": true,
               "metadata": {
                 "source": "api-probed",
@@ -72248,6 +72253,17 @@
               "ves.io.schema.rules.uint32.gt": "0"
             },
             "x-f5xc-description-short": "Specifies the base interval between retries in milliseconds.",
+            "x-f5xc-constraints": {
+              "constraintType": "number",
+              "category": "discovery",
+              "minimum": 1,
+              "deterministic": true,
+              "metadata": {
+                "source": "api-probed",
+                "confidence": 0.99,
+                "validatedAt": "2026-08-18T01:54:51+00:00"
+              }
+            },
             "x-f5xc-required-for": {
               "minimum_config": false,
               "create": false,

--- a/docs/specifications/api/container_services.json
+++ b/docs/specifications/api/container_services.json
@@ -14376,8 +14376,7 @@
               "constraintType": "number",
               "category": "discovery",
               "maximum": 5,
-              "minimum": 0,
-              "exclusiveMinimum": true,
+              "minimum": 1,
               "deterministic": true,
               "metadata": {
                 "source": "discovery",
@@ -19846,6 +19845,7 @@
               "constraintType": "number",
               "category": "discovery",
               "maximum": 65535,
+              "minimum": 1,
               "deterministic": true,
               "metadata": {
                 "source": "api-probed",
@@ -20536,8 +20536,7 @@
               "constraintType": "number",
               "category": "discovery",
               "maximum": 5,
-              "minimum": 0,
-              "exclusiveMinimum": true,
+              "minimum": 1,
               "deterministic": true,
               "metadata": {
                 "source": "discovery",

--- a/docs/specifications/api/network.json
+++ b/docs/specifications/api/network.json
@@ -60960,6 +60960,17 @@
               "ves.io.schema.rules.uint32.gt": "0"
             },
             "x-f5xc-description-short": "Specifies the base interval between retries in milliseconds.",
+            "x-f5xc-constraints": {
+              "constraintType": "number",
+              "category": "discovery",
+              "minimum": 1,
+              "deterministic": true,
+              "metadata": {
+                "source": "api-probed",
+                "confidence": 0.99,
+                "validatedAt": "2026-08-18T01:54:51+00:00"
+              }
+            },
             "x-f5xc-required-for": {
               "minimum_config": false,
               "create": false,

--- a/docs/specifications/api/rate_limiting.json
+++ b/docs/specifications/api/rate_limiting.json
@@ -10288,6 +10288,7 @@
               "constraintType": "number",
               "category": "discovery",
               "maximum": 48,
+              "minimum": 1,
               "deterministic": true,
               "metadata": {
                 "source": "api-probed",
@@ -10363,6 +10364,7 @@
               "constraintType": "number",
               "category": "discovery",
               "maximum": 60,
+              "minimum": 1,
               "deterministic": true,
               "metadata": {
                 "source": "api-probed",
@@ -10438,6 +10440,7 @@
               "constraintType": "number",
               "category": "discovery",
               "maximum": 300,
+              "minimum": 1,
               "deterministic": true,
               "metadata": {
                 "source": "api-probed",
@@ -11166,6 +11169,7 @@
               "constraintType": "number",
               "category": "discovery",
               "maximum": 100,
+              "minimum": 1,
               "deterministic": true,
               "metadata": {
                 "source": "api-probed",
@@ -11288,6 +11292,7 @@
               "constraintType": "number",
               "category": "discovery",
               "maximum": 8192,
+              "minimum": 1,
               "deterministic": true,
               "metadata": {
                 "source": "api-probed",

--- a/docs/specifications/api/service_mesh.json
+++ b/docs/specifications/api/service_mesh.json
@@ -10683,6 +10683,17 @@
               "ves.io.schema.rules.uint32.gt": "0"
             },
             "x-f5xc-description-short": "The number of failed logins beyond which the system will flag this user as malicious Required: YES.",
+            "x-f5xc-constraints": {
+              "constraintType": "number",
+              "category": "discovery",
+              "minimum": 1,
+              "deterministic": true,
+              "metadata": {
+                "source": "api-probed",
+                "confidence": 0.99,
+                "validatedAt": "2026-08-18T01:54:51+00:00"
+              }
+            },
             "x-f5xc-required-for": {
               "minimum_config": true,
               "create": true,
@@ -10747,6 +10758,17 @@
             },
             "x-f5xc-description-short": "The number of forbidden requests beyond which the system will flag this user as malicious Required: YES.",
             "x-f5xc-description-medium": "The number of forbidden requests beyond which the system will flag this user as malicious Required: YES.",
+            "x-f5xc-constraints": {
+              "constraintType": "number",
+              "category": "discovery",
+              "minimum": 1,
+              "deterministic": true,
+              "metadata": {
+                "source": "api-probed",
+                "confidence": 0.99,
+                "validatedAt": "2026-08-18T01:54:51+00:00"
+              }
+            },
             "x-f5xc-required-for": {
               "minimum_config": true,
               "create": true,
@@ -12074,6 +12096,7 @@
               "constraintType": "number",
               "category": "discovery",
               "maximum": 100,
+              "minimum": 1,
               "deterministic": true,
               "metadata": {
                 "source": "api-probed",

--- a/docs/specifications/api/shape.json
+++ b/docs/specifications/api/shape.json
@@ -140952,6 +140952,17 @@
               "ves.io.schema.rules.uint32.gt": "0"
             },
             "x-f5xc-example": "{\"key\": \"value\"}",
+            "x-f5xc-constraints": {
+              "constraintType": "number",
+              "category": "discovery",
+              "minimum": 1,
+              "deterministic": true,
+              "metadata": {
+                "source": "api-probed",
+                "confidence": 0.99,
+                "validatedAt": "2026-08-18T01:54:51+00:00"
+              }
+            },
             "x-f5xc-required-for": {
               "minimum_config": false,
               "create": false,
@@ -149692,6 +149703,7 @@
               "constraintType": "number",
               "category": "discovery",
               "maximum": 500,
+              "minimum": 1,
               "deterministic": true,
               "metadata": {
                 "source": "api-probed",
@@ -149760,6 +149772,17 @@
               "ves.io.schema.rules.message.required": "true",
               "ves.io.schema.rules.uint32.gt": "0"
             },
+            "x-f5xc-constraints": {
+              "constraintType": "number",
+              "category": "discovery",
+              "minimum": 1,
+              "deterministic": true,
+              "metadata": {
+                "source": "api-probed",
+                "confidence": 0.99,
+                "validatedAt": "2026-08-18T01:54:51+00:00"
+              }
+            },
             "x-f5xc-required-for": {
               "minimum_config": true,
               "create": true,
@@ -149788,6 +149811,7 @@
               "constraintType": "number",
               "category": "discovery",
               "maximum": 500,
+              "minimum": 1,
               "deterministic": true,
               "metadata": {
                 "source": "api-probed",

--- a/docs/specifications/api/sites.json
+++ b/docs/specifications/api/sites.json
@@ -46751,6 +46751,7 @@
               "constraintType": "number",
               "category": "discovery",
               "maximum": 65535,
+              "minimum": 1,
               "deterministic": true,
               "metadata": {
                 "source": "api-probed",
@@ -46821,6 +46822,7 @@
               "constraintType": "number",
               "category": "discovery",
               "maximum": 65535,
+              "minimum": 1,
               "deterministic": true,
               "metadata": {
                 "source": "api-probed",
@@ -48309,6 +48311,7 @@
               "constraintType": "number",
               "category": "discovery",
               "maximum": 65534,
+              "minimum": 64513,
               "deterministic": true,
               "metadata": {
                 "source": "api-probed",
@@ -48343,6 +48346,7 @@
               "constraintType": "number",
               "category": "discovery",
               "maximum": 65535,
+              "minimum": 1,
               "deterministic": true,
               "metadata": {
                 "source": "api-probed",
@@ -79150,6 +79154,7 @@
               "constraintType": "number",
               "category": "discovery",
               "maximum": 65535,
+              "minimum": 2,
               "deterministic": true,
               "metadata": {
                 "source": "api-probed",

--- a/docs/specifications/api/threat_campaign.json
+++ b/docs/specifications/api/threat_campaign.json
@@ -8850,7 +8850,7 @@
             "x-f5xc-constraints": {
               "constraintType": "number",
               "category": "discovery",
-              "minimum": 0,
+              "minimum": 1,
               "maximum": 8192,
               "multipleOf": 1,
               "metadata": {

--- a/docs/specifications/api/virtual.json
+++ b/docs/specifications/api/virtual.json
@@ -51443,7 +51443,7 @@
             "x-f5xc-constraints": {
               "constraintType": "number",
               "category": "discovery",
-              "minimum": 0,
+              "minimum": 1,
               "maximum": 8192,
               "multipleOf": 1,
               "metadata": {
@@ -86313,6 +86313,7 @@
               "constraintType": "number",
               "category": "discovery",
               "maximum": 48,
+              "minimum": 1,
               "deterministic": true,
               "metadata": {
                 "source": "api-probed",
@@ -86388,6 +86389,7 @@
               "constraintType": "number",
               "category": "discovery",
               "maximum": 60,
+              "minimum": 1,
               "deterministic": true,
               "metadata": {
                 "source": "api-probed",
@@ -86463,6 +86465,7 @@
               "constraintType": "number",
               "category": "discovery",
               "maximum": 300,
+              "minimum": 1,
               "deterministic": true,
               "metadata": {
                 "source": "api-probed",
@@ -86698,6 +86701,7 @@
               "constraintType": "number",
               "category": "discovery",
               "maximum": 100,
+              "minimum": 1,
               "deterministic": true,
               "metadata": {
                 "source": "api-probed",
@@ -86822,6 +86826,7 @@
               "constraintType": "number",
               "category": "discovery",
               "maximum": 8192,
+              "minimum": 1,
               "deterministic": true,
               "metadata": {
                 "source": "api-probed",
@@ -91874,6 +91879,17 @@
               "ves.io.schema.rules.uint32.gt": "0"
             },
             "x-f5xc-description-short": "Specifies the base interval between retries in milliseconds.",
+            "x-f5xc-constraints": {
+              "constraintType": "number",
+              "category": "discovery",
+              "minimum": 1,
+              "deterministic": true,
+              "metadata": {
+                "source": "api-probed",
+                "confidence": 0.99,
+                "validatedAt": "2026-08-18T01:54:51+00:00"
+              }
+            },
             "x-f5xc-required-for": {
               "minimum_config": false,
               "create": false,

--- a/scripts/utils/constraint_enricher.py
+++ b/scripts/utils/constraint_enricher.py
@@ -541,12 +541,16 @@ class ConstraintEnricher:
 
                     try:
                         value = int(rule_value)
-                        constraints[constraint_field] = value
-
-                        # Handle exclusive bounds
                         if rule_def.get("exclusive"):
-                            exclusive_field = f"exclusive{constraint_field.capitalize()}"
-                            constraints[exclusive_field] = True
+                            # The discovery rule families are integer-only. Convert
+                            # exclusive limits to their exact inclusive equivalent so
+                            # downstream consumers do not need a second bounds model.
+                            if constraint_field == "minimum":
+                                value += 1
+                            elif constraint_field == "maximum":
+                                value -= 1
+
+                        constraints[constraint_field] = value
 
                         if rule_def.get("source"):
                             source_override = rule_def["source"]
@@ -856,116 +860,6 @@ class ConstraintEnricher:
                 "validatedAt": artifact_timestamp(),
             },
         }
-
-    def _merge_discovery_constraints(
-        self,
-        schema: dict,
-        discovery_data: dict | None,
-    ) -> dict | None:
-        """Merge constraints from discovery data.
-
-        Args:
-            schema: Property schema
-            discovery_data: Discovery validation rules
-
-        Returns:
-            Merged constraints or None
-        """
-        if not discovery_data:
-            return None
-
-        # Extract x-ves-validation-rules
-        ves_rules = schema.get("x-ves-validation-rules", {})
-        if not ves_rules:
-            return None
-
-        self.stats["discovery_merges"] += 1
-
-        constraints = {}
-        field_type = schema.get("type")
-
-        # Map based on field type
-        if field_type == "string":
-            constraints = self._map_string_discovery_rules(ves_rules)
-        elif field_type == "array":
-            constraints = self._map_array_discovery_rules(ves_rules)
-        elif field_type in ("integer", "number"):
-            constraints = self._map_numeric_discovery_rules(ves_rules)
-
-        if constraints:
-            constraint_type = "number" if field_type in ("integer", "number") else field_type
-            return {
-                "constraintType": constraint_type,
-                "category": "discovery",
-                **constraints,
-                "metadata": {
-                    "source": "discovery",
-                    "confidence": 0.99,
-                    "validatedAt": artifact_timestamp(),
-                },
-                "deterministic": True,
-            }
-
-        return None
-
-    def _map_string_discovery_rules(self, ves_rules: dict) -> dict:
-        """Map x-ves-validation-rules to string constraints."""
-        mapping = self.config.get("discovery_mapping", {}).get("string_rules", [])
-        constraints = {}
-
-        for rule in mapping:
-            ves_rule = rule.get("ves_rule")
-            constraint_field = rule.get("constraint_field")
-            constraint_value = rule.get("constraint_value")
-
-            if ves_rule in ves_rules:
-                if constraint_value:
-                    constraints[constraint_field] = constraint_value
-                else:
-                    constraints[constraint_field] = ves_rules[ves_rule]
-
-        return constraints
-
-    def _map_array_discovery_rules(self, ves_rules: dict) -> dict:
-        """Map x-ves-validation-rules to array constraints."""
-        mapping = self.config.get("discovery_mapping", {}).get("array_rules", [])
-        constraints = {}
-
-        for rule in mapping:
-            ves_rule = rule.get("ves_rule")
-            constraint_field = rule.get("constraint_field")
-            constraint_value = rule.get("constraint_value")
-
-            if ves_rule in ves_rules:
-                if constraint_value is not None:
-                    constraints[constraint_field] = constraint_value
-                else:
-                    constraints[constraint_field] = ves_rules[ves_rule]
-
-        return constraints
-
-    def _map_numeric_discovery_rules(self, ves_rules: dict) -> dict:
-        """Map x-ves-validation-rules to numeric constraints."""
-        mapping = self.config.get("discovery_mapping", {}).get("number_rules", [])
-        constraints = {}
-
-        for rule in mapping:
-            ves_rule = rule.get("ves_rule")
-            constraint_field = rule.get("constraint_field")
-            exclusive = rule.get("exclusive", False)
-
-            if ves_rule in ves_rules:
-                value = ves_rules[ves_rule]
-                if exclusive:
-                    # Adjust for exclusive bounds
-                    if "minimum" in constraint_field:
-                        constraints["minimum"] = value + 1
-                    elif "maximum" in constraint_field:
-                        constraints["maximum"] = value - 1
-                else:
-                    constraints[constraint_field] = value
-
-        return constraints
 
     def get_stats(self) -> dict[str, Any]:
         """Get enrichment statistics.

--- a/tests/test_constraint_enricher.py
+++ b/tests/test_constraint_enricher.py
@@ -548,6 +548,57 @@ class TestConstraintEnricher:
         assert c["metadata"]["source"] == "discovery"
         assert c["metadata"]["source"] != "api-probed"
 
+    @pytest.mark.parametrize(
+        ("rule_family", "rule_suffix", "raw_value", "constraint_field", "expected"),
+        [
+            ("int32", "gt", "0", "minimum", 1),
+            ("int32", "lt", "10", "maximum", 9),
+            ("int64", "gt", "-2", "minimum", -1),
+            ("int64", "lt", "10", "maximum", 9),
+            ("uint32", "gt", "0", "minimum", 1),
+            ("uint32", "lt", "10", "maximum", 9),
+            ("uint64", "gt", "0", "minimum", 1),
+            ("uint64", "lt", "10", "maximum", 9),
+        ],
+    )
+    def test_enrich_exclusive_integer_bounds(
+        self,
+        enricher,
+        rule_family,
+        rule_suffix,
+        raw_value,
+        constraint_field,
+        expected,
+    ):
+        """Exclusive integer rules map to exact inclusive minimum/maximum values."""
+        rule = f"ves.io.schema.rules.{rule_family}.{rule_suffix}"
+        spec = {
+            "components": {
+                "schemas": {
+                    "IfSpec": {
+                        "type": "object",
+                        "properties": {
+                            "priority": {
+                                "type": "integer",
+                                "x-ves-validation-rules": {rule: raw_value},
+                            },
+                        },
+                    },
+                },
+            },
+        }
+
+        enriched = enricher.enrich_spec(spec)
+        constraints = enriched["components"]["schemas"]["IfSpec"]["properties"]["priority"][
+            "x-f5xc-constraints"
+        ]
+
+        assert constraints[constraint_field] == expected
+        assert "exclusiveMinimum" not in constraints
+        assert "exclusiveMaximum" not in constraints
+        expected_source = "api-probed" if rule_family.startswith("uint") else "discovery"
+        assert constraints["metadata"]["source"] == expected_source
+
     def test_enrich_uint32_ranges_discontinuous(self, enricher):
         """A discontinuous uint32.ranges yields maximum only (no single minimum)."""
         spec = {


### PR DESCRIPTION
## Summary

Map exclusive signed and unsigned integer discovery rules to exact inclusive bounds and remove the superseded dead discovery-mapping path.

## Related Issue

Closes #1048
Closes #1050

## Changes

- add `gt` and `lt` mappings for int64, uint32, and uint64 alongside the existing int32 rules
- convert integer-only exclusive limits to exact inclusive minima/maxima in the active enrichment path
- remove the unused discovery merge and mapper methods
- regenerate affected enriched API specifications
- add regression coverage for all four integer families and both bound directions

## Verification evidence

- `pytest -q`: 2396 passed, 72 skipped, 1 xfailed
- `pytest -q tests/test_constraint_enricher.py`: 104 passed
- Ruff format/check: passed
- yamllint on `config/constraint_patterns.yaml`: passed
- `python3 scripts/validate_configs.py`: passed
- full enrichment pipeline and API viewer generation: passed
- PII head-scope enforcement: clean
- AGY reviewer and verifier: approved independently with zero findings

## Delivery evidence

- Commit: `50e1aa5af92897303b3f70161975e132ae0f77e4`
- Durable AGY evidence retained on the Ubuntu workstation.
- CI, merge, and post-merge cleanup remain pending.

## Checklist

- [x] Linked to detailed issues with closing references
- [x] Feature-complete and verified
- [x] Regression tests cover the reported behavior
- [x] Verified locally through focused and full-suite execution
- [ ] Pending, failed, behind, or conflicted states repaired through `MERGED`
- [ ] Worktree and confirmed-merged branch cleaned
- [x] Follows project conventions and style guides
