### PR TITLE
test(release): cover empty target commit dispatch

### DIFF
--- a/tests/shell/test_dispatch_downstream.py
+++ b/tests/shell/test_dispatch_downstream.py
@@ -150,6 +150,14 @@ def test_dispatch_fails_closed_when_input_is_missing(tmp_path: Path, name: str) 
     assert not args_path.exists()
 
 
+def test_dispatch_fails_closed_when_target_commit_is_empty(tmp_path: Path) -> None:
+    result, args_path, _ = _run(tmp_path, overrides={"SOURCE_TARGET_COMMIT": ""})
+
+    assert result.returncode != 0
+    assert "SOURCE_TARGET_COMMIT" in result.stderr
+    assert not args_path.exists()
+
+
 @pytest.mark.parametrize(
     ("name", "value"),
     [


### PR DESCRIPTION
Closes #1502

Adds a regression test that verifies an empty `SOURCE_TARGET_COMMIT` fails before any GitHub API call.

Validation:
- `.venv/bin/python -m pytest -q tests/shell/test_dispatch_downstream.py tests/test_release_workflow.py` (28 passed)
- `make test` (2,486 passed, 6 skipped, 1 xfailed)
- `pre-commit run --files tests/shell/test_dispatch_downstream.py` (passed)

The full repository pre-commit run is blocked by pre-existing `main` content: `.ruff.toml` has no final newline (EditorConfig hook).