### PR TITLE
fix(ci): remove invalid runner smoke cache mode

### DIFF
--- a/.github/workflows/self-hosted-runner-tool-cache-smoke.yml
+++ b/.github/workflows/self-hosted-runner-tool-cache-smoke.yml
@@ -50,8 +50,6 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: 3.13.7
-          cache: false
-          check-latest: false
 
       - name: Verify catalogued Python version
         shell: bash
@@ -64,8 +62,6 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22.23.2
-          cache: false
-          check-latest: false
 
       - name: Verify catalogued Node and resident command-line tools
         shell: bash


### PR DESCRIPTION
Removes unsupported `cache: false` inputs from the manual runner smoke while preserving its exact Python and Node cache-hit assertions.

Closes #1569
